### PR TITLE
[HOTT-371] Quotas removal for XI service

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   include TradeTariffFrontend::ViewContext::Controller
   include ApplicationHelper
 
+  before_action :set_enable_service_switch_banner_in_action
   before_action :set_last_updated
   before_action :set_cache
   before_action :search_query
@@ -59,6 +60,10 @@ class ApplicationController < ActionController::Base
 
   def set_last_updated
     @tariff_last_updated ||= TariffUpdate.latest_applied_import_date
+  end
+
+  def set_enable_service_switch_banner_in_action
+    @enable_service_switch_banner_in_action = true
   end
 
   def search_invoked?

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -44,7 +44,6 @@ class SearchController < ApplicationController
   def quota_search
     form = QuotaSearchForm.new(params)
     @result = QuotaSearchPresenter.new(form)
-    @no_shared_switch_service_link = true
     respond_to do |format|
       format.html
     end
@@ -53,7 +52,6 @@ class SearchController < ApplicationController
   def additional_code_search
     form = AdditionalCodeSearchForm.new(params)
     @result = AdditionalCodeSearchPresenter.new(form)
-    @no_shared_switch_service_link = true
     respond_to do |format|
       format.html
     end
@@ -70,7 +68,6 @@ class SearchController < ApplicationController
   def certificate_search
     form = CertificateSearchForm.new(params)
     @result = CertificateSearchPresenter.new(form)
-    @no_shared_switch_service_link = true
     respond_to do |format|
       format.html
     end
@@ -79,7 +76,6 @@ class SearchController < ApplicationController
   def chemical_search
     form = ChemicalSearchForm.new(params)
     @result = ChemicalSearchPresenter.new(form)
-    @no_shared_switch_service_link = true
     respond_to do |format|
       format.html
     end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -46,6 +46,8 @@ class SearchController < ApplicationController
 
     form = QuotaSearchForm.new(params)
     @result = QuotaSearchPresenter.new(form)
+    @enable_service_switch_banner_in_action = false
+
     respond_to do |format|
       format.html
     end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -42,6 +42,8 @@ class SearchController < ApplicationController
   end
 
   def quota_search
+    render_404 if TradeTariffFrontend::ServiceChooser.xi?
+
     form = QuotaSearchForm.new(params)
     @result = QuotaSearchPresenter.new(form)
     respond_to do |format|

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -47,6 +47,7 @@ class SearchController < ApplicationController
     form = QuotaSearchForm.new(params)
     @result = QuotaSearchPresenter.new(form)
     @enable_service_switch_banner_in_action = false
+    @no_shared_switch_service_link = true
 
     respond_to do |format|
       format.html
@@ -56,6 +57,7 @@ class SearchController < ApplicationController
   def additional_code_search
     form = AdditionalCodeSearchForm.new(params)
     @result = AdditionalCodeSearchPresenter.new(form)
+    @no_shared_switch_service_link = true
     respond_to do |format|
       format.html
     end
@@ -72,6 +74,7 @@ class SearchController < ApplicationController
   def certificate_search
     form = CertificateSearchForm.new(params)
     @result = CertificateSearchPresenter.new(form)
+    @no_shared_switch_service_link = true
     respond_to do |format|
       format.html
     end
@@ -80,6 +83,7 @@ class SearchController < ApplicationController
   def chemical_search
     form = ChemicalSearchForm.new(params)
     @result = ChemicalSearchPresenter.new(form)
+    @no_shared_switch_service_link = true
     respond_to do |format|
       format.html
     end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -31,7 +31,7 @@ module ServiceHelper
   end
 
   def service_switch_banner(optional_classes: 'govuk-!-margin-bottom-7')
-    if TradeTariffFrontend::ServiceChooser.enabled?
+    if switching_enabled?
       tag.div(class: "tariff-breadcrumbs js-tariff-breadcrumbs clt govuk-!-font-size-15 #{optional_classes}") do
         tag.nav do
           tag.p do
@@ -43,6 +43,10 @@ module ServiceHelper
   end
 
 private
+
+  def switching_enabled?
+    @enable_service_switch_banner_in_action && TradeTariffFrontend::ServiceChooser.enabled?
+  end
 
   def uk_service_choice?
     service_choice == 'uk'

--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -14,7 +14,7 @@
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">Tariff tools</h1>
     <%= service_switch_banner %>
     <ul class="govuk-list">
-      <% if TradeTariffFrontend::ServiceChooser.quotas_enabled? %>
+      <% if TradeTariffFrontend::ServiceChooser.uk? %>
         <li>
           <p>
             <%= link_to t('breadcrumb.quotas'), quota_search_path %>

--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -14,13 +14,15 @@
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">Tariff tools</h1>
     <%= service_switch_banner %>
     <ul class="govuk-list">
-      <li>
-        <p>
-          <%= link_to t('breadcrumb.quotas'), quota_search_path %>
-          <br>
-          Search for tariff quotas, including daily updated balances.
-        </p>
-      </li>
+      <% if TradeTariffFrontend::ServiceChooser.quotas_enabled? %>
+        <li>
+          <p>
+            <%= link_to t('breadcrumb.quotas'), quota_search_path %>
+            <br>
+            Search for tariff quotas, including daily updated balances.
+          </p>
+        </li>
+      <% end %>
       <li>
         <p>
           <%= link_to "Certificate, licenses and documents", certificate_search_path %>

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -125,12 +125,8 @@ module TradeTariffFrontend
       service_choice || service_default
     end
 
-    def quotas_enabled?
-      (service_choice || service_default) == 'uk'
-    end
-
     def uk?
-      service_choice == 'uk'
+      (service_choice || service_default) == 'uk'
     end
 
     def xi?

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -125,6 +125,10 @@ module TradeTariffFrontend
       service_choice || service_default
     end
 
+    def quotas_enabled?
+      (service_choice || service_default) == 'uk'
+    end
+
     def uk?
       service_choice == 'uk'
     end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -355,6 +355,16 @@ describe SearchController, 'GET to #quota_search', type: :controller, vcr: { cas
     Rails.cache.clear
   end
 
+  context 'with xi as the service choice' do
+    before do
+      allow(TradeTariffFrontend::ServiceChooser).to receive(:xi?).and_return(true)
+
+      get :quota_search, params: { goods_nomenclature_item_id: '0301919011' }, format: :html
+    end
+
+    it { is_expected.to respond_with(:not_found) }
+  end
+
   context 'without search params' do
     render_views
 

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -114,19 +114,31 @@ describe ServiceHelper, type: :helper do
 
     before do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:enabled?).and_return(service_choosing_enabled)
+      assign(:enable_service_switch_banner_in_action, true)
+      allow(helper).to receive(:request).and_return(request)
     end
 
     context 'when on xi sections page' do
       let(:request) { double('request', filtered_path: '/xi/sections') }
 
       it 'returns the full banner that allows users to toggle between the services' do
-        expect(service_switch_banner).to include(t("service_banner.big.#{choice}", link: switch_service_link))
+        expect(helper.service_switch_banner).to include(t("service_banner.big.#{choice}", link: helper.switch_service_link))
       end
     end
 
     context 'when not on sections page' do
       it 'returns the subtle banner that allows users to toggle between the services' do
-        expect(service_switch_banner).to include(t('service_banner.small', link: switch_service_link))
+        expect(helper.service_switch_banner).to include(t('service_banner.small', link: helper.switch_service_link))
+      end
+    end
+
+    context 'when service switching is disabled for the action' do
+      before do
+        assign(:enable_service_switch_banner_in_action, false)
+      end
+
+      it 'returns nil' do
+        expect(helper.service_switch_banner).to be_nil
       end
     end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-371

### What?

Effectively removes quota functionality visibility for XI users

- [x] Quotas search page returns a 404 for XI
- [x] Quotas tools page link only shown for UK users
- [x] Quotas search page disables switching to the XI service

### Why?

I am doing this because:

- Quotas coming from the EU are currently disabled for the XI service so no data is shown
