### PR TITLE
Manually pin the version of nokogiri since it errors and causes deploy to fail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,11 +24,10 @@ gem 'webpacker'
 
 # gov UK
 gem 'govspeak'
+gem 'nokogiri', '~> 1.11.7' # https://github.com/sparklemotion/nokogiri/issues/2205
 gem 'plek'
 
 gem 'connection_pool'
-
-gem 'nokogiri'
 
 # Logging
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,15 +219,15 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     msgpack (1.4.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     newrelic_rpm (7.2.0)
     nio4r (2.5.8)
-    nokogiri (1.12.3)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.11.7)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -452,7 +452,7 @@ DEPENDENCIES
   logstash-event
   multi_json
   newrelic_rpm
-  nokogiri
+  nokogiri (~> 1.11.7)
   plek
   pry-byebug
   pry-rails


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Pin to an older version of nokogiri

### Why?

I am doing this because:

- This new version outputs an error which is blocking deploys to dev (and other spaces)
