### PR TITLE
HOTT-909: Cookies banner reappears

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ inherit_gem:
 require: rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.7.1
+  TargetRubyVersion: 3.0.2
   Exclude:
     - 'db/schema.rb'
     - 'vendor/**/*'
@@ -17,29 +17,48 @@ AllCops:
     - 'config/initializers/canonical_rails.rb'
     - 'config/puma.rb'
     - 'spec/spec_helper.rb'
-Style/FrozenStringLiteralComment:
-  Enabled: false
-Style/Documentation:
-  Enabled: false
-Metrics/AbcSize:
-  Max: 20
-Layout/LineLength:
-  Max: 120
-Style/GuardClause:
-  MinBodyLength: 2
+
 Layout/AccessModifierIndentation:
   Enabled: false
+
+Layout/LineLength:
+  Max: 120
+
+Metrics/AbcSize:
+  Max: 20
+
 Metrics/BlockLength:
   Enabled: false
+
 Metrics/ModuleLength:
   Enabled: false
+
+RSpec/Capybara/FeatureMethods:
+  Enabled: false
+
 RSpec/DescribeClass:
   Exclude:
     - tasks/**/*.rb
     - spec/features/*
+
 RSpec/ExampleLength:
   Enabled: false
+
+RSpec/MultipleExpectations:
+  Exclude:
+    - spec/features/**/*_spec.rb
+
 RSpec/NestedGroups:
   Max: 4
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/GuardClause:
+  MinBodyLength: 2
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -99,6 +99,11 @@ class ApplicationController < ActionController::Base
     expires_now
   end
 
+  def cookies_policy
+    @cookies_policy ||= Cookies::Policy.from_cookie(cookies[:cookies_policy])
+  end
+  helper_method :cookies_policy
+
   protected
 
   def maintenance_mode_if_active

--- a/app/controllers/cookies/hide_confirmations_controller.rb
+++ b/app/controllers/cookies/hide_confirmations_controller.rb
@@ -1,0 +1,12 @@
+module Cookies
+  class HideConfirmationsController < ApplicationController
+    def create
+      cookies[:cookies_preferences_set] = {
+        value: true,
+        expires: 1.year.from_now,
+      }
+
+      redirect_back(fallback_location: sections_path)
+    end
+  end
+end

--- a/app/controllers/cookies/policies_controller.rb
+++ b/app/controllers/cookies/policies_controller.rb
@@ -2,19 +2,16 @@ module Cookies
   class PoliciesController < ApplicationController
     before_action { @no_shared_search = true }
 
-    def show
-      @policy = cookies_policy
-    end
+    def show; end
 
     def create
-      @policy = cookies_policy
-      @policy.attributes = policy_params
+      cookies_policy.attributes = policy_params
 
       cookies[:cookies_policy] = {
-        value: @policy.to_cookie,
+        value: cookies_policy.to_cookie,
         expires: 1.year.from_now,
       }
-      @policy.mark_persisted!
+      cookies_policy.mark_persisted!
 
       if policy_params.key? :acceptance
         redirect_back(fallback_location: sections_path)

--- a/app/controllers/cookies/policies_controller.rb
+++ b/app/controllers/cookies/policies_controller.rb
@@ -3,17 +3,18 @@ module Cookies
     before_action { @no_shared_search = true }
 
     def show
-      @policy = Cookies::Policy.from_cookie(cookies[:cookies_policy])
+      @policy = cookies_policy
     end
 
     def create
-      @policy = Cookies::Policy.from_cookie(cookies[:cookies_policy])
+      @policy = cookies_policy
       @policy.attributes = policy_params
 
       cookies[:cookies_policy] = {
         value: @policy.to_cookie,
         expires: 1.year.from_now,
       }
+      @policy.mark_persisted!
 
       if policy_params.key? :acceptance
         redirect_back(fallback_location: sections_path)
@@ -22,6 +23,7 @@ module Cookies
         render :show
       end
     end
+    alias_method :update, :create
 
   private
 

--- a/app/controllers/cookies/policies_controller.rb
+++ b/app/controllers/cookies/policies_controller.rb
@@ -1,0 +1,34 @@
+module Cookies
+  class PoliciesController < ApplicationController
+    before_action { @no_shared_search = true }
+
+    def show
+      @policy = Cookies::Policy.from_cookie(cookies[:cookies_policy])
+    end
+
+    def create
+      @policy = Cookies::Policy.from_cookie(cookies[:cookies_policy])
+      @policy.attributes = policy_params
+
+      cookies[:cookies_policy] = {
+        value: @policy.to_cookie,
+        expires: 1.year.from_now,
+      }
+
+      if policy_params.key? :acceptance
+        redirect_back(fallback_location: sections_path)
+      else
+        @saved = true
+        render :show
+      end
+    end
+
+  private
+
+    def policy_params
+      params
+        .fetch(:cookies_policy, {}) # allow for users just hitting save
+        .permit(:usage, :remember_settings, :acceptance)
+    end
+  end
+end

--- a/app/models/cookies/policy.rb
+++ b/app/models/cookies/policy.rb
@@ -18,8 +18,16 @@ module Cookies
       @usage = value.presence
     end
 
+    def usage?
+      @usage.to_s == 'true'
+    end
+
     def remember_settings=(value)
       @remember_settings = value.presence
+    end
+
+    def remember_settings?
+      @remember_settings.to_s == 'true'
     end
 
     def settings
@@ -28,6 +36,10 @@ module Cookies
 
     def settings=(_)
       # no op
+    end
+
+    def settings?
+      true
     end
 
     def acceptance=(value)

--- a/app/models/cookies/policy.rb
+++ b/app/models/cookies/policy.rb
@@ -1,0 +1,48 @@
+module Cookies
+  class Policy
+    include ActiveModel::Model
+
+    attr_reader :usage, :remember_settings
+
+    class << self
+      def find(cookie)
+        return new if cookie.blank?
+
+        values = JSON.parse(cookie)
+
+        new values.slice('usage', 'remember_settings')
+      end
+    end
+
+    def usage=(value)
+      @usage = value.presence
+    end
+
+    def remember_settings=(value)
+      @remember_settings = value.presence
+    end
+
+    def settings
+      true
+    end
+
+    def settings=(_)
+      # no op
+    end
+
+    def acceptance=(value)
+      return if value.blank?
+
+      self.usage = (value == 'accept').to_s
+      self.remember_settings = (value == 'accept').to_s
+    end
+
+    def to_cookie
+      {
+        settings: settings,
+        usage: usage,
+        remember_settings: remember_settings,
+      }.to_json
+    end
+  end
+end

--- a/app/models/cookies/policy.rb
+++ b/app/models/cookies/policy.rb
@@ -5,7 +5,7 @@ module Cookies
     attr_reader :usage, :remember_settings
 
     class << self
-      def find(cookie)
+      def from_cookie(cookie)
         return new if cookie.blank?
 
         values = JSON.parse(cookie)

--- a/app/models/cookies/policy.rb
+++ b/app/models/cookies/policy.rb
@@ -10,7 +10,7 @@ module Cookies
 
         values = JSON.parse(cookie)
 
-        new values.slice('usage', 'remember_settings')
+        new(values).tap(&:mark_persisted!)
       end
     end
 
@@ -43,6 +43,14 @@ module Cookies
         usage: usage,
         remember_settings: remember_settings,
       }.to_json
+    end
+
+    def persisted?
+      @persisted || false
+    end
+
+    def mark_persisted!
+      @persisted = true
     end
   end
 end

