### PR TITLE
Removes unused exchange rates public endpoint

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -29,7 +29,6 @@ module TradeTariffFrontend
       chapters
       headings
       commodities
-      exchange_rates
       monetary_exchange_rates
       quotas
       goods_nomenclatures


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-855

### What?

I have added/removed/altered:

- [x] Removes the monetary exchange rate api from the list of whitelisted endpoints

### Why?

I am doing this because:

- This has been removed
