### PR TITLE
Removes unused next/prev links on declarable view

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -9,7 +9,6 @@ class CommoditiesController < GoodsNomenclaturesController
     @chapter = commodity.chapter
     @section = commodity.section
     @back_path = request.referer || heading_path(@heading.short_code)
-    commodity.prev, commodity.next = set_prev_next(commodity)
   end
 
   private
@@ -17,18 +16,6 @@ class CommoditiesController < GoodsNomenclaturesController
   def commodities_by_code
     search_term = Regexp.escape(params[:term].to_s)
     Commodity.by_code(search_term).sort_by(&:code)
-  end
-
-  def set_prev_next(commodity)
-    gnids = Heading.find(commodity.heading.short_code, query_params)
-                   .commodities.select(&:leaf?)
-                   .map(&:goods_nomenclature_item_id)
-    return [nil, nil] unless i = gnids.index(commodity.goods_nomenclature_item_id)
-
-    [
-      i == 0 ? nil : Commodity.find(gnids[i-1]),
-      i == (gnids.length - 1) ? nil : Commodity.find(gnids[i+1])
-    ]
   end
 
   def fetch_commodity

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -6,7 +6,7 @@ class Commodity < GoodsNomenclature
 
   collection_path '/commodities'
 
-  attr_accessor :parent_sid, :prev, :next
+  attr_accessor :parent_sid
 
   has_one :heading
   # vat_measure is used for commodities under the heading only

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -4,33 +4,5 @@
 <% end %>
 
 <% content_for :bodyClasses, "page--wide" %>
-<% content_for :commodity_pagination do %>
-  <nav class="commodity-pagination" aria-label="Navigation between commodities">
-    <ul>
-      <% if @commodity.prev.present? %>
-        <li class="previous">
-          <%= link_to commodity_url(@commodity.prev) do %>
-            Previous commodity<span class="govuk-visually-hidden">: </span>
-            <span class="commodity-pagination__name">
-              <%= @commodity.prev.description_plain %>
-            </span>
-            <span class="govuk-visually-hidden">(code <%= @commodity.prev.goods_nomenclature_item_id %>)</span>
-          <% end %>
-        </li>
-      <% end %>
-      <% if @commodity.next.present? %>
-        <li class="next">
-          <%= link_to commodity_url(@commodity.next) do %>
-            Next commodity<span class="govuk-visually-hidden">: </span>
-            <span class="commodity-pagination__name">
-              <%= @commodity.next.description_plain %>
-            </span>
-            <span class="govuk-visually-hidden">(code <%= @commodity.next.goods_nomenclature_item_id %>)</span>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
-  </nav>
-<% end %>
 
 <%= render 'declarables/declarable', declarable: @commodity, xi_declarable: xi_commodity, uk_declarable: uk_commodity  %>

--- a/app/views/shared/_tariff_breadcrumbs.html.erb
+++ b/app/views/shared/_tariff_breadcrumbs.html.erb
@@ -19,13 +19,4 @@ declarable ||= false %>
       <%= render partial: 'shared/tariff_breadcrumbs/section', locals: { section: section } %>
     <% end %>
   </nav>
-
-  <% if declarable && declarable.is_a?(Commodity) %>
-    <div style="margin-top: 4rem;">
-      <%= link_to "&larr;&nbsp;Previous commodity".html_safe, commodity_path(declarable.prev, request.query_parameters.symbolize_keys) if declarable.prev %>
-      <span style="float: right">
-        <%= link_to "Next commodity&nbsp;&rarr;".html_safe, commodity_path(declarable.next, request.query_parameters.symbolize_keys) if declarable.next %>
-      </span>
-    </div>
-  <% end %>
 </div>


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

The previous and next links on a commodity were added to go forwards and backwards between siblings in the commodity tree. This isn't helpful for users and wasn't actually asked for by HMRC so after a discussion with the team we've agreed to remove these links.

- [x] Removes unused prev/next on the declarable show page

### Why?

I am doing this because:

- This is unused
