### PR TITLE
Handle commodity that has meursing codes for dc

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -25,6 +25,10 @@ module Declarable
     meursing_code
   end
 
+  def no_meursing?
+    !meursing_code?
+  end
+
   def code
     goods_nomenclature_item_id
   end

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -40,7 +40,7 @@
               <p>Importing from outside the <%= TradeTariffFrontend.origin %> is subject to <strong>variable</strong> third country duty.</p>
             <% end %>
             <p> Import measures and restrictions for specific countries can be found under the <a href="#import">import</a> tab.</p>
-            <% if TradeTariffFrontend.duty_calculator_enabled? %>
+            <% if TradeTariffFrontend.duty_calculator_enabled? && declarable.no_meursing? %>
               <h3 class="govuk-heading-s">Duty calculation</h3>
               
               <p>Use our new step-by-step guide to work out the <%= link_to("duties applicable to the import of commodity #{declarable.code} into the #{import_destination}", "/duty-calculator/import-date?commodity_code=#{declarable.code}&referred_service=#{service_choice}", class: 'govuk-link') %>.</p>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
     goods_nomenclature_item_id { '0101300000' }
     goods_nomenclature_sid { Forgery(:basic).number }
     parent_sid { Forgery(:basic).number }
+    meursing_code { false }
   end
 
   factory :monetary_exchange_rate do

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -49,7 +49,7 @@ describe Commodity do
   end
 
   describe '#to_param' do
-    let(:commodity) { Commodity.new(attributes_for(:commodity).stringify_keys) }
+    let(:commodity) { described_class.new(attributes_for(:commodity).stringify_keys) }
 
     it 'returns commodity code as param' do
       expect(commodity.to_param).to eq commodity.code
@@ -57,7 +57,7 @@ describe Commodity do
   end
 
   describe '#aria_label' do
-    let(:commodity) { Commodity.new(attributes_for(:commodity).stringify_keys) }
+    let(:commodity) { described_class.new(attributes_for(:commodity).stringify_keys) }
 
     it 'formats the aria label correctly' do
       expect(commodity.aria_label).to eq("Commodity code 0101300000, #{commodity.description}")
@@ -70,6 +70,46 @@ describe Commodity do
 
       it 'does not propagate an exception' do
         expect { commodity.aria_label }.not_to raise_exception
+      end
+    end
+  end
+
+  describe '#meursing_code?' do
+    subject(:commodity) { described_class.new(attributes_for(:commodity, meursing_code: meursing_code).stringify_keys) }
+
+    context 'when the commodity has a meursing code' do
+      let(:meursing_code) { true }
+
+      it 'returns true' do
+        expect(commodity).to be_meursing_code
+      end
+    end
+
+    context 'when the commodity does not have a meursing code' do
+      let(:meursing_code) { false }
+
+      it 'returns false' do
+        expect(commodity).not_to be_meursing_code
+      end
+    end
+  end
+
+  describe '#no_meursing?' do
+    subject(:commodity) { described_class.new(attributes_for(:commodity, meursing_code: meursing_code).stringify_keys) }
+
+    context 'when the commodity has a meursing code' do
+      let(:meursing_code) { true }
+
+      it 'returns true' do
+        expect(commodity).not_to be_no_meursing
+      end
+    end
+
+    context 'when the commodity does not have a meursing code' do
+      let(:meursing_code) { false }
+
+      it 'returns false' do
+        expect(commodity).to be_no_meursing
       end
     end
   end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-486

### What?

I have added/removed/altered:

- [x] Hide link to duty calculator if a commodity has meursing code

### Why?

I am doing this because:

- This is needed for go live
