### PR TITLE
adds padding to cookie p tag

### DIFF
--- a/app/views/layouts/_cookies_consent.html.erb
+++ b/app/views/layouts/_cookies_consent.html.erb
@@ -21,13 +21,13 @@
 <% unless cookies[:cookies_preferences_set] %>
   <% if policy_cookie['usage'] == 'true' %>
     <div class="app-cookie-banner__message cookies_hide_message" id="cookies_accepted">
-      <p>You have accepted additional cookies. You can <%= link_to "change your cookie
+      <p class="govuk-!-padding-top-6">You have accepted additional cookies. You can <%= link_to "change your cookie
         settings", "/cookies" %> at any time.</p>
       <%= button_to "Hide this message", cookies_consent_confirmation_message_path, class: 'govuk-button hide_cookie_panel' %>
     </div>
   <% elsif policy_cookie['usage'] == 'false' %>
     <div class="app-cookie-banner__message cookies_hide_message" id="cookies_rejected">
-      <p>You have rejected additional cookies. You can <%= link_to "change your cookie
+      <p class="govuk-!-padding-top-6">You have rejected additional cookies. You can <%= link_to "change your cookie
         settings", "/cookies" %> at any time.</p>
       <%= button_to "Hide this message", cookies_consent_confirmation_message_path, class: 'govuk-button hide_cookie_panel' %>
     </div>

--- a/app/webpacker/src/stylesheets/_cookie_banner.scss
+++ b/app/webpacker/src/stylesheets/_cookie_banner.scss
@@ -16,6 +16,9 @@
   margin: 0;
   @include govuk-width-container;
   max-width: 1145px;
+  p {
+    padding-top: 32px;
+  }
 }
 
 form.button_to {

--- a/app/webpacker/src/stylesheets/_cookie_banner.scss
+++ b/app/webpacker/src/stylesheets/_cookie_banner.scss
@@ -16,9 +16,6 @@
   margin: 0;
   @include govuk-width-container;
   max-width: 1145px;
-  p {
-    padding-top: 32px;
-  }
 }
 
 form.button_to {


### PR DESCRIPTION
Before

<img width="873" alt="Screenshot 2021-03-31 at 09 19 20" src="https://user-images.githubusercontent.com/66415180/113113489-43cc8980-9202-11eb-9e84-9141c35e377a.png">

After
![image](https://user-images.githubusercontent.com/66415180/113113334-1a136280-9202-11eb-88fe-1deaa5f60d4a.png)


### What?

I have added/removed/altered:

Adds padding for the p tag for extra space

