### PR TITLE
[HOTT-305] Lint spec files

### DIFF
--- a/spec/controllers/chapters/changes_controller_spec.rb
+++ b/spec/controllers/chapters/changes_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Chapters::ChangesController, "GET to #index", type: :controller do
-  let!(:chapter) { Chapter.new(attributes_for(:chapter, goods_nomenclature_item_id: "0100000000").stringify_keys) }
+describe Chapters::ChangesController, 'GET to #index', type: :controller do
+  let!(:chapter) { Chapter.new(attributes_for(:chapter, goods_nomenclature_item_id: '0100000000').stringify_keys) }
 
-  describe 'chapter is valid at given date', vcr: { cassette_name: "chapters_changes#index" } do
+  describe 'chapter is valid at given date', vcr: { cassette_name: 'chapters_changes#index' } do
     before do
       get :index, params: { chapter_id: chapter.short_code }, format: :atom
     end
@@ -13,7 +13,7 @@ describe Chapters::ChangesController, "GET to #index", type: :controller do
     it { expect(assigns(:changes)).to be_a(ChangesPresenter) }
   end
 
-  describe 'chapter has no changes at given date', vcr: { cassette_name: "chapters_changes#index_0100000000_1972-01-01" } do
+  describe 'chapter has no changes at given date', vcr: { cassette_name: 'chapters_changes#index_0100000000_1972-01-01' } do
     before do
       get :index, params: { chapter_id: chapter.short_code, as_of: Date.new(1972, 1, 1) }, format: :atom
     end
@@ -27,7 +27,7 @@ describe Chapters::ChangesController, "GET to #index", type: :controller do
     end
   end
 
-  describe 'chapter is not valid at given date', vcr: { cassette_name: "chapters_changes#index_0100000000_1970-01-01" } do
+  describe 'chapter is not valid at given date', vcr: { cassette_name: 'chapters_changes#index_0100000000_1970-01-01' } do
     before do
       get :index, params: { chapter_id: chapter.short_code, as_of: Date.new(1970, 1, 1) }, format: :atom
     end

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
-describe ChaptersController, "GET to #show", type: :controller do
-  let!(:section)     { attributes_for(:section).stringify_keys }
+describe ChaptersController, 'GET to #show', type: :controller do
+  let!(:section) { attributes_for(:section).stringify_keys }
 
-  context 'with existing chapter id provided', vcr: { cassette_name: "chapters#show" } do
+  context 'with existing chapter id provided', vcr: { cassette_name: 'chapters#show' } do
     let!(:chapter)     { build :chapter, section: section }
     let!(:actual_date) { Date.today.to_s(:dashed) }
 
-    before(:each) do
+    before do
       get :show, params: { id: chapter.to_param }
     end
 
-    it { should respond_with(:success) }
+    it { is_expected.to respond_with(:success) }
     it { expect(assigns(:chapter)).to be_a(Chapter) }
     it { expect(assigns(:headings)).to be_a(Array) }
   end

--- a/spec/controllers/commodities/changes_controller_spec.rb
+++ b/spec/controllers/commodities/changes_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Commodities::ChangesController, "GET to #index", type: :controller do
-  describe "commodity is valid at given date", vcr: { cassette_name: "commodities_changes#index" } do
-    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: "0101210000").stringify_keys) }
+describe Commodities::ChangesController, 'GET to #index', type: :controller do
+  describe 'commodity is valid at given date', vcr: { cassette_name: 'commodities_changes#index' } do
+    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '0101210000').stringify_keys) }
 
     before do
       get :index, params: { commodity_id: commodity.short_code }, format: :atom
@@ -13,8 +13,8 @@ describe Commodities::ChangesController, "GET to #index", type: :controller do
     it { expect(assigns(:changes)).to be_a(ChangesPresenter) }
   end
 
-  describe 'commodity has no changes at given date', vcr: { cassette_name: "commodities_changes#index_4302130000_1998-01-01" }, type: :controller do
-    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: "4302130000").stringify_keys) }
+  describe 'commodity has no changes at given date', vcr: { cassette_name: 'commodities_changes#index_4302130000_1998-01-01' }, type: :controller do
+    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '4302130000').stringify_keys) }
 
     before do
       get :index, params: { commodity_id: commodity.short_code, as_of: Date.new(1998, 1, 1) }, format: :atom
@@ -29,8 +29,8 @@ describe Commodities::ChangesController, "GET to #index", type: :controller do
     end
   end
 
-  describe 'commodity is not valid at given date', vcr: { cassette_name: "commodities_changes#index_4302130000_2013-11-11" } do
-    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: "4302130000").stringify_keys) }
+  describe 'commodity is not valid at given date', vcr: { cassette_name: 'commodities_changes#index_4302130000_2013-11-11' } do
+    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '4302130000').stringify_keys) }
 
     before do
       get :index, params: { commodity_id: commodity.short_code, as_of: Date.new(2013, 11, 11) }, format: :atom

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -1,29 +1,29 @@
 require 'spec_helper'
 
 describe CommoditiesController, type: :controller do
-  describe "GET to #show" do
-    context 'existing commodity id provided', vcr: { cassette_name: "commodities#show" } do
-      let!(:commodity)   { Commodity.new(attributes_for(:commodity).stringify_keys) }
+  describe 'GET to #show' do
+    context 'existing commodity id provided', vcr: { cassette_name: 'commodities#show' } do
+      subject { controller }
 
-      before(:each) do
+      let!(:commodity) { Commodity.new(attributes_for(:commodity).stringify_keys) }
+
+      before do
         VCR.use_cassette('headings_show_0101_api_json_content_type') do
           get :show, params: { id: commodity.short_code }
         end
       end
 
-      subject { controller }
-
-      it { should respond_with(:success) }
+      it { is_expected.to respond_with(:success) }
       it { expect(assigns(:section)).to be_present }
       it { expect(assigns(:chapter)).to be_present }
       it { expect(assigns(:heading)).to be_present }
       it { expect(assigns(:commodity)).to be_present }
     end
 
-    context 'with non existing commodity id provided', vcr: { cassette_name: "commodities#show_0101999999" } do
+    context 'with non existing commodity id provided', vcr: { cassette_name: 'commodities#show_0101999999' } do
       let(:commodity_id) { '0101999999' } # commodity 0101999999 does not exist
 
-      before(:each) do
+      before do
         get :show, params: { id: commodity_id }
       end
 
@@ -33,16 +33,16 @@ describe CommoditiesController, type: :controller do
       end
     end
 
-    context 'with commodity id that does not exist in provided date', vcr: { cassette_name: "commodities#show_010121000_2000-01-01" } do
+    context 'with commodity id that does not exist in provided date', vcr: { cassette_name: 'commodities#show_010121000_2000-01-01' } do
       let(:commodity_id) { '0101210000' } # commodity 0101210000 does not exist at 1st of Jan, 2000
 
-      around(:each) do |example|
-        Timecop.freeze(DateTime.new(2013,11,11,12,0,0)) do
+      around do |example|
+        Timecop.freeze(DateTime.new(2013, 11, 11, 12, 0, 0)) do
           example.run
         end
       end
 
-      before(:each) do
+      before do
         get :show, params: { id: commodity_id, year: 2000, month: 1, day: 1, country: nil }
       end
 

--- a/spec/controllers/geographical_areas_controller_spec.rb
+++ b/spec/controllers/geographical_areas_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe GeographicalAreasController, "GET to #index", type: :controller, vcr: { cassette_name: "geographical_areas#countries", allow_playback_repeats: true } do
+describe GeographicalAreasController, 'GET to #index', type: :controller, vcr: { cassette_name: 'geographical_areas#countries', allow_playback_repeats: true } do
   let!(:areas) { GeographicalArea.all }
   let!(:area) { areas[0] }
   let!(:query) { area.long_description.to_s }
 
   context 'with term param' do
-    before(:each) do
+    before do
       get :index, params: { term: query }, format: :json
     end
 
@@ -17,12 +17,12 @@ describe GeographicalAreasController, "GET to #index", type: :controller, vcr: {
     end
 
     specify 'includes search results' do
-      expect(body['results']).to include({'id' => area.id, 'text' => area.long_description})
+      expect(body['results']).to include({ 'id' => area.id, 'text' => area.long_description })
     end
   end
 
   context 'without term param' do
-    before(:each) do
+    before do
       get :index, format: :json
     end
 

--- a/spec/controllers/headings/changes_controller_spec.rb
+++ b/spec/controllers/headings/changes_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Headings::ChangesController, "GET to #index", type: :controller do
-  let!(:heading) { Heading.new(attributes_for(:heading, goods_nomenclature_item_id: "0101000000").stringify_keys) }
+describe Headings::ChangesController, 'GET to #index', type: :controller do
+  let!(:heading) { Heading.new(attributes_for(:heading, goods_nomenclature_item_id: '0101000000').stringify_keys) }
 
-  describe 'heading is valid at given date', vcr: { cassette_name: "headings_changes#index" } do
+  describe 'heading is valid at given date', vcr: { cassette_name: 'headings_changes#index' } do
     before do
       get :index, params: { heading_id: heading.short_code }, format: :atom
     end
@@ -13,7 +13,7 @@ describe Headings::ChangesController, "GET to #index", type: :controller do
     it { expect(assigns(:changes)).to be_a(ChangesPresenter) }
   end
 
-  describe 'heading has no changes at given date', vcr: { cassette_name: "headings_changes#index_0101000000_1972-01-01" } do
+  describe 'heading has no changes at given date', vcr: { cassette_name: 'headings_changes#index_0101000000_1972-01-01' } do
     before do
       get :index, params: { heading_id: heading.short_code, as_of: Date.new(1972, 1, 1) }, format: :atom
     end
@@ -27,7 +27,7 @@ describe Headings::ChangesController, "GET to #index", type: :controller do
     end
   end
 
-  describe 'heading is not valid at given date', vcr: { cassette_name: "headings_changes#index_0101000000_1970-01-01" } do
+  describe 'heading is not valid at given date', vcr: { cassette_name: 'headings_changes#index_0101000000_1970-01-01' } do
     before do
       get :index, params: { heading_id: heading.short_code, as_of: Date.new(1970, 1, 1) }, format: :atom
     end

--- a/spec/controllers/headings_controller_spec.rb
+++ b/spec/controllers/headings_controller_spec.rb
@@ -1,22 +1,22 @@
 require 'spec_helper'
 
-describe HeadingsController, "GET to #show", type: :controller do
-  context 'with existing heading id provided', vcr: { cassette_name: "headings#show" } do
-    let!(:heading)     { Heading.new(attributes_for(:heading).stringify_keys) }
+describe HeadingsController, 'GET to #show', type: :controller do
+  context 'with existing heading id provided', vcr: { cassette_name: 'headings#show' } do
+    let!(:heading) { Heading.new(attributes_for(:heading).stringify_keys) }
 
-    before(:each) do
+    before do
       get :show, params: { id: heading.to_param }
     end
 
-    it { should respond_with(:success) }
+    it { is_expected.to respond_with(:success) }
     it { expect(assigns(:heading)).to be_a(HeadingPresenter) }
     it { expect(assigns(:commodities)).to be_a(HeadingCommodityPresenter) }
   end
 
-  context 'with non existing chapter id provided', vcr: { cassette_name: "headings#show_0110" } do
+  context 'with non existing chapter id provided', vcr: { cassette_name: 'headings#show_0110' } do
     let(:heading_id) { '0110' } # heading 0110 does not exist
 
-    before(:each) do
+    before do
       get :show, params: { id: heading_id }
     end
 

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 describe HealthcheckController, type: :controller do
-  it "returns success on request" do
+  it 'returns success on request' do
     allow(Section).to receive(:all).and_return([])
 
     get :check
     expect(response.status).to eq 200
   end
 
-  it "throws a 500 on no API connection" do
+  it 'throws a 500 on no API connection' do
     allow(Section).to receive(:all)
-                  .and_raise(ApiEntity::Error.new("502 Bad Gateway"))
+                  .and_raise(ApiEntity::Error.new('502 Bad Gateway'))
     get :check
     expect(response.status).to eq 500
   end

--- a/spec/controllers/monetary_exchange_rates_controller_spec.rb
+++ b/spec/controllers/monetary_exchange_rates_controller_spec.rb
@@ -3,15 +3,15 @@ require 'spec_helper'
 describe ExchangeRatesController, 'GET to #index', type: :controller do
   render_views
 
-  around(:each) do |example|
+  around do |example|
     VCR.use_cassette('exchange_rates#index') do
       example.run
     end
   end
 
-  before {
+  before do
     get :index
-  }
+  end
 
   let(:latest_rate) { MonetaryExchangeRate.all.last }
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
-describe PagesController, "GET to #opensearch", type: :controller do
+describe PagesController, 'GET to #opensearch', type: :controller do
   context 'when asked for XML file' do
     render_views
 
-    before(:each) do
+    before do
       get :opensearch, format: 'xml'
     end
 
-    it { should respond_with(:success) }
+    it { is_expected.to respond_with(:success) }
+
     it 'renders OpenSearch file successfully' do
       expect(response.body).to include 'Tariff'
     end
@@ -17,7 +18,7 @@ describe PagesController, "GET to #opensearch", type: :controller do
   context 'when asked with no format' do
     subject { get :opensearch }
 
-    it "does not raise ActionController::UnknownFormat" do
+    it 'does not raise ActionController::UnknownFormat' do
       expect(subject).to render_template('errors/not_found')
     end
   end
@@ -25,7 +26,7 @@ describe PagesController, "GET to #opensearch", type: :controller do
   context 'with unsupported format' do
     subject { get :opensearch, format: :json }
 
-    it "does not raise ActionController::UnknownFormat" do
+    it 'does not raise ActionController::UnknownFormat' do
       expect(subject).to render_template('errors/not_found')
     end
   end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,100 +1,105 @@
 require 'spec_helper'
 
-describe SearchController, "GET to #search", type: :controller do
+describe SearchController, 'GET to #search', type: :controller do
   include CrawlerCommons
 
   context 'with HTML format' do
     context 'with search term' do
-      context "with exact match query", vcr: { cassette_name: "search#search_exact" }  do
-        let(:query) { "01" }
+      context 'with exact match query', vcr: { cassette_name: 'search#search_exact' } do
+        let(:query) { '01' }
 
-        before(:each) do
+        before do
           get :search, params: { q: query }
         end
 
-        it { should respond_with(:redirect) }
+        it { is_expected.to respond_with(:redirect) }
         it { expect(assigns(:search)).to be_a(Search) }
+
         it 'assigns search attribute' do
           expect(assigns[:search].q).to eq query
         end
       end
 
-      context "with fuzzy match query", vcr: { cassette_name: "search#search_fuzzy" }  do
-        let(:query) { "horses" }
+      context 'with fuzzy match query', vcr: { cassette_name: 'search#search_fuzzy' } do
+        let(:query) { 'horses' }
 
-        before(:each) do
+        before do
           get :search, params: { q: query }
         end
 
-        it { should respond_with(:success) }
+        it { is_expected.to respond_with(:success) }
         it { expect(assigns(:search)).to be_a(Search) }
+
         it 'assigns search attribute' do
           expect(assigns[:search].q).to eq query
         end
       end
 
-      context "with blank match",  vcr: { cassette_name: "search#blank_match" } do
+      context 'with blank match', vcr: { cassette_name: 'search#blank_match' } do
         render_views
 
-        let(:query) { " !such string should not exist in the database! " }
+        let(:query) { ' !such string should not exist in the database! ' }
 
-        before(:each) do
+        before do
           get :search, params: { q: query }
         end
 
-        it { should respond_with(:success) }
+        it { is_expected.to respond_with(:success) }
         it { expect(assigns(:search)).to be_a(Search) }
+
         it 'assigns search attribute' do
           expect(assigns[:search].q).to eq query
         end
-        it "should display no results" do
-          expect(response.body).to match /no results/
+
+        it 'displays no results' do
+          expect(response.body).to match(/no results/)
         end
       end
     end
 
-    context 'without search term', vcr: { cassette_name: "search#blank_match" }  do
+    context 'without search term', vcr: { cassette_name: 'search#blank_match' } do
       let(:now) { Time.now.utc }
+
       context 'changing browse date' do
         context 'valid past date params provided' do
           let(:year)    { now.year - 1 }
           let(:month)   { now.month }
           let(:day)     { now.day }
 
-          before(:each) do
-            @request.env['HTTP_REFERER'] = "/chapters/01"
+          before do
+            @request.env['HTTP_REFERER'] = '/chapters/01'
 
             post :search, params: {
               year: year,
               month: month,
-              day: day
+              day: day,
             }
           end
 
-          it { should respond_with(:redirect) }
+          it { is_expected.to respond_with(:redirect) }
           it { expect(assigns(:search)).to be_a(Search) }
-          it { should redirect_to(chapter_path("01", year: year, month: month, day: day)) }
+          it { is_expected.to redirect_to(chapter_path('01', year: year, month: month, day: day)) }
         end
-        
+
         xcontext 'valid pre-EU Exit date params provided' do
           let(:future_date) { Date.new(2020, 12, 31) }
           let(:year)    { future_date.year }
           let(:month)   { future_date.month }
           let(:day)     { future_date.day }
 
-          before(:each) do
-            @request.env['HTTP_REFERER'] = "/chapters/01"
+          before do
+            @request.env['HTTP_REFERER'] = '/chapters/01'
 
             post :search, params: {
               year: year,
               month: month,
-              day: day
+              day: day,
             }
           end
 
-          it { should respond_with(:redirect) }
+          it { is_expected.to respond_with(:redirect) }
           it { expect(assigns(:search)).to be_a(Search) }
-          it { should redirect_to(chapter_path("01", year: year, month: month, day: day)) }
+          it { is_expected.to redirect_to(chapter_path('01', year: year, month: month, day: day)) }
         end
 
         context 'valid date params provided for today' do
@@ -102,19 +107,19 @@ describe SearchController, "GET to #search", type: :controller do
           let(:month)   { now.month }
           let(:day)     { now.day }
 
-          before(:each) do
-            @request.env['HTTP_REFERER'] = "/chapters/01"
+          before do
+            @request.env['HTTP_REFERER'] = '/chapters/01'
 
             post :search, params: {
               year: year,
               month: month,
-              day: day
+              day: day,
             }
           end
 
-          it { should respond_with(:redirect) }
+          it { is_expected.to respond_with(:redirect) }
           it { expect(assigns(:search)).to be_a(Search) }
-          it { should redirect_to(chapter_path("01") + '?') }
+          it { is_expected.to redirect_to(chapter_path('01') + '?') }
         end
 
         context 'valid past date time param(as_of) provided' do
@@ -122,44 +127,44 @@ describe SearchController, "GET to #search", type: :controller do
           let(:month)   { now.month }
           let(:day)     { now.day }
 
-          before(:each) do
-            @request.env['HTTP_REFERER'] = "/chapters/01"
+          before do
+            @request.env['HTTP_REFERER'] = '/chapters/01'
 
             post :search, params: {
-              as_of: "#{year}-#{month}-#{day}"
+              as_of: "#{year}-#{month}-#{day}",
             }
           end
 
-          it { should respond_with(:redirect) }
+          it { is_expected.to respond_with(:redirect) }
           it { expect(assigns(:search)).to be_a(Search) }
-          it { should redirect_to(chapter_path("01", year: year, month: month, day: day)) }
+          it { is_expected.to redirect_to(chapter_path('01', year: year, month: month, day: day)) }
         end
 
         context 'invalid date param provided' do
           context 'date param is a string' do
-            before(:each) do
-              post :search, params: { date: "2012-10-1" }
+            before do
+              post :search, params: { date: '2012-10-1' }
             end
 
-            it { should respond_with(:redirect) }
+            it { is_expected.to respond_with(:redirect) }
             it { expect(assigns(:search)).to be_a(Search) }
-            it { should redirect_to(sections_path) }
+            it { is_expected.to redirect_to(sections_path) }
           end
 
           context 'date param does not have all components present' do
             let(:year)    { Forgery(:date).year }
             let(:month)   { Forgery(:date).month(numerical: true) }
 
-            before(:each) do
+            before do
               post :search, params: { date: {
                 year: year,
                 month: month,
               } }
             end
 
-            it { should respond_with(:redirect) }
+            it { is_expected.to respond_with(:redirect) }
             it { expect(assigns(:search)).to be_a(Search) }
-            it { should redirect_to(sections_path) }
+            it { is_expected.to redirect_to(sections_path) }
           end
 
           context 'date param components are invalid' do
@@ -167,111 +172,111 @@ describe SearchController, "GET to #search", type: :controller do
             let(:month)   { 'er' }
             let(:day)     { 'er' }
 
-            before(:each) do
+            before do
               post :search, params: { date: {
                 year: year,
                 month: month,
-                day: day
+                day: day,
               } }
             end
 
-            it { should respond_with(:redirect) }
+            it { is_expected.to respond_with(:redirect) }
             it { expect(assigns(:search)).to be_a(Search) }
-            it { should redirect_to(sections_path) }
+            it { is_expected.to redirect_to(sections_path) }
           end
         end
       end
     end
   end
 
-  context 'with JSON format', vcr: { cassette_name: "search#search_fuzzy", match_requests_on: [:uri, :body] } do
-    let(:day) { "5" }
-    let(:month) { "4" }
-    let(:year) { "2019" }
+  context 'with JSON format', vcr: { cassette_name: 'search#search_fuzzy', match_requests_on: %i[uri body] } do
+    let(:day) { '5' }
+    let(:month) { '4' }
+    let(:year) { '2019' }
 
     describe 'common fields' do
-      let(:query) { "car parts" }
+      let(:query) { 'car parts' }
 
-      before(:each) do
+      before do
         get :search, params: { q: query, day: day, month: month, year: year }, format: :json
       end
 
-      specify "should return query and date within response body" do
+      specify 'should return query and date within response body' do
         body = JSON.parse(response.body)
 
         expect(body).to be_kind_of Hash
-        expect(body["q"]).to eq(query)
-        expect(body["as_of"]).to eq(Date.new(year.to_i, month.to_i, day.to_i).to_formatted_s("YYYY-MM-DD"))
+        expect(body['q']).to eq(query)
+        expect(body['as_of']).to eq(Date.new(year.to_i, month.to_i, day.to_i).to_formatted_s('YYYY-MM-DD'))
       end
     end
 
     describe 'exact match search result' do
-      let(:query) { "2204" }
+      let(:query) { '2204' }
 
-      before(:each) do
+      before do
         get :search, params: { q: query, day: day, month: month, year: year }, format: :json
       end
 
-      specify "should return single goods nomenclature" do
+      specify 'should return single goods nomenclature' do
         body = JSON.parse(response.body)
 
-        expect(body["results"].size).to eq(1)
-        heading = body["results"].first
-        expect(heading["goods_nomenclature_item_id"]).to start_with(query)
+        expect(body['results'].size).to eq(1)
+        heading = body['results'].first
+        expect(heading['goods_nomenclature_item_id']).to start_with(query)
       end
     end
 
     describe 'search references exact match search result' do
-      let(:query) { "account books" }
+      let(:query) { 'account books' }
 
-      before(:each) do
+      before do
         get :search, params: { q: query, day: day, month: month, year: year }, format: :json
       end
 
-      specify "should return single goods nomenclature" do
+      specify 'should return single goods nomenclature' do
         body = JSON.parse(response.body)
 
-        expect(body["results"].size).to eq(1)
-        heading = body["results"].first
-        expect(heading["goods_nomenclature_item_id"]).to eq("4820000000")
+        expect(body['results'].size).to eq(1)
+        heading = body['results'].first
+        expect(heading['goods_nomenclature_item_id']).to eq('4820000000')
       end
     end
 
     describe 'fuzzy match search result' do
-      let(:query) { "minerals" }
+      let(:query) { 'minerals' }
 
-      before(:each) do
+      before do
         get :search, params: { q: query, day: day, month: month, year: year }, format: :json
       end
 
-      specify "should return single goods nomenclature" do
+      specify 'should return single goods nomenclature' do
         body = JSON.parse(response.body)
 
-        expect(body["results"].size).to be > 1
+        expect(body['results'].size).to be > 1
       end
     end
 
     describe 'empty search result' do
-      let(:query) { "designed velocycles" }
+      let(:query) { 'designed velocycles' }
 
-      before(:each) do
+      before do
         get :search, params: { q: query, day: day, month: month, year: year }, format: :json
       end
 
-      specify "should return single goods nomenclature" do
+      specify 'should return single goods nomenclature' do
         body = JSON.parse(response.body)
 
-        expect(body["results"].size).to eq(0)
+        expect(body['results'].size).to eq(0)
       end
     end
   end
 
-  context 'with ATOM format', vcr: { cassette_name: "search#search_fuzzy" } do
+  context 'with ATOM format', vcr: { cassette_name: 'search#search_fuzzy' } do
     render_views
 
-    let(:query) { "horses" }
+    let(:query) { 'horses' }
 
-    before(:each) do
+    before do
       get :search, params: { q: query }, format: :atom
     end
 
@@ -294,27 +299,29 @@ describe SearchController, "GET to #search", type: :controller do
     end
   end
 
-  describe "header for crawlers", vcr: { cassette_name: "search#blank_match" } do
-    context "non historical" do
+  describe 'header for crawlers', vcr: { cassette_name: 'search#blank_match' } do
+    context 'non historical' do
       before { get :search }
+
       it { should_not_include_robots_tag! }
     end
 
-    context "historical" do
+    context 'historical' do
       before { historical_request :search }
+
       it { should_include_robots_tag! }
     end
   end
 end
 
-describe SearchController, "GET to #codes", type: :controller do
-  describe "GET to #suggestions", vcr: { cassette_name: 'search#suggestions', allow_playback_repeats: true } do
+describe SearchController, 'GET to #codes', type: :controller do
+  describe 'GET to #suggestions', vcr: { cassette_name: 'search#suggestions', allow_playback_repeats: true } do
     let!(:suggestions) { SearchSuggestion.all }
     let!(:suggestion) { suggestions[0] }
     let!(:query) { suggestion.value.to_s }
 
     context 'with term param' do
-      before(:each) do
+      before do
         get :suggestions, params: { term: query }, format: :json
       end
 
@@ -325,12 +332,12 @@ describe SearchController, "GET to #codes", type: :controller do
       end
 
       specify 'includes search results' do
-        expect(body['results']).to include({'id' => suggestion.value, 'text' => suggestion.value})
+        expect(body['results']).to include({ 'id' => suggestion.value, 'text' => suggestion.value })
       end
     end
 
     context 'without term param' do
-      before(:each) do
+      before do
         get :suggestions, format: :json
       end
 
@@ -343,320 +350,342 @@ describe SearchController, "GET to #codes", type: :controller do
   end
 end
 
-describe SearchController, "GET to #quota_search", type: :controller, vcr: { cassette_name: 'search#quota_search', allow_playback_repeats: true } do
-  before(:each) do
+describe SearchController, 'GET to #quota_search', type: :controller, vcr: { cassette_name: 'search#quota_search', allow_playback_repeats: true } do
+  before do
     Rails.cache.clear
   end
 
   context 'without search params' do
     render_views
 
-    before(:each) do
+    before do
       get :quota_search, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display no results' do
-      expect(response.body).not_to match /Quota search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays no results' do
+      expect(response.body).not_to match(/Quota search results/)
     end
   end
 
   context 'search by goods nomenclature' do
     render_views
 
-    before(:each) do
-      get :quota_search, params: {goods_nomenclature_item_id: '0301919011'}, format: :html
+    before do
+      get :quota_search, params: { goods_nomenclature_item_id: '0301919011' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Quota search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Quota search results/)
     end
   end
 
   context 'search by origin' do
     render_views
 
-    before(:each) do
-      get :quota_search, params: {geographical_area_id: '1011'}, format: :html
+    before do
+      get :quota_search, params: { geographical_area_id: '1011' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Quota search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Quota search results/)
     end
   end
 
   context 'search by order number' do
     render_views
 
-    before(:each) do
-      get :quota_search, params: {order_number: '090671'}, format: :html
+    before do
+      get :quota_search, params: { order_number: '090671' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Quota search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Quota search results/)
     end
   end
 
   context 'search by critical flag' do
     render_views
 
-    before(:each) do
-      get :quota_search, params: {critical: 'Y'}, format: :html
+    before do
+      get :quota_search, params: { critical: 'Y' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Quota search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Quota search results/)
     end
   end
 
   context 'search by status' do
     render_views
 
-    before(:each) do
-      get :quota_search, params: {status: 'Not blocked'}, format: :html
+    before do
+      get :quota_search, params: { status: 'Not blocked' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Quota search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Quota search results/)
     end
   end
 
   context 'search by year' do
     render_views
 
-    before(:each) do
-      get :quota_search, params: {years: '2019'}, format: :html
+    before do
+      get :quota_search, params: { years: '2019' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should restrict search by years only' do
-      expect(response.body).to match /Sorry, there is a problem with the search query. Please specify one or more search criteria./
+    it { is_expected.to respond_with(:success) }
+
+    it 'restricts search by years only' do
+      expect(response.body).to match(/Sorry, there is a problem with the search query. Please specify one or more search criteria./)
     end
   end
 end
 
-describe SearchController, "GET to #additional_code_search", type: :controller, vcr: { cassette_name: 'search#additional_code_search' } do
-  before(:each) do
+describe SearchController, 'GET to #additional_code_search', type: :controller, vcr: { cassette_name: 'search#additional_code_search' } do
+  before do
     Rails.cache.clear
   end
 
   context 'without search params' do
     render_views
 
-    before(:each) do
+    before do
       get :additional_code_search, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display no results' do
-      expect(response.body).not_to match /Additional code search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays no results' do
+      expect(response.body).not_to match(/Additional code search results/)
     end
   end
 
   context 'search by code' do
     render_views
 
-    before(:each) do
-      get :additional_code_search, params: {code: '119'}, format: :html
+    before do
+      get :additional_code_search, params: { code: '119' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Additional code search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Additional code search results/)
     end
   end
 
   context 'search by type' do
     render_views
 
-    before(:each) do
-      get :additional_code_search, params: {type: '4'}, format: :html
+    before do
+      get :additional_code_search, params: { type: '4' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Additional code search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Additional code search results/)
     end
   end
 
   context 'search by description' do
     render_views
 
-    before(:each) do
-      get :additional_code_search, params: {description: 'shanghai'}, format: :html
+    before do
+      get :additional_code_search, params: { description: 'shanghai' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Additional code search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Additional code search results/)
     end
   end
 end
 
-describe SearchController, "GET to #footnote_search", type: :controller do
-  before(:each) do
+describe SearchController, 'GET to #footnote_search', type: :controller do
+  before do
     Rails.cache.clear
   end
 
   context 'without search params', vcr: { cassette_name: 'search#footnote_search_without_params' } do
     render_views
 
-    before(:each) do
+    before do
       get :footnote_search, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display no results' do
-      expect(response.body).not_to match /Footnote search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays no results' do
+      expect(response.body).not_to match(/Footnote search results/)
     end
   end
 
   context 'search by code', vcr: { cassette_name: 'search#footnote_search_by_code' } do
     render_views
 
-    before(:each) do
-      get :footnote_search, params: {code: '133'}, format: :html
+    before do
+      get :footnote_search, params: { code: '133' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Footnote search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Footnote search results/)
     end
   end
 
   context 'search by type', vcr: { cassette_name: 'search#footnote_search_by_type' } do
     render_views
 
-    before(:each) do
-      get :footnote_search, params: {type: 'TN'}, format: :html
+    before do
+      get :footnote_search, params: { type: 'TN' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Footnote search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Footnote search results/)
     end
   end
 
   context 'search by description', vcr: { cassette_name: 'search#footnote_search_by_description' } do
     render_views
 
-    before(:each) do
-      get :footnote_search, params: {description: 'copper'}, format: :html
+    before do
+      get :footnote_search, params: { description: 'copper' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Footnote search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Footnote search results/)
     end
   end
 end
 
-describe SearchController, "GET to #certificate_search", type: :controller, vcr: { cassette_name: 'search#certificate_search' } do
-  before(:each) do
+describe SearchController, 'GET to #certificate_search', type: :controller, vcr: { cassette_name: 'search#certificate_search' } do
+  before do
     Rails.cache.clear
   end
 
   context 'without search params' do
     render_views
 
-    before(:each) do
+    before do
       get :certificate_search, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display no results' do
-      expect(response.body).not_to match /Certificate search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays no results' do
+      expect(response.body).not_to match(/Certificate search results/)
     end
   end
 
   context 'search by code' do
     render_views
 
-    before(:each) do
-      get :certificate_search, params: {code: '119'}, format: :html
+    before do
+      get :certificate_search, params: { code: '119' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Certificate search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Certificate search results/)
     end
   end
 
   context 'search by type' do
     render_views
 
-    before(:each) do
-      get :certificate_search, params: {type: 'A'}, format: :html
+    before do
+      get :certificate_search, params: { type: 'A' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Certificate search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Certificate search results/)
     end
   end
 
   context 'search by description' do
     render_views
 
-    before(:each) do
-      get :certificate_search, params: {description: 'import licence'}, format: :html
+    before do
+      get :certificate_search, params: { description: 'import licence' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Certificate search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Certificate search results/)
     end
   end
 end
 
-describe SearchController, "GET to #chemical_search", type: :controller, vcr: { cassette_name: 'search#chemical_search', record: :new_episodes } do
-  before(:each) do
+describe SearchController, 'GET to #chemical_search', type: :controller, vcr: { cassette_name: 'search#chemical_search', record: :new_episodes } do
+  before do
     Rails.cache.clear
   end
 
   context 'without search params' do
     render_views
 
-    before(:each) do
+    before do
       get :chemical_search, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display no results' do
-      expect(response.body).not_to match /Chemical search results/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays no results' do
+      expect(response.body).not_to match(/Chemical search results/)
     end
   end
 
   context 'search by CAS number' do
     render_views
 
-    before(:each) do
-      get :chemical_search, params: {cas: '121-17-5'}, format: :html
+    before do
+      get :chemical_search, params: { cas: '121-17-5' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Chemical search results/
-      expect(response.body).to match /121-17-5/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Chemical search results/)
+      expect(response.body).to match(/121-17-5/)
     end
   end
 
   context 'search by (partial) chemical name' do
     render_views
 
-    before(:each) do
-      get :chemical_search, params: {name: 'isopropyl'}, format: :html
+    before do
+      get :chemical_search, params: { name: 'isopropyl' }, format: :html
     end
 
-    it { should respond_with(:success) }
-    it 'should display results' do
-      expect(response.body).to match /Chemical search results/
-      expect(response.body).to match /isopropyl/
+    it { is_expected.to respond_with(:success) }
+
+    it 'displays results' do
+      expect(response.body).to match(/Chemical search results/)
+      expect(response.body).to match(/isopropyl/)
     end
   end
 end

--- a/spec/controllers/search_references_controller_spec.rb
+++ b/spec/controllers/search_references_controller_spec.rb
@@ -3,15 +3,15 @@ require 'spec_helper'
 describe SearchReferencesController, 'GET to #show', type: :controller do
   render_views
 
-  around(:each) do |example|
+  around do |example|
     VCR.use_cassette('a_z_index#show_m') do
       example.run
     end
   end
 
-  before {
+  before do
     get :show, params: { letter: 'm' }
-  }
+  end
 
   it 'renders links to relevant headings' do
     expect(response.body).to include 'Mace'

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -1,47 +1,49 @@
 require 'spec_helper'
 
-describe SectionsController, "GET to #index", type: :controller, vcr: { cassette_name: "sections#index" } do
+describe SectionsController, 'GET to #index', type: :controller, vcr: { cassette_name: 'sections#index' } do
   include CrawlerCommons
 
-  context "non historical" do
+  context 'non historical' do
     before { get :index }
 
-    it { should respond_with(:success) }
+    it { is_expected.to respond_with(:success) }
     it { expect(assigns(:sections)).to be_a(Array) }
     it { should_not_include_robots_tag! }
   end
 
-  context "historical request" do
-    before {
-      VCR.use_cassette "sections#historical_index" do
+  context 'historical request' do
+    before do
+      VCR.use_cassette 'sections#historical_index' do
         historical_request :index
       end
-    }
+    end
+
     it { should_include_robots_tag! }
   end
 end
 
-describe SectionsController, "GET to #show", type: :controller do
+describe SectionsController, 'GET to #show', type: :controller do
   include CrawlerCommons
 
-  context 'with existing section id provided', vcr: { cassette_name: "sections#show" } do
+  context 'with existing section id provided', vcr: { cassette_name: 'sections#show' } do
     let!(:section) { build :section }
 
-    context "non historical" do
+    context 'non historical' do
       before { get :show, params: { id: section.position } }
 
-      it { should respond_with(:success) }
+      it { is_expected.to respond_with(:success) }
       it { expect(assigns(:section)).to be_a(Section) }
       it { expect(assigns(:chapters)).to be_a(Array) }
       it { should_not_include_robots_tag! }
     end
 
-    context "historical" do
-      before {
-        VCR.use_cassette "sections#historical_show" do
+    context 'historical' do
+      before do
+        VCR.use_cassette 'sections#historical_show' do
           historical_request(:show, id: section.position)
         end
-      }
+      end
+
       it { should_include_robots_tag! }
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
   factory :goods_nomenclature do
     description { Forgery(:basic).text }
-    goods_nomenclature_item_id { "0100000000" }
+    goods_nomenclature_item_id { '0100000000' }
     validity_start_date { Date.today.ago(3.years) }
     validity_end_date   { nil }
   end
@@ -14,7 +14,7 @@ FactoryBot.define do
   factory :chapter do
     section
     description { Forgery(:basic).text }
-    goods_nomenclature_item_id { "0100000000" }
+    goods_nomenclature_item_id { '0100000000' }
     formatted_description { Forgery(:basic).text }
   end
 
@@ -22,23 +22,23 @@ FactoryBot.define do
     chapter
     description { Forgery(:basic).text }
     formatted_description { Forgery(:basic).text }
-    goods_nomenclature_item_id { "0101000000" }
+    goods_nomenclature_item_id { '0101000000' }
   end
 
   factory :commodity do
     heading
     description { Forgery(:basic).text }
     formatted_description { Forgery(:basic).text }
-    goods_nomenclature_item_id { "0101300000" }
+    goods_nomenclature_item_id { '0101300000' }
     goods_nomenclature_sid { Forgery(:basic).number }
     parent_sid { Forgery(:basic).number }
   end
 
   factory :monetary_exchange_rate do
-    child_monetary_unit_code { "GBP" }
+    child_monetary_unit_code { 'GBP' }
     exchange_rate { Random.rand.to_d.truncate(9) }
-    operation_date { Date.today.at_beginning_of_month.ago(5.days).strftime("%Y-%m-%d") }
-    validity_start_date { Date.today.at_beginning_of_month.strftime("%Y-%m-%d") }
+    operation_date { Date.today.at_beginning_of_month.ago(5.days).strftime('%Y-%m-%d') }
+    validity_start_date { Date.today.at_beginning_of_month.strftime('%Y-%m-%d') }
   end
 
   factory :measure do
@@ -51,20 +51,20 @@ FactoryBot.define do
     effective_start_date { Date.today.ago(3.years).to_s }
     effective_end_date { nil }
 
-    measure_type {
+    measure_type do
       attributes_for(:measure_type, id: Forgery(:basic).text, description: measure_type_description).stringify_keys
-    }
+    end
 
     trait :vat do
-      measure_type {
+      measure_type do
         attributes_for(:measure_type, :vat, description: measure_type_description).stringify_keys
-      }
+      end
     end
 
     trait :third_country do
-      measure_type {
+      measure_type do
         attributes_for(:measure_type, :third_country, description: measure_type_description).stringify_keys
-      }
+      end
       geographical_area { attributes_for(:geographical_area, :third_country).stringify_keys }
     end
 
@@ -94,7 +94,7 @@ FactoryBot.define do
   end
 
   factory :duty_expression do
-    base { "80.50 EUR / Hectokilogram" }
+    base { '80.50 EUR / Hectokilogram' }
     formatted_base { "80.50 EUR / <abbr title='Hectokilogram'>Hectokilogram</abbr>" }
     national_measurement_units { nil }
   end
@@ -117,7 +117,7 @@ FactoryBot.define do
     description { Forgery(:basic).text }
 
     trait :third_country do
-      id { "1011" }
+      id { '1011' }
     end
 
     trait :specific_country do
@@ -147,9 +147,9 @@ FactoryBot.define do
   end
 
   factory :tariff_update do
-    update_type {
+    update_type do
       %w[TariffSynchronizer::ChiefUpdate TariffSynchronizer::TaricUpdate].sample
-    }
+    end
     state { 'A' }
     created_at { Time.now.to_s }
     updated_at { Time.now.to_s }

--- a/spec/features/country_filtering_spec.rb
+++ b/spec/features/country_filtering_spec.rb
@@ -1,47 +1,44 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "Search", js: true, vcr: {
-  cassette_name: "country_filtering",
+describe 'Search', js: true, vcr: {
+  cassette_name: 'country_filtering',
   record: :new_episodes,
-  match_requests_on: [:query, :path]
+  match_requests_on: %i[query path],
 } do
-
-  it "is possible to filter measures by country" do
-
-    visit commodity_path("0101210000", as_of: '2019-03-05')
+  it 'is possible to filter measures by country' do
+    visit commodity_path('0101210000', as_of: '2019-03-05')
 
     sleep 2
 
-    within ".govuk-tabs" do
-      click_on "Import"
+    within '.govuk-tabs' do
+      click_on 'Import'
     end
 
-    expect(page).to have_select("import_search_country-select", selected: "All countries")
+    expect(page).to have_select('import_search_country-select', selected: 'All countries')
 
-    within "#import_edit_search" do
+    within '#import_edit_search' do
+      page.find('#import_search_country').click
 
-      page.find("#import_search_country").click
-
-      fill_in "import_search_country", with: "United States of America"
-      expect(page.find("#import_search_country").value).to eq("United States of America")
+      fill_in 'import_search_country', with: 'United States of America'
+      expect(page.find('#import_search_country').value).to eq('United States of America')
 
       sleep 2
 
-      expect(page.find_all(".autocomplete__option").length).to eq(1)
-      expect(page.find_all(".autocomplete__option")[0].text).to eq("United States of America (US)");
+      expect(page.find_all('.autocomplete__option').length).to eq(1)
+      expect(page.find_all('.autocomplete__option')[0].text).to eq('United States of America (US)')
 
-      page.find_all(".autocomplete__option")[0].click
+      page.find_all('.autocomplete__option')[0].click
 
       sleep 2
 
-      expect(page.find("#import_search_country").value).to eq("United States of America (US)")
+      expect(page.find('#import_search_country').value).to eq('United States of America (US)')
     end
 
-    expect(page).to have_content("Measures for United States of America")
+    expect(page).to have_content('Measures for United States of America')
 
-    page.find(".reset-country-picker", visible: true).click
+    page.find('.reset-country-picker', visible: true).click
 
     sleep 2
-    expect(page.find("#import_search_country").value).to eq("All countries")
+    expect(page.find('#import_search_country').value).to eq('All countries')
   end
 end

--- a/spec/features/date_currency_change_spec.rb
+++ b/spec/features/date_currency_change_spec.rb
@@ -1,34 +1,33 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "Date & Currency change", js: true, vcr: {
-  cassette_name: "date_currency",
+describe 'Date & Currency change', js: true, vcr: {
+  cassette_name: 'date_currency',
   record: :once,
-  match_requests_on: [:path, :query]
+  match_requests_on: %i[path query],
 } do
+  it 'displays the current date' do
+    visit sections_path(day: 0o1, month: 0o2, year: 2019)
 
-  it "displays the current date" do
-    visit sections_path(day: 01, month: 02, year: 2019)
-
-    expect(page).to have_content "This tariff is for 1 February 2019"
+    expect(page).to have_content 'This tariff is for 1 February 2019'
   end
 
-  it "is able to change dates and go back in time" do
-    visit sections_path(day: 01, month: 02, year: 2019)
+  it 'is able to change dates and go back in time' do
+    visit sections_path(day: 0o1, month: 0o2, year: 2019)
 
-    expect(page).to have_content "This tariff is for 1 February 2019"
-    expect(page).to have_content "Change date"
+    expect(page).to have_content 'This tariff is for 1 February 2019'
+    expect(page).to have_content 'Change date'
 
-    click_link "Change date"
+    click_link 'Change date'
 
-    expect(page).to have_content "Set date"
+    expect(page).to have_content 'Set date'
 
     page.execute_script("$('#tariff_date_year').val('2018')")
     page.execute_script("$('#tariff_date_month').val('12')")
 
-    click_link "Set date"
+    click_link 'Set date'
 
-    expect(page).to have_content "This tariff is for 1 December 2018"
-    expect(page).to have_content "Change date"
+    expect(page).to have_content 'This tariff is for 1 December 2018'
+    expect(page).to have_content 'Change date'
   end
 
   it 'displays the searched-for date, if the searched-for date is past BREXIT_DATE, and the current date is past BREXIT_DATE' do
@@ -46,7 +45,7 @@ describe "Date & Currency change", js: true, vcr: {
 
       click_link 'Set date'
 
-      expect(page).to have_content "This tariff is for #{(searched_for_date).strftime('%-d %B %Y')}"
+      expect(page).to have_content "This tariff is for #{searched_for_date.strftime('%-d %B %Y')}"
     end
   end
 end

--- a/spec/features/exchange_rates_spec.rb
+++ b/spec/features/exchange_rates_spec.rb
@@ -1,25 +1,25 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "exchange rates", vcr: {
-  cassette_name: "exchange_rates#index",
-  record: :new_episodes
+describe 'exchange rates', vcr: {
+  cassette_name: 'exchange_rates#index',
+  record: :new_episodes,
 } do
-  let(:monetary_exchange_rate) {
+  let(:monetary_exchange_rate) do
     MonetaryExchangeRate.all.last
-  }
-
-  before {
-    visit exchange_rates_path
-  }
-
-  it "should display exchange rates in tables per year" do
-    expect(page).to have_content(monetary_exchange_rate.exchange_rate)
-    expect(page).to have_content(monetary_exchange_rate.inverse_rate)
-    expect(page).to have_content(monetary_exchange_rate.validity_start_date.strftime("%d %B %Y"))
   end
 
-  it "should highlight latest exchange rate" do
-    expect(page.find(".current-rate__accent")).to have_content("#{monetary_exchange_rate.inverse_rate} EUR")
-    expect(page.find(".current-rate__inverse")).to have_content("#{monetary_exchange_rate.exchange_rate} GBP")
+  before do
+    visit exchange_rates_path
+  end
+
+  it 'displays exchange rates in tables per year' do
+    expect(page).to have_content(monetary_exchange_rate.exchange_rate)
+    expect(page).to have_content(monetary_exchange_rate.inverse_rate)
+    expect(page).to have_content(monetary_exchange_rate.validity_start_date.strftime('%d %B %Y'))
+  end
+
+  it 'highlights latest exchange rate' do
+    expect(page.find('.current-rate__accent')).to have_content("#{monetary_exchange_rate.inverse_rate} EUR")
+    expect(page.find('.current-rate__inverse')).to have_content("#{monetary_exchange_rate.exchange_rate} GBP")
   end
 end

--- a/spec/features/headings_spec.rb
+++ b/spec/features/headings_spec.rb
@@ -1,39 +1,39 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "JS behaviour", js: true, vcr: {
-  cassette_name: "headings#8501",
-  record: :new_episodes
+describe 'JS behaviour', js: true, vcr: {
+  cassette_name: 'headings#8501',
+  record: :new_episodes,
 } do
-  it "displays the correct page" do
-    visit heading_path("8501")
+  it 'displays the correct page' do
+    visit heading_path('8501')
 
-    expect(page).to have_content("Choose the commodity code below that best matches your goods to see more information")
+    expect(page).to have_content('Choose the commodity code below that best matches your goods to see more information')
   end
 
-  it "render table tools on the top and bottom" do
-    visit heading_path("8501")
+  it 'render table tools on the top and bottom' do
+    visit heading_path('8501')
 
-    expect(page.find_all(".tree-controls").length).to eq(2)
+    expect(page.find_all('.tree-controls').length).to eq(2)
 
-    page.find_all(".has_children").each do |parent|
+    page.find_all('.has_children').each do |parent|
       expect(parent).to have_xpath("//ul[@class='govuk-list' and @aria-hidden='true']")
     end
 
-    page.find_all(".tree-controls")[0].first("a").click
+    page.find_all('.tree-controls')[0].first('a').click
 
     expect(page.find_all(".has_children ul[aria-hidden='true']").length).to eq(0)
 
-    page.find_all(".tree-controls")[1].find("a:nth-child(2)").click
+    page.find_all('.tree-controls')[1].find('a:nth-child(2)').click
 
     expect(page.find_all(".has_children ul[aria-hidden='false']").length).to eq(0)
   end
 
-  it "is able to open close specific headings" do
-    visit heading_path("8501")
+  it 'is able to open close specific headings' do
+    visit heading_path('8501')
 
-    page.find_all(".tree-controls")[1].find("a:nth-child(2)").click
+    page.find_all('.tree-controls')[1].find('a:nth-child(2)').click
 
-    parent = page.first(".has_children")
+    parent = page.first('.has_children')
     expect(parent).to have_xpath("./ul[contains(concat(' ',normalize-space(@class),' '), ' govuk-list ')]")
 
     within parent do

--- a/spec/features/search_references_spec.rb
+++ b/spec/features/search_references_spec.rb
@@ -1,18 +1,18 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "a-z index", vcr: {
-  cassette_name: "search_references#az_index",
-  record: :new_episodes
+describe 'a-z index', vcr: {
+  cassette_name: 'search_references#az_index',
+  record: :new_episodes,
 } do
-  let!(:search_reference) {
+  let!(:search_reference) do
     SearchReference.all.first
-  }
+  end
 
-  before {
-    visit a_z_index_path("a")
-  }
+  before do
+    visit a_z_index_path('a')
+  end
 
   it {
-    expect(page).to have_content(search_reference.title.titleize.squeeze(" "))
+    expect(page).to have_content(search_reference.title.titleize.squeeze(' '))
   }
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,81 +1,81 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "Search", js: true do
-  context "general" do
-    it "renders the search container properly" do
-      VCR.use_cassette("search#check", record: :new_episodes) do
+describe 'Search', js: true do
+  context 'general' do
+    it 'renders the search container properly' do
+      VCR.use_cassette('search#check', record: :new_episodes) do
         visit sections_path
 
-        expect(page).to have_content("Trade Tariff: look up commodity codes, duty and VAT rates")
-        expect(page).to have_content("Search the tariff")
+        expect(page).to have_content('Trade Tariff: look up commodity codes, duty and VAT rates')
+        expect(page).to have_content('Search the tariff')
 
-        expect(page.find(".autocomplete__input#q")).to be_present
+        expect(page.find('.autocomplete__input#q')).to be_present
       end
     end
   end
 
-  context "real" do
-    it "fetches data from the server as we type" do
-      VCR.use_cassette("search#gold", record: :new_episodes) do
+  context 'real' do
+    it 'fetches data from the server as we type' do
+      VCR.use_cassette('search#gold', record: :new_episodes) do
         visit sections_path
 
-        page.find(".autocomplete__input#q").click
+        page.find('.autocomplete__input#q').click
 
-        page.find(".autocomplete__input#q").set("gold")
+        page.find('.autocomplete__input#q').set('gold')
         sleep 1
 
-        expect(page.find(".autocomplete__option--focused").text).to eq("gold")
+        expect(page.find('.autocomplete__option--focused').text).to eq('gold')
 
         using_wait_time 1 do
-          expect(page.find_all(".autocomplete__option").length).to be > 1
+          expect(page.find_all('.autocomplete__option').length).to be > 1
         end
 
-        expect(page.find(".autocomplete__option--focused").text).to eq("gold")
-        expect(page).to have_content("gold - gold coin")
+        expect(page.find('.autocomplete__option--focused').text).to eq('gold')
+        expect(page).to have_content('gold - gold coin')
 
-        page.find(".autocomplete__option--focused").click
+        page.find('.autocomplete__option--focused').click
 
         # trying to see if redirect done by JS needs some sleep to be caught up
         sleep 1
 
-        expect(page).to have_content("Search results for ‘gold’")
+        expect(page).to have_content('Search results for ‘gold’')
       end
     end
   end
 
-  context "404" do
-    it "handles no results found" do
-      VCR.use_cassette("search#gibberish", record: :new_episodes) do
+  context '404' do
+    it 'handles no results found' do
+      VCR.use_cassette('search#gibberish', record: :new_episodes) do
         visit sections_path
 
-        page.find(".autocomplete__input#q").click
+        page.find('.autocomplete__input#q').click
 
-        page.find(".autocomplete__input#q").set("dsauidoasuiodsa")
+        page.find('.autocomplete__input#q').set('dsauidoasuiodsa')
 
         sleep 1
 
-        expect(page.find_all(".autocomplete__option").length).to eq(1)
-        expect(page.find(".autocomplete__option--focused").text).to eq("dsauidoasuiodsa")
+        expect(page.find_all('.autocomplete__option').length).to eq(1)
+        expect(page.find('.autocomplete__option--focused').text).to eq('dsauidoasuiodsa')
         sleep 1
 
-        page.find(".autocomplete__option--focused").click
+        page.find('.autocomplete__option--focused').click
 
         # trying to see if redirect done by JS needs some sleep to be caught up
         sleep 1
 
-        expect(page).to have_content("Search results for ‘dsauidoasuiodsa’")
-        expect(page).to have_content("There are no results matching your query.")
+        expect(page).to have_content('Search results for ‘dsauidoasuiodsa’')
+        expect(page).to have_content('There are no results matching your query.')
       end
     end
   end
 
   context 'quota search' do
-    before(:each) do
+    before do
       Rails.cache.clear
     end
 
     context 'quota search form' do
-      it 'should contain quota search params inputs' do
+      it 'contains quota search params inputs' do
         VCR.use_cassette('search#quota_search_form', record: :new_episodes) do
           visit quota_search_path
 
@@ -95,7 +95,7 @@ describe "Search", js: true do
     end
 
     context 'quota search results' do
-      it 'should perform search and render results' do
+      it 'performs search and render results' do
         VCR.use_cassette('search#quota_search_results', record: :new_episodes) do
           visit quota_search_path
 
@@ -103,7 +103,7 @@ describe "Search", js: true do
 
           page.find('#goods_nomenclature_item_id').set('0301')
           page.find('#order_number').set('0906')
-          page.find('#years_',).set('2019')
+          page.find('#years_').set('2019')
           page.find('input[name="new_search"]').click
 
           using_wait_time 1 do
@@ -118,12 +118,12 @@ describe "Search", js: true do
   end
 
   context 'additional code search' do
-    before(:each) do
+    before do
       Rails.cache.clear
     end
 
     context 'additional code search form' do
-      it 'should contain additional code search params inputs' do
+      it 'contains additional code search params inputs' do
         VCR.use_cassette('search#additional_code_search_form', record: :new_episodes) do
           visit additional_code_search_path
 
@@ -140,7 +140,7 @@ describe "Search", js: true do
     end
 
     context 'additional code search results' do
-      it 'should perform search and render results' do
+      it 'performs search and render results' do
         VCR.use_cassette('search#additional_code_search_results', record: :new_episodes) do
           visit additional_code_search_path
 
@@ -159,14 +159,14 @@ describe "Search", js: true do
       end
     end
   end
-  
+
   context 'certificate search' do
-    before(:each) do
+    before do
       Rails.cache.clear
     end
 
     context 'certificate search form' do
-      it 'should contain certificate search params inputs' do
+      it 'contains certificate search params inputs' do
         VCR.use_cassette('search#certificate_search_form', record: :new_episodes) do
           visit certificate_search_path
 
@@ -183,7 +183,7 @@ describe "Search", js: true do
     end
 
     context 'certificate search results' do
-      it 'should perform search and render results' do
+      it 'performs search and render results' do
         VCR.use_cassette('search#certificate_search_results', record: :new_episodes) do
           visit certificate_search_path
 
@@ -212,14 +212,14 @@ describe "Search", js: true do
   end
 
   context 'chemical search' do
-    before(:each) do
+    before do
       Rails.cache.clear
     end
 
-    let(:name) { "CAS" }
+    let(:name) { 'CAS' }
 
     context 'chemical search form' do
-      it 'should contain chemical search params inputs' do
+      it 'contains chemical search params inputs' do
         VCR.use_cassette('search#chemical_search_form', record: :new_episodes) do
           visit chemical_search_path
 
@@ -233,7 +233,7 @@ describe "Search", js: true do
     end
 
     context 'chemical search results' do
-      it 'should perform search by CAS number and render results' do
+      it 'performs search by CAS number and render results' do
         VCR.use_cassette('search#chemical_cas_search_results', record: :new_episodes) do
           visit chemical_search_path
 
@@ -245,12 +245,12 @@ describe "Search", js: true do
           using_wait_time 1 do
             expect(page).to have_content('Chemical search results for “121-17-5”')
             expect(page).to have_content('4-chloro-alpha,alpha,alpha-trifluoro-3-nitrotoluene')
-            expect(page).to have_link("Other", href: "/commodities/2904990000")
+            expect(page).to have_link('Other', href: '/commodities/2904990000')
           end
         end
       end
 
-      it 'should perform search by chemical name and render results' do
+      it 'performs search by chemical name and render results' do
         VCR.use_cassette('search#chemical_name_search_results', record: :new_episodes) do
           visit chemical_search_path
 
@@ -263,7 +263,7 @@ describe "Search", js: true do
             expect(page).to have_content('Chemical search results for “benzene”')
             expect(page).to have_content('22199-08-2')
             expect(page).to have_content('4-amino-N-(pyrimidin-2(1H)-ylidene-κN 1)benzenesulfonamidato-κOsilver')
-            expect(page).to have_link("Other", href: "/commodities/2843290000")
+            expect(page).to have_link('Other', href: '/commodities/2843290000')
           end
         end
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -7,7 +7,7 @@ describe ApplicationHelper, type: :helper do
 
       it 'renders string in Markdown as HTML' do
         expect(
-          helper.govspeak(string).strip
+          helper.govspeak(string).strip,
         ).to eq '<p><strong>hello</strong></p>'
       end
     end
@@ -17,35 +17,35 @@ describe ApplicationHelper, type: :helper do
 
       it '<script> tags with a content are filtered' do
         expect(
-          helper.govspeak(string).strip
-        ).to eq ""
+          helper.govspeak(string).strip,
+        ).to eq ''
       end
     end
 
     context 'when HashWithIndifferentAccess is passed as argument' do
-      let(:hash) {
-        { "content" => "* 1\\. This chapter does not cover:" }
-      }
+      let(:hash) do
+        { 'content' => '* 1\\. This chapter does not cover:' }
+      end
 
       it 'fetches :content from the hash' do
         expect(
-          helper.govspeak(hash)
+          helper.govspeak(hash),
         ).to eq <<~FOO
-        <ul>
-          <li>1. This chapter does not cover:</li>
-        </ul>
+          <ul>
+            <li>1. This chapter does not cover:</li>
+          </ul>
         FOO
       end
     end
 
     context 'when HashWithIndifferentAccess is passed as argument with no applicable content' do
-      let(:na_hash) {
-        { "foo" => "bar" }
-      }
+      let(:na_hash) do
+        { 'foo' => 'bar' }
+      end
 
       it 'returns an empty string' do
         expect(
-          helper.govspeak(na_hash)
+          helper.govspeak(na_hash),
         ).to eq ''
       end
     end

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -6,6 +6,6 @@ describe CommoditiesHelper, type: :helper do
 
   let(:commodities) { [commodity1, commodity2] }
 
-  describe ".commodity_tree" do
+  describe '.commodity_tree' do
   end
 end

--- a/spec/middleware/trade_tariff_frontend/http_basic_authentication_spec.rb
+++ b/spec/middleware/trade_tariff_frontend/http_basic_authentication_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+# rubocop:disable Rails/HttpPositionalArguments
 describe 'Basic Auth' do
   include Rack::Test::Methods
 
@@ -56,3 +57,4 @@ describe 'Basic Auth' do
     end
   end
 end
+# rubocop:enable Rails/HttpPositionalArguments

--- a/spec/middleware/trade_tariff_frontend/http_basic_authentication_spec.rb
+++ b/spec/middleware/trade_tariff_frontend/http_basic_authentication_spec.rb
@@ -44,13 +44,13 @@ describe 'Basic Auth' do
     end
 
     context 'with incorrect credentials' do
-      before { get '/sections', {}, 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(wrong_user,wrong_password) }
+      before { get '/sections', {}, { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(wrong_user, wrong_password) } }
 
       it { expect(last_response.status).to eq(401) }
     end
 
     context 'with correct credentials' do
-      before { get '/sections', {}, 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(correct_user,correct_password) }
+      before { get '/sections', {}, { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(correct_user, correct_password) } }
 
       it { expect(last_response.status).to eq(200) }
     end

--- a/spec/middleware/trade_tariff_frontend/rack_attack_spec.rb
+++ b/spec/middleware/trade_tariff_frontend/rack_attack_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+# rubocop:disable Rails/HttpPositionalArguments
 describe Rack::Attack, vcr: { cassette_name: 'sections#index' } do
   include Rack::Test::Methods
 
@@ -128,3 +129,4 @@ describe Rack::Attack, vcr: { cassette_name: 'sections#index' } do
     end
   end
 end
+# rubocop:enable Rails/HttpPositionalArguments

--- a/spec/middleware/trade_tariff_frontend/rack_attack_spec.rb
+++ b/spec/middleware/trade_tariff_frontend/rack_attack_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rack::Attack, vcr: { cassette_name: "sections#index" } do
+describe Rack::Attack, vcr: { cassette_name: 'sections#index' } do
   include Rack::Test::Methods
 
   def app
@@ -8,25 +8,38 @@ describe Rack::Attack, vcr: { cassette_name: "sections#index" } do
   end
 
   context 'when app is not locked' do
-    before { ENV['CDS_LOCKED_IP'] = nil }
-    before { ENV['IP_ALLOWLIST'] = nil }
-    before { ENV['CDS_LOCKED_AUTH'] = nil }
-    before { ENV['CDS_USER'] = nil }
-    before { ENV['CDS_PASSWORD'] = nil }
-    before { ENV['CDN_SECRET_KEY'] = nil }
+    before do
+      ENV['CDN_SECRET_KEY'] = nil
+      ENV['CDS_LOCKED_AUTH'] = nil
+      ENV['CDS_LOCKED_IP'] = nil
+      ENV['CDS_PASSWORD'] = nil
+      ENV['CDS_USER'] = nil
+      ENV['IP_ALLOWLIST'] = nil
 
-    before { get '/sections' }
+      get '/sections'
+    end
 
     it { expect(last_response.status).to eq(200) }
   end
 
   context 'when app is locked' do
-    before { ENV['CDS_LOCKED_IP'] = 'true' }
-    before { ENV['IP_ALLOWLIST'] = '127.0.0.1' }
-    before { ENV['CDS_LOCKED_AUTH'] = nil }
-    before { ENV['CDS_USER'] = nil }
-    before { ENV['CDS_PASSWORD'] = nil }
-    before { ENV['CDN_SECRET_KEY'] = nil }
+    before do
+      ENV['CDN_SECRET_KEY'] = nil
+      ENV['CDS_LOCKED_AUTH'] = nil
+      ENV['CDS_LOCKED_IP'] = 'true'
+      ENV['CDS_PASSWORD'] = nil
+      ENV['CDS_USER'] = nil
+      ENV['IP_ALLOWLIST'] = '127.0.0.1'
+    end
+
+    after do
+      ENV['CDN_SECRET_KEY'] = nil
+      ENV['CDS_PASSWORD'] = nil
+      ENV['CDS_USER'] = nil
+      ENV['CDS_LOCKED_AUTH'] = nil
+      ENV['IP_ALLOWLIST'] = nil
+      ENV['CDS_LOCKED_IP'] = nil
+    end
 
     context 'and ip is not listed' do
       before { get '/sections', {}, { 'REMOTE_ADDR' => '1.2.3.4' } }
@@ -39,40 +52,43 @@ describe Rack::Attack, vcr: { cassette_name: "sections#index" } do
 
       it { expect(last_response.status).to eq(200) }
     end
-
-    after { ENV['CDS_LOCKED_IP'] = nil }
-    after { ENV['IP_ALLOWLIST'] = nil }
-    after { ENV['CDS_LOCKED_AUTH'] = nil }
-    after { ENV['CDS_USER'] = nil }
-    after { ENV['CDS_PASSWORD'] = nil }
-    after { ENV['CDN_SECRET_KEY'] = nil }
   end
 
   context 'when app has no CDN lock' do
-    before { ENV['CDN_SECRET_KEY'] = nil }
-    before { ENV['IP_ALLOWLIST'] = nil }
+    before do
+      ENV['CDN_SECRET_KEY'] = nil
+      ENV['IP_ALLOWLIST'] = nil
 
-    before { get '/sections' }
+      get '/sections'
+    end
 
     it { expect(last_response.status).to eq(200) }
   end
 
   context 'when app has CDN lock' do
-    before { ENV['CDN_SECRET_KEY'] = 'CDN_SECRET_KEY' }
-    before { ENV['IP_ALLOWLIST'] = nil }
+    before do
+      ENV['CDN_SECRET_KEY'] = 'CDN_SECRET_KEY'
+      ENV['IP_ALLOWLIST'] = nil
+    end
 
-    context 'request has no secret key header value' do
+    after { ENV['CDN_SECRET_KEY'] = nil }
+
+    context 'when request has no secret key header value' do
       before { get '/sections' }
 
       it { expect(last_response.status).to eq(403) }
     end
 
-    context 'request has no secret key header value but ip is allowed' do
-      before { ENV['IP_ALLOWLIST'] = '127.0.0.1' }
-      before { get '/sections', {},  { 'REMOTE_ADDR' => '127.0.0.1' }}
+    context 'when request has no secret key header value but ip is allowed' do
+      before do
+        ENV['IP_ALLOWLIST'] = '127.0.0.1'
+
+        get '/sections', {}, { 'REMOTE_ADDR' => '127.0.0.1' }
+      end
+
+      after { ENV['IP_ALLOWLIST'] = nil }
 
       it { expect(last_response.status).to eq(200) }
-      after { ENV['IP_ALLOWLIST'] = nil }
     end
 
     context 'request has wrong secret key header value' do
@@ -82,11 +98,15 @@ describe Rack::Attack, vcr: { cassette_name: "sections#index" } do
     end
 
     context 'request has wrong secret key header value but ip is allowed' do
-      before { ENV['IP_ALLOWLIST'] = '127.0.0.1' }
-      before { get '/sections', {}, { 'CDN_SECRET' => 'CDN_SECRET', 'REMOTE_ADDR' => '127.0.0.1' } }
+      before do
+        ENV['IP_ALLOWLIST'] = '127.0.0.1'
+
+        get '/sections', {}, { 'CDN_SECRET' => 'CDN_SECRET', 'REMOTE_ADDR' => '127.0.0.1' }
+      end
+
+      after { ENV['IP_ALLOWLIST'] = nil }
 
       it { expect(last_response.status).to eq(200) }
-      after { ENV['IP_ALLOWLIST'] = nil }
     end
 
     context 'request has correct secret key header value' do
@@ -96,13 +116,15 @@ describe Rack::Attack, vcr: { cassette_name: "sections#index" } do
     end
 
     context 'request has correct secret key header value and ip is not in allow list' do
-      before { ENV['IP_ALLOWLIST'] = '127.0.0.1' }
-      before { get '/sections', {}, { 'CDN_SECRET' => 'CDN_SECRET_KEY', 'REMOTE_ADDR' => '1.2.3.4' } }
+      before do
+        ENV['IP_ALLOWLIST'] = '127.0.0.1'
+
+        get '/sections', {}, { 'CDN_SECRET' => 'CDN_SECRET_KEY', 'REMOTE_ADDR' => '1.2.3.4' }
+      end
+
+      after { ENV['IP_ALLOWLIST'] = nil }
 
       it { expect(last_response.status).to eq(200) }
-      after { ENV['IP_ALLOWLIST'] = nil }
     end
-
-    after { ENV['CDN_SECRET_KEY'] = nil }
   end
 end

--- a/spec/middleware/trade_tariff_frontend/request_forwarder_spec.rb
+++ b/spec/middleware/trade_tariff_frontend/request_forwarder_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe TradeTariffFrontend::RequestForwarder do
-  let(:app)            { ->(env) { [200, env, "app"] } }
+  let(:app)            { ->(env) { [200, env, 'app'] } }
   let(:host)           { TradeTariffFrontend::ServiceChooser.api_host }
-  let(:request_path)   { "/sections/1" }
-  let(:request_params) { "?page=2" }
+  let(:request_path)   { '/sections/1' }
+  let(:request_params) { '?page=2' }
 
-  let(:response_body) { "example" }
+  let(:response_body) { 'example' }
 
   let :middleware do
     described_class.new(host: host)
@@ -25,7 +25,7 @@ describe TradeTariffFrontend::RequestForwarder do
       .to_return(
         status: 200,
         body: response_body,
-        headers: { 'Content-Length' => response_body.size }
+        headers: { 'Content-Length' => response_body.size },
       )
 
     status, env, body = middleware.call env_for(request_path)
@@ -39,13 +39,13 @@ describe TradeTariffFrontend::RequestForwarder do
       .to_return(
         status: 200,
         body: '',
-        headers: { 'Content-Length' => 0 }
+        headers: { 'Content-Length' => 0 },
       )
 
     status, env, body = middleware.call env_for(request_path, method: :head)
 
     expect(status).to eq 200
-    expect(body).to eq [""]
+    expect(body).to eq ['']
   end
 
   it 'forwards response status code from upstream backend host' do
@@ -54,7 +54,7 @@ describe TradeTariffFrontend::RequestForwarder do
       .to_return(
         status: 404,
         body: 'Not Found',
-        headers: { 'Content-Length' => 'Not Found'.size }
+        headers: { 'Content-Length' => 'Not Found'.size },
       )
 
     status, env, body = middleware.call env_for(request_path)
@@ -70,8 +70,8 @@ describe TradeTariffFrontend::RequestForwarder do
         body: response_body,
         headers: {
           'Content-Length' => response_body.size,
-          'Content-Type' => 'text/html'
-        }
+          'Content-Type' => 'text/html',
+        },
       )
 
     status, env, body = middleware.call env_for(request_path)
@@ -87,8 +87,8 @@ describe TradeTariffFrontend::RequestForwarder do
         body: response_body,
         headers: {
           'Content-Length' => response_body.size,
-          'X-UA-Compatible' => 'IE=9'
-        }
+          'X-UA-Compatible' => 'IE=9',
+        },
       )
 
     status, env, body = middleware.call env_for(request_path)
@@ -103,7 +103,7 @@ describe TradeTariffFrontend::RequestForwarder do
     expect(body).to be_blank
   end
 
-  it "forwards request params" do
+  it 'forwards request params' do
     request_uri = request_path + request_params
 
     stub_request(:get, "#{host}#{request_uri}")
@@ -111,7 +111,7 @@ describe TradeTariffFrontend::RequestForwarder do
       .to_return(
         status: 200,
         body: response_body,
-        headers: { "Content-Length" => response_body.size }
+        headers: { 'Content-Length' => response_body.size },
       )
 
     status, env, body = middleware.call env_for(request_uri)
@@ -120,7 +120,7 @@ describe TradeTariffFrontend::RequestForwarder do
   end
 
   context 'when a service prefix is included in the path' do
-    let(:request_path)   { '/xi/sections/1' }
+    let(:request_path) { '/xi/sections/1' }
 
     it 'removes the service prefix' do
       TradeTariffFrontend::ServiceChooser.service_choice = 'xi'
@@ -132,8 +132,8 @@ describe TradeTariffFrontend::RequestForwarder do
           body: response_body,
           headers: {
             'Content-Length' => response_body.size,
-            'X-UA-Compatible' => 'IE=9'
-          }
+            'X-UA-Compatible' => 'IE=9',
+          },
         )
 
       status, env, body = middleware.call env_for(request_path)

--- a/spec/models/footnote_spec.rb
+++ b/spec/models/footnote_spec.rb
@@ -5,16 +5,16 @@ describe Footnote do
     let(:measure) { Measure.new(attributes_for(:measure, id: '123').stringify_keys) }
     let(:footnote) { described_class.new(attributes_for(:footnote, casted_by: measure, code: '456').stringify_keys) }
 
-    it 'should contain casted_by info' do
+    it 'contains casted_by info' do
       expect(footnote.id).to include(footnote.casted_by.destination)
       expect(footnote.id).to include(footnote.casted_by.id)
     end
 
-    it 'should contain code' do
+    it 'contains code' do
       expect(footnote.id).to include(footnote.code)
     end
 
-    it "should contain '-footnote-'" do
+    it "contains '-footnote-'" do
       expect(footnote.id).to include('-footnote-')
     end
   end

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe GeographicalArea do
-  describe '.all', vcr: { cassette_name: "geographical_areas#countries" }  do
+  describe '.all', vcr: { cassette_name: 'geographical_areas#countries' } do
     let(:countries) { GeographicalArea.countries }
 
     it 'fetches geographical areas that are countries from the API' do
       expect(countries).to be_kind_of Array
-      expect(countries).to_not be_blank
+      expect(countries).not_to be_blank
     end
 
     it 'sorts countries by id' do
@@ -15,12 +15,12 @@ describe GeographicalArea do
 
     it 'removes excluded countries (United Kingdom)' do
       expect(
-        countries.detect { |c| c.id == 'GB' }
+        countries.detect { |c| c.id == 'GB' },
       ).to be_blank
     end
   end
 
-  describe '.by_long_description', vcr: { cassette_name: "geographical_areas#countries" } do
+  describe '.by_long_description', vcr: { cassette_name: 'geographical_areas#countries' } do
     let(:by_long_desc) { GeographicalArea.by_long_description('in') }
 
     it 'returns an array' do

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -43,9 +43,9 @@ describe GoodsNomenclature do
 
   describe '#validity_start_date' do
     context 'the date is set' do
-      let(:goods_nomenclature) {
+      let(:goods_nomenclature) do
         build(:goods_nomenclature, validity_start_date: Date.today)
-      }
+      end
 
       it 'returns instance of Date' do
         expect(goods_nomenclature.validity_start_date).to be_kind_of Date
@@ -57,9 +57,9 @@ describe GoodsNomenclature do
     end
 
     context 'date is not set' do
-      let(:goods_nomenclature) {
+      let(:goods_nomenclature) do
         build(:goods_nomenclature, validity_start_date: nil)
-      }
+      end
 
       it 'returns NullObject' do
         expect(goods_nomenclature.validity_start_date).to be_kind_of NullObject
@@ -69,9 +69,9 @@ describe GoodsNomenclature do
 
   describe '#validity_end_date' do
     context 'the date is set' do
-      let(:goods_nomenclature) {
+      let(:goods_nomenclature) do
         build(:goods_nomenclature, validity_end_date: Date.today)
-      }
+      end
 
       it 'returns instance of Date' do
         expect(goods_nomenclature.validity_end_date).to be_kind_of Date
@@ -83,9 +83,9 @@ describe GoodsNomenclature do
     end
 
     context 'date is not set' do
-      let(:goods_nomenclature) {
+      let(:goods_nomenclature) do
         build(:goods_nomenclature, validity_end_date: nil)
-      }
+      end
 
       it 'returns NullObject' do
         expect(goods_nomenclature.validity_end_date).to be_kind_of NullObject

--- a/spec/models/measure_collection_spec.rb
+++ b/spec/models/measure_collection_spec.rb
@@ -8,8 +8,8 @@ describe MeasureCollection do
 
     it 'filters measures by country code' do
       expect(
-        collection.for_country('IT')
-      ).to_not include measure2
+        collection.for_country('IT'),
+      ).not_to include measure2
     end
   end
 
@@ -19,7 +19,7 @@ describe MeasureCollection do
     let(:collection) { MeasureCollection.new([measure1, measure2]) }
 
     it 'filters VAT measures' do
-      expect(collection.vat).to_not include measure2
+      expect(collection.vat).not_to include measure2
     end
   end
 
@@ -29,7 +29,7 @@ describe MeasureCollection do
     let(:collection) { MeasureCollection.new([measure1, measure2]) }
 
     it 'filters national measures' do
-      expect(collection.national).to_not include measure2
+      expect(collection.national).not_to include measure2
     end
   end
 
@@ -61,10 +61,11 @@ describe MeasureCollection do
     end
   end
 
-  describe "#present?" do
+  describe '#present?' do
     context 'measures present' do
-      let(:measure) { Measure.new(attributes_for(:measure).stringify_keys) }
       subject { MeasureCollection.new([measure]) }
+
+      let(:measure) { Measure.new(attributes_for(:measure).stringify_keys) }
 
       it 'returns true' do
         expect(subject).to be_present
@@ -75,7 +76,7 @@ describe MeasureCollection do
       subject { MeasureCollection.new([]) }
 
       it 'returns false' do
-        expect(subject).to_not be_present
+        expect(subject).not_to be_present
       end
     end
   end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1,71 +1,71 @@
 require 'spec_helper'
 
 describe Measure do
-  describe "#relevant_for_country?" do
+  describe '#relevant_for_country?' do
     it 'returns true when no geographical area is specified' do
-      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: {id: 'br',
-                                                                         description: 'Brazil'}).stringify_keys)
+      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: { id: 'br',
+                                                                               description: 'Brazil' }).stringify_keys)
       expect(
-        measure.relevant_for_country?(nil)
+        measure.relevant_for_country?(nil),
       ).to eq true
     end
 
     it 'returns true if a national measure and geographical area code is equal to 1011' do
-      measure = Measure.new(attributes_for(:measure, :national, geographical_area: {id: '1011',
-                                                                         description: 'ERGA OMNES'}).stringify_keys)
+      measure = Measure.new(attributes_for(:measure, :national, geographical_area: { id: '1011',
+                                                                                     description: 'ERGA OMNES' }).stringify_keys)
       expect(
-        measure.relevant_for_country?('br')
+        measure.relevant_for_country?('br'),
       ).to eq true
     end
 
     it 'returns false if a national measure and it is an excluded country' do
-      measure = Measure.new(attributes_for(:measure, :national, geographical_area: {id: 'lt',
-                                                                         description: 'Lithuania'},
-                                                                         excluded_countries: [
-                                                                          {id: 'lt', description: 'Lithuania', geographical_area_id: 'lt'}
-                                                                         ]).stringify_keys)
+      measure = Measure.new(attributes_for(:measure, :national, geographical_area: { id: 'lt',
+                                                                                     description: 'Lithuania' },
+                                                                excluded_countries: [
+                                                                  { id: 'lt', description: 'Lithuania', geographical_area_id: 'lt' },
+                                                                ]).stringify_keys)
       expect(
-        measure.relevant_for_country?('lt')
+        measure.relevant_for_country?('lt'),
       ).to eq false
     end
 
     it 'returns true if geographical area code matches' do
-      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: {id: 'br',
-                                                                         description: 'Brazil'}).stringify_keys)
+      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: { id: 'br',
+                                                                               description: 'Brazil' }).stringify_keys)
       expect(
-        measure.relevant_for_country?('br')
+        measure.relevant_for_country?('br'),
       ).to eq true
       expect(
-        measure.relevant_for_country?('fr')
+        measure.relevant_for_country?('fr'),
       ).to eq false
     end
 
     it 'returns true if geographical area (group) contains matching code' do
-      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: {id: nil,
-                                                                         description: 'European Union',
-                                                                         children_geographical_areas: [
-                                                                           {id: 'lt', description: 'Lithuania'},
-                                                                           {id: 'fr', description: 'France'}
-                                                                         ]}).stringify_keys)
+      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: { id: nil,
+                                                                               description: 'European Union',
+                                                                               children_geographical_areas: [
+                                                                                 { id: 'lt', description: 'Lithuania' },
+                                                                                 { id: 'fr', description: 'France' },
+                                                                               ] }).stringify_keys)
       expect(
-        measure.relevant_for_country?('lt')
+        measure.relevant_for_country?('lt'),
       ).to eq true
       expect(
-        measure.relevant_for_country?('it')
+        measure.relevant_for_country?('it'),
       ).to eq false
     end
 
     it 'returns false if country code is among excluded countries for this measure' do
