### PR TITLE
HOTT-329: add date to country picker

### DIFF
--- a/app/views/shared/_country_picker.erb
+++ b/app/views/shared/_country_picker.erb
@@ -1,6 +1,9 @@
 <%= form_for controller, method: :post, url: url, namespace: anchor do |f| %>
   <fieldset class="govuk-fieldset country-picker js-country-picker box govuk-!-font-size-16">
     <div class="country-picker-container">
+      <%= f.hidden_field :day, value: @search.date.day %>
+      <%= f.hidden_field :month, value: @search.date.month %>
+      <%= f.hidden_field :year, value: @search.date.year %>
       <%= f.hidden_field :anchor, value: anchor %>
       <%= f.label :country, country_picker_text(tab: anchor), class: 'govuk-label' %>
       <%= f.select :country, f.object.countries.map{ |c| [c.long_description, c.id] }, { include_blank: 'All countries' }, class: 'custom-select js-country-picker-select', "aria-label": "Filter #{anchor.titleize} measures by country" %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-329

### What?

I have added/removed/altered:

- [ ] Add hidden date fields in the 'change country' form, so that the 

### Why?

I am doing this because currently the date change is not persisted on URL once country is selected for Import/Export

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

