### PR TITLE
Enable rubocop check just for files change in PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,10 @@ jobs:
      #   format: progress
      #   label: Inspecting with Rubocop
       - run:
+          name: Rubocop changed files
+          when: always
+          command: bundle exec rubocop $(git diff --name-only --diff-filter=ACM $(git merge-base master HEAD)..HEAD | egrep '\.rb|\.rake') Gemfile
+      - run:
           name: Inspecting with Brakeman
           when: always
           command: 'bundle exec brakeman -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models'


### PR DESCRIPTION
### Jira link

Not a ticket

### What?

I have added/removed/altered:

- [x] Added a step to the circle ci linters to run Rubocop just over the changed files 

### Why?

I am doing this because:

- Currently we're not running rubocop at all - because most of the code base would fail - we can enforce linting rules for files which are being modified though so adding a step to CircleCI to do that
