### PR TITLE
Use ECR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  aws-cli: circleci/aws-cli@2.0.3
   ruby: circleci/ruby@1.1.2
   node: circleci/node@2
   browser-tools: circleci/browser-tools@1.1
@@ -39,11 +40,11 @@ commands:
       - run:
           name: "Push new app in dark mode"
           command: |
-            export IMAGE=enginetransformation/tariff-frontend
-            export DOCKER_IMAGE=${IMAGE}:<<# parameters.dev-release >>dev-<</ parameters.dev-release >>${CIRCLE_SHA1}
+            export DOCKER_IMAGE=tariff-frontend
+            export DOCKER_TAG=<<# parameters.dev-release >>dev-<</ parameters.dev-release >>${CIRCLE_SHA1}
 
             # Push as "dark" instance
-            cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --docker-image "$DOCKER_IMAGE"
+            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
             # Map dark route
             cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
             # Enable routing from this service to the backend applications which are private
@@ -134,7 +135,7 @@ jobs:
 
   build:
     environment:
-      IMAGE_NAME: enginetransformation/tariff-frontend
+      IMAGE_NAME: tariff-frontend
     parameters:
       dev-build:
         default: false
@@ -146,17 +147,23 @@ jobs:
       - setup_remote_docker:
           version: 20.10.2
           docker_layer_caching: false
+      - aws-cli/install
+      - run:
+          name: "Set docker tag"
+          command: |
+            echo "export DOCKER_TAG=<<# parameters.dev-build >>dev-<</ parameters.dev-build >>${CIRCLE_SHA1}" >> $BASH_ENV
       - run:
           name: "Build Docker image"
           command: |
             export GIT_NEW_REVISION=$(git rev-parse --short HEAD)
             echo $GIT_NEW_REVISION >REVISION
-            docker build -t $IMAGE_NAME:<<# parameters.dev-build >>dev-<</ parameters.dev-build >>${CIRCLE_SHA1} .
+            docker build -t $IMAGE_NAME:$DOCKER_TAG .
       - run:
-          name: "Push image"
+          name: "Push image to ECR"
           command: |
-            echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push $IMAGE_NAME:<<# parameters.dev-build >>dev-<</ parameters.dev-build >>${CIRCLE_SHA1}
+            aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ECR_REPO
+            docker tag $IMAGE_NAME:$DOCKER_TAG $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
+            docker push $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
 
   cypress:
     docker:


### PR DESCRIPTION
### Jira link

n/a 

### What?

I have added/removed/altered:

- [ ] Use ECR instead of DockerHub


### Why?

I am doing this because:
- We are doing this because of the recent policy changed in DockerHub and the limits introduced.
- We keep our docker images in the AWS account we use for other project related resources (eg.CDN, S3)
-

### Have you? (optional)

- [ ] Added documentation for new apis
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks (optional)

- Includes destructive/migratory actions which may effect critical data
- Changes an api that is used in production
