### PR TITLE
HOTT-864 Updated the cookie banner strapline

### DIFF
--- a/app/views/layouts/_cookies_consent.html.erb
+++ b/app/views/layouts/_cookies_consent.html.erb
@@ -1,10 +1,10 @@
 <% unless cookies[:cookies_policy] %>
-  <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on HMRC services">
+  <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on the Online Tariff">
     <div class="govuk-cookie-banner__message tariff service govuk-width-container">
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on HMRC services</h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the Online Tariff</h2>
 
         <div class="govuk-cookie-banner__content">
           <p>We use some essential cookies to make our services work.</p>


### PR DESCRIPTION
### Jira link

[HOTT-864](https://transformuk.atlassian.net/browse/HOTT-864)

### What?

I have added/removed/altered:

- [x] Updated the strapline and aria tag in the cookie banner

### Why?

I am doing this because:

- we should be using the a more specific service name than HMRC Services

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Non that I'm aware of
