### PR TITLE
Revert fix for brakeman

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,15 +80,7 @@ class ApplicationController < ActionController::Base
   end
 
   def search_attributes
-    params.permit(
-      :q,
-      :country,
-      :day,
-      :month,
-      :year,
-      :as_of,
-      :country,
-    ).to_h
+    params.permit!.to_h
   end
 
   def set_layout

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,46 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "b493fd5fe63a3cff49875840e380105e9b0b7612a9852861239fff07a9348b74",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "node_modules/alphagov-static/app/controllers/root_controller.rb",
+      "line": 20,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => params[:template], { :layout => \"govuk_template\" })",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "RootController",
+        "method": "template"
+      },
+      "user_input": "params[:template]",
+      "confidence": "High",
+      "note": ""
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "ce124a147769e471dcf458c1de2f0629886545f5554cf7f88a580f387b6d8602",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/application_controller.rb",
+      "line": 83,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ApplicationController",
+        "method": "search_attributes"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": "We need to review this. It requires rearchitecting how search is rendered in the layouts. Each controller will need to permit it's own params."
+    }
+  ],
+  "updated": "2021-05-26 11:41:42 +0100",
+  "brakeman_version": "5.0.1"
+}


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Reinstate permit! on the search params
- [x] Add brakeman ignore file

### Why?

I am doing this because:

- Unfortunately the search partial is part of the application layout. We'd need to rearchitect how the params are permitted
to make this work globally and safely.
