### PR TITLE
Fixed cookie associations on form

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -88,13 +88,13 @@
               <div class="govuk-radios__item">
                 <%= form.radio_button :cookie_consent_usage, true, class: "govuk-radios__input", checked: usage_enabled? %>
                 <%= form.label(:cookie_consent_usage_1, "Use cookies that measure my website use",
-                               class: "govuk-label govuk-radios__label", for: "cookie-consent-usage_yes") %>
+                               class: "govuk-label govuk-radios__label", for: "cookie_consent_usage_true") %>
               </div>
               <div class="govuk-radios__item">
                 <%= form.radio_button :cookie_consent_usage, false, class: "govuk-radios__input", checked: usage_disabled? %>
 
                 <%= form.label(:cookie_consent_usage_2, "No, do not use cookies that measure my website use",
-                               class: "govuk-label govuk-radios__label", for: "cookie-consent-usage_no") %>
+                               class: "govuk-label govuk-radios__label", for: "cookie_consent_usage_false") %>
               </div>
             </div>
           </fieldset>
@@ -132,11 +132,11 @@
             <div class="govuk-radios govuk-radios--stacked">
               <div class="govuk-radios__item">
                 <%= form.radio_button :cookie_remember_settings, true, class: "govuk-radios__input", checked: remember_settings_enabled? %>
-                <%= form.label(:cookie_remember_settings, "Yes, use cookies that remember my settings on the site", class: "govuk-label govuk-radios__label", for: "cookie-remember_settings_yes") %>
+                <%= form.label(:cookie_remember_settings, "Yes, use cookies that remember my settings on the site", class: "govuk-label govuk-radios__label", for: "cookie_remember_settings_true") %>
               </div>
               <div class="govuk-radios__item">
                 <%= form.radio_button :cookie_remember_settings, false, class: "govuk-radios__input", checked: remember_settings_disabled? %>
-                <%= form.label(:cookie_remember_settings_2, "No, do not use cookies that remember my settings on the site", class: "govuk-label govuk-radios__label", for: "cookie-remeber_settings_no") %>
+                <%= form.label(:cookie_remember_settings_2, "No, do not use cookies that remember my settings on the site", class: "govuk-label govuk-radios__label", for: "cookie_remember_settings_false") %>
               </div>
             </div>
           </fieldset>


### PR DESCRIPTION
### Jira link

[HOTT-909](https://transformuk.atlassian.net/browse/HOTT-909)

### What?

I have added/removed/altered:

- [x] Corrected the labels on the old cookies page

### Why?

I am doing this because:

- it will allow me to run the same revised cypress cookie tests against both new and old cookie pages to compare/contrast

### Deployment risks (optional)

- This is not intended to be merged but is harmless if it is - the page will be getting dropped in #208 
