### PR TITLE
Disable cdn caching of search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,8 @@
 require 'addressable/uri'
 
 class SearchController < ApplicationController
+  before_action :expires_now
+
   def search
     @results = @search.perform
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,33 +1,21 @@
 require 'spec_helper'
 
 describe ApplicationController, type: :controller do
-  describe 'behaviour for all subclasses' do
-    controller do
-      def index
-        render plain: 'Jabberwocky'
-      end
+  controller do
+    def index
+      render plain: 'Hari Seldon'
     end
+  end
 
-    describe 'caching' do
-      before do
-        get :index
-      end
+  before do
+    get :index
+  end
 
-      it 'has a max-age of 2 hours' do
-        expect(response.headers['Cache-Control']).to include 'max-age=7200'
-      end
+  let(:expected_cache_control) do
+    'max-age=7200, public, stale-if-error=86400, stale-while-revalidate=86400'
+  end
 
-      it 'has a public directive' do
-        expect(response.headers['Cache-Control']).to include 'public'
-      end
-
-      it 'has a stale-if-error of 1 day' do
-        expect(response.headers['Cache-Control']).to include 'stale-if-error=86400'
-      end
-
-      it 'has a stale-while-revalidate of 1 day' do
-        expect(response.headers['Cache-Control']).to include 'stale-while-revalidate=86400'
-      end
-    end
+  it 'has the correct Cache-Control header' do
+    expect(response.headers['Cache-Control']).to eq(expected_cache_control)
   end
 end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe SearchController, 'GET to #search', type: :controller do
   include CrawlerCommons
 
-  controller(described_class) do
+  controller described_class do
     def index
       render plain: 'Hari Seldon'
     end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -3,6 +3,18 @@ require 'spec_helper'
 describe SearchController, 'GET to #search', type: :controller do
   include CrawlerCommons
 
+  controller(described_class) do
+    def index
+      render plain: 'Hari Seldon'
+    end
+  end
+
+  it 'has the correct Cache-Control header' do
+    get :index
+
+    expect(response.headers['Cache-Control']).to eq('no-cache')
+  end
+
   context 'with HTML format' do
     context 'with search term' do
       context 'with exact match query', vcr: { cassette_name: 'search#search_exact' } do

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -3,16 +3,18 @@ require 'spec_helper'
 describe SearchController, 'GET to #search', type: :controller do
   include CrawlerCommons
 
-  controller described_class do
-    def index
-      render plain: 'Hari Seldon'
+  describe 'caching' do
+    controller described_class do
+      def index
+        render plain: 'Hari Seldon'
+      end
     end
-  end
 
-  it 'has the correct Cache-Control header' do
-    get :index
+    it 'has the correct Cache-Control header' do
+      get :index
 
-    expect(response.headers['Cache-Control']).to eq('no-cache')
+      expect(response.headers['Cache-Control']).to eq('no-cache')
+    end
   end
 
   context 'with HTML format' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-451

### What?

I have added/removed/altered:

- [x] Adds before action in search controller that disables cdn caching
- [x] Adds test of Cache-Control header for SearchController
- [x] Refactor cache spec for the ApplicationController

### Why?

I am doing this because:

- This is costing us money without adding any value since they're cached once and often aren't reused
