### PR TITLE
HOTT-951: Show fta intro text

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -11,7 +11,7 @@ class CommoditiesController < GoodsNomenclaturesController
     @back_path = request.referer || heading_path(@heading.short_code)
 
     if params[:country].present? && TradeTariffFrontend.rules_of_origin_enabled?
-      @rules_of_origin = commodity.rules_of_origin_rules(params[:country])
+      @rules_of_origin = commodity.rules_of_origin(params[:country])
     end
   end
 

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -9,7 +9,7 @@ class HeadingsController < GoodsNomenclaturesController
     @back_path = request.referer || chapter_path(heading.chapter.short_code)
 
     if params[:country].present? && TradeTariffFrontend.rules_of_origin_enabled?
-      @rules_of_origin = heading.rules_of_origin_rules(params[:country])
+      @rules_of_origin = heading.rules_of_origin(params[:country])
     end
   end
 

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -5,7 +5,7 @@ class RulesOfOrigin::Scheme
 
   collection_path '/rules_of_origin_schemes'
 
-  attr_accessor :scheme_code, :title, :countries, :footnote
+  attr_accessor :scheme_code, :title, :countries, :footnote, :fta_intro
 
   has_many :rules, class_name: 'RulesOfOrigin::Rule'
 

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -148,7 +148,7 @@
                    country_code: @search.country,
                    country_name: @search.geographical_area.description,
                    commodity_code: declarable.code,
-                   rules: rules_of_origin %>
+                   rules_of_origin: rules_of_origin %>
       <%- else -%>
         <%= render 'measures/rules_of_origin_without_country' %>
       <%- end -%>

--- a/app/views/measures/_rules_of_origin.html.erb
+++ b/app/views/measures/_rules_of_origin.html.erb
@@ -45,7 +45,7 @@
         </tr>
         <% end %>
 
-        <% for rule in rules_of_origin.flat_map(&:rules) %>
+        <% rules_of_origin.flat_map(&:rules).each do |rule| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" data-label="Heading">
             <%= rule.heading %>
@@ -63,7 +63,7 @@
       </tbody>
     </table>
 
-    <% for fta_intro in rules_of_origin.map(&:fta_intro).map(&:presence).compact %>
+    <% rules_of_origin.map(&:fta_intro).map(&:presence).compact.each do |fta_intro| %>
     <div class="rules-of-origin-fta">
       <h3 class="govuk-heading-m">
         Trading relationship with <%= country_name %>

--- a/app/views/measures/_rules_of_origin.html.erb
+++ b/app/views/measures/_rules_of_origin.html.erb
@@ -62,5 +62,17 @@
         <% end %>
       </tbody>
     </table>
+
+    <% for fta_intro in rules_of_origin.map(&:fta_intro).map(&:presence).compact %>
+    <div class="rules-of-origin-fta">
+      <h3 class="govuk-heading-m">
+        Trading relationship with <%= country_name %>
+      </h3>
+
+      <div class="tariff-markdown">
+        <%= govspeak fta_intro %>
+      </div>
+    </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/measures/_rules_of_origin.html.erb
+++ b/app/views/measures/_rules_of_origin.html.erb
@@ -37,7 +37,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <% if rules.length.zero? %>
+        <% if rules_of_origin.flat_map(&:rules).length.zero? %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" colspan="3">
             There are no product-specific rules for commodity <% commodity_code %>
@@ -45,7 +45,7 @@
         </tr>
         <% end %>
 
-        <% for rule in rules %>
+        <% for rule in rules_of_origin.flat_map(&:rules) %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" data-label="Heading">
             <%= rule.heading %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -267,6 +267,7 @@ FactoryBot.define do
     sequence(:title) { |n| "Scheme title #{n}" }
     countries { %w[FR ES IT] }
     footnote { 'Scheme footnote' }
+    fta_intro { "## Agreement\n\nDetails of agreement" }
     rules { attributes_for_list :rules_of_origin_rule, rule_count }
   end
 end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -18,6 +18,7 @@ describe RulesOfOrigin::Scheme do
               title: 'Scheme title',
               countries: %w[FR ES IT],
               footnote: 'Footnote comments **in markdown**',
+              fta_intro: "## Markdown heading\n\n Further information",
             },
             relationships: {
               rules: {
@@ -75,6 +76,7 @@ describe RulesOfOrigin::Scheme do
         it { is_expected.to have_attributes title: 'Scheme title' }
         it { is_expected.to have_attributes countries: %w[FR ES IT] }
         it { is_expected.to have_attributes footnote: /footnote/i }
+        it { is_expected.to have_attributes fta_intro: /Further information/ }
         it { expect(scheme.rules).to have_attributes length: 1 }
       end
 

--- a/spec/views/measures/_rules_of_origin.html.erb_spec.rb
+++ b/spec/views/measures/_rules_of_origin.html.erb_spec.rb
@@ -8,10 +8,16 @@ describe 'measures/_rules_of_origin.html.erb', type: :view do
            country_code: 'FR',
            country_name: 'France',
            commodity_code: '2203000100',
-           rules: rules
+           rules_of_origin: schemes
   end
 
-  let(:rules) { [] }
+  let :rules_data do
+    attributes_for_list :rules_of_origin_rule,
+                        1,
+                        rule: "Manufacture\n\n* From materials"
+  end
+
+  let(:schemes) { build_list :rules_of_origin_scheme, 1, rules: rules_data }
 
   it 'includes the countries name in the title' do
     expect(rendered_page).to \
@@ -49,15 +55,7 @@ describe 'measures/_rules_of_origin.html.erb', type: :view do
   end
 
   context 'with matched rules' do
-    let :rules do
-      [
-        OpenStruct.new(
-          heading: 'Chapter 22',
-          description: 'Beverages',
-          rule: "Manufacture\n\n* From materials",
-        ),
-      ]
-    end
+    let(:rules) { schemes.flat_map(&:rules) }
 
     it 'shows rules table' do
       expect(rendered_page).to have_css 'table.govuk-table'
@@ -69,12 +67,12 @@ describe 'measures/_rules_of_origin.html.erb', type: :view do
 
     it 'show rule heading' do
       expect(rendered_page).to \
-        have_css 'tbody tr td', text: 'Chapter 22'
+        have_css 'tbody tr td', text: rules[0].heading
     end
 
     it 'shows rule description' do
       expect(rendered_page).to \
-        have_css 'tbody tr td', text: 'Beverages'
+        have_css 'tbody tr td', text: rules[0].description
     end
 
     it 'formats the rule detail markdown' do
@@ -84,6 +82,8 @@ describe 'measures/_rules_of_origin.html.erb', type: :view do
   end
 
   context 'without matched rules' do
+    let(:rules_data) { [] }
+
     it 'shows rules table' do
       expect(rendered_page).to have_css 'table.govuk-table'
     end

--- a/spec/views/measures/_rules_of_origin.html.erb_spec.rb
+++ b/spec/views/measures/_rules_of_origin.html.erb_spec.rb
@@ -17,7 +17,11 @@ describe 'measures/_rules_of_origin.html.erb', type: :view do
                         rule: "Manufacture\n\n* From materials"
   end
 
-  let(:schemes) { build_list :rules_of_origin_scheme, 1, rules: rules_data }
+  let(:schemes) do
+    build_list :rules_of_origin_scheme, 1, rules: rules_data, fta_intro: fta_intro
+  end
+
+  let(:fta_intro) { "## Free Trade Agreement\n\nDetails of agreement" }
 
   it 'includes the countries name in the title' do
     expect(rendered_page).to \
@@ -54,8 +58,8 @@ describe 'measures/_rules_of_origin.html.erb', type: :view do
     end
   end
 
-  context 'with matched rules' do
-    let(:rules) { schemes.flat_map(&:rules) }
+  context 'with matched rules of origin' do
+    let(:first_rule) { schemes[0].rules[0] }
 
     it 'shows rules table' do
       expect(rendered_page).to have_css 'table.govuk-table'
@@ -67,17 +71,23 @@ describe 'measures/_rules_of_origin.html.erb', type: :view do
 
     it 'show rule heading' do
       expect(rendered_page).to \
-        have_css 'tbody tr td', text: rules[0].heading
+        have_css 'tbody tr td', text: first_rule.heading
     end
 
     it 'shows rule description' do
       expect(rendered_page).to \
-        have_css 'tbody tr td', text: rules[0].description
+        have_css 'tbody tr td', text: first_rule.description
     end
 
     it 'formats the rule detail markdown' do
       expect(rendered_page).to \
         have_css '.tariff-markdown ul li', text: 'From materials'
+    end
+
+    it 'formats the scheme fta_intro markdown' do
+      expect(rendered_page).to \
+        have_css '.rules-of-origin-fta .tariff-markdown h2',
+                 text: 'Free Trade Agreement'
     end
   end
 
@@ -91,6 +101,14 @@ describe 'measures/_rules_of_origin.html.erb', type: :view do
     it 'shows no matched rules message' do
       expect(rendered_page).to \
         have_css 'tbody td', text: /no product-specific rules/
+    end
+  end
+
+  context 'with blank fta_intro field' do
+    let(:fta_intro) { '' }
+
+    it 'does not show details of fta field' do
+      expect(rendered_page).not_to have_css '.rules-of-origin-fta'
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-956](https://transformuk.atlassian.net/browse/HOTT-956)

### What?

I have added/removed/altered:

- [x] Load Rules of Origin schemes as well as rules in the Headings and Commodities controller
- [x] Show the fta_intro information from the scheme below the rules on the Rules of Origin tab

### Why?

I am doing this because:

- Our users will want to see this information

