### PR TITLE
HOTT-846 responsive Rules of Origin tab

### DIFF
--- a/app/views/measures/_rules_of_origin.html.erb
+++ b/app/views/measures/_rules_of_origin.html.erb
@@ -20,7 +20,7 @@
       of them.
     </p>
 
-    <table class="govuk-table commodity-rules-of-origin">
+    <table class="govuk-table govuk-table--responsive commodity-rules-of-origin">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">
@@ -47,15 +47,15 @@
 
         <% for rule in rules %>
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell" data-label="Heading">
             <%= rule.heading %>
           </td>
 
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell" data-label="Description">
             <%= rule.description %>
           </td>
 
-          <td class="govuk-table__cell tariff-markdown">
+          <td class="govuk-table__cell tariff-markdown responsive-full-width" data-label="Rule">
             <%= govspeak rule.rule %>
           </td>
         </tr>

--- a/app/webpacker/src/stylesheets/_tables.scss
+++ b/app/webpacker/src/stylesheets/_tables.scss
@@ -223,3 +223,69 @@ table.section-browser {
     //}
   }
 }
+
+.govuk-table--responsive {
+  @include govuk-media-query($until: tablet) {
+    & > caption, & > thead, & > tbody {
+      display: block;
+    }
+
+    & > caption, & > thead, & > tbody {
+      display: block;
+
+      & > tr {
+        display: block;
+        border-width: 0 0 1px 0;
+        border-style: solid;
+        border-color: $govuk-border-colour;
+
+        &:first-of-type {
+          border-top-width: 2px;
+        }
+
+        & > th {
+          display: block;
+        }
+
+        & > td {
+          display: block;
+          position: relative;
+          padding-left: 45%;
+          padding-right: 0;
+          width: auto;
+
+          &:before {
+            @include govuk-typography-weight-bold;
+            position: absolute;
+            top: govuk-spacing(2);
+            left: 0;
+            width: 40%;
+            padding-right: 5%;
+            white-space: nowrap;
+            content: attr(data-label);
+          }
+
+          &.responsive-full-width {
+            padding-left: 0;
+            position: static;
+
+            &:before {
+              position: static;
+              display: block;
+              padding-right: 0;
+              width: 100%;
+              padding-bottom: govuk-spacing(2);
+            }
+          }
+        }
+      }
+    }
+
+    & > thead tr {
+      /* Hide table headers but keep them screenreader-accessible */
+      position: absolute;
+      top: -9999px;
+      left: -9999px;
+    }
+  }
+}


### PR DESCRIPTION
### Jira link

[HOTT-846](https://transformuk.atlassian.net/browse/HOTT-846)

### What?

I have added/removed/altered:

- [x] Added a `.govuk-table--responsive` class - this will switch to using 'vertical' tables on mobile, deriving column headings from `data-label` attributes on the cells
- [x] Added a `.responsive-full-width` cell modifier, to force certain cells to be 'stacked' - ie cell label above the cell content instead of side by side

### Why?

I am doing this because:

- The rules of origin tab uses govuk tables but these are not responsive - the 2 options were to switch to the existing responsive table pattern which would require a lot of custom theming to handle the embedded markdown content properly, or make the `.govuk-table` class work on mobile. I've made this a modifier css class so that it is opt in.
- There is an optional `.responsive-full-width` cell modifier class because the rule content is potentially long and out of our control so doubling the horizontal width will halve the vertical space taken up by it, at a cost of a predicable 1 additional row for the cell label.
-

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None - the css changes are opt-in only

### Before

![Screenshot from 2021-08-19 10-57-35](https://user-images.githubusercontent.com/10818/130063431-5e0be57b-4ca6-4007-bacf-862b06f33680.png)

### After

![Screenshot from 2021-08-19 12-29-20](https://user-images.githubusercontent.com/10818/130063472-4592153a-dfac-48c4-83c1-4a8db82c0f83.png)

