### PR TITLE
HOTT-960: Show the no rules message in a <p>

### DIFF
--- a/app/views/rules_of_origin/_rules_table.html.erb
+++ b/app/views/rules_of_origin/_rules_table.html.erb
@@ -1,0 +1,45 @@
+<p>
+  If your product has been produced using any non-originating materials, the
+  product has to fulfil the following product-specific rule to be considered
+  originating in the <%= rules_of_origin_service_name %> or <%= country_name %>.
+</p>
+
+<p>
+  If there are alternative rules, your product needs to comply with only one
+  of them.
+</p>
+
+<table class="govuk-table govuk-table--responsive commodity-rules-of-origin">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">
+        Heading
+      </th>
+
+      <th class="govuk-table__header" scope="col">
+        Description
+      </th>
+
+      <th class="govuk-table__header" scope="col">
+        Rule
+      </th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% rules.each do |rule| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell" data-label="Heading">
+        <%= rule.heading %>
+      </td>
+
+      <td class="govuk-table__cell" data-label="Description">
+        <%= rule.description %>
+      </td>
+
+      <td class="govuk-table__cell tariff-markdown responsive-full-width" data-label="Rule">
+        <%= govspeak rule.rule %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -11,59 +11,15 @@
       Product-specific rules for commodity <%= commodity_code %>
     </h3>
 
-    <p>
-      If your product has been produced using any non-originating materials, the
-      product has to fulfil the following product-specific rule to be considered
-      originating in the <%= uk_service_choice? ? 'UK' : 'EU' %> or <%= country_name %>.
-    </p>
-
-    <p>
-      If there are alternative rules, your product needs to comply with only one
-      of them.
-    </p>
-
-    <table class="govuk-table govuk-table--responsive commodity-rules-of-origin">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="col">
-            Heading
-          </th>
-
-          <th class="govuk-table__header" scope="col">
-            Description
-          </th>
-
-          <th class="govuk-table__header" scope="col">
-            Rule
-          </th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <% if rules_of_origin.flat_map(&:rules).length.zero? %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell" colspan="3">
-            There are no product-specific rules for commodity <% commodity_code %>
-          </td>
-        </tr>
-        <% end %>
-
-        <% rules_of_origin.flat_map(&:rules).each do |rule| %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell" data-label="Heading">
-            <%= rule.heading %>
-          </td>
-
-          <td class="govuk-table__cell" data-label="Description">
-            <%= rule.description %>
-          </td>
-
-          <td class="govuk-table__cell tariff-markdown responsive-full-width" data-label="Rule">
-            <%= govspeak rule.rule %>
-          </td>
-        </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <%- if (rules = rules_of_origin.flat_map(&:rules)).any? -%>
+      <%= render 'rules_of_origin/rules_table',
+                 country_name: country_name,
+                 rules: rules %>
+    <%- else -%>
+      <p>
+        There are no product-specific rules for commodity <% commodity_code %>
+      </p>
+    <%- end -%>
 
     <%= render 'rules_of_origin/instructions' %>
 

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -106,13 +106,13 @@ describe 'rules_of_origin/_tab.html.erb', type: :view do
   context 'without matched rules' do
     let(:rules_data) { [] }
 
-    it 'shows rules table' do
-      expect(rendered_page).to have_css 'table.govuk-table'
+    it 'does not shows rules table' do
+      expect(rendered_page).not_to have_css 'table.govuk-table'
     end
 
     it 'shows no matched rules message' do
       expect(rendered_page).to \
-        have_css 'tbody td', text: /no product-specific rules/
+        have_css 'p', text: /no product-specific rules/
     end
   end
 


### PR DESCRIPTION
### Jira link

[HOTT-960](https://transformuk.atlassian.net/browse/HOTT-960)

### What?

I have added/removed/altered:

- [x] Show the no rules message in a `<p>` tag when there are no rules
- [x] Don't show the intro para's when there are no rules
- [x] Moved the rules table to its own partial

### Why?

I am doing this because:

- So users are not shown irrelevant content