-      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: {id: nil,
-                                                                         description: 'European Union',
-                                                                         children_geographical_areas: [
-                                                                           {id: 'lt', description: 'Lithuania', geographical_area_id: 'lt'}
-                                                                         ]},
-                                                     excluded_countries: [
-                                                                          {id: 'lt', description: 'Lithuania', geographical_area_id: 'lt'}
-                                                                         ]).stringify_keys)
+      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: { id: nil,
+                                                                               description: 'European Union',
+                                                                               children_geographical_areas: [
+                                                                                 { id: 'lt', description: 'Lithuania', geographical_area_id: 'lt' },
+                                                                               ] },
+                                                          excluded_countries: [
+                                                            { id: 'lt', description: 'Lithuania', geographical_area_id: 'lt' },
+                                                          ]).stringify_keys)
       expect(
-        measure.relevant_for_country?('lt')
+        measure.relevant_for_country?('lt'),
       ).to eq false
     end
   end

--- a/spec/models/monetary_exchange_rate_spec.rb
+++ b/spec/models/monetary_exchange_rate_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe MonetaryExchangeRate do
-  describe "#validity_start_date" do
+  describe '#validity_start_date' do
     it 'returns a Date object from a string' do
       rate = MonetaryExchangeRate.new(attributes_for(:monetary_exchange_rate).stringify_keys)
 
@@ -9,7 +9,7 @@ describe MonetaryExchangeRate do
     end
   end
 
-  describe "#operation_date" do
+  describe '#operation_date' do
     it 'returns a Date object from a string' do
       rate = MonetaryExchangeRate.new(attributes_for(:monetary_exchange_rate).stringify_keys)
 
@@ -17,9 +17,9 @@ describe MonetaryExchangeRate do
     end
   end
 
-  describe "#inverse_rate" do
+  describe '#inverse_rate' do
     it 'returns the exchange rate from GBP to EUR' do
-      rate = MonetaryExchangeRate.new(attributes_for(:monetary_exchange_rate, exchange_rate: "0.8").stringify_keys)
+      rate = MonetaryExchangeRate.new(attributes_for(:monetary_exchange_rate, exchange_rate: '0.8').stringify_keys)
 
       expect(rate.inverse_rate).to eq 1.25
     end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -15,7 +15,7 @@ describe Search do
       allow(Search).to receive(:api).and_return(api_mock)
     end
 
-    it "search" do
+    it 'search' do
       expect { Search.new(q: 'abc').perform }.to raise_error ApiEntity::Error
     end
   end

--- a/spec/models/search_suggestion_spec.rb
+++ b/spec/models/search_suggestion_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe SearchSuggestion do
-  describe '.all', vcr: { cassette_name: 'search#suggestions', allow_playback_repeats: true }  do
+  describe '.all', vcr: { cassette_name: 'search#suggestions', allow_playback_repeats: true } do
     let(:suggestions) { SearchSuggestion.all }
 
     it 'fetches suggestions from the API' do
       expect(suggestions).to be_kind_of Array
-      expect(suggestions).to_not be_blank
+      expect(suggestions).not_to be_blank
     end
 
     it 'sorts suggestions by value' do
@@ -14,9 +14,9 @@ describe SearchSuggestion do
     end
   end
 
-  describe '.start_with', vcr: { cassette_name: 'search#suggestions', allow_playback_repeats: true  } do
+  describe '.start_with', vcr: { cassette_name: 'search#suggestions', allow_playback_repeats: true } do
     it 'invokes .cached_suggestions method' do
-      expect(described_class).to receive(:cached_suggestions) { [] }
+      expect(described_class).to receive(:cached_suggestions).and_return([])
       described_class.start_with('123')
     end
 

--- a/spec/models/tariff_date_spec.rb
+++ b/spec/models/tariff_date_spec.rb
@@ -23,7 +23,7 @@ describe TariffDate do
 
     it 'ignores incorrect date in param' do
       expect(
-        subject.new('2011').to_s
+        subject.new('2011').to_s,
       ).to eq subject.new(nil).date.to_s(:dashed)
     end
   end

--- a/spec/presenters/commodity_presenter_spec.rb
+++ b/spec/presenters/commodity_presenter_spec.rb
@@ -4,7 +4,7 @@ describe CommodityPresenter do
   describe '#show_commodity_tree?' do
     it 'returns true because commodities have ancestors' do
       expect(
-        CommodityPresenter.new(Commodity.new()).show_commodity_tree?
+        CommodityPresenter.new(Commodity.new).show_commodity_tree?,
       ).to be_truthy
     end
   end

--- a/spec/presenters/declarable_presenter_spec.rb
+++ b/spec/presenters/declarable_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe DeclarablePresenter do
   it 'relays all undefined methods to presented declarable object' do
     expect(
-      DeclarablePresenter.new(Commodity.new(goods_nomenclature_item_id: "0102210000")).heading_code
-    ).to eq("02")
+      DeclarablePresenter.new(Commodity.new(goods_nomenclature_item_id: '0102210000')).heading_code,
+    ).to eq('02')
   end
 end

--- a/spec/presenters/heading_commodity_presenter_spec.rb
+++ b/spec/presenters/heading_commodity_presenter_spec.rb
@@ -8,14 +8,14 @@ describe HeadingCommodityPresenter do
 
     it 'returns commodities that have root identication' do
       expect(
-        HeadingCommodityPresenter.new(commodities).root_commodities
+        HeadingCommodityPresenter.new(commodities).root_commodities,
       ).to include root_commodity
     end
 
     it 'does not return commodity not marked as root' do
       expect(
-        HeadingCommodityPresenter.new(commodities).root_commodities
-      ).to_not include non_root_commodity
+        HeadingCommodityPresenter.new(commodities).root_commodities,
+      ).not_to include non_root_commodity
     end
   end
 end

--- a/spec/presenters/heading_presenter_spec.rb
+++ b/spec/presenters/heading_presenter_spec.rb
@@ -4,7 +4,7 @@ describe HeadingPresenter do
   describe '#show_commodity_tree?' do
     it 'returns false because headings do not have ancestor commodities' do
       expect(
-        HeadingPresenter.new(Heading.new()).show_commodity_tree?
+        HeadingPresenter.new(Heading.new).show_commodity_tree?,
       ).to be false
     end
   end

--- a/spec/presenters/measure_presenter_spec.rb
+++ b/spec/presenters/measure_presenter_spec.rb
@@ -1,38 +1,38 @@
 require 'spec_helper'
 
 describe MeasurePresenter do
