### PR TITLE
Suppress pre-population of hidden_field_tag

### DIFF
--- a/app/webpacker/src/javascripts/commodities.js.erb
+++ b/app/webpacker/src/javascripts/commodities.js.erb
@@ -800,7 +800,6 @@ import debounce from "./debounce";
                 showAllValues: false,
                 confirmOnBlur: true,
                 displayMenu: "overlay",
-                defaultValue: $(".js-commodity-picker-target").val(),
                 placeholder: "Enter the name of the goods or commodity code",
                 onConfirm: function(text) {
                   let obj = null;


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

To improve users experience, we decided to stop
pre-populating the search field, as sometimes a random
Base64 encoded variable appears in the DOM.

We have not been yet able to understand where it is
coming from as it only happens on the PaaS but never
locally, which makes it hard to debug.