### PR TITLE
Added default .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# https://gds-way.cloudapps.digital/manuals/programming-languages/editorconfig
+root = true
+
+[*.{css,erb,js,json,rb,scss,sh,yml}]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
### Jira link

????

### What?

I have added/removed/altered:

- [x] Added an `.editorconfig` file, copied from the duty-calculator

### Why?

I am doing this because:

- it avoids each developer needing to manually configure their editor for tab spacing/tabs vs spaces/stripping whitespace, etc

