### PR TITLE
HOTT-790: Change the date selection to govuk date fields

### DIFF
--- a/app/views/shared/_search_date_picker.html.erb
+++ b/app/views/shared/_search_date_picker.html.erb
@@ -1,29 +1,51 @@
-<fieldset class="govuk-fieldset js-date-picker datepicker date-picker govuk-!-font-size-16 govuk-form-group inline"  aria-live="polite">
-  <span class="fields">This tariff is for
-    <label class="govuk-visually-hidden" for="tariff_date_date">Date</label>
-    <span class="js-search-date js-show">
-      <%= text_field_tag(:date, @search.date.strftime("%d/%m/%Y"), { id: 'tariff_date_date', name: 'date', class: "govuk-input" }) %>
-      <button id="search-datepicker-button">
-        <svg height="1em" viewBox="0 0 1792 1792" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M192 1664h288v-288h-288v288zm352 0h320v-288h-320v288zm-352-352h288v-320h-288v320zm352 0h320v-320h-320v320zm-352-384h288v-288h-288v288zm736 736h320v-288h-320v288zm-384-736h320v-288h-320v288zm768 736h288v-288h-288v288zm-384-352h320v-320h-320v320zm-352-864v-288q0-13-9.5-22.5t-22.5-9.5h-64q-13 0-22.5 9.5t-9.5 22.5v288q0 13 9.5 22.5t22.5 9.5h64q13 0 22.5-9.5t9.5-22.5zm736 864h288v-320h-288v320zm-384-384h320v-288h-320v288zm384 0h288v-288h-288v288zm32-480v-288q0-13-9.5-22.5t-22.5-9.5h-64q-13 0-22.5 9.5t-9.5 22.5v288q0 13 9.5 22.5t22.5 9.5h64q13 0 22.5-9.5t9.5-22.5zm384-64v1280q0 52-38 90t-90 38h-1408q-52 0-90-38t-38-90v-1280q0-52 38-90t90-38h128v-96q0-66 47-113t113-47h64q66 0 113 47t47 113v96h384v-96q0-66 47-113t113-47h64q66 0 113 47t47 113v96h128q52 0 90 38t38 90z"/></svg>
-      </button>
-      <%= render "shared/datepicker_dialog" %>
-    </span>
-    <span class="no-js-search-date">
-      <label class="govuk-visually-hidden" for="tariff_date_day">Day</label>
-      <%= text_field_tag(:day, @search.date.day, { id: 'tariff_date_day', name: 'day', class: "govuk-input govuk-input--width-2", maxlength: 2, placeholder: "DD" }) %>
-      <label class="govuk-visually-hidden" for="tariff_date_month">Month</label>
-      <%= text_field_tag(:month, @search.date.month, { id: 'tariff_date_month', name: 'month', class: "govuk-input govuk-input--width-2", maxlength: 2, placeholder: "MM" }) %>
-      <label class="govuk-visually-hidden" for="tariff_date_year">Year</label>
-      <%= text_field_tag(:year, @search.date.year, { id: 'tariff_date_year', name: 'year', class: "govuk-input govuk-input--width-4", maxlength: 4, placeholder: "YYYY" }) %>&emsp;
-    </span>
-
-    <noscript>
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset js-date-picker datepicker date-picker govuk-!-font-size-16 govuk-form-group inline"  aria-live="polite">
+    <span class="fields">This tariff is for
+      <label class="govuk-visually-hidden" for="tariff_date_date">Date</label>
+      <label class="govuk-visually-hidden govuk-label govuk-date-input__label" for="tariff_date_day">Day</label>
+      <%= text_field_tag(:day,
+                         @search.date.day,
+                         {
+                           id: 'tariff_date_day',
+                           name: 'day',
+                           class: "govuk-input govuk-date-input__input govuk-input--width-2",
+                           maxlength: 2,
+                           placeholder: "DD",
+                           pattern: "[0-9]*",
+                           inputmode: :numeric
+                         }
+                        ) %>
+      <label class="govuk-visually-hidden govuk-label govuk-date-input__label" for="tariff_date_month">Month</label>
+      <%= text_field_tag(:month,
+                         @search.date.month,
+                         {
+                           id: 'tariff_date_month',
+                           name: 'month',
+                           class: "govuk-input govuk-date-input__input govuk-input--width-2",
+                           maxlength: 2,
+                           placeholder: "MM",
+                           pattern: "[0-9]*",
+                           inputmode: :numeric
+                         }
+                        ) %>
+      <label class="govuk-visually-hidden govuk-label govuk-date-input__label" for="tariff_date_year">Year</label>
+      <%= text_field_tag(:year,
+                         @search.date.year,
+                         {
+                           id: 'tariff_date_year',
+                           name: 'year',
+                           class: "govuk-input govuk-date-input__input govuk-input--width-4",
+                           maxlength: 4,
+                           placeholder: "YYYY",
+                           pattern: "[0-9]*",
+                           inputmode: :numeric
+                         }
+                        ) %>&emsp;
       <button class="govuk-button" type="submit">Set date</button>
-    </noscript>
-    <a class="submit js-show" role="button" href="#" title="set date" rel="nofollow">Set date</a>&emsp;
-  </span>
-  <span class="text <%= @section_css %> js-show">
-    This tariff is for <%= @search.date.to_formatted_s(:long) %>&emsp;
-    <a href="#" title="change date" role="button">Change date</a>&emsp;
-  </span>
-</fieldset>
+    </span>
+    <span class="text <%= @section_css %> js-show">
+      This tariff is for <%= @search.date.to_formatted_s(:long) %>&emsp;
+      <a href="#" title="change date" role="button">Change date</a>&emsp;
+    </span>
+  </fieldset>
+</div>

--- a/spec/features/date_currency_change_spec.rb
+++ b/spec/features/date_currency_change_spec.rb
@@ -24,7 +24,7 @@ describe 'Date & Currency change', js: true, vcr: {
     page.execute_script("$('#tariff_date_year').val('2018')")
     page.execute_script("$('#tariff_date_month').val('12')")
 
-    click_link 'Set date'
+    click_button 'Set date'
 
     expect(page).to have_content 'This tariff is for 1 December 2018'
     expect(page).to have_content 'Change date'
@@ -43,7 +43,7 @@ describe 'Date & Currency change', js: true, vcr: {
       page.execute_script("$('#tariff_date_month').val('#{searched_for_date.month}')")
       page.execute_script("$('#tariff_date_day').val('#{searched_for_date.day}')")
 
-      click_link 'Set date'
+      click_button 'Set date'
 
       expect(page).to have_content "This tariff is for #{searched_for_date.strftime('%-d %B %Y')}"
     end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-790

### What?

I have added/removed/altered:

- [ ] Change the date selection to govuk date fields
- [ ] Change the relevant specs to fit the new setup

### Why?

I am doing this because the currently existing non-Gov.UK date picker is not accessible.

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes
