### PR TITLE
HOTT-954: Added details section on RoO tab

### DIFF
--- a/app/views/measures/_rules_of_origin.html.erb
+++ b/app/views/measures/_rules_of_origin.html.erb
@@ -63,6 +63,8 @@
       </tbody>
     </table>
 
+    <%= render 'measures/rules_of_origin_instructions' %>
+
     <% rules_of_origin.map(&:fta_intro).map(&:presence).compact.each do |fta_intro| %>
     <div class="rules-of-origin-fta">
       <h3 class="govuk-heading-m">

--- a/app/views/measures/_rules_of_origin_instructions.html.erb
+++ b/app/views/measures/_rules_of_origin_instructions.html.erb
@@ -1,0 +1,598 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">How to read rules of origin</span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <p>The rules of origin table contains:</p>
+
+    <ul class="govuk-list--bullet">
+      <li>
+        the product classification heading ('HS heading') or chapter number
+        (column 1)
+      </li>
+
+      <li>
+        a description of the product, or the headings / subheadings covered by
+        the rules (column 2)
+      </li>
+
+      <li>
+        a description of how non-originating materials must be worked or
+        processed to get country of origin status (column 3)
+      </li>
+    </ul>
+
+    <p>For each row:</p>
+
+    <ul class="govuk-list--bullet">
+      <li>
+        check column 1 to find the product classification heading or chapter
+        number for the product being exported
+      </li>
+
+      <li>check column 2 to find the description that applies to the product</li>
+
+      <li>
+        check column 3 <!--(and 4 if present)//--> to see how the product must
+        be worked or processed to gain country of origin status
+      </li>
+    </ul>
+
+    <p>
+      Unless preceded by ‘ex’, the rules in column 3 <!--(or 4 if present)//-->
+      apply to all products that come under the headings and chapters in column
+      1.
+    </p>
+
+    <p>
+      If the heading in column 1 starts with ‘ex’, the rules in column 3
+      <!--(and 4 if present)//--> will only apply to the product as described
+      in column 2.
+    </p>
+
+    <h2 class="govuk-heading-m">Introductory notes</h2>
+
+    <h3 class="govuk-heading-s" id="Note 1:">Note 1:</h3>
+
+    <p>
+      The list sets out the conditions required for all products to be
+      considered as sufficiently worked or processed within the meaning of
+      Article 5 of this Annex.
+    </p>
+
+    <h3 class="govuk-heading-s" id="Note 2:">Note 2:</h3>
+
+    <ol class="govuk-list govuk-list--number">
+      <li>
+        <p>
+          The first two columns in the list describe the product obtained.
+          The first column gives the heading number or chapter number used in
+          the Harmonised System and the second column gives the description of
+          goods used in that system for that heading or chapter. For each entry
+          in the first two columns, a rule is specified in column 3 or 4.
+          Where, in some cases, the entry in the first column is preceded by
+          an “ex”, this signifies that the rules in column 3 or 4 apply only to
+          the part of that heading as described in column 2.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          Where several heading numbers are grouped together in column 1 or a
+          chapter number is given and the description of products in column 2
+          is therefore given in general terms, the adjacent rules in column 3
+          or 4 apply to all products which, under the Harmonised System, are
+          classified in headings of the chapter or in any of the headings
+          grouped together in column 1.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          Where there are different rules in the list applying to different
+          products within a heading, each indent contains the description of
+          that part of the heading covered by the adjacent rules in column 3
+          or 4.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          Where, for an entry in the first two columns, a rule is specified in
+          both columns 3 and 4, the exporter may opt, as an alternative, to
+          apply either the rule set out in column 3 or that set out in column 4.
+          If no origin rule is given in column 4, the rule set out in column 3
+          is to be applied.
+        </p>
+      </li>
+    </ol>
+
+    <h3 class="govuk-heading-s" id="Note 3:">Note 3:</h3>
+
+    <ol class="govuk-list govuk-list--number">
+      <li>
+        <p>
+          The provisions of Article 5 of this Annex, concerning products having
+          acquired originating status which are used in the manufacture of other
+          products, shall apply, regardless of whether this status has been
+          acquired inside the factory where these products are used or in
+          another factory in the Community or in Chile.
+        </p>
+
+        <p>Example:</p>
+
+        <p>
+          An engine of heading 8407, for which the rule states that the value
+          of the non-originating materials which may be incorporated may not
+          exceed 40 % of the ex-works price, is made from “other alloy steel
+          roughly shaped by forging” of heading ex 7224.
+        </p>
+
+        <p>
+          If this forging has been forged in the Community from a
+          non-originating ingot, it has already acquired originating status by
+          virtue of the rule for heading ex 7224 in the list. The forging can
+          then count as originating in the value-calculation for the engine,
+          regardless of whether it was produced in the same factory or in
+          another factory in the Community. The value of the non-originating
+          ingot is thus not taken into account when adding up the value of the
+          non-originating materials used.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          The rule in the list represents the minimum amount of working or
+          processing required, and the carrying-out of more working or
+          processing also confers originating status; conversely, the
+          carrying-out of less working or processing cannot confer originating
+          status. Thus, if a rule provides that non-originating material, at a
+          certain level of manufacture, may be used, the use of such material
+          at an earlier stage of manufacture is allowed, and the use of such
+          material at a later stage is not.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          Without prejudice to Note 3.2, where a rule uses the expression
+          “Manufacture from materials of any heading”, then materials of any
+          heading(s) (even materials of the same description and heading as the
+          product) may be used, subject, however, to any specific limitations
+          which may also be contained in the rule.
+        </p>
+
+        <p>
+          However, the expression “Manufacture from materials of any heading,
+          including other materials of heading ...” or “Manufacture from
+          materials of any heading, including other materials of the same
+          heading as the product” means that materials of any heading(s) may be
+          used, except those of the same description as the product as given in
+          column 2 of the list.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          When a rule in the list specifies that a product may be manufactured
+          from more than one material, this means that one or more materials
+          may be used. It does not require that all be used.
+        </p>
+
+        <p>Example:</p>
+
+        <p>
+          The rule for fabrics of headings 5208 to 5212 provides that natural
+          fibres may be used and that chemical materials, among other materials,
+          may also be used. This does not mean that both have to be used; it is
+          possible to use one or the other, or both.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          Where a rule in the list specifies that a product must be manufactured
+          from a particular material, the condition obviously does not prevent
+          the use of other materials which, because of their inherent nature,
+          cannot satisfy the rule. (See also Note 6.2 below in relation to
+          textiles).
+        </p>
+
+        <p>Example:</p>
+
+        <p>
+          The rule for prepared foods of heading 1904, which specifically
+          excludes the use of cereals and their derivatives, does not prevent
+          the use of mineral salts, chemicals and other additives which are not
+          products from cereals.
+        </p>
+
+        <p>
+          However, this does not apply to products which, although they cannot
+          be manufactured from the particular materials specified in the list,
+          can be produced from a material of the same nature at an earlier
+          stage of manufacture.
+        </p>
+
+        <p>Example:</p>
+
+        <p>
+          In the case of an article of apparel of ex Chapter 62 made from
+          non-woven materials, if the use of only non-originating yarn is
+          allowed for this class of article, it is not possible to start from
+          non-woven cloth - even if non-woven cloths cannot normally be made
+          from yarn. In such cases, the starting material would normally be at
+          the stage before yarn - that is, the fibre stage.
+          </p>
+      </li>
+
+      <li>
+        <p>
+          Where, in a rule in the list, two percentages are given for the
+          maximum value of non-originating materials that can be used, then
+          these percentages may not be added together. In other words, the
+          maximum value of all the non-originating materials used may never
+          exceed the higher of the percentages given. Furthermore, the
+          individual percentages must not be exceeded, in relation to the
+          particular materials to which they apply.
+        </p>
+      </li>
+    </ol>
+
+    <h3 class="govuk-heading-s" id="Note 4:">Note 4:</h3>
+
+    <ol class="govuk-list govuk-list--number">
+      <li>
+        <p>
+          The term “natural fibres” is used in the list to refer to fibres other
+          than artificial or synthetic fibres. It is restricted to the stages
+          before spinning takes place, including waste, and, unless otherwise
+          specified, includes fibres which have been carded, combed or
+          otherwise processed, but not spun.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          The term “natural fibres” includes horsehair of heading 0503, silk of
+          headings 5002 and 5003, as well as wool-fibres and fine or coarse
+          animal hair of headings 5101 to 5105, cotton fibres of headings 5201
+          to 5203, and other vegetable fibres of headings 5301 to 5305.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          The terms “textile pulp”, “chemical materials” and “paper-making
+          materials” are used in the list to describe the materials, not
+          classified in Chapters 50 to 63, which can be used to manufacture
+          artificial, synthetic or paper fibres or yarns.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          The term “man-made staple fibres” is used in the list to refer to
+          synthetic or artificial filament tow, staple fibres or waste, of
+          headings 5501 to 5507.
+        </p>
+      </li>
+    </ol>
+
+    <h3 class="govuk-heading-s" id="Note 5:">Note 5:</h3>
+
+    <ol class="govuk-list govuk-list--number">
+      <li>
+        <p>
+          Where, for a given product in the list, reference is made to this
+          Note, the conditions set out in column 3 shall not be applied to any
+          basic textile materials used in the manufacture of this product and
+          which, taken together, represent 10 % or less of the total weight of
+          all the basic textile materials used. (See also Notes 5.3 and 5.4)
+        </p>
+      </li>
+
+      <li>
+        <p>
+          However, the tolerance mentioned in Note 5.1 may be applied only to
+          mixed products which have been made from two or more basic textile
+          materials.
+        </p>
+
+        <p>The following are the basic textile materials:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>silk,</li>
+          <li>wool,</li>
+          <li>coarse animal hair,</li>
+          <li>fine animal hair,</li>
+          <li>horsehair,</li>
+          <li>cotton,</li>
+          <li>paper-making materials and paper,</li>
+          <li>flax,</li>
+          <li>true hemp,</li>
+          <li>jute and other textile bast fibres,</li>
+          <li>sisal and other textile fibres of the genus Agave,</li>
+          <li>coconut, abaca, ramie and other vegetable textile fibres,</li>
+          <li>synthetic man-made filaments,</li>
+          <li>artificial man-made filaments,</li>
+          <li>current-conducting filaments,</li>
+          <li>synthetic man-made staple fibres of polypropylene,</li>
+          <li>synthetic man-made staple fibres of polyester,</li>
+          <li>synthetic man-made staple fibres of polyamide,</li>
+          <li>synthetic man-made staple fibres of polyacrylonitrile,</li>
+          <li>synthetic man-made staple fibres of polyimide,</li>
+          <li>synthetic man-made staple fibres of polytetrafluoroethylene,</li>
+          <li>synthetic man-made staple fibres of poly(phenylene sulphide),</li>
+          <li>synthetic man-made staple fibres of poly(vinyl chloride),</li>
+          <li>other synthetic man-made staple fibres,</li>
+          <li>artificial man-made staple fibres of viscose,</li>
+          <li>other artificial man-made staple fibres,</li>
+          <li>
+            yarn made of polyurethane segmented with flexible segments of
+            polyether, whether or not gimped,
+          </li>
+          <li>
+            yarn made of polyurethane segmented with flexible segments of
+            polyester, whether or not gimped,
+          </li>
+          <li>
+            products of heading 5605 (metallised yarn) incorporating strip
+            consisting of a core of aluminium foil or of a core of plastic film
+            whether or not coated with aluminium powder, of a width not
+            exceeding 5 mm, sandwiched by means of a transparent or coloured
+            adhesive between two layers of plastic film,
+          </li>
+          <li>
+            other products of heading 5605.
+            <br>
+            Example:
+            <br>
+            A yarn, of heading 5205, made from cotton fibres of heading 5203
+            and synthetic staple fibres of heading 5506, is a mixed yarn.
+            Therefore, non-originating synthetic staple fibres which do not
+            satisfy the origin-rules (which require manufacture from chemical
+            materials or textile pulp) may be used, provided that their total
+            weight does not exceed 10 % of the weight of the yarn.
+            <br>
+            Example:
+            <br>
+            A woollen fabric, of heading 5112, made from woollen yarn of heading
+            5107 and synthetic yarn of staple fibres of heading 5509, is a mixed
+            fabric. Therefore, synthetic yarn which does not satisfy the
+            origin-rules (which require manufacture from chemical materials or
+            textile pulp), or woollen yarn which does not satisfy the
+            origin-rules (which require manufacture from natural fibres, not
+            carded or combed or otherwise prepared for spinning), or a
+            combination of the two, may be used, provided that their total
+            weight does not exceed 10 % of the weight of the fabric.
+            <br>
+            Example:
+            <br>
+            Tufted textile fabric, of heading 5802, made from cotton yarn of
+            heading 5205 and cotton fabric of heading 5210, is a only mixed
+            product if the cotton fabric is itself a mixed fabric made from
+            yarns classified in two separate headings, or if the cotton yarns
+            used are themselves mixtures.
+            <br>
+            Example:
+            <br>
+            If the tufted textile fabric concerned had been made from cotton
+            yarn of heading 5205 and synthetic fabric of heading 5407, then,
+            obviously, the yarns used are two separate basic textile materials
+            and the tufted textile fabric is, accordingly, a mixed product.
+          </li>
+        </ul>
+      </li>
+
+      <li>
+        <p>
+          In the case of products incorporating “yarn made of polyurethane
+          segmented with flexible segments of polyether, whether or not gimped”,
+          this tolerance is 20 % in respect of this yarn.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          In the case of products incorporating “strip consisting of a core of
+          aluminium foil or of a core of plastic film whether or not coated
+          with aluminium powder, of a width not exceeding 5 mm, sandwiched by
+          means of a transparent or coloured adhesive between two layers of
+          plastic film”, this tolerance is 30 % in respect of this strip.
+        </p>
+      </li>
+    </ol>
+
+    <h3 class="govuk-heading-s" id="Note 6:">Note 6:</h3>
+
+    <ol class="govuk-list govuk-list--number">
+      <li>
+        <p>
+          Where, in the list, reference is made to this Note, textile materials
+          (with the exception of linings and interlinings), which do not satisfy
+          the rule set out in the list in column 3 for the made-up product
+          concerned, may be used, provided that they are classified in a heading
+          other than that of the product and that their value does not exceed
+          8 % of the ex-works price of the product.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          Without prejudice to Note 6.3, materials, which are not classified
+          within Chapters 50 to 63, may be used freely in the manufacture of
+          textile products, whether or not they contain textiles.
+        </p>
+
+        <p>Example:</p>
+
+        <p>
+          If a rule in the list provides that, for a particular textile item
+          (such as trousers), yarn must be used, this does not prevent the use
+          of metal items, such as buttons, because buttons are not classified
+          within Chapters 50 to 63. For the same reason, it does not prevent
+          the use of slide-fasteners, even though slide-fasteners normally
+          contain textiles.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          Where a percentage-rule applies, the value of materials which are not
+          classified within Chapters 50 to 63 must be taken into account when
+          calculating the value of the non-originating materials incorporated.
+        </p>
+      </li>
+    </ol>
+
+    <h3 class="govuk-heading-s" id="Note 7:">Note 7:</h3>
+
+    <ol class="govuk-list govuk-list--number">
+      <li>
+        <p>
+          For the purposes of headings ex 2707, 2713 to 2715, ex 2901, ex 2902
+          and ex 3403, the “specific processes” are the following:
+        </p>
+
+        <p>
+          (a) vacuum-distillation;<br>
+          (b) redistillation by a very thorough fractionation-process (¹),<br>
+          (c) cracking;<br>
+          (d) reforming;<br>
+          (e) extraction by means of selective solvents;<br>
+          (f) the process comprising all of the following operations: processing with concentrated sulphuric acid, oleum or sulphuric anhydride; neutralisation with alkaline agents; decolourisation and purification with naturally-active earth, activated earth, activated charcoal or bauxite;<br>
+          (g) polymerisation;<br>
+          (h) alkylation;<br>
+          (i) isomerisation.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          For the purposes of headings 2710, 2711 and 2712, the “specific
+          processes” are the following:
+        </p>
+      </li>
+    </ol>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>vacuum-distillation;</li>
+      <li>redistillation by a very thorough fractionation-process (¹),</li>
+      <li>cracking;</li>
+      <li>reforming;</li>
+      <li>extraction by means of selective solvents;</li>
+      <li>
+        the process comprising all of the following operations: processing with
+        concentrated sulphuric acid, oleum or sulphuric anhydride;
+        neutralisation with alkaline agents; decolourisation and purification
+        with naturally-active earth, activated earth, activated charcoal or
+        bauxite;
+      </li>
+      <li>polymerisation;</li>
+      <li>alkylation;</li>
+      <li>isomerisation;</li>
+      <li>
+        in respect of heavy oils of heading ex 2710 only, desulphurisation with
+        hydrogen, resulting in a reduction of at least 85 % of the
+        sulphur-content of the products processed (ASTM D 1266.59 T method);
+      </li>
+      <li>
+        in respect of products of heading 2710 only, deparaffining by a process
+        other than filtering;
+      </li>
+      <li>
+        in respect of heavy oils of heading ex 2710 only, treatment with
+        hydrogen, at a pressure of more than 20 bar and a temperature of more
+        than 250 °C, with the use of a catalyst, other than to effect
+        desulphurisation, when the hydrogen constitutes an active element in a
+        chemical reaction. The further treatment, with hydrogen, of lubricating
+        oils of heading ex 2710 (e.g. hydrofinishing or decolourisation), in
+        order, more especially, to improve colour or stability shall not,
+        however, be deemed to be a specific process;
+      </li>
+      <li>
+        in respect of fuel oils of heading ex 2710 only, atmospheric
+        distillation, on condition that less than 30 % of these products
+        distils, by volume, including losses, at 300 °C, by the ASTM D 86
+        method;
+      </li>
+      <li>
+        in respect of heavy oils other than gas oils and fuel oils of
+        heading ex 2710 only, treatment by means of a high-frequency electrical
+        brush-discharge;
+      </li>
+      <li>
+        in respect of crude products (other than petroleum jelly, ozokerite,
+        lignite wax or peat wax, paraffin wax containing by weight less than
+        0,75 % of oil) of heading ex 2712 only, de-oiling by fractional
+        crystallisation.
+      </li>
+    </ul>
+
+    <ol class="govuk-list govuk-list--number" start="3">
+      <li>
+        <p>
+          For the purposes of headings ex 2707, 2713 to 2715, ex 2901, ex 2902
+          and ex 3403, simple operations, such as cleaning, decanting,
+          desalting, water-separation, filtering, colouring, marking, obtaining
+          a sulphur-content as a result of mixing products with different
+          sulphur-contents, or any combination of these operations or like
+          operations, do not confer origin.
+        </p>
+      </li>
+
+      <li>
+        <p>
+          Redistillation by a very thorough fractionation process means
+          distillation (other than topping) by a continuous or batch process
+          employed in industrial installations using distillates of subheading
+          Nos 2710 11 to 2710 99, 2711 11, 2711 12 to 2711 19, 2711 21 and 2711
+          29 (other than propane of a purity of 99 % or more) to obtain:
+        </p>
+      </li>
+
+      <li>
+        <p>
+          isolated high-purity hydrocarbons (90 % or more in the case of olefins
+          and 95 % or more in the case of other hydrocarbons, mixtures of
+          isomers having the same organic composition being regarded as isolated
+          hydrocarbons;
+        </p>
+
+        <p>
+          only those process by means of which at least three different products
+          are obtained are admissible, but this restriction does not apply in
+          any instance where the process consists in the separation of isomers.
+          In so far this concerns xylenes, ethylbenzene is included with xylene
+          isomers;
+        </p>
+      </li>
+
+      <li>
+        <p>Products of subheading Nos 2707 10 to 2707 30, 2707 50 and 2710 11 to 2710 99,</p>
+
+        <ol class="govuk-list govuk-list--number">
+          <li>
+            (with no overlapping of the final boiling point of one fraction and
+            the initial boiling point of the succeeding fraction and a
+            difference of not more than 60 °C between the temperatures at which
+            5 and 90 % by the volume (including losses) distil by the ASTM D
+            86-67 method (reapproved 1972);
+          </li>
+
+          <li>
+            with an overlapping of the final boiling point of one fraction and
+            the initial boiling point of the succeeding fraction and a
+            difference of not more than 30 °C between the temperatures at which
+            5 and 90 % by volume (including losses) distil by the ASTM D
+            86-67 method (reapproved 1972).
+          </li>
+        </ol>
+      </li>
+    </ol>
+
+    <p>(¹) See introductory Note 7.4.</p>
+  </div>
+</details>

--- a/spec/views/measures/_rules_of_origin.html.erb_spec.rb
+++ b/spec/views/measures/_rules_of_origin.html.erb_spec.rb
@@ -36,6 +36,10 @@ describe 'measures/_rules_of_origin.html.erb', type: :view do
     expect(rendered_page).to have_css 'h3', text: /for commodity 2203000100/
   end
 
+  it 'includes the "How to read the rules" section' do
+    expect(rendered_page).to have_css 'details summary span', text: /How to read/
+  end
+
   context 'with UK service' do
     before do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('uk')


### PR DESCRIPTION
### Jira link

[HOTT-954](https://transformuk.atlassian.net/browse/HOTT-954)

### What?

I have added/removed/altered:

- [x] Added in the missing details section explaining how to use the rules of origin

### Why?

I am doing this because:

- This section of the page needs to be added

