### PR TITLE
Fixes cdn caching to no-cache if no cookies are set

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
   include CookiesHelper
 
-
   before_action :set_cache
   before_action :set_enable_service_switch_banner_in_action
   before_action :set_last_updated
@@ -92,7 +91,11 @@ class ApplicationController < ActionController::Base
 
   def set_cache
     unless Rails.env.development?
-      expires_in 2.hours, :public => true, 'stale-if-error' => 86_400, 'stale-while-revalidate' => 86_400
+      if cookies_set?
+        expires_in 2.hours, :public => true, 'stale-if-error' => 86_400, 'stale-while-revalidate' => 86_400
+      else
+        expires_now
+      end
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -25,6 +25,7 @@ class PagesController < ApplicationController
   end
 
   def tariff_cookies
+    expires_now
     render :cookies
   end
 

--- a/app/helpers/cookies_helper.rb
+++ b/app/helpers/cookies_helper.rb
@@ -5,6 +5,14 @@ module CookiesHelper
     cookie.present? ? JSON.parse(cookie) : {}
   end
 
+  def preference_cookie
+    cookies['cookies_preferences_set']
+  end
+
+  def cookies_set?
+    policy_cookie.present? && preference_cookie.present?
+  end
+
   def updated_cookies?
     ga_tracking || remember_settings
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,12 +7,6 @@ describe ApplicationController, type: :controller do
     end
   end
 
-  before do
-    get :index
-    cookies['cookies_policy'] = policy_cookie
-    cookies['cookies_preferences_set'] = true
-  end
-
   let(:policy_cookie) do
     {
       settings: true,
@@ -21,11 +15,24 @@ describe ApplicationController, type: :controller do
     }.to_json
   end
 
-  let(:expected_cache_control) do
-    'max-age=7200, public, stale-if-error=86400, stale-while-revalidate=86400'
+  it 'has the correct Cache-Control header' do
+    get :index
+    expect(response.headers['Cache-Control']).to eq('no-cache')
   end
 
-#   it 'has the correct Cache-Control header' do
-#     expect(response.headers['Cache-Control']).to eq(expected_cache_control)
-#   end
+  context 'when cookies are set' do
+    before do
+      request.cookies['cookies_policy'] = policy_cookie
+      request.cookies['cookies_preferences_set'] = true
+      get :index
+    end
+
+    let(:expected_cache_control) do
+      'max-age=7200, public, stale-if-error=86400, stale-while-revalidate=86400'
+    end
+
+    it 'has the correct Cache-Control header' do
+      expect(response.headers['Cache-Control']).to eq(expected_cache_control)
+    end
+  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -9,13 +9,23 @@ describe ApplicationController, type: :controller do
 
   before do
     get :index
+    cookies['cookies_policy'] = policy_cookie
+    cookies['cookies_preferences_set'] = true
+  end
+
+  let(:policy_cookie) do
+    {
+      settings: true,
+      usage: 'true',
+      remember_settings: 'true',
+    }.to_json
   end
 
   let(:expected_cache_control) do
     'max-age=7200, public, stale-if-error=86400, stale-while-revalidate=86400'
   end
 
-  it 'has the correct Cache-Control header' do
-    expect(response.headers['Cache-Control']).to eq(expected_cache_control)
-  end
+#   it 'has the correct Cache-Control header' do
+#     expect(response.headers['Cache-Control']).to eq(expected_cache_control)
+#   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -31,6 +31,14 @@ describe PagesController, 'GET to #opensearch', type: :controller do
     end
   end
 
+  describe 'GET tariff_cookies' do
+    it 'has the correct Cache-Control header' do
+      get :tariff_cookies
+
+      expect(response.headers['Cache-Control']).to eq('no-cache')
+    end
+  end
+
   describe 'POST update_cookies' do
     subject(:response) { post :update_cookies, params: params }
 

--- a/spec/helpers/cookies_helper_spec.rb
+++ b/spec/helpers/cookies_helper_spec.rb
@@ -33,6 +33,22 @@ describe CookiesHelper, type: :helper do
     end
   end
 
+  describe '#preference_cookie' do
+    it 'returns a nil' do
+      expect(helper.preference_cookie).to be_nil
+    end
+
+    context 'when the cookies preference is present' do
+      before do
+        helper.request.cookies['cookies_preferences_set'] = 'true'
+      end
+
+      it 'returns the parsed cookie value' do
+        expect(helper.preference_cookie).to eq('true')
+      end
+    end
+  end
+
   describe '#updated_cookies?' do
     it 'returns nil' do
       expect(helper.updated_cookies?).to be_nil
@@ -75,6 +91,23 @@ describe CookiesHelper, type: :helper do
 
       it 'returns "false"' do
         expect(helper.updated_cookies?).to eq('false')
+      end
+    end
+  end
+
+  describe '#cookies_set?' do
+    it 'returns false' do
+      expect(helper).not_to be_cookies_set
+    end
+
+    context 'when both the cookies policy and cookies preference is present' do
+      before do
+        helper.request.cookies['cookies_policy'] = { 'foo' => 'bar' }.to_json
+        helper.request.cookies['cookies_preferences_set'] = 'true'
+      end
+
+      it 'returns the parsed cookie value' do
+        expect(helper).to be_cookies_set
       end
     end
   end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-539

### What?

I have added/removed/altered:

- [x] Set Cache-Control to no-cache when the cookies aren't all set

### Why?

I am doing this because:

- We need to make sure the content is rendered for variations of the page that require the cookie elements to be loaded fresh
