### PR TITLE
Adds requirement getter method to force html_safe the requirement

### DIFF
--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -3,5 +3,10 @@ require 'api_entity'
 class MeasureCondition
   include ApiEntity
 
-  attr_accessor :condition_code, :condition, :document_code, :requirement, :action, :duty_expression
+  attr_accessor :condition_code, :condition, :document_code, :action, :duty_expression
+  attr_writer :requirement
+
+  def requirement
+    @requirement&.html_safe
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -131,10 +131,12 @@ FactoryBot.define do
   end
 
   factory :measure_condition do
-    document_code { Forgery(:basic).text }
-    action { Forgery(:basic).text }
+    condition_code { Forgery(:basic).text(exactly: 1) }
     condition { Forgery(:basic).text }
-    requirement_type { Forgery(:basic).text }
+    document_code { Forgery(:basic).text(exactly: 4) }
+    requirement { Forgery(:basic).text }
+    action { Forgery(:basic).text }
+    duty_expression { Forgery(:basic).text }
   end
 
   factory :additional_code do

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe MeasureCondition do
+  subject(:condition) { build(:measure_condition) }
+
+  describe '#requirement' do
+    it { expect(condition.requirement).to be_html_safe }
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-647

### What?

I have added/removed/altered:

- [x] Adds a getter for the requirement attribute of a measure condition so that we can render the html embedded within the requirement string.
- [x] Adds a test for the new getter to validate the requirement is html safe

We trust that the data source is safe since the origin of the data is
one of the Taric (European) or CDS (HMRC/UK) databases

### Why?

I am doing this because:

- This is needed so that we can safely render the condition requirement
that comes from the json api resource in the backend
- This has been requested by a couple of stakeholders that use the tariff service
