### PR TITLE
HOTT-909: Excluded nil values from cookie output

### DIFF
--- a/app/models/cookies/policy.rb
+++ b/app/models/cookies/policy.rb
@@ -54,7 +54,7 @@ module Cookies
         settings: settings,
         usage: usage,
         remember_settings: remember_settings,
-      }.to_json
+      }.compact.to_json
     end
 
     def persisted?

--- a/spec/models/cookies/policy_spec.rb
+++ b/spec/models/cookies/policy_spec.rb
@@ -150,5 +150,12 @@ RSpec.describe Cookies::Policy do
     end
 
     it { is_expected.to eql cookie }
+
+    context 'with partial answers' do
+      let(:instance) { described_class.new(usage: 'true') }
+      let(:cookie)   { { settings: true, usage: 'true' }.to_json }
+
+      it { is_expected.to eql cookie }
+    end
   end
 end

--- a/spec/requests/cookies/policies_controller_spec.rb
+++ b/spec/requests/cookies/policies_controller_spec.rb
@@ -93,13 +93,7 @@ RSpec.describe Cookies::PoliciesController, type: :request do
     context 'without choosing options' do
       before { post cookies_policy_path }
 
-      let(:expected_cookies) do
-        {
-          settings: true,
-          usage: nil,
-          remember_settings: nil,
-        }.to_json
-      end
+      let(:expected_cookies) { { settings: true }.to_json }
 
       it 'sets the cookie policy correctly' do
         expect(response.cookies['cookies_policy']).to eq(expected_cookies)


### PR DESCRIPTION
### Jira link

[HOTT-909](https://transformuk.atlassian.net/browse/HOTT-909)

### What?

I have added/removed/altered:

- [x] Changed the `Cookies::Policy#to_cookie` to not include unset cookie values - rather then record them as null - this matches the behaviour of the existing code

### Why?

I am doing this because:

- The new code should match the cookie structures of the old code