-  describe "#geo_class" do
+  describe '#geo_class' do
     context 'when geographical area is a country group' do
-      let(:children_ga)       { [attributes_for(:geographical_area).stringify_keys, attributes_for(:geographical_area).stringify_keys]}
-      let(:geographical_area) { attributes_for(:geographical_area, geographical_area_id: nil, children_geographical_areas: children_ga).stringify_keys }
-      let(:measure)           { Measure.new(attributes_for(:measure, geographical_area: geographical_area).stringify_keys)}
-
       subject { MeasurePresenter.new(measure) }
 
+      let(:children_ga)       { [attributes_for(:geographical_area).stringify_keys, attributes_for(:geographical_area).stringify_keys] }
+      let(:geographical_area) { attributes_for(:geographical_area, geographical_area_id: nil, children_geographical_areas: children_ga).stringify_keys }
+      let(:measure)           { Measure.new(attributes_for(:measure, geographical_area: geographical_area).stringify_keys) }
+
       it 'returns list of contained children geographical area ids' do
-        expect(subject.geo_class).to match /#{children_ga.first[:geographical_area_id]}/
-        expect(subject.geo_class).to match /#{children_ga.last[:geographical_area_id]}/
+        expect(subject.geo_class).to match(/#{children_ga.first[:geographical_area_id]}/)
+        expect(subject.geo_class).to match(/#{children_ga.last[:geographical_area_id]}/)
       end
     end
 
     context 'when geographical area is a country' do
-      let(:geographical_area) { attributes_for(:geographical_area).stringify_keys }
-      let(:measure)           { Measure.new(attributes_for(:measure, geographical_area: geographical_area).stringify_keys)}
-
       subject { MeasurePresenter.new(measure) }
 
+      let(:geographical_area) { attributes_for(:geographical_area).stringify_keys }
+      let(:measure)           { Measure.new(attributes_for(:measure, geographical_area: geographical_area).stringify_keys) }
+
       it 'returns geographical area id of geographical area' do
-        expect(subject.geo_class).to match /#{geographical_area[:geographical_area_id]}/
+        expect(subject.geo_class).to match(/#{geographical_area[:geographical_area_id]}/)
       end
     end
   end
 
-  describe "#has_children_geographical_areas?" do
-    let(:children_ga)       { [attributes_for(:geographical_area).stringify_keys, attributes_for(:geographical_area).stringify_keys]}
+  describe '#has_children_geographical_areas?' do
+    let(:children_ga)       { [attributes_for(:geographical_area).stringify_keys, attributes_for(:geographical_area).stringify_keys] }
     let(:geographical_area) { attributes_for(:geographical_area, geographical_area_id: nil, children_geographical_areas: children_ga).stringify_keys }
     let(:measure1)          { MeasurePresenter.new(Measure.new(attributes_for(:measure, geographical_area: geographical_area).stringify_keys)) }
 
-    let(:measure2)          { MeasurePresenter.new(Measure.new(attributes_for(:measure, geographical_area: attributes_for(:geographical_area).stringify_keys).stringify_keys))}
+    let(:measure2)          { MeasurePresenter.new(Measure.new(attributes_for(:measure, geographical_area: attributes_for(:geographical_area).stringify_keys).stringify_keys)) }
 
     it 'returns true if measures geographical area contains any children geographical area' do
       expect(measure1.has_children_geographical_areas?).to be true
@@ -43,8 +43,8 @@ describe MeasurePresenter do
     end
   end
 
-  describe "#children_geographical_areas" do
-    let(:children_ga)       { [attributes_for(:geographical_area).stringify_keys, attributes_for(:geographical_area).stringify_keys]}
+  describe '#children_geographical_areas' do
+    let(:children_ga)       { [attributes_for(:geographical_area).stringify_keys, attributes_for(:geographical_area).stringify_keys] }
     let(:geographical_area) { attributes_for(:geographical_area, geographical_area_id: nil, children_geographical_areas: children_ga).stringify_keys }
     let(:measure1)          { MeasurePresenter.new(Measure.new(attributes_for(:measure, geographical_area: geographical_area))) }
 
@@ -54,7 +54,7 @@ describe MeasurePresenter do
     end
   end
 
-  describe "#has_measure_conditions?" do
+  describe '#has_measure_conditions?' do
     let(:measure1)          { MeasurePresenter.new(Measure.new(attributes_for(:measure, :with_conditions).stringify_keys)) }
     let(:measure2)          { MeasurePresenter.new(Measure.new(attributes_for(:measure).stringify_keys)) }
 
@@ -67,7 +67,7 @@ describe MeasurePresenter do
     end
   end
 
-  describe "#has_additional_code?" do
+  describe '#has_additional_code?' do
     let(:measure1)          { MeasurePresenter.new(Measure.new(attributes_for(:measure, :with_additional_code).stringify_keys)) }
     let(:measure2)          { MeasurePresenter.new(Measure.new(attributes_for(:measure).stringify_keys)) }
 
@@ -80,7 +80,7 @@ describe MeasurePresenter do
     end
   end
 
-  describe "#has_references?" do
+  describe '#has_references?' do
     let(:measure1)          { MeasurePresenter.new(Measure.new(attributes_for(:measure, :with_conditions).stringify_keys)) }
     let(:measure2)          { MeasurePresenter.new(Measure.new(attributes_for(:measure, :with_footnotes).stringify_keys)) }
     let(:measure3)          { MeasurePresenter.new(Measure.new(attributes_for(:measure).stringify_keys)) }

--- a/spec/requests/chapter_spec.rb
+++ b/spec/requests/chapter_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe 'Chapter page', type: :request do
   context 'as HTML' do
-    it 'should display chapter name and headings in the chapter' do
+    it 'displays chapter name and headings in the chapter' do
       VCR.use_cassette('geographical_areas#countries') do
         VCR.use_cassette('chapters#show') do
-          visit chapter_path("01")
+          visit chapter_path('01')
 
           expect(page).to have_content 'Live animals'
           expect(page).to have_content 'Live bovine animals'
@@ -19,12 +19,12 @@ describe 'Chapter page', type: :request do
     context 'requested with json format' do
       it 'renders direct API response' do
         VCR.use_cassette('chapters#show_01_api_json_format') do
-          get "/chapters/01.json"
+          get '/chapters/01.json'
 
           json = JSON.parse(response.body)
 
-          expect(json["goods_nomenclature_item_id"]).to eq '0100000000'
-          expect(json["formatted_description"]).to eq 'Live animals'
+          expect(json['goods_nomenclature_item_id']).to eq '0100000000'
+          expect(json['formatted_description']).to eq 'Live animals'
         end
       end
     end
@@ -32,12 +32,12 @@ describe 'Chapter page', type: :request do
     context 'requested with json HTTP Accept header' do
       it 'renders direct API response' do
         VCR.use_cassette('chapters#show_01_api_json_content_type') do
-          get "/chapters/01", headers: { 'HTTP_ACCEPT' => 'application/json' }
+          get '/chapters/01', headers: { 'HTTP_ACCEPT' => 'application/json' }
 
           json = JSON.parse(response.body)
 
-          expect(json["goods_nomenclature_item_id"]).to eq '0100000000'
-          expect(json["formatted_description"]).to eq 'Live animals'
+          expect(json['goods_nomenclature_item_id']).to eq '0100000000'
+          expect(json['formatted_description']).to eq 'Live animals'
         end
       end
     end

--- a/spec/requests/chapters/changes_spec.rb
+++ b/spec/requests/chapters/changes_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe 'GET to #index - getting chapter change feed', type: :request do
-  let!(:chapter) { Chapter.new(attributes_for(:chapter, goods_nomenclature_item_id: "0101000000").stringify_keys) }
+  let!(:chapter) { Chapter.new(attributes_for(:chapter, goods_nomenclature_item_id: '0101000000').stringify_keys) }
 
   describe 'no request format supplied' do
     before do
-      VCR.use_cassette("chapters_changes#index") do
-        get "/chapters/01/changes"
+      VCR.use_cassette('chapters_changes#index') do
+        get '/chapters/01/changes'
       end
     end
 

--- a/spec/requests/commodities/changes_spec.rb
+++ b/spec/requests/commodities/changes_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe 'GET to #index - getting commodity change feed', type: :request do
-  let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: "0101000000").stringify_keys) }
+  let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '0101000000').stringify_keys) }
 
   describe 'no request format supplied' do
     before do
-      VCR.use_cassette("commodities_changes#index") do
-        get "/commodities/0101210000/changes"
+      VCR.use_cassette('commodities_changes#index') do
+        get '/commodities/0101210000/changes'
       end
     end
 

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -7,7 +7,7 @@ describe 'Commodity page', type: :request do
         VCR.use_cassette('geographical_areas#countries') do
           VCR.use_cassette('commodities#show_0101300000') do
             VCR.use_cassette('headings#show_0101') do
-              visit commodity_path("0101300000")
+              visit commodity_path('0101300000')
 
               expect(page).to have_content 'Importing from outside the EU is subject to a third country duty of 7.70 %'
             end
@@ -21,12 +21,12 @@ describe 'Commodity page', type: :request do
         it 'renders direct API response' do
           VCR.use_cassette('commodities#show_0101300000_api_json_format') do
             VCR.use_cassette('headings#show_0101') do
-              get "/commodities/0101300000.json"
+              get '/commodities/0101300000.json'
 
               json = JSON.parse(response.body)
 
-              expect(json["declarable"]).to be true
-              expect(json["import_measures"]).to be_kind_of Array
+              expect(json['declarable']).to be true
+              expect(json['import_measures']).to be_kind_of Array
             end
           end
         end
@@ -36,12 +36,12 @@ describe 'Commodity page', type: :request do
         it 'renders direct API response' do
           VCR.use_cassette('commodities#show_0101300000_api_json_content_type') do
             VCR.use_cassette('headings#show_0101') do
-              get "/commodities/0101300000", headers: { 'HTTP_ACCEPT' => 'application/json' }
+              get '/commodities/0101300000', headers: { 'HTTP_ACCEPT' => 'application/json' }
 
               json = JSON.parse(response.body)
 
-              expect(json["declarable"]).to be true
-              expect(json["import_measures"]).to be_kind_of Array
+              expect(json['declarable']).to be true
+              expect(json['import_measures']).to be_kind_of Array
             end
           end
         end
@@ -54,7 +54,7 @@ describe 'Commodity page', type: :request do
       VCR.use_cassette('geographical_areas#countries') do
         VCR.use_cassette('commodities#show_8714930019') do
           VCR.use_cassette('headings#show_8714') do
-            visit commodity_path("8714930019")
+            visit commodity_path('8714930019')
 
             expect(page).to have_content 'Importing from outside the EU is subject to a third country duty of 4.70 % unless subject to other measures.'
           end
@@ -68,13 +68,13 @@ describe 'Commodity page', type: :request do
       VCR.use_cassette('geographical_areas#countries') do
         VCR.use_cassette('commodities#show_0101300000') do
           VCR.use_cassette('headings#show_0101') do
-            visit commodity_path("0101300000", country: "AD")
+            visit commodity_path('0101300000', country: 'AD')
 
-            within("#import table.measures") do
+            within('#import table.measures') do
               expect(page).to have_content 'Andorra'
             end
 
-            within("#import table.measures") do
+            within('#import table.measures') do
               expect(page).to have_content 'Animal Health Certificate'
             end
           end
@@ -88,9 +88,9 @@ describe 'Commodity page', type: :request do
       VCR.use_cassette('geographical_areas#countries') do
         VCR.use_cassette('commodities#show_1701910000_2006-02-01') do
           VCR.use_cassette('headings#show_1701') do
-            visit commodity_path("1701910000", as_of: "2006-02-01")
+            visit commodity_path('1701910000', as_of: '2006-02-01')
 
-            within("#import") do
+            within('#import') do
               expect(page).to have_content 'Additional duty based on cif price'
             end
           end
@@ -104,9 +104,9 @@ describe 'Commodity page', type: :request do
       VCR.use_cassette('geographical_areas#countries') do
         VCR.use_cassette('commodities#show_2208909110') do
           VCR.use_cassette('headings#show_2208') do
-            visit commodity_path("2208909110")
+            visit commodity_path('2208909110')
 
-            within("#import") do
+            within('#import') do
               expect(page).to have_content 'l alc. 100%'
             end
           end

--- a/spec/requests/goods_nomenclature_spec.rb
+++ b/spec/requests/goods_nomenclature_spec.rb
@@ -4,7 +4,7 @@ describe 'Goods nomenclature API request', type: :request do
   context 'as JSON' do
     it 'renders direct API response as JSON' do
       VCR.use_cassette('goods_nomenclatures_heading_01_v2_api_json_format') do
-        get "/api/v2/goods_nomenclatures/heading/0101.json"
+        get '/api/v2/goods_nomenclatures/heading/0101.json'
 
         json = JSON.parse(response.body)
 
@@ -20,7 +20,7 @@ describe 'Goods nomenclature API request', type: :request do
   context 'as CSV' do
     it 'renders direct API response as CSV' do
       VCR.use_cassette('goods_nomenclatures_heading_01_v2_api_csv_format') do
-        get "/api/v2/goods_nomenclatures/heading/0101.csv"
+        get '/api/v2/goods_nomenclatures/heading/0101.csv'
 
         expect(response.body).to include('SID,Goods Nomenclature Item ID,Indents,Description,Product Line Suffix,Href')
       end
@@ -30,7 +30,7 @@ describe 'Goods nomenclature API request', type: :request do
   context 'scoped by date' do
     it 'renders direct API response scoped by date' do
       VCR.use_cassette('goods_nomenclatures_heading_01_as_of_date_v2_api_json_format') do
-        get "/api/v2/goods_nomenclatures/heading/0101.json?as_of=1971-12-31"
+        get '/api/v2/goods_nomenclatures/heading/0101.json?as_of=1971-12-31'
 
         json = JSON.parse(response.body)
 

--- a/spec/requests/heading_spec.rb
+++ b/spec/requests/heading_spec.rb
@@ -7,7 +7,7 @@ describe 'Heading page', type: :request do
         it 'displays declarable related information' do
           VCR.use_cassette('geographical_areas#countries') do
             VCR.use_cassette('headings#show_declarable') do
-              visit heading_path("0501")
+              visit heading_path('0501')
 
               expect(page).to have_content 'Importing from outside the EU is subject to a third country duty of 0.00 % unless subject to other measures.'
             end
@@ -19,17 +19,16 @@ describe 'Heading page', type: :request do
         it 'displays declarable related information' do
           VCR.use_cassette('geographical_areas#countries') do
             VCR.use_cassette('headings#show_declarable') do
