### PR TITLE
HOTT-915: Fix cookie names overflowing table cell

### DIFF
--- a/app/webpacker/src/stylesheets/_tables.scss
+++ b/app/webpacker/src/stylesheets/_tables.scss
@@ -253,6 +253,8 @@ table.section-browser {
           padding-left: 45%;
           padding-right: 0;
           width: auto;
+          word-wrap: break-word; /* IE11 compatibility */
+          overflow-wrap: break-word;
 
           &:before {
             @include govuk-typography-weight-bold;


### PR DESCRIPTION
### Jira link

[HOTT-915](https://transformuk.atlassian.net/browse/HOTT-915)

### What?

I have added/removed/altered:

- [x] Added word breaking to responsive table cells

### Why?

I am doing this because:

- Long cookie names are overflowing the table cells on mobile and now being wrapped

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None, will resolve a very minor UI glitch

### Before

Table cell contents overflow

![Screenshot from 2021-09-03 11-46-07](https://user-images.githubusercontent.com/10818/131996155-56d45548-2a59-4e41-ae02-682fda614c25.png)

### After

Table cell contents get broken if overlong

![Screenshot from 2021-09-03 11-47-25](https://user-images.githubusercontent.com/10818/131996195-21caa10c-4cfe-4d3b-9ede-91d608698c8b.png)

