### PR TITLE
HOTT-265: On the chapter page, include both the chapter and heading number in the list of headings

### DIFF
--- a/app/views/headings/_heading.html.erb
+++ b/app/views/headings/_heading.html.erb
@@ -1,8 +1,8 @@
 <% if heading.leaf? %>
   <tr class="govuk-table__row">
-    <td class="govuk-table__cell" width="30">
-      <div class="heading-code">
-        <div class="code-text"><%= heading.display_short_code %></div>
+    <td class="govuk-table__cell" width="70">
+      <div class="full-heading-code">
+        <%= chapter_and_heading_codes(heading.short_code) %>
       </div>
     </td>
     <td class="govuk-table__cell">

--- a/spec/requests/chapter_spec.rb
+++ b/spec/requests/chapter_spec.rb
@@ -13,6 +13,22 @@ describe 'Chapter page', type: :request do
         end
       end
     end
+
+    it 'displays chapter and heading codes for all headings in the chapter' do
+      VCR.use_cassette('geographical_areas#countries') do
+        VCR.use_cassette('chapters#show') do
+          visit chapter_path('01')
+
+          expect(page).to have_selector '.chapter-code', text: '01', count: 7
+          expect(page).to have_selector '.heading-code', text: '01', count: 1
+          expect(page).to have_selector '.heading-code', text: '02', count: 1
+          expect(page).to have_selector '.heading-code', text: '03', count: 1
+          expect(page).to have_selector '.heading-code', text: '04', count: 1
+          expect(page).to have_selector '.heading-code', text: '05', count: 1
+          expect(page).to have_selector '.heading-code', text: '06', count: 1
+        end
+      end
+    end
   end
 
   context 'as JSON' do


### PR DESCRIPTION
On the chapter page, include both the chapter and heading number in the list of headings

### Jira link

https://transformuk.atlassian.net/browse/HOTT-265

### What?

I have added/removed/altered:

- [x] Add chapter number in the list of headings
- [x] Add specs

### Why?

I am doing this because:

Traders could be confused by the omission of the chapter id from the list of headings
