### PR TITLE
HOTT-737: Add VAT content

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -149,6 +149,7 @@
     <%= render partial: 'measures/measure_references', collection: declarable.import_measures.for_country(@search.country), as: 'measure' %>
     <% if TradeTariffFrontend::ServiceChooser.xi? %>
       <%= render partial: 'measures/measure_references', collection: uk_declarable.import_measures.import_controls.for_country(@search.country), as: 'measure' %>
+      <%= render partial: 'measures/measure_references', collection: uk_declarable.import_measures.vat_excise.for_country(@search.country), as: 'measure' %>
     <% end %>
   </div>
   <div id="export-measure-references">


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-737

### What?

I have added/removed/altered:

- [ ] Content for VAT

### Why?

I am doing this because I had initially missed that VAT is fetched from UK as well, and will be unavailable on a xi service.

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes
