### PR TITLE
HOTT-955 Remove a footer link 

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -66,7 +66,6 @@
       <ul class="govuk-footer__list">
         <!-- <li><a href="#">How to use the Tariff</a></li> -->
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/guidance/finding-commodity-codes-for-imports-or-exports">Finding commodity codes for imports or exports</a></li>
-        <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/guidance/using-the-trade-tariff-tool-to-find-a-commodity-code">Using the Trade Tariff tool to find a commodity code</a></li>
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/topic/business-tax/import-export">Import and export</a></li>
       </ul>
     </div>


### PR DESCRIPTION
### What?
Remove the footer link "Using the Trade Tariff tool to find a commodity code".

### Jira link

https://transformuk.atlassian.net/browse/HOTT-955

### Why?

I am doing this because:
The link removed pointed to exactly the same link as the one above.
