### PR TITLE
Move declarable footnotes to separate tab

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -3,6 +3,10 @@ module CommoditiesHelper
     (@commodity || @heading).code
   end
 
+  def footnote_heading(declarable)
+    t('tabs.footnote.heading', goods_nomenclature_item_id: declarable.id, declarable_type: declarable.model_name.singular)
+  end
+
   def leaf_position(commodity)
     if commodity.last_child?
       ' last-child'

--- a/app/views/footnotes/_footnote.html.erb
+++ b/app/views/footnotes/_footnote.html.erb
@@ -1,4 +1,6 @@
-<tr class="govuk-table__row">
-  <th scope="row" class="govuk-table__header"><%= footnote.code %></th>
-  <td class="govuk-table__cell"><%= simple_format footnote.formatted_description %></td>
-</tr>
+<% if footnote&.code.present? %>
+  <tr class="govuk-table__row" >
+    <th scope="row" class="govuk-table__header"><%= footnote.code %></th>
+    <td class="govuk-table__cell"><%= simple_format footnote.formatted_description %></td>
+  </tr>
+<% end %>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -9,6 +9,9 @@
     <li class="govuk-tabs__list-item"s>
       <a class="govuk-tabs__tab" href="#export">Export</a>
     </li>
+    <li class="govuk-tabs__list-item"s>
+      <a class="govuk-tabs__tab" href="#footnotes">Footnotes</a>
+    </li>
   </ul>
 
   <!-- Overview tab -->
@@ -65,7 +68,6 @@
           </div>
         </div>
       </div>
-      <%= render 'headings/footnote', footnotes: declarable.footnotes %>
       <% if declarable.meursing_code? %>
         <h2 class="govuk-heading-m">This commodity has a meursing code</h2>
         <p>Use the <%= link_to "Look up Meursing code", "https://www.gov.uk/additional-commodity-code", rel: "external", target: "_blank", title: "Opens in a new window" %> tool to find the additional code required for importing and exporting. To calculate the duty rate, enter the meursing code (without the 7 at the start) into the <%= link_to "meursing calculator", declarable.meursing_tool_link_for(@search.date.to_taric_date), rel: "external", target: "_blank", title: "Opens in a new window" %>.</p>
@@ -144,6 +146,29 @@
     <%= render 'headings/footnote', footnotes: declarable.footnotes %>
   </div>
 
+  <!-- Footnotes tab -->
+  <div class="govuk-tabs__panel" id="footnotes">
+    <h2 class="govuk-heading-m"><%= footnote_heading(declarable) %></h2>
+    <table class="govuk-table govuk-!-margin-top-8">
+      <colgroup>
+        <col width="100">
+        <col width="*">
+      </colgroup>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Code</th>
+          <th scope="col" class="govuk-table__header">Description</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% declarable.footnotes.each do |footnote| %>
+          <% next unless footnote&.code.present? %>
+          <%= render footnote %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
   <!-- Footnote popups -->
   <div id="import-measure-references">
     <%= render partial: 'measures/measure_references', collection: declarable.import_measures.for_country(@search.country), as: 'measure' %>
@@ -155,5 +180,4 @@
   <div id="export-measure-references">
     <%= render partial: 'measures/measure_references', collection: declarable.export_measures.for_country(@search.country), as: 'measure' %>
   </div>
-
 </div>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -161,10 +161,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <% declarable.footnotes.each do |footnote| %>
-          <% next unless footnote&.code.present? %>
-          <%= render footnote %>
-        <% end %>
+        <%= render partial: 'footnotes/footnote', collection: declarable.footnotes %>
       </tbody>
     </table>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,9 @@ en:
     uk: "UK Global Online Tariff"
     xi: "Northern Ireland Online Tariff"
 
+  tabs:
+    footnote:
+      heading: Footnotes for %{declarable_type} %{goods_nomenclature_item_id}
   breadcrumb:
     home: Home
     privacy: Privacy Notice

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -12,22 +12,22 @@ FactoryBot.define do
   end
 
   factory :chapter do
-    section
+    section { attributes_for(:section) }
     description { Forgery(:basic).text }
     goods_nomenclature_item_id { '0100000000' }
     formatted_description { Forgery(:basic).text }
   end
 
   factory :heading do
-    chapter
+    chapter { attributes_for(:chapter) }
     description { Forgery(:basic).text }
     formatted_description { Forgery(:basic).text }
     goods_nomenclature_item_id { '0101000000' }
   end
 
   factory :commodity do
-    heading
-    section
+    heading { attributes_for(:heading) }
+    section { attributes_for(:section) }
     description { Forgery(:basic).text }
     formatted_description { Forgery(:basic).text }
     goods_nomenclature_item_id { '0101300000' }

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -26,4 +26,26 @@ describe CommoditiesHelper, type: :helper do
       end
     end
   end
+
+  describe '#footnote_heading' do
+    context 'when a heading is passed' do
+      let(:declarable) { HeadingPresenter.new(build(:heading)) }
+
+      it 'returns the correct footnote heading' do
+        expect(helper.footnote_heading(declarable)).to eq(
+          'Footnotes for heading 0101000000',
+        )
+      end
+    end
+
+    context 'when a commodity is passed' do
+      let(:declarable) { CommodityPresenter.new(build(:commodity)) }
+
+      it 'returns the correct footnote heading' do
+        expect(helper.footnote_heading(declarable)).to eq(
+          'Footnotes for commodity 0101300000',
+        )
+      end
+    end
+  end
 end

--- a/spec/views/measures/_measure.html.erb_spec.rb
+++ b/spec/views/measures/_measure.html.erb_spec.rb
@@ -9,7 +9,7 @@ describe 'measures/_measure.html.erb', type: :view do
   end
 
   before do
-    render 'measures/measure.html.erb', measure: MeasurePresenter.new(measure)
+    render 'measures/measure', measure: MeasurePresenter.new(measure)
   end
 
   context 'with formatted_base' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-741

### What?

I have added/removed/altered:

- [x] Adds footnote heading helper
- [x] Fixes broken factories
- [x] Moves footnotes to their own tab

**Commodity**

![Screenshot from 2021-06-18 13-50-47](https://user-images.githubusercontent.com/8156884/122565045-ef38ed80-d03d-11eb-8d04-067f27f79d4d.png)

**Heading**

![Screenshot from 2021-06-18 13-51-43](https://user-images.githubusercontent.com/8156884/122565036-ee07c080-d03d-11eb-8ff1-f45cc66133e4.png)



### Why?

I am doing this because:

- This is a business requirement and is part of moving towards removing the unliked overview tab