--- a/app/views/cookies/policies/show.html.erb
+++ b/app/views/cookies/policies/show.html.erb
@@ -1,0 +1,190 @@
+<% content_for :before_main_content do %>
+  <%= generate_breadcrumbs(
+          "Cookies on UK Global Online Tariff",
+          [
+              [t('breadcrumb.home'), sections_path],
+          ]
+      )
+  %>
+<% end %>
+
+<%= form_for @policy do |form| %>
+  <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <% if @saved %>
+          <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+              <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                Success
+              </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+              <h3 class="govuk-notification-banner__heading">
+                Your cookie settings were saved
+              </h3>
+              <p>You can update these settings at any time.</p>
+            </div>
+          </div>
+        <% end %>
+        <h1 class="govuk-heading-l">
+          Cookies on the UK Global Online Tariff
+        </h1>
+        <p>Cookies are files saved on your phone, tablet or computer when you visit a website.
+        We use cookies to store information about how you use this website, such as the pages you visit.
+        </p>
+        <h2 class="govuk-heading-m">Cookie settings</h2>
+        <p>We use 3 types of cookie. You can choose which cookies you're happy for us to use.</p>
+        <h3 class="govuk-heading-s">Cookies that measure website use</h3>
+        <p>We use Google Analytics to measure how you use the website so we can improve it based on user needs. We
+        do not allow Google to use or share the data about how you use this site.</p>
+        <p>Google Analytics sets cookies that store anonymised information about:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>how you got to the site</li>
+          <li>the pages you visit on the UK Global Online Tariff, and how long you spend on each page</li>
+          <li>what you click on while you're visiting the site</li>
+        </ul>
+        <p>Google Analytics sets the following cookies:</p>
+        <table class="govuk-table govuk-table--m">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Name</th>
+              <th scope="col" class="govuk-table__header">Purpose</th>
+              <th scope="col" class="govuk-table__header">Expires</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">_ga</td>
+              <td class="govuk-table__cell">These help us count how many people visit the service by tracking if
+                you’ve visited before
+              </td>
+              <td class="govuk-table__cell">2 years</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">_gid</td>
+              <td class="govuk-table__cell">This randomly generated number is used to determine unique visitors to our
+                site
+              </td>
+              <td class="govuk-table__cell">24 hours</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">_gat_govuk_shared</td>
+              <td class="govuk-table__cell">This randomly generated number is used to reduce the number of requests
+                made
+              </td>
+              <td class="govuk-table__cell">2 years</td>
+            </tr>
+          </tbody>
+        </table>
+        <br>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" aria-describedby="cookie-consent-usage-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xs">
+              Do you consent to cookies that measure website use?
+            </legend>
+            <div id="cookie-consent-usage-hint" class="govuk-hint">
+            </div>
+            <div class="govuk-radios govuk-radios--stacked">
+              <div class="govuk-radios__item">
+                <%= form.radio_button :usage, 'true', class: "govuk-radios__input" %>
+                <%= form.label(:usage, "Use cookies that measure my website use",
+                               class: "govuk-label govuk-radios__label", value: 'true') %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= form.radio_button :usage, 'false', class: "govuk-radios__input" %>
+                <%= form.label(:usage, "No, do not use cookies that measure my website use",
+                               class: "govuk-label govuk-radios__label", value: 'false') %>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <h3 class="govuk-heading-s">Cookies that remember your settings</h3>
+        <p>These cookies do things like remember your preferences and the choices you make, to personalise your
+        experience of using the site.</p>
+        <p>We use the following cookies to remember your settings:</p>
+        <table class="govuk-table govuk-table--m">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Name</th>
+              <th scope="col" class="govuk-table__header">Purpose</th>
+              <th scope="col" class="govuk-table__header">Expires</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">commodityTree</td>
+              <td class="govuk-table__cell">Remembers if you’ve chosen the ‘Open all headings’ or ‘Close all headings’
+                option when viewing a hierarchical list of commodities
+              </td>
+              <td class="govuk-table__cell">28 days</td>
+            </tr>
+          </tbody>
+        </table>
+        <br>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" aria-describedby="cookie-consent-settings-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xs">
+              Do you consent to cookies that remember your settings?
+            </legend>
+            <div id="cookie-consent-settings-hint" class="govuk-hint">
+            </div>
+            <div class="govuk-radios govuk-radios--stacked">
+              <div class="govuk-radios__item">
+                <%= form.radio_button :remember_settings, true, class: "govuk-radios__input" %>
+                <%= form.label(:remember_settings, "Yes, use cookies that remember my settings on the site", class: "govuk-label govuk-radios__label", value: true) %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= form.radio_button :remember_settings, false, class: "govuk-radios__input" %>
+                <%= form.label(:remember_settings, "No, do not use cookies that remember my settings on the site", class: "govuk-label govuk-radios__label", value: false) %>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <h3 class="govuk-heading-s">Strictly necessary cookies</h3>
+        <p>These essential cookies do things like remember your progress through the application.
+        They always need to be on, or the service will not function.
+        </p>
+        <table class="govuk-table govuk-table--m">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Name</th>
+              <th scope="col" class="govuk-table__header">Purpose</th>
+              <th scope="col" class="govuk-table__header">Expires</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">_tradetarifffrontend_session</td>
+              <td class="govuk-table__cell">Used to remember details of the pages
+                that you have visited in the current session
+              </td>
+              <td class="govuk-table__cell">Until you close your browser</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">_trade_tariff_duty_calculator_session</td>
+              <td class="govuk-table__cell">Used to remember data that you have
+                entered into the online duty calculator, for the dureation of the current session
+              </td>
+              <td class="govuk-table__cell">Until you close your browser</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">cookies_preferences_set</td>
+              <td class="govuk-table__cell">Lets us know that you’ve saved your cookie consent settings</td>
+              <td class="govuk-table__cell">1 year</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">cookies_policy</td>
+              <td class="govuk-table__cell">Saves your cookie consent settings</td>
+              <td class="govuk-table__cell">1 year</td>
+            </tr>
+          </tbody>
+        </table>
+        <%= submit_tag "Save Changes", class: "govuk-button
+        cookies_save_changes" %>
+      <p>Last updated 16 Mar 2021</p>
+      </div>
+      <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+  </main>
+<% end %>

--- a/app/views/cookies/policies/show.html.erb
+++ b/app/views/cookies/policies/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main_content do %>
   <%= generate_breadcrumbs(
-          "Cookies on UK Global Online Tariff",
+          "Cookies on UK Integrated Online Tariff",
           [
               [t('breadcrumb.home'), sections_path],
           ]
@@ -28,7 +28,7 @@
           </div>
         <% end %>
         <h1 class="govuk-heading-l">
-          Cookies on the UK Global Online Tariff
+          Cookies on the UK Integrated Online Tariff
         </h1>
         <p>Cookies are files saved on your phone, tablet or computer when you visit a website.
         We use cookies to store information about how you use this website, such as the pages you visit.
@@ -41,7 +41,7 @@
         <p>Google Analytics sets cookies that store anonymised information about:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>how you got to the site</li>
-          <li>the pages you visit on the UK Global Online Tariff, and how long you spend on each page</li>
+          <li>the pages you visit on the UK Integrated Online Tariff, and how long you spend on each page</li>
           <li>what you click on while you're visiting the site</li>
         </ul>
         <p>Google Analytics sets the following cookies:</p>

--- a/app/views/cookies/policies/show.html.erb
+++ b/app/views/cookies/policies/show.html.erb
@@ -8,7 +8,7 @@
   %>
 <% end %>
 
-<%= form_for @policy do |form| %>
+<%= form_for cookies_policy do |form| %>
   <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -92,7 +92,7 @@
           <%= link_to('Privacy', privacy_path, class: 'govuk-footer__link') %>
         </li>
         <li class="govuk-footer__inline-list-item">
-          <%= link_to 'Cookies', cookies_path, class: 'govuk-footer__link' %>
+          <%= link_to 'Cookies', cookies_policy_path, class: 'govuk-footer__link' %>
         </li>
         <li class="govuk-footer__inline-list-item">
           <%= link_to 'Terms and conditions', terms_path, class: 'govuk-footer__link' %>

--- a/app/views/layouts/_cookies_consent.html.erb
+++ b/app/views/layouts/_cookies_consent.html.erb
@@ -34,7 +34,7 @@
 </div>
 <% end %>
 <% unless cookies[:cookies_preferences_set] %>
-  <% if policy_cookie['usage'] == 'true' %>
+  <% if cookies_policy.usage? %>
     <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on HMRC services">
       <div class="govuk-cookie-banner__message tariff service govuk-width-container" id="cookies_accepted">
         <p>You have accepted additional cookies. You can <%= link_to "change your cookie
@@ -42,7 +42,7 @@
         <%= button_to "Hide this message", cookies_hide_confirmation_path, class: 'govuk-button hide_cookie_panel' %>
       </div>
     </div>
-  <% elsif policy_cookie['usage'] == 'false' %>
+  <% elsif cookies_policy.usage == 'false' %>
     <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on HMRC services">
       <div class="govuk-cookie-banner__message tariff service govuk-width-container" id="cookies_rejected">
         <p>You have rejected additional cookies. You can <%= link_to "change your cookie

--- a/app/views/layouts/_cookies_consent.html.erb
+++ b/app/views/layouts/_cookies_consent.html.erb
@@ -19,11 +19,11 @@
 
     <%= form_tag cookies_consent_path do %>
       <div class="govuk-button-group">
-        <%= button_tag class: 'govuk-button cookie_accept_all', name: "cookie_acceptance", value: "accept" do %>
+        <%= button_tag class: 'govuk-button cookie_accept_all', name: "cookies_policy[acceptance]", value: "accept" do %>
           Accept additional cookies
         <% end %>
 
-        <%= button_tag class: 'govuk-button cookie_reject_all', name: "cookie_acceptance", value: "reject" do %>
+        <%= button_tag class: 'govuk-button cookie_reject_all', name: "cookies_policy[acceptance]", value: "reject" do %>
           Reject additional cookies
         <% end %>
 

--- a/app/views/layouts/_cookies_consent.html.erb
+++ b/app/views/layouts/_cookies_consent.html.erb
@@ -17,17 +17,17 @@
       </div>
     </div>
 
-    <%= form_tag cookies_consent_path do %>
+    <%= form_for Cookies::Policy.new do |form| %>
       <div class="govuk-button-group">
-        <%= button_tag class: 'govuk-button cookie_accept_all', name: "cookies_policy[acceptance]", value: "accept" do %>
+        <%= form.button class: 'govuk-button cookie_accept_all', name: "#{form.object_name}[acceptance]", value: "accept" do %>
           Accept additional cookies
         <% end %>
 
-        <%= button_tag class: 'govuk-button cookie_reject_all', name: "cookies_policy[acceptance]", value: "reject" do %>
+        <%= form.button class: 'govuk-button cookie_reject_all', name: "#{form.object_name}[acceptance]", value: "reject" do %>
           Reject additional cookies
         <% end %>
 
-        <%= link_to('View cookies', cookies_path, class: "govuk-link") %>
+        <%= link_to('View cookies', cookies_policy_path, class: "govuk-link") %>
       </div>
     <% end %>
   </div>
@@ -38,7 +38,7 @@
     <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on HMRC services">
       <div class="govuk-cookie-banner__message tariff service govuk-width-container" id="cookies_accepted">
         <p>You have accepted additional cookies. You can <%= link_to "change your cookie
-          settings", "/cookies" %> at any time.</p>
+          settings", cookies_policy_path %> at any time.</p>
         <%= button_to "Hide this message", cookies_hide_confirmation_path, class: 'govuk-button hide_cookie_panel' %>
       </div>
     </div>
@@ -46,7 +46,7 @@
     <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on HMRC services">
       <div class="govuk-cookie-banner__message tariff service govuk-width-container" id="cookies_rejected">
         <p>You have rejected additional cookies. You can <%= link_to "change your cookie
-          settings", "/cookies" %> at any time.</p>
+          settings", cookies_policy_path %> at any time.</p>
         <%= button_to "Hide this message", cookies_hide_confirmation_path, class: 'govuk-button hide_cookie_panel' %>
       </div>
     </div>

--- a/app/views/layouts/_cookies_consent.html.erb
+++ b/app/views/layouts/_cookies_consent.html.erb
@@ -1,4 +1,4 @@
-<% unless cookies[:cookies_policy] %>
+<% unless cookies_policy.persisted? %>
   <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on the Online Tariff">
     <div class="govuk-cookie-banner__message tariff service govuk-width-container">
 

--- a/app/views/layouts/_cookies_consent.html.erb
+++ b/app/views/layouts/_cookies_consent.html.erb
@@ -39,7 +39,7 @@
       <div class="govuk-cookie-banner__message tariff service govuk-width-container" id="cookies_accepted">
         <p>You have accepted additional cookies. You can <%= link_to "change your cookie
           settings", "/cookies" %> at any time.</p>
-        <%= button_to "Hide this message", cookies_consent_confirmation_message_path, class: 'govuk-button hide_cookie_panel' %>
+        <%= button_to "Hide this message", cookies_hide_confirmation_path, class: 'govuk-button hide_cookie_panel' %>
       </div>
     </div>
   <% elsif policy_cookie['usage'] == 'false' %>
@@ -47,7 +47,7 @@
       <div class="govuk-cookie-banner__message tariff service govuk-width-container" id="cookies_rejected">
         <p>You have rejected additional cookies. You can <%= link_to "change your cookie
           settings", "/cookies" %> at any time.</p>
-        <%= button_to "Hide this message", cookies_consent_confirmation_message_path, class: 'govuk-button hide_cookie_panel' %>
+        <%= button_to "Hide this message", cookies_hide_confirmation_path, class: 'govuk-button hide_cookie_panel' %>
       </div>
     </div>
   <% end %>

--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,4 +1,4 @@
-<% if usage_enabled? -%>
+<% if cookies_policy.usage? -%>
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/app/views/layouts/_google_tag_manager_no_script.html.erb
+++ b/app/views/layouts/_google_tag_manager_no_script.html.erb
@@ -1,4 +1,4 @@
-<% if usage_enabled? -%>
+<% if cookies_policy.usage? -%>
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MNNT6SX"
                     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,10 @@ Rails.application.routes.draw do
   get 'feedback/thanks', to: 'feedback#thanks'
   get 'tools', to: 'pages#tools'
 
+  namespace :cookies do
+    resource :hide_confirmation, only: %i[create]
+  end
+
   match '/search', to: 'search#search', as: :perform_search, via: %i[get post]
   get 'search_suggestions', to: 'search#suggestions', as: :search_suggestions
   get 'quota_search', to: 'search#quota_search', as: :quota_search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,8 +45,10 @@ Rails.application.routes.draw do
   get 'tools', to: 'pages#tools'
 
   namespace :cookies do
+    resource :policy, only: %i[show create]
     resource :hide_confirmation, only: %i[create]
   end
+  resolve('Cookies::Policy') { %i[cookies policy] }
 
   match '/search', to: 'search#search', as: :perform_search, via: %i[get post]
   get 'search_suggestions', to: 'search#suggestions', as: :search_suggestions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
   get 'tools', to: 'pages#tools'
 
   namespace :cookies do
-    resource :policy, only: %i[show create]
+    resource :policy, only: %i[show create update]
     resource :hide_confirmation, only: %i[create]
   end
   resolve('Cookies::Policy') { %i[cookies policy] }

--- a/spec/features/cookies_spec.rb
+++ b/spec/features/cookies_spec.rb
@@ -44,7 +44,6 @@ RSpec.feature 'Cookies management' do
     expect(page).to have_css '.govuk-cookie-banner', text: /We use some essential cookies/
     expect(page).not_to have_css '.govuk-notification-banner'
     choose 'Use cookies that measure my website use'
-    choose 'No, do not use cookies that remember my settings on the site'
     click_on 'Save Changes'
 
     expect(page).to have_css 'h1', text: 'Cookies on the UK Global Online Tariff'
@@ -55,5 +54,12 @@ RSpec.feature 'Cookies management' do
     expect(page).to have_css 'h1', text: 'Cookies on the UK Global Online Tariff'
     expect(page).not_to have_css '.govuk-notification-banner'
     expect(page).not_to have_css 'govuk-cookie-banner'
+
+    choose 'No, do not use cookies that measure my website use'
+    choose 'Yes, use cookies that remember my settings on the site'
+    click_on 'Save Changes'
+
+    expect(page).to have_css 'h1', text: 'Cookies on the UK Global Online Tariff'
+    expect(page).to have_css '.govuk-notification-banner h3', text: 'Your cookie settings were saved'
   end
 end

--- a/spec/features/cookies_spec.rb
+++ b/spec/features/cookies_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.feature 'Cookies management' do
+  scenario 'accepting cookies from banner' do
+    visit help_path
+
+    expect(page).to have_css 'h1', text: 'Help on using the tariff'
+    expect(page).to have_css '.govuk-cookie-banner', text: /We use some essential cookies/
+    click_on 'Accept additional cookies'
+
+    expect(page).to have_css 'h1', text: 'Help on using the tariff'
+    expect(page).not_to have_css '.govuk-cookie-banner', text: /We use some essential cookies/
+    expect(page).to have_css '#cookies_accepted'
+    click_on 'Hide this message'
+
+    expect(page).not_to have_css 'govuk-cookie-banner'
+    expect(page).to have_css 'h1', text: 'Help on using the tariff'
+  end
+
+  scenario 'rejecting cookies from banner' do
+    visit help_path
+
+    expect(page).to have_css 'h1', text: 'Help on using the tariff'
+    expect(page).to have_css '.govuk-cookie-banner', text: /We use some essential cookies/
+    click_on 'Reject additional cookies'
+
+    expect(page).to have_css 'h1', text: 'Help on using the tariff'
+    expect(page).not_to have_css '.govuk-cookie-banner', text: /We use some essential cookies/
+    expect(page).to have_css '#cookies_rejected'
+    click_on 'Hide this message'
+
+    expect(page).not_to have_css 'govuk-cookie-banner'
+    expect(page).to have_css 'h1', text: 'Help on using the tariff'
+  end
+
+  scenario 'manually setting cookies' do
+    visit help_path
+
+    expect(page).to have_css 'h1', text: 'Help on using the tariff'
+    expect(page).to have_css '.govuk-cookie-banner', text: /We use some essential cookies/
+    click_on 'View cookies'
+
+    expect(page).to have_css 'h1', text: 'Cookies on the UK Global Online Tariff'
+    expect(page).to have_css '.govuk-cookie-banner', text: /We use some essential cookies/
+    expect(page).not_to have_css '.govuk-notification-banner'
+    choose 'Use cookies that measure my website use'
+    choose 'No, do not use cookies that remember my settings on the site'
+    click_on 'Save Changes'
+
+    expect(page).to have_css 'h1', text: 'Cookies on the UK Global Online Tariff'
+    expect(page).to have_css '.govuk-notification-banner h3', text: 'Your cookie settings were saved'
+    expect(page).to have_css '#cookies_accepted'
+    click_on 'Hide this message'
+
+    expect(page).to have_css 'h1', text: 'Cookies on the UK Global Online Tariff'
+    expect(page).not_to have_css '.govuk-notification-banner'
+    expect(page).not_to have_css 'govuk-cookie-banner'
+  end
+end

--- a/spec/features/cookies_spec.rb
+++ b/spec/features/cookies_spec.rb
@@ -40,18 +40,18 @@ RSpec.feature 'Cookies management' do
     expect(page).to have_css '.govuk-cookie-banner', text: /We use some essential cookies/
     click_on 'View cookies'
 
-    expect(page).to have_css 'h1', text: 'Cookies on the UK Global Online Tariff'
+    expect(page).to have_css 'h1', text: 'Cookies on the UK Integrated Online Tariff'
     expect(page).to have_css '.govuk-cookie-banner', text: /We use some essential cookies/
     expect(page).not_to have_css '.govuk-notification-banner'
     choose 'Use cookies that measure my website use'
     click_on 'Save Changes'
 
-    expect(page).to have_css 'h1', text: 'Cookies on the UK Global Online Tariff'
+    expect(page).to have_css 'h1', text: 'Cookies on the UK Integrated Online Tariff'
     expect(page).to have_css '.govuk-notification-banner h3', text: 'Your cookie settings were saved'
     expect(page).to have_css '#cookies_accepted'
     click_on 'Hide this message'
 
-    expect(page).to have_css 'h1', text: 'Cookies on the UK Global Online Tariff'
+    expect(page).to have_css 'h1', text: 'Cookies on the UK Integrated Online Tariff'
     expect(page).not_to have_css '.govuk-notification-banner'
     expect(page).not_to have_css 'govuk-cookie-banner'
 
@@ -59,7 +59,7 @@ RSpec.feature 'Cookies management' do
     choose 'Yes, use cookies that remember my settings on the site'
     click_on 'Save Changes'
 
-    expect(page).to have_css 'h1', text: 'Cookies on the UK Global Online Tariff'
+    expect(page).to have_css 'h1', text: 'Cookies on the UK Integrated Online Tariff'
     expect(page).to have_css '.govuk-notification-banner h3', text: 'Your cookie settings were saved'
   end
 end

--- a/spec/models/cookies/policy_spec.rb
+++ b/spec/models/cookies/policy_spec.rb
@@ -98,14 +98,26 @@ RSpec.describe Cookies::Policy do
   end
 
   describe '.from_cookie' do
-    subject { described_class.from_cookie cookie }
+    context 'with cookie' do
+      subject { described_class.from_cookie cookie }
 
-    it { is_expected.to have_attributes settings: true }
-    it { is_expected.to have_attributes usage: 'true' }
-    it { is_expected.to have_attributes remember_settings: 'false' }
+      it { is_expected.to have_attributes settings: true }
+      it { is_expected.to have_attributes usage: 'true' }
+      it { is_expected.to have_attributes remember_settings: 'false' }
+      it { is_expected.to be_persisted }
+    end
+
+    context 'without cookie' do
+      subject { described_class.from_cookie nil }
+
+      it { is_expected.to have_attributes settings: true }
+      it { is_expected.to have_attributes usage: nil }
+      it { is_expected.to have_attributes remember_settings: nil }
+      it { is_expected.not_to be_persisted }
+    end
   end
 
-  describe '.to_cookie' do
+  describe '#to_cookie' do
     subject { instance.to_cookie }
 
     let(:instance) do

--- a/spec/models/cookies/policy_spec.rb
+++ b/spec/models/cookies/policy_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+RSpec.describe Cookies::Policy do
+  subject(:policy) { described_class.new nil }
+
+  let(:cookie) do
+    {
+      settings: true,
+      usage: 'true',
+      remember_settings: 'false',
+    }.to_json
+  end
+
+  describe 'attributes' do
+    it { is_expected.to respond_to :settings }
+    it { is_expected.to respond_to :usage }
+    it { is_expected.to respond_to :remember_settings }
+
+    describe '#settings=' do
+      context 'with value' do
+        before { policy.settings = false }
+
+        it { is_expected.to have_attributes settings: true }
+      end
+
+      context 'with nil' do
+        before { policy.settings = nil }
+
+        it { is_expected.to have_attributes settings: true }
+      end
+    end
+
+    describe '#usage=' do
+      context 'with value' do
+        before { policy.usage = 'false' }
+
+        it { is_expected.to have_attributes usage: 'false' }
+      end
+
+      context 'with blank' do
+        before { policy.usage = '' }
+
+        it { is_expected.to have_attributes usage: nil }
+      end
+
+      context 'with nil' do
+        before { policy.usage = nil }
+
+        it { is_expected.to have_attributes usage: nil }
+      end
+    end
+
+    describe '#remember_settings=' do
+      context 'with value' do
+        before { policy.remember_settings = 'false' }
+
+        it { is_expected.to have_attributes remember_settings: 'false' }
+      end
+
+      context 'with blank' do
+        before { policy.remember_settings = '' }
+
+        it { is_expected.to have_attributes remember_settings: nil }
+      end
+
+      context 'with nil' do
+        before { policy.remember_settings = nil }
+
+        it { is_expected.to have_attributes remember_settings: nil }
+      end
+    end
+
+    describe '#acceptance=' do
+      context 'with accept' do
+        before { policy.acceptance = 'accept' }
+
+        it { is_expected.to have_attributes settings: true }
+        it { is_expected.to have_attributes usage: 'true' }
+        it { is_expected.to have_attributes remember_settings: 'true' }
+      end
+
+      context 'with reject' do
+        before { policy.acceptance = 'reject' }
+
+        it { is_expected.to have_attributes settings: true }
+        it { is_expected.to have_attributes usage: 'false' }
+        it { is_expected.to have_attributes remember_settings: 'false' }
+      end
+
+      context 'with no value' do
+        before { policy.acceptance = '' }
+
+        it { is_expected.to have_attributes settings: true }
+        it { is_expected.to have_attributes usage: nil }
+        it { is_expected.to have_attributes remember_settings: nil }
+      end
+    end
+  end
+
+  describe '.find' do
+    subject { described_class.find cookie }
+
+    it { is_expected.to have_attributes settings: true }
+    it { is_expected.to have_attributes usage: 'true' }
+    it { is_expected.to have_attributes remember_settings: 'false' }
+  end
+
+  describe '.to_cookie' do
+    subject { instance.to_cookie }
+
+    let(:instance) do
+      described_class.new(usage: 'true', remember_settings: 'false')
+    end
+
+    it { is_expected.to eql cookie }
+  end
+end

--- a/spec/models/cookies/policy_spec.rb
+++ b/spec/models/cookies/policy_spec.rb
@@ -13,60 +13,85 @@ RSpec.describe Cookies::Policy do
 
   describe 'attributes' do
     it { is_expected.to respond_to :settings }
+    it { is_expected.to respond_to :settings? }
     it { is_expected.to respond_to :usage }
+    it { is_expected.to respond_to :usage? }
     it { is_expected.to respond_to :remember_settings }
+    it { is_expected.to respond_to :remember_settings? }
 
     describe '#settings=' do
       context 'with value' do
         before { policy.settings = false }
 
         it { is_expected.to have_attributes settings: true }
+        it { is_expected.to have_attributes settings?: true }
       end
 
       context 'with nil' do
         before { policy.settings = nil }
 
         it { is_expected.to have_attributes settings: true }
+        it { is_expected.to have_attributes settings?: true }
       end
     end
 
     describe '#usage=' do
-      context 'with value' do
+      context 'with false value' do
         before { policy.usage = 'false' }
 
         it { is_expected.to have_attributes usage: 'false' }
+        it { is_expected.to have_attributes usage?: false }
+      end
+
+      context 'with true value' do
+        before { policy.usage = 'true' }
+
+        it { is_expected.to have_attributes usage: 'true' }
+        it { is_expected.to have_attributes usage?: true }
       end
 
       context 'with blank' do
         before { policy.usage = '' }
 
         it { is_expected.to have_attributes usage: nil }
+        it { is_expected.to have_attributes usage?: false }
       end
 
       context 'with nil' do
         before { policy.usage = nil }
 
         it { is_expected.to have_attributes usage: nil }
+        it { is_expected.to have_attributes usage?: false }
       end
     end
 
     describe '#remember_settings=' do
-      context 'with value' do
+      context 'with false value' do
         before { policy.remember_settings = 'false' }
 
         it { is_expected.to have_attributes remember_settings: 'false' }
+        it { is_expected.to have_attributes remember_settings?: false }
+      end
+
+      context 'with true value' do
+        before { policy.remember_settings = 'true' }
+
+        it { is_expected.to have_attributes remember_settings: 'true' }
+        it { is_expected.to have_attributes remember_settings?: true }
       end
 
       context 'with blank' do
         before { policy.remember_settings = '' }
 
         it { is_expected.to have_attributes remember_settings: nil }
+        it { is_expected.to have_attributes remember_settings?: false }
       end
 
       context 'with nil' do
         before { policy.remember_settings = nil }
 
         it { is_expected.to have_attributes remember_settings: nil }
+        it { is_expected.to have_attributes remember_settings?: false }
       end
     end
 

--- a/spec/models/cookies/policy_spec.rb
+++ b/spec/models/cookies/policy_spec.rb
@@ -97,8 +97,8 @@ RSpec.describe Cookies::Policy do
     end
   end
 
-  describe '.find' do
-    subject { described_class.find cookie }
+  describe '.from_cookie' do
+    subject { described_class.from_cookie cookie }
 
     it { is_expected.to have_attributes settings: true }
     it { is_expected.to have_attributes usage: 'true' }

--- a/spec/requests/cookies/hide_confirmations_controller_spec.rb
+++ b/spec/requests/cookies/hide_confirmations_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe Cookies::HideConfirmationsController, type: :request do
+  describe 'POST #create' do
+    before { post cookies_hide_confirmation_path }
+
+    it 'sets the cookie preference correctly' do
+      expect(response.cookies['cookies_preferences_set']).to eq('true')
+    end
+
+    it 'redirects to the correct fallback location' do
+      expect(response).to redirect_to(sections_path)
+    end
+  end
+end

--- a/spec/requests/cookies/policies_controller_spec.rb
+++ b/spec/requests/cookies/policies_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Cookies::PoliciesController, type: :request do
     before { get cookies_policy_path }
 
     it { is_expected.to have_http_status :success }
-    it { is_expected.to have_attributes body: /Cookies on the UK Global Online Tariff/ }
+    it { is_expected.to have_attributes body: /Cookies on the UK Integrated Online Tariff/ }
   end
 
   describe 'POST #create' do

--- a/spec/requests/cookies/policies_controller_spec.rb
+++ b/spec/requests/cookies/policies_controller_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+RSpec.describe Cookies::PoliciesController, type: :request do
+  subject { response }
+
+  describe 'GET #show' do
+    before { get cookies_policy_path }
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.to have_attributes body: /Cookies on the UK Global Online Tariff/ }
+  end
+
+  describe 'POST #create' do
+    describe 'with form submission' do
+      before do
+        post cookies_policy_path, params: {
+          cookies_policy: {
+            usage: 'true',
+            remember_settings: 'false',
+          },
+        }
+      end
+
+      let(:expected_cookies) do
+        {
+          settings: true,
+          usage: 'true',
+          remember_settings: 'false',
+        }.to_json
+      end
+
+      it 'sets the cookie policy correctly' do
+        expect(response.cookies['cookies_policy']).to eq(expected_cookies)
+      end
+
+      it 'renders the form again' do
+        expect(response).to have_http_status :success
+      end
+
+      it 'shows the saved message' do
+        expect(response.body).to match('cookie settings were saved')
+      end
+    end
+
+    describe 'with accept' do
+      before do
+        post cookies_policy_path, params: {
+          cookies_policy: { acceptance: 'accept' },
+        }
+      end
+
+      let(:expected_cookies) do
+        {
+          settings: true,
+          usage: 'true',
+          remember_settings: 'true',
+        }.to_json
+      end
+
+      it 'sets the cookie policy correctly' do
+        expect(response.cookies['cookies_policy']).to eq(expected_cookies)
+      end
+
+      it 'redirects to the correct fallback location' do
+        expect(response).to redirect_to(sections_path)
+      end
+    end
+
+    describe 'with reject' do
+      before do
+        post cookies_policy_path, params: {
+          cookies_policy: { acceptance: 'reject' },
+        }
+      end
+
+      let(:expected_cookie) do
+        {
+          settings: true,
+          usage: 'false',
+          remember_settings: 'false',
+        }.to_json
+      end
+
+      it 'sets the cookie policy correctly' do
+        expect(response.cookies['cookies_policy']).to eq(expected_cookie)
+      end
+
+      it 'redirects to the correct fallback location' do
+        expect(response).to redirect_to(sections_path)
+      end
+    end
+
+    context 'without choosing options' do
+      before { post cookies_policy_path }
+
+      let(:expected_cookies) do
+        {
+          settings: true,
+          usage: nil,
+          remember_settings: nil,
+        }.to_json
+      end
+
+      it 'sets the cookie policy correctly' do
+        expect(response.cookies['cookies_policy']).to eq(expected_cookies)
+      end
+
+      it 'renders the form again' do
+        expect(response).to have_http_status :success
+      end
+
+      it 'shows the saved message' do
+        expect(response.body).to match('cookie settings were saved')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-909](https://transformuk.atlassian.net/browse/HOTT-909)

### What?

I have added/removed/altered:

- [x] Added a `Cookies::Policy` model to control access to the policy cookie - this provides replacements for the various methods in `CookiesHelper` for reading and writing to the cookie
- [x] Added a `Cookies::PoliciesController` to manipulate that cookie, this takes over from `PagesController#tariff_cookies`, `PagesController#update_cookies`, and `CookiesConsentController`
- [x] Added a `Cookies::HideConfirmationsController` to manipulate the 'hide confirmation' cookie - this takes over from `CookiesConsentController#add_seen_confirmation`
- [x] Added a `Cookies` feature spec to verify the different paths a user can follow

### Why?

I am doing this because:

- We are getting inconsistent behaviour from the Cookies banner with it reappearing some of the time. I've not been able to identify the source of the bug but the existing code is hard to follow and there are multiple points reading and writing from the cookie. Hopefully this rewrite will solve the problem but if it doesn't, it should make it _much_ simpler to debug and resolve.

### Follow on PRs
[ ] There will be a follow on PR to drop the existing cookies controller+helper code but I'm rolling it out in two deploys to avoid causing 404s for users - see #208 
[ ] The tables listing cookies do not show correctly on mobile at present. the is an existing issue - I'll add the new responsive functionality from the Rules of Origin PRs once those are merged - see #216 