### PR TITLE
HOTT-615: restore footnotes link

### DIFF
--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -39,6 +39,12 @@
       </li>
       <li>
         <p>
+          <%= link_to t('breadcrumb.footnotes'), footnote_search_path %>
+          <br>Search the tariff for footnotes
+        </p>
+      </li>
+      <li>
+        <p>
           <%= link_to t('breadcrumb.chemicals'), chemical_search_path %>
           <br>Search the tariff for chemicals by <abbr title="Chemical Abstracts Service">CAS</abbr> Registry Number (RN)
         </p>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-615

### What?

I have added/removed/altered:

- [ ] Restore the link to the footnote search tool in the tools page

### Why?

I am doing this because DIT has said that they use it and want it back.

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Screenshots

#### UK version

<img width="955" alt="Screen Shot 2021-07-16 at 16 18 10" src="https://user-images.githubusercontent.com/2742327/125970725-efb0b5b4-3d1a-43f6-995b-460ebeb1f025.png">

#### XI version

<img width="963" alt="Screen Shot 2021-07-16 at 16 17 58" src="https://user-images.githubusercontent.com/2742327/125970757-82169d2d-9807-4d37-a9c6-aafe096c89f9.png">