-              visit heading_path("0501", country: 'ZW')
+              visit heading_path('0501', country: 'ZW')
 
-              within("#import table.measures") do
+              within('#import table.measures') do
                 expect(page).to     have_content 'Zimbabwe'
                 expect(page).to     have_content 'Eastern and Southern Africa States' # Zimbabwe is member of latter
               end
 
-              within("#import table.measures") do
+              within('#import table.measures') do
                 expect(page).to     have_content 'Animal Health Certificate'
               end
-
             end
           end
         end
@@ -37,10 +36,10 @@ describe 'Heading page', type: :request do
     end
 
     context 'regular heading' do
-      it 'should display heading name and children commodities' do
+      it 'displays heading name and children commodities' do
         VCR.use_cassette('geographical_areas#countries') do
           VCR.use_cassette('headings#show') do
-            visit heading_path("0101")
+            visit heading_path('0101')
 
             expect(page).to have_content 'Live horses, asses, mules and hinnies'
             expect(page).to have_content 'Horses'
@@ -55,7 +54,7 @@ describe 'Heading page', type: :request do
     context 'requested with json format' do
       it 'renders direct API response' do
         VCR.use_cassette('headings#show_0101_api_json_format') do
-          get "/headings/0101.json"
+          get '/headings/0101.json'
 
           json = JSON.parse(response.body)
 
@@ -68,7 +67,7 @@ describe 'Heading page', type: :request do
     context 'requested with json HTTP Accept header' do
       it 'renders direct API response' do
         VCR.use_cassette('headings#show_0101_api_json_content_type') do
-          get "/headings/0101", headers: { 'HTTP_ACCEPT' => 'application/json' }
+          get '/headings/0101', headers: { 'HTTP_ACCEPT' => 'application/json' }
 
           json = JSON.parse(response.body)
 

--- a/spec/requests/headings/changes_spec.rb
+++ b/spec/requests/headings/changes_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe 'GET to #index - getting heading change feed', type: :request do
-  let!(:heading) { Heading.new(attributes_for(:heading, goods_nomenclature_item_id: "0101000000").stringify_keys) }
+  let!(:heading) { Heading.new(attributes_for(:heading, goods_nomenclature_item_id: '0101000000').stringify_keys) }
 
   describe 'no request format supplied' do
     before do
-      VCR.use_cassette("headings_changes#index") do
-        get "/headings/0101/changes"
+      VCR.use_cassette('headings_changes#index') do
+        get '/headings/0101/changes'
       end
     end
 

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe 'Search page', type: :request do
-  describe "search results" do
-    before {
+  describe 'search results' do
+    before do
       allow(Section).to receive(:all).and_return([])
-    }
+    end
 
     context 'exact match' do
-      it 'should redirect user to exact match page' do
+      it 'redirects user to exact match page' do
         VCR.use_cassette('tariff_updates#index') do
           VCR.use_cassette('geographical_areas#countries') do
             visit sections_path(q: '0101210000')
@@ -15,7 +15,7 @@ describe 'Search page', type: :request do
             VCR.use_cassette('chapters#show') do
               VCR.use_cassette('search#search_exact') do
                 VCR.use_cassette('headings#show_0101') do
-                  within("#new_search") do
+                  within('#new_search') do
                     # fill_in 'q', with: '0101210000'
                     # select2('0101210000', css: ".js-commodity-picker-select")
                     click_button 'Search'
@@ -38,25 +38,25 @@ describe 'Search page', type: :request do
             visit sections_path(q: 'horses')
 
             VCR.use_cassette('search#fuzzy_match') do
-              within("#new_search") do
+              within('#new_search') do
                 # fill_in 'q', with: 'horses'
                 click_button 'Search'
               end
 
-              expect(page).to have_content "Other results containing the term ‘horses’"
+              expect(page).to have_content 'Other results containing the term ‘horses’'
             end
           end
         end
       end
     end
 
-    context 'no results found', vcr: { cassette_name: "search#blank_match" } do
-      it 'should display no results message' do
+    context 'no results found', vcr: { cassette_name: 'search#blank_match' } do
+      it 'displays no results message' do
         VCR.use_cassette('tariff_updates#index') do
           VCR.use_cassette('geographical_areas#countries') do
-            visit sections_path(q: "!!!!!!!!!!!!")
+            visit sections_path(q: '!!!!!!!!!!!!')
 
-            within("#new_search") do
+            within('#new_search') do
               # fill_in 'q', with: " !such string should not exist in the database! "
               click_button 'Search'
             end
@@ -67,17 +67,17 @@ describe 'Search page', type: :request do
       end
     end
 
-    context "duplicate results - when search results page is finished" do
-      it "Display section when matching" do
+    context 'duplicate results - when search results page is finished' do
+      it 'Display section when matching' do
         VCR.use_cassette('tariff_updates#index') do
           VCR.use_cassette('geographical_areas#countries') do
-            visit sections_path(q: "synonym 1")
-            VCR.use_cassette("search#duplicate_results") do
-              within("#new_search") do
+            visit sections_path(q: 'synonym 1')
+            VCR.use_cassette('search#duplicate_results') do
+              within('#new_search') do
                 # fill_in "q", with: "synonym 1"
-                click_button "Search"
+                click_button 'Search'
               end
-              expect(page).to have_content("Section I")
+              expect(page).to have_content('Section I')
             end
           end
         end

--- a/spec/requests/sections_spec.rb
+++ b/spec/requests/sections_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Sections Index page', type: :request do
   context 'as HTML' do
-    it 'should display section names' do
+    it 'displays section names' do
       VCR.use_cassette('geographical_areas#countries') do
         VCR.use_cassette('sections#index') do
           visit sections_path
@@ -19,7 +19,7 @@ describe 'Sections Index page', type: :request do
     context 'requested with json format' do
       it 'renders direct API response' do
         VCR.use_cassette('sections#index_api_json_format') do
-          get "/sections.json"
+          get '/sections.json'
 
           json = JSON.parse(response.body)
 
@@ -32,7 +32,7 @@ describe 'Sections Index page', type: :request do
     context 'requested with json HTTP Accept header' do
       it 'renders direct API response' do
         VCR.use_cassette('sections#index_api_json_content_type') do
-          get "/sections", headers: { 'HTTP_ACCEPT' => 'application/json' }
+          get '/sections', headers: { 'HTTP_ACCEPT' => 'application/json' }
 
           json = JSON.parse(response.body)
 
@@ -46,7 +46,7 @@ end
 
 describe 'Section page', type: :request do
   context 'as HTML' do
-    it 'should display section name and chapters in the section' do
+    it 'displays section name and chapters in the section' do
       VCR.use_cassette('geographical_areas#countries') do
         VCR.use_cassette('sections#show') do
           visit section_path(1)
@@ -63,7 +63,7 @@ describe 'Section page', type: :request do
     context 'requested with json format' do
       it 'renders direct API response' do
         VCR.use_cassette('sections#show_1_api_json_format') do
-          get "/sections/1.json"
+          get '/sections/1.json'
 
           json = JSON.parse(response.body)
 
@@ -76,7 +76,7 @@ describe 'Section page', type: :request do
     context 'requested with json HTTP Accept header' do
       it 'renders direct API response' do
         VCR.use_cassette('sections#show_1_api_json_content_type') do
-          get "/sections/1", headers: { 'HTTP_ACCEPT' => 'application/json' }
+          get '/sections/1', headers: { 'HTTP_ACCEPT' => 'application/json' }
 
           json = JSON.parse(response.body)
 

--- a/spec/routing/service_path_prefix_handling_spec.rb
+++ b/spec/routing/service_path_prefix_handling_spec.rb
@@ -9,13 +9,13 @@ describe RoutingFilter::ServicePathPrefixHandler, type: :routing do
 
   describe 'matching routes' do
     context 'when the service choice prefix is xi' do
-      let(:prefix) { "/xi" }
+      let(:prefix) { '/xi' }
 
       it 'sets the request params service choice to the xi backend' do
         expect(get: path).to route_to(
-          controller: "commodities",
-          action: "show",
-          id: "0101300000",
+          controller: 'commodities',
+          action: 'show',
+          id: '0101300000',
         )
         expect(Thread.current[:service_choice]).to eq('xi')
       end
@@ -26,9 +26,9 @@ describe RoutingFilter::ServicePathPrefixHandler, type: :routing do
 
       it 'does not specify the service backend' do
         expect(get: path).to route_to(
-          controller: "commodities",
-          action: "show",
-          id: "0101300000",
+          controller: 'commodities',
+          action: 'show',
+          id: '0101300000',
         )
         expect(Thread.current[:service_choice]).to be_nil
       end
@@ -39,29 +39,29 @@ describe RoutingFilter::ServicePathPrefixHandler, type: :routing do
 
       it 'does not set the request params service choice' do
         expect(get: path).to route_to(
-          controller: "commodities",
-          action: "show",
-          id: "0101300000",
+          controller: 'commodities',
+          action: 'show',
+          id: '0101300000',
         )
         expect(Thread.current[:service_choice]).to eq('uk')
       end
     end
 
     context 'when the service choice prefix is set to an unsupported service choice' do
-      let(:prefix) { "/xixi" }
+      let(:prefix) { '/xixi' }
 
       it 'routes to a not_found action in the errors controller' do
         expect(get: path).to route_to(
-          controller: "errors",
-          action: "not_found",
-          path: "xixi/commodities/0101300000"
+          controller: 'errors',
+          action: 'not_found',
+          path: 'xixi/commodities/0101300000',
         )
         expect(Thread.current[:service_choice]).to eq(nil)
       end
     end
 
     context 'when the service choice prefix is the only thing in the path' do
-      let(:path) { "#{prefix}" }
+      let(:path) { prefix.to_s }
       let(:prefix) { '/xi' }
 
       it 'routes to a not_found action in the errors controller' do
@@ -84,19 +84,19 @@ describe RoutingFilter::ServicePathPrefixHandler, type: :routing do
       it 'prepends the choice to the url' do
         result = commodity_url(
           id: commodity_id,
-          currency: 'EUR'
+          currency: 'EUR',
         )
 
-        expect(result).to eq("http://test.host/xi/commodities/0101210000?currency=EUR")
+        expect(result).to eq('http://test.host/xi/commodities/0101210000?currency=EUR')
       end
 
       it 'prepends the choice to the path' do
         result = commodity_path(
           id: commodity_id,
-          currency: 'EUR'
+          currency: 'EUR',
         )
 
-        expect(result).to eq("/xi/commodities/0101210000?currency=EUR")
+        expect(result).to eq('/xi/commodities/0101210000?currency=EUR')
       end
     end
 
@@ -106,19 +106,19 @@ describe RoutingFilter::ServicePathPrefixHandler, type: :routing do
       it 'does not prepend the choice to the url' do
         result = commodity_path(
           id: commodity_id,
-          currency: 'EUR'
+          currency: 'EUR',
         )
 
-        expect(result).to eq("/commodities/0101210000?currency=EUR")
+        expect(result).to eq('/commodities/0101210000?currency=EUR')
       end
 
       it 'does not prepend the choice to the path' do
         result = commodity_path(
           id: commodity_id,
-          currency: 'EUR'
+          currency: 'EUR',
         )
 
-        expect(result).to eq("/commodities/0101210000?currency=EUR")
+        expect(result).to eq('/commodities/0101210000?currency=EUR')
       end
     end
 

--- a/spec/support/crawler_commons.rb
+++ b/spec/support/crawler_commons.rb
@@ -1,13 +1,13 @@
 module CrawlerCommons
   def should_not_include_robots_tag!
-    expect(response.headers["X-Robots-Tag"]).to_not be_present
+    expect(response.headers['X-Robots-Tag']).not_to be_present
   end
 
   def should_include_robots_tag!
-    expect(response.headers["X-Robots-Tag"]).to eq("none")
+    expect(response.headers['X-Robots-Tag']).to eq('none')
   end
 
-  def historical_request(action, options={})
+  def historical_request(action, options = {})
     def_options = { month: 1, year: 2008, day: 1 }
     get action, params: def_options.merge(options)
   end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -9,10 +9,10 @@ VCR.configure do |c|
   c.default_cassette_options = { match_requests_on: [:path] }
   c.configure_rspec_metadata!
   c.ignore_request do |request|
-    if request.uri.start_with?("https://chromedriver.storage.googleapis.com")
+    if request.uri.start_with?('https://chromedriver.storage.googleapis.com')
       true
     else
-      URI(request.uri).host.in?(%w(localhost 127.0.0.1)) &&
+      URI(request.uri).host.in?(%w[localhost 127.0.0.1]) &&
         service_ports.exclude?(URI(request.uri).port)
     end
   end

--- a/spec/views/measures/_measure.html.erb_spec.rb
+++ b/spec/views/measures/_measure.html.erb_spec.rb
@@ -1,35 +1,35 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "measures/_measure.html.erb", type: :view do
-  let(:measure) {
+describe 'measures/_measure.html.erb', type: :view do
+  let(:measure) do
     Measure.new(
       attributes_for(:measure, :third_country,
-                               duty_expression: duty_expression).stringify_keys
+                     duty_expression: duty_expression).stringify_keys,
     )
-  }
+  end
 
-  before {
-    render "measures/measure.html.erb", measure: MeasurePresenter.new(measure)
-  }
+  before do
+    render 'measures/measure.html.erb', measure: MeasurePresenter.new(measure)
+  end
 
-  context "with formatted_base" do
+  context 'with formatted_base' do
     let(:duty_expression) { attributes_for(:duty_expression).stringify_keys }
 
     it {
-      expect(rendered).to match /EUR/
-      expect(rendered).to match /Hectokilogram/
-      expect(rendered).to match /<abbr title='Hectokilogram'>/
+      expect(rendered).to match(/EUR/)
+      expect(rendered).to match(/Hectokilogram/)
+      expect(rendered).to match(/<abbr title='Hectokilogram'>/)
     }
   end
 
-  context "without formatted_base" do
-    let(:duty_expression) {
+  context 'without formatted_base' do
+    let(:duty_expression) do
       attributes_for(:duty_expression, formatted_base: nil).stringify_keys
-    }
+    end
 
     it {
-      expect(rendered).to match /EUR/
-      expect(rendered).to match /Hectokilogram/
+      expect(rendered).to match(/EUR/)
+      expect(rendered).to match(/Hectokilogram/)
     }
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-305

### What?

I have added/removed/altered:

- [x] Automatically lint all spec files

### Why?

I am doing this because:

- We're not in a good place with code hygiene and have a ridiculous number of deprecation warnings
- This will reduce linting visibility issues with actual code files
