### PR TITLE
[HOTT-463] Enable routing to exchange rates path in backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ cf-ssh.yml
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+.nvimlog

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,14 +53,14 @@ Rails.application.routes.draw do
         constraints: { letter: /[a-z]{1}/i }
 
   constraints TradeTariffFrontend::ApiConstraints.new(
-    TradeTariffFrontend.accessible_api_endpoints
+    TradeTariffFrontend.accessible_api_endpoints,
   ) do
     match ':endpoint/(*path)',
           via: :get,
           to: TradeTariffFrontend::RequestForwarder.new(
             api_request_path_formatter: lambda { |path|
               path.gsub("#{APP_SLUG}/", '')
-            }
+            },
           )
   end
 
@@ -100,13 +100,13 @@ Rails.application.routes.draw do
       get ':version/*path', to: TradeTariffFrontend::RequestForwarder.new(
         api_request_path_formatter: lambda { |path|
           path.gsub(/api\/v\d+\//, '')
-        }
+        },
       ), constraints: { version: /v[1-2]{1}/ }
 
       get 'v2/goods_nomenclatures/*path', to: TradeTariffFrontend::RequestForwarder.new(
         api_request_path_formatter: lambda { |path|
           path.gsub(/api\/v2\//, '')
-        }
+        },
       )
     end
   end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -8,15 +8,41 @@ module TradeTariffFrontend
 
   # API Endpoints of the Tariff Backend API app that can be reached via Frontend
   def accessible_api_endpoints
-    %w[sections chapters headings commodities updates monetary_exchange_rates quotas
-       goods_nomenclatures search_references geographical_areas]
+    %w[
+      sections
+      chapters
+      headings
+      commodities
+      updates
+      monetary_exchange_rates
+      quotas
+      goods_nomenclatures
+      search_references
+      geographical_areas
+    ]
   end
 
   # API Endpoints of the Tariff Backend API app that can be reached via external client
   def public_api_endpoints
-    %w[sections chapters headings commodities monetary_exchange_rates quotas goods_nomenclatures
-       search_references additional_codes certificates footnotes geographical_areas chemicals
-       additional_code_types certificate_types footnote_types]
+    %w[
+      sections
+      chapters
+      headings
+      commodities
+      exchange_rates
+      monetary_exchange_rates
+      quotas
+      goods_nomenclatures
+      search_references
+      additional_codes
+      certificates
+      footnotes
+      geographical_areas
+      chemicals
+      additional_code_types
+      certificate_types
+      footnote_types
+    ]
   end
 
   def production?
@@ -56,7 +82,7 @@ module TradeTariffFrontend
   def simulation_date
     ENV.fetch('SIMULATION_DATE', nil)
   end
-  
+
   def uk_regulations_enabled?
     ENV.fetch('UK_REGULATIONS', 'false').to_s.downcase == 'true'
   end
@@ -78,7 +104,7 @@ module TradeTariffFrontend
   module ServiceChooser
     SERVICE_CURRENCIES = {
       'uk' => 'GBP',
-      'xi' => 'EUR'
+      'xi' => 'EUR',
     }.freeze
 
     module_function
@@ -205,7 +231,7 @@ module TradeTariffFrontend
       [
         @status,
         { 'Content-Type' => 'application/json' },
-        error_object
+        error_object,
       ]
     end
 
@@ -216,10 +242,10 @@ module TradeTariffFrontend
             {
               status: @status.to_s,
               title: 'There was a problem with your query',
-              source: { parameter: @query_string }
-            }
-          ]
-        }.to_json
+              source: { parameter: @query_string },
+            },
+          ],
+        }.to_json,
       ]
     end
   end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-463

### What?

I have added/removed/altered:

- [x] Extends the list of api resources that are routable via the frontend
- [x] Lints the routes and TradeTariffFrontend files
- [x] Adds a .gitignore entry for my editor

### Why?

I am doing this because:

We have added an exchange rate api for the duty calculator. Everything routes via the request forwarder in the frontend (for now) and it is configured to be strict about which resources are accessible.