### PR TITLE
Handle headings which can be declared more gracefully

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -1,6 +1,8 @@
 module Declarable
   extend ActiveSupport::Concern
 
+  HEADING_PATTERN = '000000'.freeze
+
   included do
     include ApiEntity
 
@@ -25,8 +27,20 @@ module Declarable
     meursing_code
   end
 
+  def calculate_duties?
+    no_meursing? && no_heading?
+  end
+
   def no_meursing?
     !meursing_code?
+  end
+
+  def heading?
+    code && code.last(6) == HEADING_PATTERN
+  end
+
+  def no_heading?
+    !heading?
   end
 
   def code

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -40,7 +40,7 @@
               <p>Importing from outside the <%= TradeTariffFrontend.origin %> is subject to <strong>variable</strong> third country duty.</p>
             <% end %>
             <p> Import measures and restrictions for specific countries can be found under the <a href="#import">import</a> tab.</p>
-            <% if TradeTariffFrontend.duty_calculator_enabled? && declarable.no_meursing? %>
+            <% if TradeTariffFrontend.duty_calculator_enabled? && declarable.calculate_duties? %>
               <h3 class="govuk-heading-s">Duty calculation</h3>
               
               <p>Use our new step-by-step guide to work out the <%= link_to("duties applicable to the import of commodity #{declarable.code} into the #{import_destination}", "/duty-calculator/import-date?commodity_code=#{declarable.code}&referred_service=#{service_choice}", class: 'govuk-link') %>.</p>

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -113,4 +113,24 @@ describe Commodity do
       end
     end
   end
+
+  describe '#heading?' do
+    it { is_expected.not_to be_heading }
+  end
+
+  describe '#calculate_duties?' do
+    subject(:commodity) { described_class.new(attributes_for(:commodity, meursing_code: meursing_code).stringify_keys) }
+
+    context 'when the commodity has a meursing code' do
+      let(:meursing_code) { true }
+
+      it { is_expected.not_to be_calculate_duties }
+    end
+
+    context 'when the commodity does not have a meursing code' do
+      let(:meursing_code) { false }
+
+      it { is_expected.to be_calculate_duties }
+    end
+  end
 end

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -1,25 +1,25 @@
 require 'spec_helper'
 
 describe Heading do
-  describe '#to_param' do
-    let(:heading) { Heading.new(attributes_for(:heading).stringify_keys) }
+  subject(:heading) { described_class.new(attributes_for(:heading).stringify_keys) }
 
-    it 'returns heading code as param' do
-      expect(heading.to_param).to eq heading.short_code
-    end
+  describe '#to_param' do
+    it { expect(heading.to_param).to eq heading.short_code }
   end
 
   describe '#commodity_code' do
-    let(:heading) { Heading.new(attributes_for(:heading).stringify_keys) }
-
-    it 'returns first ten symbols of code' do
-      expect(heading.commodity_code).to eq heading.code.to_s.first(10)
-    end
+    it { expect(heading.commodity_code).to eq(heading.code) }
   end
 
   describe '#consigned?' do
-    it 'returns false (there are no consigned declarable headings)' do
-      expect(subject.consigned?).to be false
-    end
+    it { is_expected.not_to be_consigned }
+  end
+
+  describe '#heading?' do
+    it { is_expected.to be_heading }
+  end
+
+  describe '#calculate_duties?' do
+    it { is_expected.not_to be_calculate_duties }
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-599

### What?

Ultimately the duty calculator needs to work with headings as well as
commodities that can be calculated. We need to decide on the work that
is required to enable this however.

I have added/removed/altered:

- [x] Hide link to calculate duties when the declarable is a heading

### Why?

I am doing this because:

-  This is to avoid ugly ui experience when calculating duties

### Heading

![Screenshot from 2021-04-16 13-38-33](https://user-images.githubusercontent.com/8156884/115025281-14cc3e00-9eb9-11eb-82bb-f90272bb4fe4.png)

### Commodity

![Screenshot from 2021-04-16 13-37-11](https://user-images.githubusercontent.com/8156884/115025185-f23a2500-9eb8-11eb-81b2-98451abed059.png)


