### PR TITLE
HOTT-796 Helper to show countries flag given its iso code

### DIFF
--- a/app/helpers/country_flag_helper.rb
+++ b/app/helpers/country_flag_helper.rb
@@ -1,0 +1,7 @@
+module CountryFlagHelper
+  def country_flag(iso_2_code)
+    # 127_397 offsets to the appropriate unicode values
+    iso_2_code.codepoints.map { |codepoint| codepoint + 127_397 }.pack('U*')
+  end
+end
+  

--- a/app/helpers/country_flag_helper.rb
+++ b/app/helpers/country_flag_helper.rb
@@ -1,7 +1,10 @@
 module CountryFlagHelper
-  def country_flag(iso_2_code)
+  def country_flag_emoji(iso_2_code)
     # 127_397 offsets to the appropriate unicode values
     iso_2_code.codepoints.map { |codepoint| codepoint + 127_397 }.pack('U*')
   end
+
+  def country_flag_tag(iso_2_code)
+    tag.span(country_flag_emoji(iso_2_code), class: 'country-flag')
+  end
 end
-  

--- a/app/helpers/country_flag_helper.rb
+++ b/app/helpers/country_flag_helper.rb
@@ -1,10 +1,10 @@
 module CountryFlagHelper
-  def country_flag_emoji(iso_2_code)
+  def country_flag_emoji(two_letter_country_code)
     # 127_397 offsets to the appropriate unicode values
-    iso_2_code.codepoints.map { |codepoint| codepoint + 127_397 }.pack('U*')
+    two_letter_country_code.codepoints.map { |codepoint| codepoint + 127_397 }.pack('U*')
   end
 
-  def country_flag_tag(iso_2_code)
-    tag.span(country_flag_emoji(iso_2_code), class: 'country-flag')
+  def country_flag_tag(two_letter_country_code)
+    tag.span(country_flag_emoji(two_letter_country_code), class: 'country-flag')
   end
 end

--- a/app/views/sections/index.html.erb
+++ b/app/views/sections/index.html.erb
@@ -2,6 +2,17 @@
   <link rel='alternate' type='application/json' href='<%= sections_url(format: :json) %>' title='Section list in JSON format' />
 <% end %>
 
+<h1 class="govuk-heading-xl">
+  <%= country_flag_tag('GB') %>
+
+  <%= country_flag_tag 'CA' %>
+
+  <%= country_flag_tag 'US' %>
+
+  <%= country_flag_tag 'FR' %>
+  <%= country_flag_tag 'DE' %>
+</h1>
+
 <h2 class="govuk-heading-m all-sections">All sections</h2>
 
 <section class="sections">

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -47,3 +47,4 @@ $govuk-images-path: "~govuk-frontend/govuk/assets/images/";
 @import "../src/stylesheets/pagination";
 @import "../src/stylesheets/tariff-custom";
 @import "../src/stylesheets/copy_code";
+@import "../src/stylesheets/country_flags";

--- a/app/webpacker/src/stylesheets/_country_flags.scss
+++ b/app/webpacker/src/stylesheets/_country_flags.scss
@@ -1,0 +1,3 @@
+span.country-flag {
+  text-shadow: 2px 2px 4px #666666;
+}

--- a/spec/helpers/country_flag_helper_spec.rb
+++ b/spec/helpers/country_flag_helper_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe CountryFlagHelper, type: :helper do
+  describe "#country_flag" do
+    subject { helper.country_flag(iso_2_code) }
+
+    context "with GB" do
+      let(:iso_2_code) { 'GB' }
+
+      it { is_expected.to eql('🇬🇧') }
+    end
+  end
+end

--- a/spec/helpers/country_flag_helper_spec.rb
+++ b/spec/helpers/country_flag_helper_spec.rb
@@ -1,13 +1,23 @@
 require 'spec_helper'
 
 describe CountryFlagHelper, type: :helper do
-  describe "#country_flag" do
-    subject { helper.country_flag(iso_2_code) }
+  describe "#country_flag_emoji" do
+    subject { helper.country_flag_emoji(iso_2_code) }
 
     context "with GB" do
       let(:iso_2_code) { 'GB' }
 
       it { is_expected.to eql('🇬🇧') }
+    end
+  end
+
+  describe "#country_flag_tag" do
+    subject { helper.country_flag_tag(iso_2_code) }
+
+    context "with GB" do
+      let(:iso_2_code) { 'GB' }
+
+      it { is_expected.to have_css('span.country-flag', text: '🇬🇧') }
     end
   end
 end

--- a/spec/helpers/country_flag_helper_spec.rb
+++ b/spec/helpers/country_flag_helper_spec.rb
@@ -2,20 +2,20 @@ require 'spec_helper'
 
 describe CountryFlagHelper, type: :helper do
   describe "#country_flag_emoji" do
-    subject { helper.country_flag_emoji(iso_2_code) }
+    subject { helper.country_flag_emoji(two_letter_country_code) }
 
     context "with GB" do
-      let(:iso_2_code) { 'GB' }
+      let(:two_letter_country_code) { 'GB' }
 
       it { is_expected.to eql('🇬🇧') }
     end
   end
 
   describe "#country_flag_tag" do
-    subject { helper.country_flag_tag(iso_2_code) }
+    subject { helper.country_flag_tag(two_letter_country_code) }
 
     context "with GB" do
-      let(:iso_2_code) { 'GB' }
+      let(:two_letter_country_code) { 'GB' }
 
       it { is_expected.to have_css('span.country-flag', text: '🇬🇧') }
     end


### PR DESCRIPTION
### Jira link

[HOTT-796](https://transformuk.atlassian.net/browse/HOTT-796)

### What?

I have added/removed/altered:

- [x] Added a `country_flag` helper which, given a countrys 2 letter iso code, will return the unicode char for the countries flag

### Why?

I am doing this because:

- We will be showing relevant flags on a future version of the commodities screen to help with visual differentiation

### Deployment risks (optional)

- None

![Screenshot from 2021-07-30 17-49-26](https://user-images.githubusercontent.com/10818/127686002-ee8d4ea8-a422-474a-9cb1-fb7eca533ace.png)
