### PR TITLE
Remove mimemagic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,14 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'rails', '>= 6.0.3.4'
+# Exclude mimemagic dependency and fetch only what we need
+gem 'actionmailer', '~> 6.0'
+gem 'actionpack', '~> 6.0'
+gem 'actionview', '~> 6.0'
+gem 'activemodel', '~> 6.0'
+gem 'activerecord', '~> 6.0'
+gem 'activesupport', '~> 6.0'
+gem 'railties', '~> 6.0'
 
 gem 'addressable', '~> 2.3'
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.3)
@@ -395,6 +397,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionmailer (~> 6.0)
+  actionpack (~> 6.0)
+  actionview (~> 6.0)
+  activemodel (~> 6.0)
+  activerecord (~> 6.0)
+  activesupport (~> 6.0)
   addressable (~> 2.3)
   aws-sdk-rails (~> 3)
   bootsnap
@@ -420,8 +428,8 @@ DEPENDENCIES
   rack-attack
   rack-cors
   rack-test
-  rails (>= 6.0.3.4)
   rails-controller-testing!
+  railties (~> 6.0)
   redis-rails
   responders (~> 3.0.0)
   routing-filter (~> 0.6.3)


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

We don't need this dependency and it has licensing issues: https://ukgovernmentdfe.slack.com/archives/CAGBHB4JV/p1616668662022200

Rationale for rails dep changes here: rails/rails#41750 (comment)
Relevant govuk-component changes: DFE-Digital/govuk-components#124