### PR TITLE
Stop using Hashie to be defensive of our own api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'rails', '~> 6'
 gem 'addressable', '~> 2.8'
 gem 'faraday', '= 1.3.0' # TODO: Debug issue with newer versions of Faraday client under high loads
 gem 'faraday_middleware', '~> 1'
-gem 'hashie', '~> 3.4'
 gem 'multi_json', '~> 1.11'
 gem 'routing-filter', github: 'svenfuchs/routing-filter'
 gem 'yajl-ruby', '~> 1.3.1', require: 'yajl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,6 @@ GEM
       rouge
       sprockets (< 4)
     hashdiff (1.0.1)
-    hashie (3.6.0)
     htmlentities (4.3.4)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -436,7 +435,6 @@ DEPENDENCIES
   faraday_middleware (~> 1)
   forgery
   govspeak (~> 6)
-  hashie (~> 3.4)
   kaminari (~> 1.0)
   letter_opener
   lograge

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -1,9 +1,6 @@
 require 'api_entity'
 
 class Change
-  class Record < Hashie::Mash
-  end
-
   include ApiEntity
   extend  ActiveModel::Naming
 
@@ -14,7 +11,7 @@ class Change
   end
 
   def record=(record_attributes)
-    @record = record_class.new(record_attributes)
+    @record = model_name.constantize.new(record_attributes)
   end
 
   def operation_date=(operation_date)
@@ -23,13 +20,5 @@ class Change
 
   def change_url(_changeable)
     '/'
-  end
-
-  private
-
-  def record_class
-    model_name.constantize # if change has relevant model, e.g. Measure
-  rescue NameError # if change has no relevant model revert to Hashie
-    Change::Record
   end
 end

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -5,6 +5,7 @@ require 'tariff_jsonapi_parser'
 
 module ApiEntity
   class NotFound < StandardError; end
+
   class Error < StandardError; end
 
   extend ActiveSupport::Concern
@@ -100,7 +101,7 @@ module ApiEntity
     def find(id, opts = {})
       retries = 0
       begin
-        resp = api.get("/#{self.name.pluralize.parameterize}/#{id}", opts)
+        resp = api.get("/#{name.pluralize.parameterize}/#{id}", opts)
         case resp.status
         when 404
           raise ApiEntity::NotFound
@@ -126,7 +127,7 @@ module ApiEntity
 
       attr_accessor association.to_sym
 
-      class_eval <<-METHODS
+      class_eval <<-METHODS, __FILE__, __LINE__ + 1
         def #{association}=(data)
           data ||= {}
 
@@ -138,7 +139,7 @@ module ApiEntity
     def has_many(associations, opts = {})
       options = opts.reverse_merge(class_name: associations.to_s.singularize.classify, wrapper: Array)
 
-      class_eval <<-METHODS
+      class_eval <<-METHODS, __FILE__, __LINE__ + 1
         def #{associations}
           #{options[:wrapper]}.new(@#{associations}.presence || [])
         end
@@ -161,7 +162,7 @@ module ApiEntity
     def paginate_collection(collection, pagination)
       Kaminari.paginate_array(
         collection,
-        total_count: pagination['total_count']
+        total_count: pagination['total_count'],
       ).page(pagination['page']).per(pagination['per_page'])
     end
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] We use Hashie::Mash to create a flexible struct. Remove this

### Why?

I am doing this because:

- We are in control of our own api and what it returns
