### PR TITLE
HOTT-910: Drop EU regulations URL from the footer

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -76,7 +76,6 @@
       <ul class="govuk-footer__list">
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/government/collections/uk-trade-tariff-volume-1">UK Trade Tariff: Volume 1 &ndash; background information for importers and exporters</a></li>
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/government/collections/uk-trade-tariff-volume-3">UK Trade Tariff: Volume 3 &ndash; procedures, codes and declaration entry details</a></li>
-        <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="http://ec.europa.eu/taxation_customs/dds2/taric/taric_consultation.jsp?Lang=en&Screen=0&Expand=true">Integrated tariff of the European Community (TARIC) database</a></li>
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://api.trade-tariff.service.gov.uk/#gov-uk-trade-tariff-api">API Documentation</a></li>
       </ul>
     </div>


### PR DESCRIPTION
### Jira link

[HOTT-910](https://transformuk.atlassian.net/browse/HOTT-910)

### What?

I have added/removed/altered:

- [x] Removed the link to the TARIC regulations in the footer

### Why?

I am doing this because:

- We derive data from CDS  and should not be sign posting users to the TARIC service

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes
