### PR TITLE
HOTT-695 - home points to /sections

### DIFF
--- a/app/controllers/cookies_consent_controller.rb
+++ b/app/controllers/cookies_consent_controller.rb
@@ -4,20 +4,20 @@ class CookiesConsentController < ApplicationController
   before_action :set_cookie_policy, only: %i[accept_cookies reject_cookies]
 
   def accept_cookies
-    redirect_back(fallback_location: root_path)
+    redirect_back(fallback_location: sections_path)
   end
 
   def reject_cookies
-    redirect_back(fallback_location: root_path)
+    redirect_back(fallback_location: sections_path)
   end
 
   def add_seen_confirmation_message
     set_cookie_preference
 
-    redirect_back(fallback_location: root_path)
+    redirect_back(fallback_location: sections_path)
   end
 
-  private 
+  private
 
   def set_cookie_policy
     cookies[:cookies_policy] = { value: policy, expires: Time.zone.now + 1.year }

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
           "Cookies on UK Global Online Tariff",
           [
-              [t('breadcrumb.home'), root_path],
+              [t('breadcrumb.home'), sections_path],
           ]
       )
   %>

--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.tools'),
       [
-        [t('breadcrumb.home'), root_path]
+        [t('breadcrumb.home'), sections_path]
       ]
     )
   %>

--- a/app/views/search/additional_code_search.erb
+++ b/app/views/search/additional_code_search.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.additional_codes'),
       [
-        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.home'), sections_path],
         [t('breadcrumb.tools'), tools_path]
       ]
     )

--- a/app/views/search/certificate_search.erb
+++ b/app/views/search/certificate_search.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.certificates'),
       [
-        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.home'), sections_path],
         [t('breadcrumb.tools'), tools_path]
       ]
     )

--- a/app/views/search/chemical_search.html.erb
+++ b/app/views/search/chemical_search.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.chemicals'),
       [
-        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.home'), sections_path],
         [t('breadcrumb.tools'), tools_path]
       ]
     )

--- a/app/views/search/quota_search.html.erb
+++ b/app/views/search/quota_search.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.quotas'),
       [
-        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.home'), sections_path],
         [t('breadcrumb.tools'), tools_path]
       ]
     )

--- a/app/views/search_references/show.html.erb
+++ b/app/views/search_references/show.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.az'),
       [
-        [t('breadcrumb.home'), root_path],
+        [t('breadcrumb.home'), sections_path],
       ]
     )
   %>

--- a/spec/controllers/cookies_consent_controller_spec.rb
+++ b/spec/controllers/cookies_consent_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CookiesConsentController, type: :controller do
     end
 
     it 'redirects to the correct fallback location' do
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(sections_path)
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe CookiesConsentController, type: :controller do
     end
 
     it 'redirects to the correct fallback location' do
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(sections_path)
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe CookiesConsentController, type: :controller do
     end
 
     it 'redirects to the correct fallback location' do
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(sections_path)
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-695

### What?

I have added/removed/altered:

- [ ] Change the `home` breadcrumbs links to point explicitly to `/sections`

### Why?

I am doing this because:
The correct home for the app is the `/sections` page. 
Previously in the production environment the app was being redirected to `https://www.gov.uk/trade-tariff`, which is a landing page and adds overhead for the end user.
This was also causing the path to lose the xi selection and redirecting to the uk version.

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes
