### PR TITLE
HOTT-665: Modifications to 'breadcrumbs' for commodity code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,5 +38,7 @@ RSpec/DescribeClass:
     - tasks/**/*.rb
 RSpec/ExampleLength:
   Enabled: false
+RSpec/NestedGroups:
+  Max: 4
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -62,7 +62,7 @@ module CommoditiesHelper
 
   def format_commodity_code(commodity)
     code = commodity.display_short_code.to_s
-    "#{code[0..1]}&nbsp;#{code[2..3]}&nbsp;#{code[4..-1]}".html_safe
+    "#{code[0..1]}&nbsp;#{code[2..3]}&nbsp;#{code[4..]}".html_safe
   end
 
   def format_commodity_code_based_on_level(commodity)
@@ -71,7 +71,7 @@ module CommoditiesHelper
 
     if commodity.number_indents > 1 || display_full_code
       # remove trailing pairs of zeros for non declarable
-      code = code.gsub(/[0]{2}+$/, '') if commodity.has_children?
+      code = code.gsub(/0{2}+$/, '') if commodity.has_children?
       tree_code(code, klass: nil)
     end
   end
@@ -97,10 +97,10 @@ module CommoditiesHelper
     if deeper_node.present? && deeper_node.number_indents < main_commodity.number_indents
       tag.ul do
         tag.li do
-          tree_code(deeper_node.code.gsub(/[0]{2}+$/, '')) +
+          tree_code(deeper_node.code.gsub(/0{2}+$/, '')) +
             tag.p(deeper_node.to_s.html_safe) +
             # if deeper_node.producline_suffix == '80'
-            #   tree_code(deeper_node.code.gsub(/[0]{2}+$/, ''))
+            #   tree_code(deeper_node.code.gsub(/0{2}+$/, ''))
             # end +
             tree_node(main_commodity, commodities, deeper_node.number_indents)
         end
@@ -131,15 +131,6 @@ module CommoditiesHelper
                 tag.div(format_full_code(commodity), class: 'code-text')
               end
       tag.p(commodity.to_s.html_safe)
-    end
-  end
-
-  def declarable_heading(commodity)
-    tag.p do
-      tree_code(commodity.code) +
-        tag.p(commodity.formatted_description.html_safe,
-              class: '',
-              id: "commodity-#{commodity.code}")
     end
   end
 

--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -99,9 +99,6 @@ module CommoditiesHelper
         tag.li do
           tree_code(deeper_node.code.gsub(/0{2}+$/, '')) +
             tag.p(deeper_node.to_s.html_safe) +
-            # if deeper_node.producline_suffix == '80'
-            #   tree_code(deeper_node.code.gsub(/0{2}+$/, ''))
-            # end +
             tree_node(main_commodity, commodities, deeper_node.number_indents)
         end
       end

--- a/app/views/shared/_tariff_breadcrumbs.html.erb
+++ b/app/views/shared/_tariff_breadcrumbs.html.erb
@@ -5,122 +5,18 @@ declarable ||= false %>
 
 <div class="tariff-breadcrumbs js-tariff-breadcrumbs clt govuk-!-font-size-16">
   <nav>
+    <p>
+      <%= link_to 'All sections', root_path %>
+    </p>
+
     <% if declarable %>
-      <p>
-        Section <%= declarable.section_numeral %>: <%= declarable.section %>
-      </p>
-      <div class="desktop-only">
-        <ul>
-          <li class="chapter-li">
-            <%= tree_chapter_code(declarable.chapter) %>
-            <%= link_to declarable.chapter, chapter_path(declarable.chapter, request.query_parameters.symbolize_keys) %>
-            <ul>
-              <li class="heading-li">
-                <%= tree_heading_code(declarable.heading) unless declarable.heading? %>
-                <% if declarable.show_commodity_tree? %>
-                  <%= link_to declarable.heading.to_s.html_safe, heading_path(declarable.heading, request.query_parameters.symbolize_keys) %>
-                  <%= commodity_tree(declarable, declarable.ancestors) %>
-                <% else %>
-                  <%= declarable_heading(declarable) %>
-                <% end %>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-      <div class="mobile-only">
-        <ul class="js-full-tree">
-          <li class="chapter-li">
-            <%= tree_chapter_code(declarable.chapter) %>
-            <%= link_to declarable.chapter, chapter_path(declarable.chapter, request.query_parameters.symbolize_keys) %>
-            <ul>
-              <li class="heading-under-chapter-li">
-                <% if declarable.show_commodity_tree? %>
-                  <%= tree_heading_code(declarable.heading) unless declarable.heading? %>
-                  <%= link_to declarable.heading.to_s.html_safe, heading_path(declarable.heading, request.query_parameters.symbolize_keys) %>
-                  <%= commodity_tree(declarable, declarable.ancestors) %>
-                <% else %>
-                  <%= declarable_heading(declarable) %>
-                <% end %>
-              </li>
-            </ul>
-          </li>
-        </ul>
-        <ul class="js-summary-tree">
-          <li>
-            <a href="#" class="show-full-tree-link js-show-full-tree-link">[Show all]</a>
-            <ul>
-              <% if declarable.show_commodity_tree? %>
-                <%= commodity_heading_full(declarable) %>
-              <% else %>
-                <%= declarable_heading_full(declarable) %>
-              <% end %>
-            </ul>
-          </li>
-        </ul>
-      </div>
-
+      <%= render partial: 'shared/tariff_breadcrumbs/declarable', locals: { declarable: declarable } %>
     <% elsif heading %>
-      <p>
-        Section <%= heading.section.numeral %>: <%= heading.section.title %>
-      </p>
-      <div class="desktop-only">
-        <ul>
-          <li class="chapter-li">
-            <%= tree_chapter_code(heading.chapter) %>
-            <%= link_to heading.chapter, chapter_path(heading.chapter, request.query_parameters.symbolize_keys) %>
-            <ul>
-              <li class="heading-li">
-                <%= tree_heading_code(heading) %>
-                <div class="line-text">
-                  <%= heading.formatted_description.html_safe %>
-                </div>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-      <div class="mobile-only">
-        <ul class="js-full-tree">
-          <li class="chapter-li">
-            <%= tree_chapter_code(heading.chapter) %>
-            <%= link_to heading.chapter, chapter_path(heading.chapter, request.query_parameters.symbolize_keys) %>
-            <ul>
-              <li class="heading-li">
-                <%= tree_heading_code(heading) %>
-                <p><%= heading.formatted_description.html_safe %></p>
-              </li>
-            </ul>
-          </li>
-        </ul>
-        <ul class="mobile-only js-summary-tree">
-          <li>
-            <a href="#" class="show-full-tree-link js-show-full-tree-link">[Show all]</a>
-            <ul>
-              <li class="chapter-and-heading-li">
-                <%= tree_heading_code(heading) %>
-                <p><%= heading.formatted_description.html_safe %></p>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-
+      <%= render partial: 'shared/tariff_breadcrumbs/heading', locals: { heading: heading } %>
     <% elsif chapter %>
-      <p>
-        Section <%= chapter.section_numeral %>: <%= chapter.section %>
-      </p>
-      <ul>
-        <li class="chapter-li">
-          <%= tree_chapter_code(chapter) %>
-          <p>
-            <%= chapter %>
-          </p>
-        </li>
-      </ul>
-
+      <%= render partial: 'shared/tariff_breadcrumbs/chapter', locals: { chapter: chapter } %>
     <% elsif section %>
-      <p><strong><%= "Section #{section.numeral}: #{section}" %></strong></p>
+      <%= render partial: 'shared/tariff_breadcrumbs/section', locals: { section: section } %>
     <% end %>
   </nav>
 

--- a/app/views/shared/tariff_breadcrumbs/_chapter.html.erb
+++ b/app/views/shared/tariff_breadcrumbs/_chapter.html.erb
@@ -1,0 +1,31 @@
+<div class="desktop-only">
+  <ul>
+    <li class="section-li">
+      <%= link_to "Section #{chapter.section.numeral}: #{chapter.section}",
+                  section_path(chapter.section, request.query_parameters.symbolize_keys),
+                  class: %w[full-width] %>
+      <ul>
+        <li class="chapter-li">
+          <%= tree_chapter_code(chapter) %>
+          <%= tag.p chapter, class: 'line-text' %>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+
+<div class="mobile-only">
+  <ul>
+    <li class="section-li">
+      <%= link_to "Section #{chapter.section.numeral}: #{chapter.section}",
+                  section_path(chapter.section, request.query_parameters.symbolize_keys),
+                  class: %w[full-width] %>
+      <ul>
+        <li class="chapter-li">
+          <%= tree_chapter_code(chapter) %>
+          <%= tag.p chapter, class: 'line-text' %>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>

