### PR TITLE
Adds privacy page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,6 +19,9 @@ class PagesController < ApplicationController
     @no_shared_switch_service_link = true
   end
 
+  def privacy
+  end
+
   def tariff_cookies
     render :cookies
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,9 +19,6 @@ class PagesController < ApplicationController
     @no_shared_switch_service_link = true
   end
 
-  def privacy
-  end
-
   def tariff_cookies
     render :cookies
   end

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -89,7 +89,7 @@
       <h2 class="govuk-visually-hidden">Support links</h2>
       <ul class="govuk-footer__inline-list">
         <li class="govuk-footer__inline-list-item">
-          <a class="govuk-footer__link" href="https://www.gov.uk/help/privacy-notice">
+          <a class="govuk-footer__link" href="<%= privacy_path %>">
             Privacy
           </a>
         </li>

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -89,7 +89,7 @@
       <h2 class="govuk-visually-hidden">Support links</h2>
       <ul class="govuk-footer__inline-list">
         <li class="govuk-footer__inline-list-item">
-          <a class="govuk-footer__link" href="<%= privacy_path %>">
+          <%= link_to('Privacy', privacy_path, class: 'govuk-footer__link') %>
             Privacy
           </a>
         </li>

--- a/app/views/pages/privacy.html
+++ b/app/views/pages/privacy.html
@@ -1,0 +1,575 @@
+<main role="main" id="content" class="help-page" lang="en">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="gem-c-title govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+        <h1 class="gem-c-title__text govuk-heading-xl">Privacy notice</h1>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="responsive-bottom-margin">
+        <div
+          class="gem-c-govspeak govuk-govspeak direction-ltr disable-youtube"
+          data-module="govspeak"
+        >
+          <p>
+            GOV.UK (or www.gov.uk) is provided by the
+            <a href="/government/organisations/government-digital-service"
+              >Government Digital Service</a
+            >
+            (<abbr title="Government Digital Service">GDS</abbr>), part of the
+            Cabinet Office.
+          </p>
+
+          <p>
+            Cabinet Office is the data controller for pages starting with
+            www.gov.uk - for example, <a href="/pip">www.gov.uk/pip</a>.
+          </p>
+
+          <p>
+            If you follow a link to a service provided by another government
+            department, agency or local authority, that organisation will:
+          </p>
+
+          <ul>
+            <li>be the data controller</li>
+            <li>be responsible for processing any data you share with them</li>
+            <li>
+              publish and manage their own privacy notice with details of how to
+              contact them
+            </li>
+          </ul>
+
+          <div class="example">
+            <p>
+              <strong>Example</strong><br />
+              If you make a claim for Universal Credit
+              <a
+                rel="external"
+                href="https://www.universal-credit.service.gov.uk/postcode-checker"
+                >www.universal-credit.service.gov.uk</a
+              >, the Department for Work and Pensions will be the responsible
+              controller. The service’s own
+              <a
+                rel="external"
+                href="https://www.universal-credit.service.gov.uk/privacypolicy"
+                >privacy notice</a
+              >
+              will apply.
+            </p>
+          </div>
+
+          <p>
+            A data controller determines how and why personal data is processed.
+            For more information, read the Cabinet Office’s entry in the
+            <a
+              rel="external"
+              href="https://ico.org.uk/ESDWebPages/Entry/Z7414053"
+              >Data Protection Public Register</a
+            >.
+          </p>
+
+          <h2 id="what-data-we-collect">What data we collect</h2>
+
+          <p>The personal data we collect from you includes:</p>
+
+          <ul>
+            <li>
+              questions, queries or feedback you leave, including your email
+              address if you contact GOV.UK
+            </li>
+            <li>
+              your postcode if you use a GOV.UK service that includes a postcode
+              lookup function (such as the
+              <a href="/school-term-holiday-dates"
+                >school term and holiday dates service</a
+              >)
+            </li>
+            <li>
+              your email address and subscription preferences when you sign up
+              to our email alerts
+            </li>
+            <li>
+              how you use our emails - for example whether you open them and
+              which links you click on
+            </li>
+            <li>
+              your Internet Protocol (<abbr title="Internet Protocol">IP</abbr>)
+              address, and details of which version of
+              <a href="/support/browsers">web browser</a> you used
+            </li>
+            <li>
+              information on how you use the site, using
+              <a href="/support/cookies">cookies</a> and page tagging techniques
+            </li>
+          </ul>
+
+          <p>
+            We use
+            <a
+              rel="external"
+              href="https://support.google.com/analytics/topic/2919631"
+              >Google Analytics</a
+            >
+            and
+            <a rel="external" href="https://speedcurve.com/features/lux/"
+              >LUX Real User Monitoring (<abbr title="Real User Monitoring"
+                >RUM</abbr
+              >)</a
+            >
+            software to collect information about how you use GOV.UK and how the
+            website performs during your visit. This includes
+            <abbr title="Internet Protocol">IP</abbr> addresses. The data is
+            anonymised before being used for analytics and web performance
+            processing.
+          </p>
+
+          <p>Google Analytics processes anonymised information about:</p>
+
+          <ul>
+            <li>the pages you visit on GOV.UK</li>
+            <li>how long you spend on each GOV.UK page</li>
+            <li>how you got to the site</li>
+            <li>what you click on while you’re visiting the site</li>
+          </ul>
+
+          <p>
+            LUX Real User Monitoring software processes anonymised information
+            about:
+          </p>
+
+          <ul>
+            <li>how well the pages performed on your device</li>
+            <li>performance bottlenecks your device experienced</li>
+            <li>JavaScript errors your device encountered</li>
+          </ul>
+
+          <p>
+            We do not store your personal information through Google Analytics
+            or LUX (for example your name or address).
+          </p>
+
+          <p>
+            We will not identify you through analytics information, and we will
+            not combine analytics information with other data sets in a way that
+            would identify who you are.
+          </p>
+
+          <p>
+            We continuously test and monitor our data protection controls to
+            make sure they’re effective and to detect any weaknesses.
+          </p>
+
+          <h2 id="why-we-need-your-data">Why we need your data</h2>
+
+          <p>
+            We collect information through Google Analytics to see how you use
+            GOV.UK and government digital services and through LUX to see how
+            well the site performs on your device. We do this to help:
+          </p>
+
+          <ul>
+            <li>make sure GOV.UK is meeting the needs of its users</li>
+            <li>
+              make improvements, for example
+              <a
+                rel="external"
+                href="https://insidegovuk.blog.gov.uk/2015/03/26/new-tool-to-see-trending-searches/"
+                >improving site search</a
+              >
+            </li>
+            <li>
+              make performance improvements, for example improving page load
+              time and data usage
+            </li>
+          </ul>
+
+          <p>We also collect data in order to:</p>
+
+          <ul>
+            <li>
+              gather feedback to improve our services, for example our email
+              alerts
+            </li>
+            <li>respond to any feedback you send us, if you’ve asked us to</li>
+            <li>send email alerts to users who request them</li>
+            <li>
+              allow you to access government services and make transactions
+            </li>
+            <li>provide you with information about local services</li>
+            <li>monitor use of the site to identify security threats</li>
+            <li>
+              monitor the performance of the site to identify inefficiencies and
+              JavaScript errors
+            </li>
+          </ul>
+
+          <h2 id="our-legal-basis-for-processing-your-data">
+            Our legal basis for processing your data
+          </h2>
+
+          <p>
+            The legal basis for processing personal data in relation to site
+            security is our legitimate interests, and the legitimate interests
+            of our users, in ensuring the security and integrity of GOV.UK.
+          </p>
+
+          <p>
+            The legal basis for processing anonymised data for Google Analytics
+            and LUX is your consent.
+          </p>
+
+          <p>
+            The legal basis for processing all other personal data is that it’s
+            necessary:
+          </p>
+
+          <ul>
+            <li>to perform a task in the public interest</li>
+            <li>in the exercise of our functions as a government department</li>
+          </ul>
+
+          <h2 id="what-we-do-with-your-data">What we do with your data</h2>
+
+          <p>
+            The data we collect may be shared with other government departments,
+            agencies and public bodies. It may also be shared with our
+            technology suppliers, for example our hosting provider.
+          </p>
+
+          <p>We will not:</p>
+
+          <ul>
+            <li>sell or rent your data to third parties</li>
+            <li>share your data with third parties for marketing purposes</li>
+            <li>use your data in analytics</li>
+          </ul>
+
+          <p>
+            We will share your data if we are required to do so by law - for
+            example, by court order, or to prevent fraud or other crime.
+          </p>
+
+          <h2 id="how-long-we-keep-your-data">How long we keep your data</h2>
+
+          <p>We will only retain your personal data for as long as:</p>
+
+          <ul>
+            <li>it is needed for the purposes set out in this document</li>
+            <li>the law requires us to</li>
+          </ul>
+
+          <p>
+            We will keep your email data until you unsubscribe. We will keep
+            your feedback data for 2 years. We will delete access log data after
+            120 days.
+          </p>
+
+          <h2 id="childrens-privacy-protection">
+            Children’s privacy protection
+          </h2>
+
+          <p>
+            Our services are not designed for, or intentionally targeted at,
+            children 13 years of age or younger. We do not intentionally collect
+            or maintain data about anyone under the age of 13.
+          </p>
+
+          <h2 id="where-your-data-is-processed-and-stored">
+            Where your data is processed and stored
+          </h2>
+
+          <p>
+            We design, build and run our systems to make sure that your data is
+            as safe as possible at all stages, both while it’s processed and
+            when it’s stored.
+          </p>
+
+          <p>
+            All personal data is stored in the
+            <a href="/eu-eea">European Economic Area</a> (<abbr
+              title="European Economic Area"
+              >EEA</abbr
+            >). Data collected by Google Analytics and LUX may be transferred
+            outside the <abbr title="European Economic Area">EEA</abbr> for
+            processing.
+          </p>
+
+          <h2 id="how-we-protect-your-data-and-keep-it-secure">
+            How we protect your data and keep it secure
+          </h2>
+
+          <p>
+            We are committed to doing all that we can to keep your data secure.
+            We have set up systems and processes to prevent unauthorised access
+            or disclosure of your data - for example, we protect your data using
+            varying levels of encryption.
+          </p>
+
+          <p>
+            We also make sure that any third parties that we deal with keep all
+            personal data they process on our behalf secure.
+          </p>
+
+          <h2 id="your-rights">Your rights</h2>
+
+          <p>You have the right to request:</p>
+
+          <ul>
+            <li>information about how your personal data is processed</li>
+            <li>a copy of that personal data</li>
+            <li>
+              that anything inaccurate in your personal data is corrected
+              immediately
+            </li>
+          </ul>
+
+          <p>You can also:</p>
+
+          <ul>
+            <li>
+              raise an objection about how your personal data is processed
+            </li>
+            <li>
+              request that your personal data is erased if there is no longer a
+              justification for it
+            </li>
+            <li>
+              ask that the processing of your personal data is restricted in
+              certain circumstances
+            </li>
+          </ul>
+
+          <p>
+            If you have any of these requests, get in contact with our Privacy
+            Team.
+          </p>
+
+          <h2 id="links-to-other-websites">Links to other websites</h2>
+
+          <p>GOV.UK contains links to other websites.</p>
+
+          <p>
+            This privacy notice only applies to GOV.UK, and does not cover other
+            government services and transactions that we link to. These
+            services, such as
+            <a
+              rel="external"
+              href="https://www.universal-credit.service.gov.uk/postcode-checker"
+              >Universal Credit</a
+            >, have their own terms and conditions and privacy policies.
+          </p>
+
+          <h3 id="following-a-link-to-another-website">
+            Following a link to another website
+          </h3>
+
+          <p>
+            If you go to another website from this one, read the privacy policy
+            on that website to find out what it does with your information.
+          </p>
+
+          <h3 id="following-a-link-to-govuk-from-another-website">
+            Following a link to GOV.UK from another website
+          </h3>
+
+          <p>
+            If you come to GOV.UK from another website, we may receive personal
+            information from the other website. You should read the privacy
+            policy of the website you came from to find out more about this.
+          </p>
+
+          <h2 id="govuk-accounts-trial">GOV.UK accounts trial</h2>
+
+          <p>
+            GOV.UK is trialling accounts to try to improve online public
+            services.
+          </p>
+
+          <p>
+            Creating an account is optional and all GOV.UK services are
+            accessible with or without an account. You can access, update or
+            permanently delete your account and all the information stored in it
+            at any time.
+          </p>
+
+          <p>
+            This privacy notice covers most things related to GOV.UK accounts
+            but accounts need to collect and store some extra data to make them
+            work. Read the
+            <a
+              href="/government/publications/govuk-accounts-trial-full-privacy-notice-and-accessibility-statement"
+              >full GOV.UK accounts trial privacy notice</a
+            >
+            for more detail on how GOV.UK accounts store, process and share your
+            personal information.
+          </p>
+
+          <h2 id="contact-us-or-make-a-complaint">
+            Contact us or make a complaint
+          </h2>
+
+          <p>Contact the Privacy Team if you:</p>
+
+          <ul>
+            <li>have a question about anything in this privacy notice</li>
+            <li>
+              think that your personal data has been misused or mishandled
+            </li>
+          </ul>
+
+          <div class="contact">
+            <p>
+              Privacy Team<br />
+              <a href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk"
+                >gds-privacy-office@digital.cabinet-office.gov.uk</a
+              >
+            </p>
+          </div>
+
+          <p>
+            You can also contact our Data Protection Officer (<abbr
+              title="Data Protection Officer"
+              >DPO</abbr
+            >):
+          </p>
+
+          <div class="contact">
+            <p>
+              Data Protection Officer<br />
+              <a href="mailto:DPO@cabinetoffice.gov.uk"
+                >DPO@cabinetoffice.gov.uk</a
+              ><br />
+              Cabinet Office<br />
+              70 Whitehall<br />
+              London <br />
+              SW1A 2AS
+            </p>
+          </div>
+
+          <p>
+            The <abbr title="Data Protection Officer">DPO</abbr> provides
+            independent advice and monitoring of our use of personal
+            information.
+          </p>
+
+          <p>
+            You can also make a complaint to the Information Commissioner, who
+            is an independent regulator.
+          </p>
+
+          <div class="contact">
+            <p>
+              Information Commissioner<br />
+              <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br />
+              Telephone: 0303 123 1113<br />
+              Textphone: 01625 545860<br />
+              Monday to Friday, 9am to 4:30pm<br />
+              <a href="/call-charges">Find out about call charges</a>
+            </p>
+          </div>
+
+          <div class="address">
+            <div class="adr org fn">
+              <p>
+                Information Commissioner's Office
+                <br />Wycliffe House <br />Water Lane <br />Wilmslow
+                <br />Cheshire SK9 5AF
+                <br />
+              </p>
+            </div>
+          </div>
+
+          <h2 id="changes-to-this-policy">Changes to this policy</h2>
+
+          <p>
+            We may change this privacy policy. In that case, the ‘last updated’
+            date at the bottom of this page will also change. Any changes to
+            this privacy policy will apply to you and your data immediately.
+          </p>
+
+          <p>
+            If these changes affect how your personal data is processed,
+            <abbr title="Government Digital Service">GDS</abbr> will take
+            reasonable steps to let you know.
+          </p>
+        </div>
+
+        <div class="app-c-published-dates" lang="en">
+          Last updated 16 June 2021
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <div class="gem-c-contextual-sidebar">
+        <div class="gem-c-related-navigation">
+          <h2
+            id="related-nav-related_items-32869d6f"
+            class="gem-c-related-navigation__main-heading"
+            data-track-count="sidebarRelatedItemSection"
+          >
+            Related content
+          </h2>
+
+          <nav
+            role="navigation"
+            class="gem-c-related-navigation__nav-section"
+            aria-labelledby="related-nav-related_items-32869d6f"
+            data-module="gem-toggle"
+          >
+            <ul
+              class="gem-c-related-navigation__link-list"
+              data-module="gem-track-click"
+            >
+              <li class="gem-c-related-navigation__link">
+                <a
+                  class="
+                    govuk-link govuk-link
+                    gem-c-related-navigation__section-link
+                    govuk-link
+                    gem-c-related-navigation__section-link--sidebar
+                    govuk-link
+                    gem-c-related-navigation__section-link--other
+                  "
+                  data-track-category="relatedLinkClicked"
+                  data-track-action="1.1 Related content"
+                  data-track-label="/help/about-govuk"
+                  data-track-options='{"dimension28":"2","dimension29":"About GOV.UK"}'
+                  href="/help/about-govuk"
+                  >About GOV.UK</a
+                >
+              </li>
+              <li class="gem-c-related-navigation__link">
+                <a
+                  class="
+                    govuk-link govuk-link
+                    gem-c-related-navigation__section-link
+                    govuk-link
+                    gem-c-related-navigation__section-link--sidebar
+                    govuk-link
+                    gem-c-related-navigation__section-link--other
+                  "
+                  data-track-category="relatedLinkClicked"
+                  data-track-action="1.2 Related content"
+                  data-track-label="/help/terms-conditions"
+                  data-track-options='{"dimension28":"2","dimension29":"Terms and conditions"}'
+                  href="/help/terms-conditions"
+                  >Terms and conditions</a
+                >
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="gem-c-contextual-footer"></div>
+    </div>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
   get 'opensearch', to: 'pages#opensearch', constraints: { format: :xml }
   get 'terms', to: 'pages#terms'
   get 'cookies', to: 'pages#tariff_cookies', as: 'cookies'
+  get 'privacy', to: 'pages#privacy', as: 'privacy'
   post 'cookies', to: 'pages#update_cookies'
   post 'cookies_consent_accept', to: 'cookies_consent#accept_cookies'
   post 'cookies_consent_reject', to: 'cookies_consent#reject_cookies'

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -114,4 +114,11 @@ describe PagesController, 'GET to #opensearch', type: :controller do
       end
     end
   end
+
+  describe 'GET #privacy' do
+    subject(:response) { get :privacy }
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template('pages/privacy') }
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-764

### What?

I have added/removed/altered:

- [x] Privacy page. This page is a direct copy of the privacy page here: https://www.gov.uk/help/privacy-notice

### Why?

I am doing this because:

- This is a better placeholder than what we have currently and will be updated later/railsified
