### PR TITLE
Removes redundant sections of help page

### DIFF
--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -257,16 +257,6 @@
             </p>
           </div>
 
-          <div id="RVC">
-            <h3 class="govuk-heading-s" id="Regional Value Content (RVC)">Regional Value Content (RVC)</h3>
-            <p class='govuk-body'>
-              For a minority of goods, a specific rule of origin will require the good to meet an additional requirement to qualify as originating.  Usually, this additional requirement tests the good's regional value content (RVC), which requires that a certain percentage of the good’s value originates in an FTA country.</p>
-            <p class='govuk-body'>
-              For example, some rules may specify that a good must have at least a 35% RVC based on the build-up method.  To qualify for originating status under the FTA, therefore, importers have to demonstrate that at least 35% of the good’s value originated in the territory of the other party as determined using the build-up method. If a rule requires an HS classification change and an RVC test, the good has to meet both of these requirements to be an originating good.</p>
-            <p class='govuk-body'>
-              <a href="/roo/rvc">How to calculate Regional Value Content</a></p>
-          </div>
-
           <div id="MaxNOM">
             <h3 class="govuk-heading-s" id="Maximum value of non-originating materials (MaxNOM)">Maximum value of non-originating materials (MaxNOM)</h3>
             <p class='govuk-body'>"MaxNOM" means the maximum value of non-originating materials expressed as a percentage and shall be calculated according to the following formula:</p>
@@ -288,16 +278,6 @@
             <p class='govuk-body'>"FOB" or "Free on Board" means:</p>
             <p class='govuk-body'>Free on board indicates whether the seller or the buyer is liable for goods that are damaged or destroyed during shipping. When used with an identified physical location, the designation determines which party has responsibility for the payment of the freight charges and at what point title for the shipment passes from the seller to the buyer.</p>
             <p class='govuk-body'>In international shipping, for example, “FOB [name of originating port]” means that the seller (consignor) is responsible for transportation of the goods to the port of shipment and the cost of loading. The buyer (consignee) pays the costs of ocean freight, insurance, unloading, and transportation from the arrival port to the final destination. The seller passes the risk to the buyer when the goods are loaded at the originating port.</p>
-          </div>
-
-          <div id="sub-heading">
-            <h3 class="govuk-heading-s" id="Subheading">Subheading</h3>
-            <p class='govuk-body'>Some words about subheadings</p>
-          </div>
-
-          <div id="heading">
-            <h3 class="govuk-heading-s" id="Heading">Heading</h3>
-            <p class='govuk-body'>Some words about headings</p>
           </div>
 
           <div id="Accumulation">


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removes broken regional value content section
- [x] Removes unpopulated heading and subheading glossary items

### Why?

I am doing this because:

- These aren't quite complete and so have been removed
