### PR TITLE
HOTT-785: steel safeguards banner for UK site

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -41,9 +41,16 @@ module ServiceHelper
           tag.p do
             banner_copy
           end
-        end
+        end +
+        steel_safeguards
       end
     end
+  end
+
+  def steel_safeguards
+    return t("service_banner.steel_safeguards").html_safe if uk_service_choice? && request.filtered_path == sections_path
+
+    ''
   end
 
   def search_label_text

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -48,7 +48,7 @@ module ServiceHelper
   end
 
   def steel_safeguards
-    return t("service_banner.steel_safeguards").html_safe if uk_service_choice? && request.filtered_path == sections_path
+    return t("service_banner.steel_safeguards_html").html_safe if uk_service_choice? && request.filtered_path == sections_path
 
     ''
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
     big:
       uk: From 1 January 2021, if you’re bringing goods into Northern Ireland from outside the UK and the EU, you will pay the UK duty rate <a href="https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu-from-1-january-2021" class="govuk-link">if your goods are not ‘at risk’ of onward movement to the EU</a>. If they are at risk of onward movement to the EU, use the %{link}.
       xi: From 1 January 2021, if you’re bringing goods into Northern Ireland from outside the UK and the EU, you will pay the UK duty rate <a href="https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu-from-1-january-2021" class="govuk-link">if your goods are not ‘at risk’ of onward movement to the EU</a>. If they are not at risk of onward movement to the EU, use the %{link}.
-    steel_safeguards: >- # Temporary warning regarding the steel safeguards
+    steel_safeguards_html: >- # Temporary warning regarding the steel safeguards
       <div class="govuk-warning-text govuk-!-margin-bottom-0 govuk-!-margin-top-6 govuk-!-padding-top-0">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,7 +11,7 @@ en:
     uk:
       import: UK Global Tariff imports from
       export: UK Global Tariff exports to
-    xi: 
+    xi:
       import: <abbr title="Northern Ireland">NI</abbr> imports from
       export: <abbr title="Northern Ireland">NI</abbr> exports to
   measures_heading:
@@ -69,3 +69,24 @@ en:
     big:
       uk: From 1 January 2021, if you’re bringing goods into Northern Ireland from outside the UK and the EU, you will pay the UK duty rate <a href="https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu-from-1-january-2021" class="govuk-link">if your goods are not ‘at risk’ of onward movement to the EU</a>. If they are at risk of onward movement to the EU, use the %{link}.
       xi: From 1 January 2021, if you’re bringing goods into Northern Ireland from outside the UK and the EU, you will pay the UK duty rate <a href="https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu-from-1-january-2021" class="govuk-link">if your goods are not ‘at risk’ of onward movement to the EU</a>. If they are not at risk of onward movement to the EU, use the %{link}.
+    steel_safeguards: >- # Temporary warning regarding the steel safeguards
+      <div class="govuk-warning-text govuk-!-margin-bottom-0 govuk-!-margin-top-6 govuk-!-padding-top-0">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          <p>
+            <strong>The Trade Remedies Authority has published its final recommendation to the Secretary of State for International Trade on the future of the UK’s steel safeguard measure. The recommendation comes into force on 1st July 2021. We are working to update the data on this service.</strong>
+          </p>
+          <p></p>
+          <p>For additional information, see:</p>
+          <ul class="govuk-list">
+            <li>
+              <a target="_blank" href="https://www.gov.uk/government/publications/trade-remedies-notice-safeguard-measures-on-certain-steel-products-application-of-tariff-rate-quotas">Trade remedies notice: safeguard measures on certain steel products – application of tariff rate quotas (opens in new window)</a>
+            </li>
+            <li>
+              <a target="_blank" href="https://questions-statements.parliament.uk/written-statements/detail/2021-06-30/hcws136">Statement made on 30 June 2021 by the Secretary of State for International Trade (opens in new window)</a>
+            </li>
+          </ul>
+        </strong>
+      </div>
+


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-785

### What?

I have added/removed/altered:

- [ ] Add steel safeguards banner for UK site and sections pages only

### Why?

I am doing this because:

UK government has made a decision on 30th June for implementation of steel safeguards. This has involved the creation of new steel safeguard quotas.

Notice of this was only given on 30th June and needs to be implemented the next day.

It takes a lot of time to create this data, so there is a need to put a temporary banner up while the data is loaded.

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Screenshots:

#### UK sections

<img width="1206" alt="Screen Shot 2021-07-01 at 09 34 02" src="https://user-images.githubusercontent.com/2742327/124093276-9b6fd080-da4f-11eb-93c1-597ad57ccd81.png">

#### XI sections

<img width="1250" alt="Screen Shot 2021-07-01 at 09 34 14" src="https://user-images.githubusercontent.com/2742327/124093303-a296de80-da4f-11eb-8394-55ce3d19600f.png">

#### UK other than section (example)

<img width="1228" alt="Screen Shot 2021-07-01 at 09 34 26" src="https://user-images.githubusercontent.com/2742327/124093333-acb8dd00-da4f-11eb-8832-716fb079d80d.png">
