### PR TITLE
Reenable git revision healthcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,10 @@ commands:
           command: |
             export BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#<< parameters.buildpack_version >>"
 
+            # Enables /healthcheck to show the current deployed git sha
+            export GIT_NEW_REVISION=$(git rev-parse --short HEAD)
+            echo $GIT_NEW_REVISION >REVISION
+
             # Push as "dark" instance
             cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --buildpack $BUILDPACK
 

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -8,7 +8,7 @@ class HealthcheckController < ActionController::Base
   def check
     # Check API connectivity
     Section.all(headers: original_ua_headers)
-    render json: { git_sha1: CURRENT_RELEASE_SHA }
+    render json: { git_sha1: CURRENT_REVISION }
   end
 
   private

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,6 +1,0 @@
-if File.exists?("#{Rails.root}/REVISION")
-  revision = `cat #{Rails.root}/REVISION`.chomp
-  CURRENT_RELEASE_SHA = revision
-else
-  CURRENT_RELEASE_SHA = 'development'
-end

--- a/config/initializers/revision.rb
+++ b/config/initializers/revision.rb
@@ -1,0 +1,12 @@
+require 'open3'
+
+revision_file = Rails.root.join('REVISION').to_s
+
+revision = if File.exist?(revision_file)
+             stdout, _status = Open3.capture2e('cat', revision_file)
+             stdout.chomp
+           else
+             Rails.env
+           end
+
+CURRENT_REVISION = revision


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-717

### What?

I have added/removed/altered:

- [x] Enable /healthcheck endpoint to return the current revision of the code

### Why?

I am doing this because:

- This is needed for debug

### Enable healthcheck again

![image](https://user-images.githubusercontent.com/8156884/120773952-b23b0a00-c519-11eb-9985-74153d0bfa5b.png)
