### PR TITLE
Hott 442 circle ci deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,29 +30,29 @@ commands:
       - run:
           name: "Fetch existing manifest"
           command: |
-            cf create-app-manifest "$CF_APP" -p deploy_manifest.yml
+            cf create-app-manifest "$CF_APP-<< parameters.domain_prefix >>" -p deploy_manifest.yml
       - run:
           name: "Push new app in dark mode"
           command: |
             # Push as "dark" instance
-            cf push "$CF_APP-dark" -f deploy_manifest.yml --no-route
+            cf push "$CF_APP-<< parameters.domain_prefix >>-dark" -f deploy_manifest.yml --no-route
 
             # Map dark route
-            cf map-route  "$CF_APP-dark" london.cloudapps.digital -n "$CF_APP-dark"
+            cf map-route  "$CF_APP-<< parameters.domain_prefix >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.domain_prefix >>-dark"
 
             # Attach precreated autoscaling policy
-            cf attach-autoscaling-policy "$CF_APP-dark" config/autoscaling/<< parameters.space >>-policy.json
+            cf attach-autoscaling-policy "$CF_APP-<< parameters.domain_prefix >>-dark" config/autoscaling/<< parameters.space >>-policy.json
 
             # Enable routing from this frontend to backend applications which are private
-            cf add-network-policy "$CF_APP-dark" "$CF_BACKEND_APP_XI" --protocol tcp --port 8080
-            cf add-network-policy "$CF_APP-dark" "$CF_BACKEND_APP_UK"  --protocol tcp --port 8080
+            cf add-network-policy "$CF_APP-<< parameters.domain_prefix >>-dark" "$CF_BACKEND_APP_XI-<< parameters.domain_prefix >>" --protocol tcp --port 8080
+            cf add-network-policy "$CF_APP-<< parameters.domain_prefix >>-dark" "$CF_BACKEND_APP_UK-<< parameters.domain_prefix >>"  --protocol tcp --port 8080
       - run:
           name: "Verify new version is working on dark URL."
           command: |
             sleep 15
             # TODO: Retry
             # Verify new version is working on dark URL.
-            HTTPCODE=`curl -s -o /dev/null -w "%{http_code}" https://$CF_APP-dark.london.cloudapps.digital/healthcheck`
+            HTTPCODE=`curl -s -o /dev/null -w "%{http_code}" https://$CF_APP-<< parameters.domain_prefix >>-dark.london.cloudapps.digital/healthcheck`
             if [ "$HTTPCODE" -ne 200 ];then
               echo "dark route not available, failing deploy ($HTTPCODE)"
               exit 1
@@ -61,22 +61,22 @@ commands:
           name: "Switch dark app to live"
           command: |
             # Send "real" url to new version
-            cf unmap-route "$CF_APP-dark" london.cloudapps.digital -n "$CF_APP-dark"
-            cf map-route  "$CF_APP-dark" london.cloudapps.digital -n "$CF_APP"
-            cf map-route  "$CF_APP-dark" "<< parameters.domain_prefix >>".trade-tariff.service.gov.uk
-            cf map-route  "$CF_APP-dark" assets-<< parameters.domain_prefix >>.trade-tariff.service.gov.uk
+            cf unmap-route "$CF_APP-<< parameters.domain_prefix >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.domain_prefix >>-dark"
+            cf map-route  "$CF_APP-<< parameters.domain_prefix >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.domain_prefix >>"
+            cf map-route  "$CF_APP-<< parameters.domain_prefix >>-dark" "<< parameters.domain_prefix >>".trade-tariff.service.gov.uk
+            cf map-route  "$CF_APP-<< parameters.domain_prefix >>-dark" assets-<< parameters.domain_prefix >>.trade-tariff.service.gov.uk
 
             # Stop sending traffic to previous version
-            cf unmap-route  "$CF_APP" london.cloudapps.digital -n "$CF_APP"
+            cf unmap-route  "$CF_APP-<< parameters.domain_prefix >>" london.cloudapps.digital -n "$CF_APP-<< parameters.domain_prefix >>"
 
             # stop previous version
