### PR TITLE
Surface declarable for headings and commodities

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -19,7 +19,7 @@ module Declarable
                   :formatted_description, :consigned, :consigned_from, :basic_duty_rate,
                   :meursing_code, :producline_suffix, :declarable
 
-    alias :declarable? :declarable
+    alias_method :declarable?, :declarable
 
     delegate :numeral, to: :section, prefix: true
     delegate :code, :short_code, to: :chapter, prefix: true

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -17,7 +17,9 @@ module Declarable
     attr_accessor :description, :goods_nomenclature_item_id,
                   :number_indents, :goods_nomenclature_sid, :bti_url, :description_plain,
                   :formatted_description, :consigned, :consigned_from, :basic_duty_rate,
-                  :meursing_code, :producline_suffix
+                  :meursing_code, :producline_suffix, :declarable
+
+    alias :declarable? :declarable
 
     delegate :numeral, to: :section, prefix: true
     delegate :code, :short_code, to: :chapter, prefix: true

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -11,7 +11,7 @@ class Heading < GoodsNomenclature
 
   attr_accessor :leaf, :declarable
 
-  alias :leaf? :leaf
+  alias_method :leaf?, :leaf
 
   def eql?(other)
     goods_nomenclature_item_id == other.goods_nomenclature_item_id
@@ -32,7 +32,7 @@ class Heading < GoodsNomenclature
   def display_short_code
     code[2..3]
   end
-  alias :heading_display_short_code :display_short_code
+  alias_method :heading_display_short_code, :display_short_code
 
   def display_export_code
     code[0..-3]

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -12,7 +12,6 @@ class Heading < GoodsNomenclature
   attr_accessor :leaf, :declarable
 
   alias :leaf? :leaf
-  alias :declarable? :declarable
 
   def eql?(other)
     goods_nomenclature_item_id == other.goods_nomenclature_item_id

--- a/app/serializers/search_result/commodity_serializer.rb
+++ b/app/serializers/search_result/commodity_serializer.rb
@@ -3,14 +3,14 @@ module SearchResult
     include ActiveModel::Serializers::JSON
     def serializable_hash(_opts = {})
       {
-        type: 'commodity',
-        goods_nomenclature_item_id: goods_nomenclature_item_id,
-        producline_suffix: producline_suffix,
-        number_indents: number_indents,
         declarable: declarable,
-        validity_start_date: validity_start_date.to_s,
-        validity_end_date: validity_end_date.to_s,
         description: description,
+        goods_nomenclature_item_id: goods_nomenclature_item_id,
+        number_indents: number_indents,
+        producline_suffix: producline_suffix,
+        type: 'commodity',
+        validity_end_date: validity_end_date.to_s,
+        validity_start_date: validity_start_date.to_s,
       }
     end
   end

--- a/app/serializers/search_result/commodity_serializer.rb
+++ b/app/serializers/search_result/commodity_serializer.rb
@@ -7,6 +7,7 @@ module SearchResult
         goods_nomenclature_item_id: goods_nomenclature_item_id,
         producline_suffix: producline_suffix,
         number_indents: number_indents,
+        declarable: declarable,
         validity_start_date: validity_start_date.to_s,
         validity_end_date: validity_end_date.to_s,
         description: description,

--- a/app/serializers/search_result/heading_serializer.rb
+++ b/app/serializers/search_result/heading_serializer.rb
@@ -1,16 +1,17 @@
 module SearchResult
   class HeadingSerializer < SimpleDelegator
     include ActiveModel::Serializers::JSON
+
     def serializable_hash(_opts = {})
       {
-        type: 'heading',
-        goods_nomenclature_item_id: goods_nomenclature_item_id,
-        producline_suffix: producline_suffix,
-        number_indents: number_indents,
-        validity_start_date: validity_start_date.to_s,
-        validity_end_date: validity_end_date.to_s,
-        description: description,
         declarable: declarable,
+        description: description,
+        goods_nomenclature_item_id: goods_nomenclature_item_id,
+        number_indents: number_indents,
+        producline_suffix: producline_suffix,
+        type: 'heading',
+        validity_end_date: validity_end_date.to_s,
+        validity_start_date: validity_start_date.to_s,
       }
     end
   end

--- a/app/serializers/search_result/heading_serializer.rb
+++ b/app/serializers/search_result/heading_serializer.rb
@@ -10,6 +10,7 @@ module SearchResult
         validity_start_date: validity_start_date.to_s,
         validity_end_date: validity_end_date.to_s,
         description: description,
+        declarable: declarable,
       }
     end
   end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -33,6 +33,7 @@ module TradeTariffFrontend
       quotas
       goods_nomenclatures
       search_references
+      search
       additional_codes
       certificates
       footnotes

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Commodity do
+  subject(:commodity) { build(:commodity) }
+
+  it_behaves_like 'a declarable'
+
   describe 'parent/children relationships' do
     let(:associated_commodities) do
       {
@@ -32,18 +36,22 @@ describe Commodity do
         heading
 
         root_children = heading.commodities.select(&:root)
-        expect(root_children).to     include heading.commodities.first
-        expect(root_children).not_to include heading.commodities.last
+
+        expect(root_children).to eq([heading.commodities.first])
       end
     end
 
     describe '#leaf?' do
-      let(:commodity_non_leaf) { heading.commodities.first }
-      let(:commodity_leaf)     { heading.commodities.last }
+      context 'when a leaf commodity' do
+        subject(:commodity) { heading.commodities.last }
 
-      it 'returns true if it is a left and false otherwise' do
-        expect(commodity_non_leaf.leaf?).to be false
-        expect(commodity_leaf.leaf?).to be true
+        it { is_expected.to be_leaf }
+      end
+
+      context 'when a NON leaf commodity' do
+        subject(:commodity) { heading.commodities.first }
+
+        it { is_expected.not_to be_leaf }
       end
     end
   end

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
 describe Heading do
-  subject(:heading) { described_class.new(attributes_for(:heading).stringify_keys) }
+  subject(:heading) { build(:heading) }
+
+  it_behaves_like 'a declarable'
 
   describe '#to_param' do
     it { expect(heading.to_param).to eq heading.short_code }

--- a/spec/support/shared_examples/a_declarable.rb
+++ b/spec/support/shared_examples/a_declarable.rb
@@ -1,0 +1,3 @@
+RSpec.shared_examples 'a declarable' do
+  it { is_expected.to respond_to(:declarable) }
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-811

### What?

I have added/removed/altered:

- Surface declarable on search results (see https://github.com/trade-tariff/trade-tariff-backend/pull/195)
- Expose search endpoint to be used by api (see https://github.com/trade-tariff/trade-tariff-backend/pull/195)

### Why?

I am doing this because:

- We need to surface whether a search result is declarable (only ever true
for a commodity or heading) for the Single Trade Window team.
- We also need to make sure that the STW team use the actual api endpoint
to do search so we're exposing this ability in the public api endpoint
whitelist configuration.
