### PR TITLE
Added dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+


### PR DESCRIPTION
### Jira link

???

### What?

I have added/removed/altered:

- [x] Added dependabot config

### Why?

I am doing this because:

- We can get automatic PRs for gem updates and this avoids gems becoming stale when developers are busy

### Deployment risks (optional)

- repo only change