### PR TITLE
Remove the footnotes from Import/Export tabs as well

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -99,8 +99,6 @@
     <% else %>
       <p>There are no import measures for this commodity on this date.</p>
     <% end %>
-
-    <%= render 'headings/footnote', footnotes: declarable.footnotes %>
   </div>
 
   <!-- Export tab -->
@@ -143,7 +141,6 @@
     <% else %>
       <p>There are no export measures for this commodity on this date.</p>
     <% end %>
-    <%= render 'headings/footnote', footnotes: declarable.footnotes %>
   </div>
 
   <!-- Footnotes tab -->


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [ ] Remove the footnotes from Import/Export tabs as well

### Why?

I am doing this because:

- Since we moved the footnotes to its own tab it doesn't make sense to have them on any other tabs