### PR TITLE
[HOTT-425] Log to $stdout in production

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,4 +39,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.logger = ActiveSupport::Logger.new($stdout)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,6 +56,8 @@ Rails.application.configure do
 
   # See everything in the log (default is :info)
   config.log_level = :info
+
+  config.logger = ActiveSupport::Logger.new($stdout)
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Logstash.new
   config.lograge.custom_options = lambda do |event|


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-425

### What?

I have added/removed/altered:

- [x] Move to logging to stdout fd instead of the environment log file

### Why?

I am doing this because:

- This is needed so that we can tail the logregator logs and see what's happening in each of the applications