### PR TITLE
HOTT-973: Feature flag RoO data loading ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ yarn-debug.log*
 .yarn-integrity
 
 .nvimlog
+.byebug_history

--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -10,7 +10,7 @@ class CommoditiesController < GoodsNomenclaturesController
     @section = commodity.section
     @back_path = request.referer || heading_path(@heading.short_code)
 
-    if params[:country].present? && TradeTariffFrontend.rules_of_origin_enabled?
+    if params[:country].present? && TradeTariffFrontend.rules_of_origin_api_requests_enabled?
       @rules_of_origin = commodity.rules_of_origin(params[:country])
     end
   end

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -8,7 +8,7 @@ class HeadingsController < GoodsNomenclaturesController
     @commodities = HeadingCommodityPresenter.new(heading.commodities)
     @back_path = request.referer || chapter_path(heading.chapter.short_code)
 
-    if params[:country].present? && TradeTariffFrontend.rules_of_origin_enabled?
+    if params[:country].present? && TradeTariffFrontend.rules_of_origin_api_requests_enabled?
       @rules_of_origin = heading.rules_of_origin(params[:country])
     end
   end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -84,6 +84,11 @@ module TradeTariffFrontend
     ENV['RULES_OF_ORIGIN_ENABLED'].to_s.downcase == 'true'
   end
 
+  def rules_of_origin_api_requests_enabled?
+    rules_of_origin_enabled? ||
+      ENV['RULES_OF_ORIGIN_API_REQUESTS_ENABLED'].to_s.downcase == 'true'
+  end
+
   def revision
     `cat REVISION 2>/dev/null || git rev-parse --short HEAD`.strip
   end


### PR DESCRIPTION
Indepently of showing the Rules of Origin tab itself

### Jira link

[HOTT-973](https://transformuk.atlassian.net/browse/HOTT-973)

### What?

I have added/removed/altered:

- [x] Added a separate data flag for loading RoO data - this will also enable if the full Rules of Origin feature is enabled

### Why?

I am doing this because:

- I want to do a graduated roll out
