### PR TITLE
HOTT-959: Fixed RoO when selecting country

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -92,7 +92,7 @@ class SearchController < ApplicationController
   private
 
   def anchor
-    safe_anchor = params.dig(:search, :anchor).to_s.gsub(/[^a-z]/, '')
+    safe_anchor = params.dig(:search, :anchor).to_s.gsub(/[^a-zA-Z_\-]/, '')
     safe_anchor.present? ? "##{safe_anchor}" : ''
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-959](https://transformuk.atlassian.net/browse/HOTT-959)

### What?

I have added/removed/altered:

- [x] Fixed the filtering on the anchor field

### Why?

I am doing this because:

- Previously the code to remain on a tab would strip anything which wasn't lowercase letters. This meant if the user was on tab which has upper case letters or hyphens the tab position would be lost upon selecting a country. The regex has been opened up slightly to allow for upper case, hyphens and underscores.

