### PR TITLE
Hott 736: UK service - Accessing commodities which are also headings (using URL) navigates to XI service

### DIFF
--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -8,14 +8,6 @@ class GoodsNomenclaturesController < ApplicationController
   end
 
   def find_relevant_goods_code_or_fallback
-    # Restore the request's original service, since this rescue branch will
-    # always be triggered from `fetch_heading_from_xi` in CommoditiesController
-    # and from `fetch_heading_from_xi` in HeadingsController, regardless of
-    # whether the original call was from UK or XI
-    service_match = RoutingFilter::ServicePathPrefixHandler::SERVICE_CHOICE_PREFIXES_REGEX.match(request.path)
-    original_service_choice = service_match.present? ? service_match[1] : nil
-    TradeTariffFrontend::ServiceChooser.service_choice = original_service_choice
-
     @search = Search.new(q: goods_code_id, as_of: @tariff_last_updated)
     results = @search.perform
 

--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -8,6 +8,14 @@ class GoodsNomenclaturesController < ApplicationController
   end
 
   def find_relevant_goods_code_or_fallback
+    # Restore the request's original service, since this rescue branch will
+    # always be triggered from `fetch_heading_from_xi` in CommoditiesController
+    # and from `fetch_heading_from_xi` in HeadingsController, regardless of
+    # whether the original call was from UK or XI
+    service_match = RoutingFilter::ServicePathPrefixHandler::SERVICE_CHOICE_PREFIXES_REGEX.match(request.path)
+    original_service_choice = service_match.present? ? service_match[1] : nil
+    TradeTariffFrontend::ServiceChooser.service_choice = original_service_choice
+
     @search = Search.new(q: goods_code_id, as_of: @tariff_last_updated)
     results = @search.perform
 

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -33,4 +33,4 @@
   </nav>
 <% end %>
 
-<%= render 'declarables/declarable', declarable: @commodity, xi_declarable: @xi_commodity, uk_declarable: @uk_commodity  %>
+<%= render 'declarables/declarable', declarable: @commodity, xi_declarable: xi_commodity, uk_declarable: uk_commodity  %>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -7,7 +7,7 @@
 <% content_for :bodyClasses, "page--wide" %>
 
 <% if @heading.declarable? %>
-  <%= render 'declarables/declarable', declarable: @heading, uk_declarable: @uk_heading, xi_declarable: @xi_heading %>
+  <%= render 'declarables/declarable', declarable: @heading, uk_declarable: uk_heading, xi_declarable: xi_heading %>
 <% else %>
   <h2 class="govuk-heading-s">Choose the commodity code below that best matches your goods to see more information</h2>
   <p>If your item is not listed by name, it may be shown under what it's used for, what it's made from or 'other'.</p>

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -127,6 +127,11 @@ module TradeTariffFrontend
       self.service_choice = original_service_source
 
       result
+    rescue StandardError => e
+      # Restore the request's original service source
+      self.service_choice = original_service_source
+
+      raise e
     end
 
     def service_default

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -2,75 +2,79 @@ require 'spec_helper'
 
 describe CommoditiesController, type: :controller do
   describe 'GET to #show' do
-    before do
-      allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('xi')
-      allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:xi).and_call_original
-      allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:uk).and_call_original
-    end
-
-    it 'fetches the commodity from the XI service', vcr: { cassette_name: 'commodities#show_0101210000_2000-01-01' } do
-      get :show, params: { id: '0101210000' }
-
-      expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:xi)
-    end
-
-    it 'fetches the commodity from the UK service', vcr: { cassette_name: 'commodities#show_0101210000_2000-01-01' } do
-      get :show, params: { id: '0101210000' }
-
-      expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:uk)
-    end
-
-    context 'existing commodity id provided', vcr: { cassette_name: 'commodities#show' } do
-      subject { controller }
-
+    context 'with UK site' do
       before do
-        VCR.use_cassette('headings_show_0101_api_json_content_type') do
-          get :show, params: { id: '0101300000' }
+        allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('xi')
+        allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:xi).and_call_original
+        allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:uk).and_call_original
+      end
+
+      it 'doesn\'t uses with_source to fetch the commodity from the XI service', vcr: { cassette_name: 'commodities#show_0101210000_2000-01-01' } do
+        get :show, params: { id: '0101210000' }
+
+        expect(TradeTariffFrontend::ServiceChooser).not_to have_received(:with_source).with(:xi)
+      end
+
+      it 'fetches the commodity from the UK service', vcr: { cassette_name: 'commodities#show_0101210000_2000-01-01' } do
+        get :show, params: { id: '0101210000' }
+
+        expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:uk)
+      end
+
+      context 'existing commodity id provided', vcr: { cassette_name: 'commodities#show' } do
+        subject { controller }
+
+        before do
+          VCR.use_cassette('headings_show_0101_api_json_content_type') do
+            get :show, params: { id: '0101300000' }
+          end
+        end
+
+        it { is_expected.to respond_with(:success) }
+        it { expect(assigns(:section)).to be_present }
+        it { expect(assigns(:chapter)).to be_present }
+        it { expect(assigns(:heading)).to be_present }
+        it { expect(assigns(:commodity)).to be_present }
+      end
+
+      context 'with non existing commodity id provided', vcr: { cassette_name: 'commodities#show_0101999999' } do
+        let(:commodity_id) { '0101999999' } # commodity 0101999999 does not exist
+
+        before do
+          get :show, params: { id: commodity_id }
+        end
+
+        it 'redirects to heading page (strips exceeding commodity id characters)' do
+          expect(response.status).to eq 302
+          expect(response.location).to eq heading_url(id: commodity_id.first(4))
         end
       end
 
-      it { is_expected.to respond_with(:success) }
-      it { expect(assigns(:section)).to be_present }
-      it { expect(assigns(:chapter)).to be_present }
-      it { expect(assigns(:heading)).to be_present }
-      it { expect(assigns(:commodity)).to be_present }
-    end
+      context 'with commodity id that does not exist in provided date', vcr: { cassette_name: 'commodities#show_010121000_2000-01-01' } do
+        let(:commodity_id) { '0101210000' } # commodity 0101210000 does not exist at 1st of Jan, 2000
 
-    context 'with non existing commodity id provided', vcr: { cassette_name: 'commodities#show_0101999999' } do
-      let(:commodity_id) { '0101999999' } # commodity 0101999999 does not exist
-
-      before do
-        get :show, params: { id: commodity_id }
-      end
-
-      it 'redirects to heading page (strips exceeding commodity id characters)' do
-        expect(response.status).to eq 302
-        expect(response.location).to eq heading_url(id: commodity_id.first(4))
-      end
-    end
-
-    context 'with commodity id that does not exist in provided date', vcr: { cassette_name: 'commodities#show_010121000_2000-01-01' } do
-      let(:commodity_id) { '0101210000' } # commodity 0101210000 does not exist at 1st of Jan, 2000
-
-      around do |example|
-        Timecop.freeze(DateTime.new(2013, 11, 11, 12, 0, 0)) do
-          example.run
+        around do |example|
+          Timecop.freeze(DateTime.new(2013, 11, 11, 12, 0, 0)) do
+            example.run
+          end
         end
-      end
 
-      before do
-        get :show, params: { id: commodity_id, year: 2000, month: 1, day: 1, country: nil }
-      end
+        before do
+          get :show, params: { id: commodity_id, year: 2000, month: 1, day: 1, country: nil }
+        end
 
-      it 'redirects to actual version of the commodity page' do
-        expect(response.status).to eq 302
-        expect(response.location).to eq commodity_url(id: commodity_id.first(10))
+        it 'redirects to actual version of the commodity page' do
+          expect(response.status).to eq 302
+          expect(response.location).to eq commodity_url(id: commodity_id.first(10))
+        end
       end
     end
 
     context 'with UK site' do
       before do
         allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_call_original
+        allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:xi).and_call_original
+        allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:uk).and_call_original
       end
 
       context 'with non existing commodity id provided', vcr: { cassette_name: 'commodities#show_0101999999' } do
@@ -98,6 +102,7 @@ describe CommoditiesController, type: :controller do
         end
 
         before do
+          TradeTariffFrontend::ServiceChooser.service_choice = nil
           get :show, params: { id: commodity_id, year: 2000, month: 1, day: 1, country: nil }
         end
 

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -7,6 +7,7 @@ describe CommoditiesController, type: :controller do
         allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('xi')
         allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:xi).and_call_original
         allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:uk).and_call_original
+        TradeTariffFrontend::ServiceChooser.service_choice = 'xi'
       end
 
       it 'doesn\'t uses with_source to fetch the commodity from the XI service', vcr: { cassette_name: 'commodities#show_0101210000_2000-01-01' } do

--- a/spec/controllers/headings_controller_spec.rb
+++ b/spec/controllers/headings_controller_spec.rb
@@ -7,10 +7,10 @@ describe HeadingsController, 'GET to #show', type: :controller do
     allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:uk).and_call_original
   end
 
-  it 'fetches the heading from the XI service', vcr: { cassette_name: 'headings#show_0110', record: :new_episodes } do
+  it 'doesn\'t uses with_source to fetch the heading from the XI service', vcr: { cassette_name: 'headings#show_0110', record: :new_episodes } do
     get :show, params: { id: '0501' }
 
-    expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:xi)
+    expect(TradeTariffFrontend::ServiceChooser).not_to have_received(:with_source).with(:xi)
   end
 
   it 'fetches the heading from the UK service', vcr: { cassette_name: 'headings#show_0110' } do

--- a/spec/controllers/headings_controller_spec.rb
+++ b/spec/controllers/headings_controller_spec.rb
@@ -43,4 +43,24 @@ describe HeadingsController, 'GET to #show', type: :controller do
       expect(response.location).to eq sections_url
     end
   end
+
+  context 'with UK site' do
+    before do
+      allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_call_original
+    end
+
+    context 'with non existing chapter id provided', vcr: { cassette_name: 'headings#show_0110' } do
+      let(:heading_id) { '0110' } # heading 0110 does not exist
+
+      before do
+        TradeTariffFrontend::ServiceChooser.service_choice = nil
+        get :show, params: { id: heading_id }
+      end
+
+      it 'redirects to sections index page as fallback' do
+        expect(response.status).to eq 302
+        expect(response.location).to eq sections_url
+      end
+    end
+  end
 end

--- a/spec/controllers/search_quotas_controller_spec.rb
+++ b/spec/controllers/search_quotas_controller_spec.rb
@@ -3,11 +3,13 @@ require 'spec_helper'
 describe SearchController, '#quota_search', type: :controller, vcr: { cassette_name: 'search#quota_search', allow_playback_repeats: true } do
   before do
     Rails.cache.clear
+    TradeTariffFrontend::ServiceChooser.service_choice = nil
   end
 
   context 'with xi as the service choice' do
     before do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:xi?).and_return(true)
+      TradeTariffFrontend::ServiceChooser.service_choice = 'xi'
 
       get :quota_search, params: { goods_nomenclature_item_id: '0301919011' }, format: :html
     end

--- a/spec/features/commodities_spec.rb
+++ b/spec/features/commodities_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe 'JS behaviour', js: true do
   before do
+    TradeTariffFrontend::ServiceChooser.service_choice = 'xi'
     VCR.use_cassette('headings#show_0201', record: :new_episodes) do
       visit commodity_path('0201100021', day: 31, month: 5, year: 2018)
     end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'Search', js: true do
+  before do
+    TradeTariffFrontend::ServiceChooser.service_choice = nil
+  end
+
   context 'when reaching the search page' do
     it 'renders the search container properly' do
       VCR.use_cassette('search#check') do

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'Commodity page', type: :request do
+  before do
+    TradeTariffFrontend::ServiceChooser.service_choice = nil
+  end
+
   context 'when mime type is HTML' do
     it 'displays declarable related information' do
       VCR.use_cassette('headings#show_0101') do

--- a/spec/requests/heading_spec.rb
+++ b/spec/requests/heading_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'Heading page', type: :request do
+  before do
+    TradeTariffFrontend::ServiceChooser.service_choice = nil
+  end
+
   context 'when requesting as as HTML' do
     context 'with a declarable heading' do
       context 'without country filter' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-736

### What?

I have added/removed/altered:

- [ ] Add specs to highlight the issue
- [ ] Add exception handling in the `with_source` function that will reset the service choice to the original one
- [ ] Rework the CommoditiesController to fetch the xi commodity only for xi site, and to use the `with_source` only for the "other" source
- [ ] Rework the HeadingsController to fetch the xi heading only for xi site, and to use the `with_source` only for the "other" source

### Why?

I am doing this because on a commodity code not found in the UK app, the app was erroneously redirecting to the NI version of the page

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