--- a/app/views/shared/tariff_breadcrumbs/_declarable.html.erb
+++ b/app/views/shared/tariff_breadcrumbs/_declarable.html.erb
@@ -1,0 +1,67 @@
+<div class="desktop-only">
+  <ul>
+    <li class="section-li">
+      <%= link_to "Section #{declarable.section.numeral}: #{declarable.section}",
+        section_path(declarable.section, request.query_parameters.symbolize_keys),
+        class: %w[full-width] %>
+      <ul>
+        <li class="chapter-li">
+          <%= tree_chapter_code(declarable.chapter) %>
+          <%= link_to declarable.chapter, chapter_path(declarable.chapter, request.query_parameters.symbolize_keys) %>
+          <ul>
+            <li class="heading-li">
+              <%= tree_heading_code(declarable.heading) unless declarable.heading? %>
+              <% if declarable.show_commodity_tree? %>
+                <%= link_to declarable.heading.to_s.html_safe, heading_path(declarable.heading, request.query_parameters.symbolize_keys) %>
+                <%= commodity_tree(declarable, declarable.ancestors) %>
+              <% else %>
+                <%= tree_code(declarable.code) %>
+                <%= tag.p declarable.formatted_description.html_safe, class: 'line-text' %>
+              <% end %>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+
+<div class="mobile-only">
+  <ul>
+    <li class="section-li">
+      <%= link_to "Section #{declarable.section.numeral}: #{declarable.section}",
+        section_path(declarable.section, request.query_parameters.symbolize_keys),
+        class: %w[full-width] %>
+      <ul class="js-full-tree">
+        <li class="chapter-li">
+          <%= tree_chapter_code(declarable.chapter) %>
+          <%= link_to declarable.chapter, chapter_path(declarable.chapter, request.query_parameters.symbolize_keys) %>
+          <ul>
+            <li class="heading-under-chapter-li">
+              <% if declarable.show_commodity_tree? %>
+                <%= tree_heading_code(declarable.heading) unless declarable.heading? %>
+                <%= link_to declarable.heading.to_s.html_safe, heading_path(declarable.heading, request.query_parameters.symbolize_keys) %>
+                <%= commodity_tree(declarable, declarable.ancestors) %>
+              <% else %>
+                <%= tree_code(declarable.code) %>
+                <%= tag.p declarable.formatted_description.html_safe, class: 'line-text' %>
+              <% end %>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <ul class="js-summary-tree">
+        <li>
+          <a href="#" class="show-full-tree-link js-show-full-tree-link">[Show all]</a>
+          <ul>
+            <% if declarable.show_commodity_tree? %>
+              <%= commodity_heading_full(declarable) %>
+            <% else %>
+              <%= declarable_heading_full(declarable) %>
+            <% end %>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>

--- a/app/views/shared/tariff_breadcrumbs/_heading.html.erb
+++ b/app/views/shared/tariff_breadcrumbs/_heading.html.erb
@@ -1,0 +1,54 @@
+<div class="desktop-only">
+  <ul>
+    <li class="section-li">
+      <%= link_to "Section #{heading.section.numeral}: #{heading.section}",
+                  section_path(heading.section, request.query_parameters.symbolize_keys),
+                  class: %w[full-width] %>
+      <ul>
+        <li class="chapter-li">
+          <%= tree_chapter_code(heading.chapter) %>
+          <%= link_to heading.chapter, chapter_path(heading.chapter, request.query_parameters.symbolize_keys) %>
+          <ul>
+            <li class="heading-li">
+              <%= tree_heading_code(heading) %>
+              <%= tag.p heading.to_s.html_safe, class: 'line-text' %>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+
+<div class="mobile-only">
+  <ul>
+    <li class="section-li">
+      <%= link_to "Section #{heading.section.numeral}: #{heading.section}",
+                  section_path(heading.section, request.query_parameters.symbolize_keys),
+                  class: %w[full-width] %>
+      <ul class="js-full-tree">
+        <li class="chapter-li">
+          <%= tree_chapter_code(heading.chapter) %>
+          <%= link_to heading.chapter, chapter_path(heading.chapter, request.query_parameters.symbolize_keys) %>
+          <ul>
+            <li class="heading-li">
+              <%= tree_heading_code(heading) %>
+              <%= tag.p heading.formatted_description.html_safe, class: 'line-text' %>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <ul class="mobile-only js-summary-tree">
+        <li>
+          <a href="#" class="show-full-tree-link js-show-full-tree-link">[Show all]</a>
+          <ul>
+            <li class="chapter-and-heading-li">
+              <%= tree_heading_code(heading) %>
+              <%= tag.p heading.formatted_description.html_safe, class: 'line-text' %>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>

--- a/app/views/shared/tariff_breadcrumbs/_section.html.erb
+++ b/app/views/shared/tariff_breadcrumbs/_section.html.erb
@@ -1,0 +1,15 @@
+<div class="desktop-only">
+  <ul>
+    <li class="section-li">
+      <%= tag.p "Section #{section.numeral}: #{section}", class: %w[full-width] %>
+    </li>
+  </ul>
+</div>
+
+<div class="mobile-only">
+  <ul>
+    <li class="section-li">
+      <%= tag.p "Section #{section.numeral}: #{section}", class: %w[full-width] %>
+    </li>
+  </ul>
+</div>

--- a/app/webpacker/src/stylesheets/_tariff-breadcrumbs.scss
+++ b/app/webpacker/src/stylesheets/_tariff-breadcrumbs.scss
@@ -45,7 +45,7 @@
           display: block !important;
           padding-top: 2px;
           line-height: 1.3;
-          
+
 
           &.show-full-tree-link {
             padding-top: 0 !important;
@@ -56,6 +56,11 @@
             min-height: 30px;
             padding-right: 200px;
           }
+        }
+
+        p.full-width,
+        a.full-width {
+          padding-right: 2px;
         }
 
         .feed {
@@ -142,7 +147,7 @@
         display: inline-block !important;
         padding-right: 0 !important;
         min-height: 0 !important;
-        
+
         @media (min-width: $desktop-min-width) {
           background-image: url('../images/feed-icon-black.png');
           background-position: 0.2em center;

--- a/spec/requests/chapter_spec.rb
+++ b/spec/requests/chapter_spec.rb
@@ -1,60 +1,100 @@
 require 'spec_helper'
 
 describe 'Chapter page', type: :request do
-  context 'as HTML' do
-    it 'displays chapter name and headings in the chapter' do
+  context 'when requesting as HTML' do
+    before do
       VCR.use_cassette('geographical_areas#countries') do
         VCR.use_cassette('chapters#show') do
           visit chapter_path('01')
-
-          expect(page).to have_content 'Live animals'
-          expect(page).to have_content 'Live bovine animals'
-          expect(page).to have_content 'Live swine'
         end
       end
     end
 
-    it 'displays chapter and heading codes for all headings in the chapter' do
-      VCR.use_cassette('geographical_areas#countries') do
-        VCR.use_cassette('chapters#show') do
-          visit chapter_path('01')
+    it 'displays the link to all sections' do
+      expect(page).to have_link 'All sections',
+                                href: '/'
+    end
 
-          expect(page).to have_selector '.chapter-code', text: '01', count: 7
-          expect(page).to have_selector '.heading-code', text: '01', count: 1
-          expect(page).to have_selector '.heading-code', text: '02', count: 1
-          expect(page).to have_selector '.heading-code', text: '03', count: 1
-          expect(page).to have_selector '.heading-code', text: '04', count: 1
-          expect(page).to have_selector '.heading-code', text: '05', count: 1
-          expect(page).to have_selector '.heading-code', text: '06', count: 1
-        end
-      end
+    it 'displays the section as a link' do
+      expect(page).to have_link 'Section I: Live animals; animal products',
+                                href: '/sections/1'
+    end
+
+    it 'displays the chapter name' do
+      expect(page).to have_content 'Live animals'
+    end
+
+    it 'displays the second heading in the chapter as a link' do
+      expect(page).to have_link 'Live bovine animals'
+    end
+
+    it 'displays the third heading in the chapter as a link' do
+      expect(page).to have_link 'Live swine'
+    end
+
+    it 'displays chapter codes for all headings in the chapter' do
+      expect(page).to have_selector '.chapter-code', text: '01', count: 8
+    end
+
+    it 'displays heading codes for the first heading in the chapter' do
+      expect(page).to have_selector '.heading-code', text: '01', count: 1
+    end
+
+    it 'displays heading codes for the second heading in the chapter' do
+      expect(page).to have_selector '.heading-code', text: '02', count: 1
+    end
+
+    it 'displays heading codes for the third heading in the chapter' do
+      expect(page).to have_selector '.heading-code', text: '03', count: 1
+    end
+
+    it 'displays heading codes for the fourth heading in the chapter' do
+      expect(page).to have_selector '.heading-code', text: '04', count: 1
+    end
+
+    it 'displays heading codes for the fifth heading in the chapter' do
+      expect(page).to have_selector '.heading-code', text: '05', count: 1
+    end
+
+    it 'displays heading codes for the sixth heading in the chapter' do
+      expect(page).to have_selector '.heading-code', text: '06', count: 1
     end
   end
 
-  context 'as JSON' do
-    context 'requested with json format' do
-      it 'renders direct API response' do
+  context 'when requesting as JSON' do
+    context 'when requested with json format' do
+      before do
         VCR.use_cassette('chapters#show_01_api_json_format') do
           get '/chapters/01.json'
-
-          json = JSON.parse(response.body)
-
-          expect(json['goods_nomenclature_item_id']).to eq '0100000000'
-          expect(json['formatted_description']).to eq 'Live animals'
         end
+      end
+
+      let(:json) { JSON.parse(response.body) }
+
+      it 'renders the correct item id' do
+        expect(json['goods_nomenclature_item_id']).to eq '0100000000'
+      end
+
+      it 'renders direct API response' do
+        expect(json['formatted_description']).to eq 'Live animals'
       end
     end
 
-    context 'requested with json HTTP Accept header' do
-      it 'renders direct API response' do
+    context 'when requested with json HTTP Accept header' do
+      before do
         VCR.use_cassette('chapters#show_01_api_json_content_type') do
           get '/chapters/01', headers: { 'HTTP_ACCEPT' => 'application/json' }
-
-          json = JSON.parse(response.body)
-
-          expect(json['goods_nomenclature_item_id']).to eq '0100000000'
-          expect(json['formatted_description']).to eq 'Live animals'
         end
+      end
+
+      let(:json) { JSON.parse(response.body) }
+
+      it 'renders the correct item id' do
+        expect(json['goods_nomenclature_item_id']).to eq '0100000000'
+      end
+
+      it 'renders direct API response' do
+        expect(json['formatted_description']).to eq 'Live animals'
       end
     end
   end

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -66,4 +66,36 @@ describe 'Commodity page', type: :request do
       end
     end
   end
+
+  context 'when commodity with whatever' do
+    before do
+      VCR.use_cassette('headings#show_0101') do
+        visit commodity_path('0101300000')
+      end
+    end
+
+    it 'displays the link to all sections' do
+      expect(page).to have_link 'All sections',
+                                href: '/'
+    end
+
+    it 'displays the section as a link' do
+      expect(page).to have_link 'Section I: Live animals; animal products',
+                                href: '/sections/1'
+    end
+
+    it 'displays the chapter name as a link' do
+      expect(page).to have_link 'Live animals',
+                                href: '/chapters/01'
+    end
+
+    it 'displays the header name as a link' do
+      expect(page).to have_link 'Live horses, asses, mules and hinnies',
+                                href: '/headings/0101'
+    end
+
+    it 'displays the commodity name' do
+      expect(page).to have_content 'Asses'
+    end
+  end
 end

--- a/spec/requests/heading_spec.rb
+++ b/spec/requests/heading_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'Heading page', type: :request do
-  context 'as HTML' do
-    context 'declarable heading' do
+  context 'when requesting as as HTML' do
+    context 'with a declarable heading' do
       context 'without country filter' do
         it 'displays declarable related information' do
           VCR.use_cassette('headings#show_declarable') do
@@ -24,45 +24,78 @@ describe 'Heading page', type: :request do
       end
     end
 
-    context 'regular heading' do
-      it 'displays heading name and children commodities' do
+    context 'with a regular heading' do
+      before do
         VCR.use_cassette('geographical_areas#countries') do
           VCR.use_cassette('headings#show') do
             visit heading_path('0101')
-
-            expect(page).to have_content 'Live horses, asses, mules and hinnies'
-            expect(page).to have_content 'Horses'
-            expect(page).to have_content 'Pure-bred breeding animals'
           end
         end
+      end
+
+      it 'displays the link to all sections' do
+        expect(page).to have_link 'All sections',
+                                  href: '/'
+      end
+
+      it 'displays the section as a link' do
+        expect(page).to have_link 'Section I: Live animals; animal products',
+                                  href: '/sections/1'
+      end
+
+      it 'displays the chapter as a link' do
+        expect(page).to have_link 'Live animals',
+                                  href: '/chapters/01'
+      end
+
+      it 'displays the current header' do
+        expect(page).to have_content 'Live horses, asses, mules and hinnies'
+      end
+
+      it 'displays the first level of children commodities' do
+        expect(page).to have_content 'Horses'
+      end
+
+      it 'displays the leaf level of children commodities as a link' do
+        expect(page).to have_link 'Pure-bred breeding animals'
       end
     end
   end
 
-  context 'as JSON' do
-    context 'requested with json format' do
-      it 'renders direct API response' do
+  context 'when requesting as JSON' do
+    context 'when requested with json format' do
+      before do
         VCR.use_cassette('headings#show_0101_api_json_format') do
           get '/headings/0101.json'
-
-          json = JSON.parse(response.body)
-
-          expect(json['goods_nomenclature_item_id']).to eq '0101000000'
-          expect(json['commodities']).to be_kind_of Array
         end
+      end
+
+      let(:json) { JSON.parse(response.body) }
+
+      it 'renders the correct item id' do
+        expect(json['goods_nomenclature_item_id']).to eq '0101000000'
+      end
+
+      it 'renders direct API response' do
+        expect(json['commodities']).to be_kind_of Array
       end
     end
 
-    context 'requested with json HTTP Accept header' do
-      it 'renders direct API response' do
+    context 'when requested with json HTTP Accept header' do
+      before do
         VCR.use_cassette('headings#show_0101_api_json_content_type') do
           get '/headings/0101', headers: { 'HTTP_ACCEPT' => 'application/json' }
-
-          json = JSON.parse(response.body)
-
-          expect(json['goods_nomenclature_item_id']).to eq '0101000000'
-          expect(json['commodities']).to be_kind_of Array
         end
+      end
+
+      let(:json) { JSON.parse(response.body) }
+
+      it 'renders the correct item id' do
+        expect(json['goods_nomenclature_item_id']).to eq '0101000000'
+      end
+
+      it 'renders direct API response' do
+        expect(json['commodities']).to be_kind_of Array
       end
     end
   end

--- a/spec/requests/sections_spec.rb
+++ b/spec/requests/sections_spec.rb
@@ -1,88 +1,129 @@
 require 'spec_helper'
 
 describe 'Sections Index page', type: :request do
-  context 'as HTML' do
-    it 'displays section names' do
+  context 'when requesting as HTML' do
+    before do
       VCR.use_cassette('geographical_areas#countries') do
         VCR.use_cassette('sections#index') do
           visit sections_path
-
-          expect(page).to have_content 'Live animals; animal products'
-          expect(page).to have_content 'Vehicles, aircraft'
-          expect(page).to have_content 'Privacy'
         end
       end
+    end
+
+    it 'displays the first section as a link' do
+      expect(page).to have_link 'Live animals; animal products'
+    end
+
+    it 'displays the second section as a link' do
+      expect(page).to have_link 'Vehicles, aircraft'
+    end
+
+    it 'displays the third section as a link' do
+      expect(page).to have_link 'Privacy'
     end
   end
 
-  context 'as JSON' do
-    context 'requested with json format' do
-      it 'renders direct API response' do
+  context 'when requesting as JSON' do
+    context 'when requested with json format' do
+      before do
         VCR.use_cassette('sections#index_api_json_format') do
           get '/sections.json'
-
-          json = JSON.parse(response.body)
-
-          expect(json).to be_kind_of Array
-          expect(json.first['title']).to eq 'Live animals; animal products'
         end
+      end
+
+      let(:json) { JSON.parse(response.body) }
+
+      it 'renders direct API response' do
+        expect(json).to be_kind_of Array
+      end
+
+      it 'renders the correct title for the first element' do
+        expect(json.first['title']).to eq 'Live animals; animal products'
       end
     end
 
-    context 'requested with json HTTP Accept header' do
-      it 'renders direct API response' do
+    context 'when requested with json HTTP Accept header' do
+      before do
         VCR.use_cassette('sections#index_api_json_content_type') do
           get '/sections', headers: { 'HTTP_ACCEPT' => 'application/json' }
-
-          json = JSON.parse(response.body)
-
-          expect(json).to be_kind_of Array
-          expect(json.first['title']).to eq 'Live animals; animal products'
         end
+      end
+
+      let(:json) { JSON.parse(response.body) }
+
+      it 'renders direct API response' do
+        expect(json).to be_kind_of Array
+      end
+
+      it 'renders the correct title for the first element' do
+        expect(json.first['title']).to eq 'Live animals; animal products'
       end
     end
   end
 end
 
 describe 'Section page', type: :request do
-  context 'as HTML' do
-    it 'displays section name and chapters in the section' do
+  context 'when requested as HTML' do
+    before do
       VCR.use_cassette('geographical_areas#countries') do
         VCR.use_cassette('sections#show') do
           visit section_path(1)
-
-          expect(page).to have_content 'Live animals; animal products'
-          expect(page).to have_content 'Live animals'
-          expect(page).to have_content 'Meat and edible meat offal'
         end
       end
+    end
+
+    it 'displays the link to all sections' do
+      expect(page).to have_link 'All sections',
+                                href: '/'
+    end
+
+    it 'displays section name' do
+      expect(page).to have_content 'Live animals; animal products'
+    end
+
+    it 'displays the first chapter in the section' do
+      expect(page).to have_content 'Live animals'
+    end
+
+    it 'displays the second chapter in the section' do
+      expect(page).to have_content 'Meat and edible meat offal'
     end
   end
 
-  context 'as JSON' do
-    context 'requested with json format' do
-      it 'renders direct API response' do
+  context 'when requested as JSON' do
+    context 'when requested with json format' do
+      before do
         VCR.use_cassette('sections#show_1_api_json_format') do
           get '/sections/1.json'
-
-          json = JSON.parse(response.body)
-
-          expect(json['title']).to eq 'Live animals; animal products'
-          expect(json['chapters']).to be_kind_of Array
         end
+      end
+
+      let(:json) { JSON.parse(response.body) }
+
+      it 'renders the correct title' do
+        expect(json['title']).to eq 'Live animals; animal products'
+      end
+
+      it 'renders direct API response' do
+        expect(json['chapters']).to be_kind_of Array
       end
     end
 
-    context 'requested with json HTTP Accept header' do
-      it 'renders direct API response' do
+    context 'when requested with json HTTP Accept header' do
+      before do
         VCR.use_cassette('sections#show_1_api_json_content_type') do
           get '/sections/1', headers: { 'HTTP_ACCEPT' => 'application/json' }
-
-          json = JSON.parse(response.body)
-
-          expect(json['title']).to eq 'Live animals; animal products'
-          expect(json['chapters']).to be_kind_of Array
         end
+      end
+
+      let(:json) { JSON.parse(response.body) }
+
+      it 'renders the correct title' do
+        expect(json['title']).to eq 'Live animals; animal products'
+      end
+
+      it 'renders direct API response' do
+        expect(json['chapters']).to be_kind_of Array
       end
     end
   end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -3,7 +3,7 @@ require 'webmock/rspec'
 
 VCR.configure do |c|
   service_ports = [3018, 3019]
-  c.cassette_library_dir = Rails.root.join('spec', 'vcr')
+  c.cassette_library_dir = Rails.root.join('spec/vcr')
   c.hook_into :webmock
   # c.debug_logger = $stdout
   c.default_cassette_options = { match_requests_on: [:path] }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-665

### What?

I have added/removed/altered:

- [ ] Modify the breadcrumbs structure
- [ ] Move each structure (section, header, chapter, "declarable") into a separate partial
- [ ] Extend the specs
- [ ] Fix some linting issues in the affected files

### Why?

I am doing this because users have complained that they find it hard to navigate back to the top of the catalogue hierarchy

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes