### PR TITLE
HOTT-805: On first accessing quota search, please hide the error message

### DIFF
--- a/app/presenters/quota_search_presenter.rb
+++ b/app/presenters/quota_search_presenter.rb
@@ -4,7 +4,7 @@ class QuotaSearchPresenter
   def initialize(search_form)
     @with_errors = false
     @search_form = search_form
-    @search_result = OrderNumber::Definition.search(search_form.to_params) if search_form.present?
+    @search_result = search_form.present? ? OrderNumber::Definition.search(search_form.to_params) : []
     @search_result.reject! { |result| result.instance_of?(OrderNumber::Definition) && result.quota_definition_sid.negative? }
   rescue StandardError
     @with_errors = true


### PR DESCRIPTION
On first accessing quota search, please hide the error message "Sorry, there is a problem with the search query. Please specify one or more search criteria"

### Jira link

https://transformuk.atlassian.net/browse/HOTT-805

### What?

I have added/removed/altered:

- [ ] Add a guard in the presenter, so that the following line won't try `reject!` on nil, and the search result will be an array in any case

### Why?

I am doing this because when a search is not provided, the app tries to run a `reject!` on a nil object, and errors.

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes
