### PR TITLE
HOTT-908: Use GovUK notification pattern for saved msg

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -11,12 +11,21 @@
   <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="cookie-settings__confirmation-<%= updated_cookies? ? 'show' : 'hide' %> govuk-!-margin-bottom-4" id="cookie-settings__confirmation" data-cookie-confirmation="true">
-          <section class="govuk-!-padding-4" aria-label="Notice" aria-live="polite" role="region">
-            <h2 class="govuk-heading-m">Your cookie settings were saved</h2>
-            <p>You can update these settings at any time.</p>
-          </section>
-        </div>
+        <% if updated_cookies? %>
+          <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+              <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                Success
+              </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+              <h3 class="govuk-notification-banner__heading">
+                Your cookie settings were saved
+              </h3>
+              <p>You can update these settings at any time.</p>
+            </div>
+          </div>
+        <% end %>
         <h1 class="govuk-heading-l">
           Cookies on the UK Global Online Tariff
         </h1>


### PR DESCRIPTION

![Screenshot from 2021-08-20 12-06-48](https://user-images.githubusercontent.com/10818/130226434-17153124-7a94-4f01-8656-c1d4dc4bd7ba.png)
### Jira link

[HOTT-908](https://transformuk.atlassian.net/browse/HOTT-908)

### What?

I have added/removed/altered:

- [x] Replaced the cookie's saved notification with one using the GovUK notification pattern
- [x] Removed using CSS to show/hide the notification since that wasn't working

### Why?

I am doing this because:

- Currently the notification is showing all the time, and unstyled. It should have been showing in green so I've used the 'green' versino of GovUK notification component

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

