### PR TITLE
HOTT-954: Show links in sidebar

### DIFF
--- a/app/models/rules_of_origin/link.rb
+++ b/app/models/rules_of_origin/link.rb
@@ -1,0 +1,7 @@
+require 'api_entity'
+
+class RulesOfOrigin::Link
+  include ApiEntity
+
+  attr_accessor :text, :url
+end

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -8,6 +8,7 @@ class RulesOfOrigin::Scheme
   attr_accessor :scheme_code, :title, :countries, :footnote, :fta_intro
 
   has_many :rules, class_name: 'RulesOfOrigin::Rule'
+  has_many :links, class_name: 'RulesOfOrigin::Link'
 
   class << self
     def all(heading_code, country_code, opts = {})

--- a/app/views/measures/_rules_of_origin.html.erb
+++ b/app/views/measures/_rules_of_origin.html.erb
@@ -77,4 +77,22 @@
     </div>
     <% end %>
   </div>
+
+  <% if rules_of_origin.flat_map(&:links).any? %>
+  <div class="grid-column-one-third" id="rules-of-origin__related-content">
+    <h2 class="govuk-heading-m">
+      Related content
+    </h2>
+
+    <nav role="navigation">
+      <ul class="govuk-list govuk-list-s">
+        <% rules_of_origin.flat_map(&:links).each do |link| %>
+          <li>
+            <%= link_to link.text, link.url %>
+          </li>
+        <% end %>
+      </ul>
+    </nav>
+  </div>
+  <% end %>
 </div>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -258,9 +258,15 @@ FactoryBot.define do
     rule { 'Rule' }
   end
 
+  factory :rules_of_origin_link, class: 'RulesOfOrigin::Link' do
+    sequence(:text) { |n| "GovUK page #{n}" }
+    url { 'https://www.gov.uk' }
+  end
+
   factory :rules_of_origin_scheme, class: 'RulesOfOrigin::Scheme' do
     transient do
       rule_count { 3 }
+      link_count { 2 }
     end
 
     sequence(:scheme_code) { |n| "SC#{n}" }
@@ -269,5 +275,6 @@ FactoryBot.define do
     footnote { 'Scheme footnote' }
     fta_intro { "## Agreement\n\nDetails of agreement" }
     rules { attributes_for_list :rules_of_origin_rule, rule_count }
+    links { attributes_for_list :rules_of_origin_link, link_count }
   end
 end

--- a/spec/models/rules_of_origin/link_spec.rb
+++ b/spec/models/rules_of_origin/link_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe RulesOfOrigin::Link do
+  it { is_expected.to respond_to :text }
+  it { is_expected.to respond_to :url }
+end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -4,6 +4,14 @@ describe RulesOfOrigin::Scheme do
   let(:api_host) { TradeTariffFrontend::ServiceChooser.api_host }
   let(:response_headers) { { content_type: 'application/json; charset=utf-8' } }
 
+  it { is_expected.to respond_to :scheme_code }
+  it { is_expected.to respond_to :title }
+  it { is_expected.to respond_to :countries }
+  it { is_expected.to respond_to :footnote }
+  it { is_expected.to respond_to :fta_intro }
+  it { is_expected.to respond_to :rules }
+  it { is_expected.to respond_to :links }
+
   describe '.all' do
     let(:json_response) { response_data.to_json }
 
@@ -29,6 +37,14 @@ describe RulesOfOrigin::Scheme do
                   },
                 ],
               },
+              links: {
+                data: [
+                  {
+                    id: 'EU-link-1',
+                    type: 'rules_of_origin_link',
+                  },
+                ],
+              },
             },
           },
         ],
@@ -41,6 +57,14 @@ describe RulesOfOrigin::Scheme do
               heading: 'Chapter 22',
               description: 'Beverages',
               rule: "Rule\n\n* Requirement 1\n* Requirement 2",
+            },
+          },
+          {
+            id: 'EU-link-1',
+            type: 'rules_of_origin_link',
+            attributes: {
+              text: 'GovUK',
+              url: 'https://www.gov.uk',
             },
           },
         ],
@@ -136,7 +160,7 @@ describe RulesOfOrigin::Scheme do
       it { is_expected.to eql [] }
     end
 
-    context 'with response with no rules' do
+    context 'with response with no rules or links' do
       include_context 'with mocked response'
 
       let :response_data do
@@ -154,6 +178,7 @@ describe RulesOfOrigin::Scheme do
               relationships: {
                 rules: {
                   data: [],
+                  links: [],
                 },
               },
             },
@@ -169,6 +194,20 @@ describe RulesOfOrigin::Scheme do
 
         it { is_expected.to have_attributes scheme_code: 'EU' }
         it { is_expected.to have_attributes rules: [] }
+        it { is_expected.to have_attributes links: [] }
+      end
+    end
+
+    describe 'links' do
+      include_context 'with mocked response'
+
+      it { expect(schemes.first.links.length).to be 1 }
+
+      context 'with single link' do
+        subject { schemes.first.links.first }
+
+        it { is_expected.to have_attributes text: 'GovUK' }
+        it { is_expected.to have_attributes url: 'https://www.gov.uk' }
       end
     end
   end

--- a/spec/views/measures/_rules_of_origin.html.erb_spec.rb
+++ b/spec/views/measures/_rules_of_origin.html.erb_spec.rb
@@ -40,6 +40,10 @@ describe 'measures/_rules_of_origin.html.erb', type: :view do
     expect(rendered_page).to have_css 'details summary span', text: /How to read/
   end
 
+  it 'includes links in the sidebar' do
+    expect(rendered_page).to have_css '#rules-of-origin__related-content nav li'
+  end
+
   context 'with UK service' do
     before do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('uk')


### PR DESCRIPTION
### Jira link

[HOTT-954](https://transformuk.atlassian.net/browse/HOTT-954)

### What?

I have added/removed/altered:

- [x] Added Schem links in to the sidebar on the Rules of Origin tab

### Why?

I am doing this because:

- We wish to present this information to the user
