### PR TITLE
Ignore master on development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,11 +178,19 @@ workflows:
 #          context: trade-tariff
       - test:
           context: trade-tariff
+          filters:
+            branches:
+              ignore:
+                - master
 # TODO: We don't need the build stage with buildpacks
 #      - build:
 #          context: trade-tariff
       - deploy_dev:
           context: trade-tariff
+          filters:
+            branches:
+              ignore:
+                - master
           requires:
             - test
       - deploy_staging:


### PR DESCRIPTION
### Jira link

fix n/a

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adding a filter to ignore dev deploy on master

### Why?

I am doing this because:

- We are running dev twice
