### PR TITLE
HOTT-865 Corrected the govuk page width variables value

### DIFF
--- a/app/views/layouts/_cookies_consent.html.erb
+++ b/app/views/layouts/_cookies_consent.html.erb
@@ -1,6 +1,6 @@
 <% unless cookies_policy.persisted? %>
   <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on the Online Tariff">
-    <div class="govuk-cookie-banner__message tariff service govuk-width-container">
+    <div class="govuk-cookie-banner__message govuk-width-container">
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -35,16 +35,16 @@
 <% end %>
 <% unless cookies[:cookies_preferences_set] %>
   <% if cookies_policy.usage? %>
-    <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on HMRC services">
-      <div class="govuk-cookie-banner__message tariff service govuk-width-container" id="cookies_accepted">
+    <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on the Online Tariff">
+      <div class="govuk-cookie-banner__message govuk-width-container" id="cookies_accepted">
         <p>You have accepted additional cookies. You can <%= link_to "change your cookie
           settings", cookies_policy_path %> at any time.</p>
         <%= button_to "Hide this message", cookies_hide_confirmation_path, class: 'govuk-button hide_cookie_panel' %>
       </div>
     </div>
   <% elsif cookies_policy.usage == 'false' %>
-    <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on HMRC services">
-      <div class="govuk-cookie-banner__message tariff service govuk-width-container" id="cookies_rejected">
+    <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on the Online Tariff">
+      <div class="govuk-cookie-banner__message govuk-width-container" id="cookies_rejected">
         <p>You have rejected additional cookies. You can <%= link_to "change your cookie
           settings", cookies_policy_path %> at any time.</p>
         <%= button_to "Hide this message", cookies_hide_confirmation_path, class: 'govuk-button hide_cookie_panel' %>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -1,6 +1,7 @@
 
 $govuk-global-styles: true;
 $govuk-use-legacy-palette: false;
+$govuk-page-width: 1140px;
 $govuk-fonts-path: "~govuk-frontend/govuk/assets/fonts/";
 $govuk-images-path: "~govuk-frontend/govuk/assets/images/";
 


### PR DESCRIPTION
Before:

The GovUK page width is left as the default, we then add classes to elements with govuk-width-container to 'correct' the width

After:

setting `govuk-width-container` will render the page as 1140px wide was already the case when the class override is applied

### Jira link

https://transformuk.atlassian.net/browse/HOTT-859

### What?

I have added/removed/altered:

- [x] Change the govuk page width variable to reflect our actual page width

### Why?

Whilst working on the layout issue for HOTT-859 (cookies banner) - I found there was a lot of historical commits trying to resolve alignment issues with the original implementation. I believe these were because the `govuk-width-container` class actually sets an the width to be too narrow - this needs to be corrected by also adding `tariff` and `service` css classes.

This is an easy requirement to miss and it would make more sense to change the width returned in the govuk-width-container class as suggested in the v3.4.0 release notes - https://github.com/alphagov/govuk-frontend/releases/tag/v3.4.0

I am doing this because:

- it resolves scenarios where the page header is narrower than the page body

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- This is a change affecting all pages - its split out as a separate PR/commit so that if there are unintended consequences it can be easily reverted

### Before

Note the inconsistent widths between the cookie banner, header bar and page content

![Screenshot from 2021-07-26 17-08-30](https://user-images.githubusercontent.com/10818/127022345-b71edcfe-a943-452f-b479-2dfc53e9fadf.png)

### After

![Screenshot from 2021-07-26 16-57-27](https://user-images.githubusercontent.com/10818/127022263-8b45860a-3556-4d7d-a46d-b80995b9b32d.png)
