### PR TITLE
HOTT-846 Apply GovUK styles to converted markdown

### DIFF
--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -48,3 +48,4 @@ $govuk-images-path: "~govuk-frontend/govuk/assets/images/";
 @import "../src/stylesheets/tariff-custom";
 @import "../src/stylesheets/copy_code";
 @import "../src/stylesheets/country_flags";
+@import "../src/stylesheets/markdown";

--- a/app/webpacker/src/stylesheets/_markdown.scss
+++ b/app/webpacker/src/stylesheets/_markdown.scss
@@ -1,0 +1,32 @@
+.tariff-markdown {
+  h1         { @extend .govuk-heading-l }
+  h2         { @extend .govuk-heading-m }
+  h3         { @extend .govuk-heading-s }
+  h4         { @extend .govuk-heading-s }
+  p          { @extend .govuk-body }
+  a          { @extend .govuk-link }
+  blockquote { @extend .govuk-inset-text }
+
+  ul {
+    @extend .govuk-list;
+    @extend .govuk-list--bullet;
+  }
+
+  ol {
+    @extend .govuk-list;
+    @extend .govuk-list--number;
+  }
+
+  table {
+    @extend .govuk-table;
+
+    tr { @extend .govuk-table__row }
+    th { @extend .govuk-table__header }
+    td { @extend .govuk-table__cell }
+  }
+
+  hr {
+    @extend .govuk-section-break;
+    @extend .govuk-section-break--visible;
+  }
+}


### PR DESCRIPTION
### Jira link

[HOTT-846](https://transformuk.atlassian.net/browse/HOTT-846)

### What?

I have added/removed/altered:

- [x] Added a `.tariff-markdown` class which applies GovUK styles to standard HTML elements within, eg links get `govuk-link` automatically and `<ul>` gets `govuk-list` and `govuk-list--bullet` applied automatically

### Why?

I am doing this because:

- As part of the HOTT-846 ticket I will need to convert supplied markdown to HTML and render it using appropriate GovUK styles. Kramdown will only handle converting to HTML but wont apply the styles, by wrapping the output in this `.tariff-markdown` class, all converted markdown will render correctly.

### Before

Left column shows 'plain HTML' version and right shows a version with gov styles manually applied.

![Screenshot from 2021-08-16 15-50-36](https://user-images.githubusercontent.com/10818/129686709-21776849-2ce1-4fe8-8462-a789c643f1f3.png)

### After

Left column shows 'plain HTML' version with Gov styles automatically applied by `.tariff-markdown` - right column shows with manually applied styles.

![Screenshot from 2021-08-16 16-35-32](https://user-images.githubusercontent.com/10818/129686922-53f3ad03-0263-4c35-95c3-f4340f52c32e.png)