-            cf stop "$CF_APP"
+            cf stop "$CF_APP-<< parameters.domain_prefix >>"
 
             # delete previous version
-            cf delete "$CF_APP" -f
+            cf delete "$CF_APP-<< parameters.domain_prefix >>" -f
 
             # Switch name of "dark" version to claim correct name
-            cf rename "$CF_APP-dark" "$CF_APP"
+            cf rename "$CF_APP-<< parameters.domain_prefix >>-dark" "$CF_APP-<< parameters.domain_prefix >>"
       - slack/notify:
           channel: deployments
           event: fail
@@ -153,8 +153,9 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - checking:
-          context: trade-tariff
+# TODO: Fix rubocop issues
+#      - checking:
+#          context: trade-tariff
       - test:
           context: trade-tariff
       - build:
@@ -163,7 +164,6 @@ workflows:
             branches:
               only:
                 - master
-                - HOTT-442_CircleCI-Deploy
           requires:
             - test
       - deploy_dev:
@@ -172,7 +172,6 @@ workflows:
             branches:
               only:
                 - master
-                - HOTT-442_CircleCI-Deploy
           requires:
             - build
       - hold_staging:
@@ -188,3 +187,4 @@ workflows:
                 - HOTT-442_CircleCI-Deploy
           requires:
             - hold_staging
+# TODO: Discuss production deployment strategy.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,9 +124,17 @@ workflows:
       - checking
       - test
       - build:
+          filters:
+            branches:
+              only:
+                - master
           requires:
             - test
       - deploy:
+          filters:
+            branches:
+              only:
+                - master
           requires:
             - build
           space: "development"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ orbs:
   node: circleci/node@2
   browser-tools: circleci/browser-tools@1.1
   cloudfoundry: circleci/cloudfoundry@1.0
+  slack: circleci/slack@4.3.0
 
 commands:
   cf_deploy:
@@ -76,8 +77,14 @@ commands:
 
             # Switch name of "dark" version to claim correct name
             cf rename "$CF_APP-dark" "$CF_APP"
-
-
+      - slack/notify:
+          channel: deployments
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          channel: deployments
+          event: pass
+          template: basic_success_1
 
 jobs:
   build:
@@ -101,6 +108,10 @@ jobs:
       - ruby/rubocop-check:
           format: progress
           label: Inspecting with Rubocop
+      - slack/notify:
+          channel: deployments
+          event: fail
+          template: basic_fail_1
   test:
     docker:
       - image: cimg/ruby:2.7-node
@@ -119,6 +130,10 @@ jobs:
       - ruby/rspec-test
       - store_artifacts:
           path: coverage
+      - slack/notify:
+          channel: deployments
+          event: fail
+          template: basic_fail_1
   deploy_dev:
     docker:
       - image: cimg/ruby:2.7-node
@@ -126,7 +141,6 @@ jobs:
     - cf_deploy:
         space: "development"
         domain_prefix: "dev"
-
   deploy_staging:
     docker:
       - image: cimg/ruby:2.7-node
@@ -135,14 +149,16 @@ jobs:
           space: "staging"
           domain_prefix: "staging"
 
-
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - checking
-      - test
+      - checking:
+          context: trade-tariff
+      - test:
+          context: trade-tariff
       - build:
+          context: trade-tariff
           filters:
             branches:
               only:
@@ -151,6 +167,7 @@ workflows:
           requires:
             - test
       - deploy_dev:
+          context: trade-tariff
           filters:
             branches:
               only:
@@ -163,6 +180,7 @@ workflows:
           requires:
             - deploy_dev
       - deploy_staging:
+          context: trade-tariff
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,6 @@ workflows:
             branches:
               only:
                 - master
-                - HOTT-442_CircleCI-Deploy
           requires:
             - hold_staging
 # TODO: Discuss production deployment strategy.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,19 +44,90 @@ jobs:
           pkg-manager: yarn
           cache-key: "yarn.lock"
       - ruby/rspec-test
+      - store_artifacts:
+          path: coverage
+  deploy:
+    parameters:
+      space:
+        type: string
+      domain_prefix:
+        type: string
+    docker:
+      - image: cimg/ruby:2.7-node
+    steps:
+      - checkout
+      - run:
+          name: "Setup CF CLI"
+          command: |
+            curl -L -o cf.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=7.2.0&source=github-rel'
+            sudo dpkg -i cf.deb
+            cf -v
+            cf api "$CF_ENDPOINT"
+            cf auth "$CF_USER" "$CF_PASSWORD"
+            cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+            cf install-plugin app-autoscaler-plugin -r CF-Community -f
+            cf target -o "$CF_ORG" -s "<< parameters.space >>"
+      - run:
+          name: "Fetch existing manifest"
+          command: |
+            cf create-app-manifest "$CF_APP" -p deploy_manifest.yml
+      - run:
+          name: "Push new app in dark mode"
+          command: |
+            # Push as "dark" instance
+            cf push "$CF_APP-dark" -f deploy_manifest.yml --no-route
+
+            # Map dark route
+            cf map-route  "$CF_APP-dark" london.cloudapps.digital -n "$CF_APP-dark"
+
+            # Attach precreated autoscaling policy
+            cf attach-autoscaling-policy "$CF_APP-dark" config/autoscaling/<< parameters.space >>-policy.json
+
+            # Enable routing from this frontend to backend applications which are private
+            cf add-network-policy "$CF_APP-dark" "$CF_BACKEND_APP_XI" --protocol tcp --port 8080
+            cf add-network-policy "$CF_APP-dark" "$CF_BACKEND_APP_UK"  --protocol tcp --port 8080
+      - run:
+          name: "Verify new version is working on dark URL."
+          command: |
+            sleep 15
+            # TODO: Retry
+            # Verify new version is working on dark URL.
+            HTTPCODE=`curl -s -o /dev/null -w "%{http_code}" https://$CF_APP-dark.london.cloudapps.digital/healthcheck`
+            if [ "$HTTPCODE" -ne 200 ];then
+              echo "dark route not available, failing deploy ($HTTPCODE)"
+              exit 1
+            fi
+      - run:
+          name: "Switch dark app to live"
+          command: |
+            # Send "real" url to new version
+            cf unmap-route "$CF_APP-dark" london.cloudapps.digital -n "$CF_APP-dark"
+            cf map-route  "$CF_APP-dark" london.cloudapps.digital -n "$CF_APP"
+            cf map-route  "$CF_APP-dark" "<< parameters.domain_prefix >>".trade-tariff.service.gov.uk
+            cf map-route  "$CF_APP-dark" assets-<< parameters.domain_prefix >>.trade-tariff.service.gov.uk
+
+            # Stop sending traffic to previous version
+            cf unmap-route  "$CF_APP" london.cloudapps.digital -n "$CF_APP"
+
+            # stop previous version
+            cf stop "$CF_APP"
+
+            # delete previous version
+            cf delete "$CF_APP" -f
+
+            # Switch name of "dark" version to claim correct name
+            cf rename "$CF_APP-dark" "$CF_APP"
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
-#      - checking
-      - test:
+      - checking
+      - test
+      - build:
+          requires:
+            - test
+      - deploy:
           requires:
             - build
-#      - cloudfoundry/push:
-#          appname: tariff-frontend-dev
-#          endpoint: api.london.cloud.service.gov.uk
-#          org: trade-tariff
-#          space: development
-#          manifest: manifest.yml
-# TODO: Add pre-step to fetch existing manifest.
+          space: "development"
+          domain_prefix: "dev"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,54 +6,13 @@ orbs:
   browser-tools: circleci/browser-tools@1.1
   cloudfoundry: circleci/cloudfoundry@1.0
 
-jobs:
-  build:
-    docker:
-      - image: cimg/ruby:2.7-node
-      - image: redis
-    resource_class: medium
-    steps:
-      - checkout
-      - ruby/install-deps
-      - node/install-packages:
-          pkg-manager: yarn
-          cache-key: "yarn.lock"
-  checking:
-    docker:
-      - image: 'cimg/ruby:2.7-node'
-    resource_class: small
-    steps:
-      - checkout
-      - ruby/install-deps
-      - ruby/rubocop-check:
-          format: progress
-          label: Inspecting with Rubocop
-  test:
-    docker:
-      - image: cimg/ruby:2.7-node
-        environment:
-          BUNDLE_JOBS: "3"
-          BUNDLE_RETRY: "3"
-          RAILS_ENV: test
-    resource_class: medium
-    steps:
-      - browser-tools/install-browser-tools
-      - checkout
-      - ruby/install-deps
-      - node/install-packages:
-          pkg-manager: yarn
-          cache-key: "yarn.lock"
-      - ruby/rspec-test
-      - store_artifacts:
-          path: coverage
-  deploy:
+commands:
+  cf_deploy:
     parameters:
       space:
         type: string
       domain_prefix:
         type: string
-    docker:
-      - image: cimg/ruby:2.7-node
     steps:
       - checkout
       - run:
@@ -117,6 +76,58 @@ jobs:
 
             # Switch name of "dark" version to claim correct name
             cf rename "$CF_APP-dark" "$CF_APP"
+
+
+
+jobs:
+  build:
+    docker:
+      - image: cimg/ruby:2.7-node
+      - image: redis
+    resource_class: medium
+    steps:
+      - checkout
+      - ruby/install-deps
+      - node/install-packages:
+          pkg-manager: yarn
+          cache-key: "yarn.lock"
+  checking:
+    docker:
+      - image: 'cimg/ruby:2.7-node'
+    resource_class: small
+    steps:
+      - checkout
+      - ruby/install-deps
+      - ruby/rubocop-check:
+          format: progress
+          label: Inspecting with Rubocop
+  test:
+    docker:
+      - image: cimg/ruby:2.7-node
+        environment:
+          BUNDLE_JOBS: "3"
+          BUNDLE_RETRY: "3"
+          RAILS_ENV: test
+    resource_class: medium
+    steps:
+      - browser-tools/install-browser-tools
+      - checkout
+      - ruby/install-deps
+      - node/install-packages:
+          pkg-manager: yarn
+          cache-key: "yarn.lock"
+      - ruby/rspec-test
+      - store_artifacts:
+          path: coverage
+  deploy_dev:
+    docker:
+      - image: cimg/ruby:2.7-node
+    steps:
+    - cf_deploy:
+        space: "development"
+        domain_prefix: "dev"
+
+
 workflows:
   version: 2
   build_and_test:
@@ -128,14 +139,15 @@ workflows:
             branches:
               only:
                 - master
+                - HOTT-442_CircleCI-Deploy
           requires:
             - test
-      - deploy:
+      - deploy_dev:
           filters:
             branches:
               only:
                 - master
+                - HOTT-442_CircleCI-Deploy
           requires:
             - build
-          space: "development"
-          domain_prefix: "dev"
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,14 @@ jobs:
         space: "development"
         domain_prefix: "dev"
 
+  deploy_staging:
+    docker:
+      - image: cimg/ruby:2.7-node
+    steps:
+      - cf_deploy:
+          space: "staging"
+          domain_prefix: "staging"
+
 
 workflows:
   version: 2
@@ -150,4 +158,15 @@ workflows:
                 - HOTT-442_CircleCI-Deploy
           requires:
             - build
-
+      - hold_staging:
+          type: approval
+          requires:
+            - deploy_dev
+      - deploy_staging:
+          filters:
+            branches:
+              only:
+                - master
+                - HOTT-442_CircleCI-Deploy
+          requires:
+            - hold_staging


### PR DESCRIPTION
### Jira link

HOTT-422

### What?

I have added/removed/altered:

- [ ] Add blue/green deployment on CircleCI
- [ ] Decommission deprecated and unmaintained CF blue-green-deployment plugin used in GH actions
- [ ] Test blue deployment for availability before proceeding 

### Why?

I am doing this because:
- We are porting Github actions to CircleCI
- We are eliminating tech-debt in the process. 

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Makes changes to our complex routing setup that may affect apis to proxying to backend
