### PR TITLE
Fixed dependabot branch filter to actually work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ workflows:
             branches:
               ignore:
                 - master
-                - /^dependabot\//
+                - /^dependabot\/.*/
       - deploy_dev:
           context: trade-tariff
           requires:


### PR DESCRIPTION
Turns out the regex needs to match the entire branch name, not just part of it
