### PR TITLE
HOTT-343: Presentational bug on commodity code pages - ghost tier in the breadcrumb

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -15,16 +15,16 @@ module CommoditiesHelper
 
   def commodity_tree(main_commodity, commodities)
     if commodities.any?
-      content_tag(:ul, class: 'commodities') do
-        content_tag(:li) do
-          tree_code(commodities.first.code) + 
-          content_tag(:p, commodities.first.to_s.html_safe) +
-          tree_node(main_commodity, commodities, commodities.first.number_indents)
+      tag.ul(class: 'commodities') do
+        tag.li do
+          tree_code(commodities.first.code) +
+            tag.p(commodities.first.to_s.html_safe) +
+            tree_node(main_commodity, commodities, commodities.first.number_indents)
         end
       end
     else
-      content_tag(:ul, class: 'commodities') do
-        content_tag(:li, commodity_heading(main_commodity))
+      tag.ul(class: 'commodities') do
+        commodity_heading(main_commodity)
       end
     end
   end
@@ -95,64 +95,61 @@ module CommoditiesHelper
   def tree_node(main_commodity, commodities, depth)
     deeper_node = commodities.select { |c| c.number_indents == depth + 1 }.first
     if deeper_node.present? && deeper_node.number_indents < main_commodity.number_indents
-      content_tag(:ul) do
-        content_tag(:li) do
-          tree_code(deeper_node.code.gsub(/[0]{2}+$/, '')) + 
-          content_tag(:p, deeper_node.to_s.html_safe) +
-          # if deeper_node.producline_suffix == '80'
-          #   tree_code(deeper_node.code.gsub(/[0]{2}+$/, ''))
-          # end +
-          tree_node(main_commodity, commodities, deeper_node.number_indents)
+      tag.ul do
+        tag.li do
+          tree_code(deeper_node.code.gsub(/[0]{2}+$/, '')) +
+            tag.p(deeper_node.to_s.html_safe) +
+            # if deeper_node.producline_suffix == '80'
+            #   tree_code(deeper_node.code.gsub(/[0]{2}+$/, ''))
+            # end +
+            tree_node(main_commodity, commodities, deeper_node.number_indents)
         end
       end
     else
-      content_tag(:ul) do
+      tag.ul do
         commodity_heading(main_commodity)
       end
     end
   end
 
   def commodity_heading(commodity)
-    content_tag(:li, class: 'commodity-li') do
-      content_tag(:div,
-                  title: "Full tariff code: #{commodity.code}",
-                  class: 'commodity-code',
-                  'aria-describedby' => "commodity-#{commodity.code}") do
-        content_tag(:div, format_commodity_code(commodity), class: 'code-text')
-      end
-      tree_commodity_code(commodity) +
-      content_tag(:p, commodity.to_s.html_safe)
+    tag.li(class: 'commodity-li') do
+      tag.div(title: "Full tariff code: #{commodity.code}",
+              class: 'commodity-code',
+              'aria-describedby' => "commodity-#{commodity.code}") do
+                tag.div(format_commodity_code(commodity), class: 'code-text')
+              end
+      tree_commodity_code(commodity) + tag.p(commodity.to_s.html_safe)
     end
   end
 
   def commodity_heading_full(commodity)
-    content_tag(:li, class: 'commodity-li') do
-      content_tag(:div,
-                  title: "Full tariff code: #{commodity.code}",
-                  class: 'full-code',
-                  'aria-describedby' => "commodity-#{commodity.code}") do
-        content_tag(:div, format_full_code(commodity), class: 'code-text')
-      end
-      content_tag(:p, commodity.to_s.html_safe)
+    tag.li(class: 'commodity-li') do
+      tag.div(title: "Full tariff code: #{commodity.code}",
+              class: 'full-code',
+              'aria-describedby' => "commodity-#{commodity.code}") do
+                tag.div(format_full_code(commodity), class: 'code-text')
+              end
+      tag.p(commodity.to_s.html_safe)
     end
   end
 
   def declarable_heading(commodity)
-    content_tag(:p) do
-      tree_code(commodity.code) + 
-      content_tag(:p, commodity.formatted_description.html_safe,
-                          class: '',
-                          id: "commodity-#{commodity.code}")
+    tag.p do
+      tree_code(commodity.code) +
+        tag.p(commodity.formatted_description.html_safe,
+              class: '',
+              id: "commodity-#{commodity.code}")
     end
   end
 
   def declarable_heading_full(commodity)
-    content_tag(:li, class: 'commodity-li') do
-      content_tag(:div, format_full_code(commodity),
-                         title: "Full tariff code: #{commodity.code}",
-                         class: 'full-code',
-                         'aria-describedby' => "commodity-#{commodity.code}") +
-        content_tag(:p, commodity.to_s.html_safe)
+    tag.li(class: 'commodity-li') do
+      tag.div(format_full_code(commodity),
+              title: "Full tariff code: #{commodity.code}",
+              class: 'full-code',
+              'aria-describedby' => "commodity-#{commodity.code}") +
+        tag.p(commodity.to_s.html_safe)
     end
   end
 end

--- a/app/views/shared/_tariff_breadcrumbs.html.erb
+++ b/app/views/shared/_tariff_breadcrumbs.html.erb
@@ -10,7 +10,6 @@ declarable ||= false %>
         Section <%= declarable.section_numeral %>: <%= declarable.section %>
       </p>
       <div class="desktop-only">
-
         <ul>
           <li class="chapter-li">
             <%= tree_chapter_code(declarable.chapter) %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-343

### What?

I have added/removed/altered:

- [ ] Remove the extra `li` tag that was causing the issue
- [ ] Fixed most of the linting issues in the page

### Why?

I am doing this because there was a presentational bug that needed to be fixed

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes
