### PR TITLE
Remove BitZesty references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - `quiet_assets` gem
 - ActionDispatch::ParamsParser::DEFAULT_PARSERS was deprecated and `remove_parsers.rb` initializer was removed
 
-[August 28, 2017]: https://github.com/bitzesty/trade-tariff-frontend/compare/a72e3a4...9c2d125
+[August 28, 2017]: https://github.com/trade-tariff/trade-tariff-frontend/compare/a72e3a4...9c2d125
 
 
 ## [May 27, 2017]
@@ -61,7 +61,7 @@ Maintained at now at the Bit Zesty repo - not the alphagov one.
 ### Removed
 - GDS report a problem, will replace with another form
 
-[May 27, 2017]: https://github.com/bitzesty/trade-tariff-frontend/compare/ac8b487...b120373
+[May 27, 2017]: https://github.com/trade-tariff/trade-tariff-frontend/compare/ac8b487...b120373
 
 ## [August 05, 2016]
 
@@ -93,7 +93,7 @@ Maintained at now at the Bit Zesty repo - not the alphagov one.
 - Remove the `therubyracer` gem.
 - Remove ci reporter rake tasks.
 
-[August 05, 2016]: https://github.com/bitzesty/trade-tariff-frontend/compare/bcb1ea1...58633f0
+[August 05, 2016]: https://github.com/trade-tariff/trade-tariff-frontend/compare/bcb1ea1...58633f0
 
 ## [July 25, 2016]
 
@@ -122,7 +122,7 @@ Maintained at now at the Bit Zesty repo - not the alphagov one.
 - Remove hard-coded text about changes in procedures.
 - Remove `jenkins.sh` file.
 
-[July 25, 2016]: https://github.com/bitzesty/trade-tariff-frontend/compare/69114b5...1c74294
+[July 25, 2016]: https://github.com/trade-tariff/trade-tariff-frontend/compare/69114b5...1c74294
 
 
 ## [June 16, 2016]
@@ -157,7 +157,7 @@ Maintained at now at the Bit Zesty repo - not the alphagov one.
 - Remove capistrano.
 - Remove `govuk_artefact` dependency.
 
-[June 16, 2016]: https://github.com/bitzesty/trade-tariff-frontend/compare/eb1f40b...69114b5
+[June 16, 2016]: https://github.com/trade-tariff/trade-tariff-frontend/compare/eb1f40b...69114b5
 
 
 ## [March 01, 2016]
@@ -178,7 +178,7 @@ Maintained at now at the Bit Zesty repo - not the alphagov one.
 - Remove the `bundler-audit` gem and rake task.
 - Remove redundant precompiled assets
 
-[March 01, 2016]: https://github.com/bitzesty/trade-tariff-frontend/compare/58633f0...eb1f40b
+[March 01, 2016]: https://github.com/trade-tariff/trade-tariff-frontend/compare/58633f0...eb1f40b
 
 ## [September 23, 2015]
 
@@ -197,7 +197,7 @@ Maintained at now at the Bit Zesty repo - not the alphagov one.
 ### Removed
 - Remove panopticon registration
 
-[September 23, 2015]: https://github.com/bitzesty/trade-tariff-frontend/compare/bcb1ea1...58633f0
+[September 23, 2015]: https://github.com/trade-tariff/trade-tariff-frontend/compare/bcb1ea1...58633f0
 
 ## [release_754...release_776](https://github.com/alphagov/trade-tariff-frontend/compare/release_754...release_776)
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Trade Tariff Frontend
 
-__Now maintained at https://github.com/bitzesty/trade-tariff-frontend__
+__Now maintained at https://github.com/trade-tariff/trade-tariff-frontend__
 
 https://www.trade-tariff.service.gov.uk/trade-tariff/sections
 
 This is the front-end application for:
 
-* [Trade Tariff Backend](https://github.com/bitzesty/trade-tariff-backend)
+* [Trade Tariff Backend](https://github.com/trade-tariff/trade-tariff-backend)
 
 This application requires one or more Trade Tariff Backend APIs to be running and the following env variables set: `API_SERVICE_BACKEND_DEFAULT`, `API_SERVICE_BACKEND_URL_OPTIONS`.
 
@@ -90,7 +90,7 @@ To create or update autoscaling policy for your application run:
     cf attach-autoscaling-policy APP_NAME ./policy.json
 
 
-Current autosscaling policy files are [here](https://github.com/bitzesty/trade-tariff-frontend/tree/master/config/autoscaling).
+Current autosscaling policy files are [here](https://github.com/trade-tariff/trade-tariff-frontend/tree/master/config/autoscaling).
 
 
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Remove BitZesty's references

### Why?

I am doing this because:

- They no longer maintain this project