### PR TITLE
HOTT-788 - Move country selector out of tabs

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -92,14 +92,7 @@ class SearchController < ApplicationController
   private
 
   def anchor
-    if params.dig(:search, :anchor).present?
-      if params[:search][:anchor] == 'import'
-        '#import'
-      else
-        '#export'
-      end
-    else
-      ''
-    end
+    safe_anchor = params.dig(:search, :anchor).to_s.gsub(/[^a-z]/, '')
+    safe_anchor.present? ? "##{safe_anchor}" : ''
   end
 end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -54,8 +54,8 @@ module ServiceHelper
     t("measures_heading.#{service_choice}.#{tab}").html_safe
   end
 
-  def country_picker_text(tab: 'import')
-    t("country_picker.#{service_choice}.#{tab}").html_safe
+  def country_picker_text
+    t("country_picker.#{service_choice}_html")
   end
 
   def service_choice

--- a/app/views/declarables/_declarable.html.erb
+++ b/app/views/declarables/_declarable.html.erb
@@ -2,5 +2,6 @@
 
 <article class="tariff commodity">
   <%= render 'shared/tariff_breadcrumbs', declarable: declarable %>
+  <%= render partial: 'shared/country_picker', locals: { controller: @search, url: perform_search_path } %>
   <%= render 'measures/measures', declarable: declarable, uk_declarable: uk_declarable, xi_declarable: xi_declarable %>
 </article>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -85,7 +85,6 @@
     <h2 class="govuk-heading-m"><%= measures_heading(tab: 'import') %></h2>
     <%= render partial: 'declarables/consigned', locals: { declarable: declarable } %>
     <%= render partial: 'declarables/filtered', locals: { search: @search } %>
-    <%= render partial: 'shared/country_picker', locals: { controller: @search, url: perform_search_path, anchor: 'import' } %>
 
     <% if declarable.import_measures.for_country(@search.country).any? %>
       <%= render partial: 'measures/grouped/navigation', locals: { uk_declarable: uk_declarable, xi_declarable: xi_declarable } %>
@@ -106,7 +105,6 @@
     <h2 class="govuk-heading-m"><%= measures_heading(tab: 'export') %></h2>
     <%= render partial: 'declarables/consigned', locals: { declarable: declarable } %>
     <%= render partial: 'declarables/filtered', locals: { search: @search } %>
-    <%= render partial: 'shared/country_picker', locals: { controller: @search, url: perform_search_path, anchor: 'export' } %>
 
     <% if declarable.export_measures.for_country(@search.country).any? %>
 

--- a/app/views/shared/_country_picker.erb
+++ b/app/views/shared/_country_picker.erb
@@ -1,12 +1,11 @@
-<%= form_for controller, method: :post, url: url, namespace: anchor do |f| %>
+<%= form_for controller, method: :post, url: url do |f| %>
   <fieldset class="govuk-fieldset country-picker js-country-picker box govuk-!-font-size-16">
     <div class="country-picker-container">
       <%= f.hidden_field :day, value: @search.date.day %>
       <%= f.hidden_field :month, value: @search.date.month %>
       <%= f.hidden_field :year, value: @search.date.year %>
-      <%= f.hidden_field :anchor, value: anchor %>
-      <%= f.label :country, country_picker_text(tab: anchor), class: 'govuk-label' %>
-      <%= f.select :country, f.object.countries.map{ |c| [c.long_description, c.id] }, { include_blank: 'All countries' }, class: 'custom-select js-country-picker-select', "aria-label": "Filter #{anchor.titleize} measures by country" %>
+      <%= f.label :country, country_picker_text, class: 'govuk-label' %>
+      <%= f.select :country, f.object.countries.map{ |c| [c.long_description, c.id] }, { include_blank: 'All countries' }, class: 'custom-select js-country-picker-select', "aria-label": "Filter measures by country" %>
       <a class="reset-country-picker" href="#" title="Reset country picker" role="button">Reset<span class="long-text">&nbsp;to all countries</span></a>
     </div>
     <%= f.button 'Set country', class: 'button search-submit' %>

--- a/app/views/shared/_country_picker.erb
+++ b/app/views/shared/_country_picker.erb
@@ -4,10 +4,11 @@
       <%= f.hidden_field :day, value: @search.date.day %>
       <%= f.hidden_field :month, value: @search.date.month %>
       <%= f.hidden_field :year, value: @search.date.year %>
+      <%= f.hidden_field :anchor, value: nil %>
       <%= f.label :country, country_picker_text, class: 'govuk-label' %>
       <%= f.select :country, f.object.countries.map{ |c| [c.long_description, c.id] }, { include_blank: 'All countries' }, class: 'custom-select js-country-picker-select', "aria-label": "Filter measures by country" %>
       <a class="reset-country-picker" href="#" title="Reset country picker" role="button">Reset<span class="long-text">&nbsp;to all countries</span></a>
     </div>
-    <%= f.button 'Set country', class: 'button search-submit' %>
+    <%= f.button 'Set country', class: 'button search-submit govuk-button' %>
   </fieldset>
 <% end %>

--- a/app/webpacker/src/javascripts/commodities.js.erb
+++ b/app/webpacker/src/javascripts/commodities.js.erb
@@ -575,6 +575,7 @@ import debounce from "./debounce";
 
           $controlForm.on('click', 'a.reset-country-picker', function (e) {
             $(this).parents('form:first').find('select').val('');
+            $(this).siblings("input[name$='[anchor]']").val(window.location.hash.substring(1));
             $(this).parents('form:first').trigger('submit');
             return false;
           });
@@ -752,6 +753,7 @@ import debounce from "./debounce";
                 onConfirm: function(confirmed) {
                   var code = /\((\w\w)\)/.test(confirmed) ? /\((\w\w)\)/.exec(confirmed)[1] : null;
                   $(this.selectElement).val(code);
+                  $(this.selectElement).siblings('input[name$="[anchor]"]').val(window.location.hash.substring(1)); // maintain the tab
                   $(this.selectElement).parents('form:first').trigger("submit");
                 },
               });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,12 +8,8 @@ en:
     uk: United Kingdom
     xi: Northern Ireland
   country_picker:
-    uk:
-      import: UK Global Tariff imports from
-      export: UK Global Tariff exports to
-    xi:
-      import: <abbr title="Northern Ireland">NI</abbr> imports from
-      export: <abbr title="Northern Ireland">NI</abbr> exports to
+    uk_html: Trade between the UK and
+    xi_html: Trade between <abbr title="Northern Ireland">NI</abbr> and
   measures_heading:
     uk:
       import: Measures and restrictions for importing into the UK under the <abbr title="UK Global Tariff">UKGT</abbr>


### PR DESCRIPTION
### Jira link

[HOTT-788](https://transformuk.atlassian.net/browse/HOTT-788)

### What?

I have added/removed/altered:

- [x] Moved the country selector on the commodities page to outside of the tabs because we will soon have a third tab with a country selector on
- [x] Replaced the translation texts for the fields with a single version for XI and single version for UK
- [x] Dropped knowledge of the users tab from the country_selector_text
- [x] Added javascript to assign the hidden 'anchor' field prior to submitting the 'select country' form - this wont work for the non-js case, but tabs don't work for the non-js case either
- [x] Changed the search controller to sanitise the tab anchor it will pass through instead of white listing it - this was because it was redirecting from overview and footnotes tabs back to the export tab - the controller doesn't need to know which anchor its redirecting the user to, just needs to ensure its not an open redirect which sanitisation will achieve
- [x] [Drive by fix] - the submit button on the country selector in the non-js scenario was not correctly formatted so added the govuk-button class to it

### Why?

I am doing this because:

- There is a rules of origin tab coming which will also require a country selector.

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Non I'm aware of

### Before

![Screenshot from 2021-07-27 16-46-16](https://user-images.githubusercontent.com/10818/127185270-914d9443-c617-4650-8e0a-c4cf2cea4357.png)

### After

![Screenshot from 2021-07-27 16-45-17](https://user-images.githubusercontent.com/10818/127185295-867f3b8d-8482-4e6b-b236-2dabbeb5c891.png)

