### PR TITLE
HOTT-975: Refer to EU not UK on XI RoO tab

### DIFF
--- a/app/views/rules_of_origin/_without_country.html.erb
+++ b/app/views/rules_of_origin/_without_country.html.erb
@@ -5,8 +5,8 @@
     </h2>
 
     <p>
-      To view rules of origin, select a country with which the UK has a trade
-      agreement from the list above
+      To view rules of origin, select a country with which the <%= rules_of_origin_service_name %>
+      has a trade agreement from the list above
     </p>
 
     <p>
@@ -23,7 +23,8 @@
 
         <li class="govuk-body-s">
           <a href="https://www.gov.uk/guidance/import-and-export-goods-using-preference-agreements">
-            Pay less Customs Duty on goods from a country with a UK trade agreement
+            Pay less Customs Duty on goods from a country with a <%= rules_of_origin_service_name %>
+            trade agreement
           </a>
         </li>
       </ul>


### PR DESCRIPTION
### Jira link

[HOTT-975](https://transformuk.atlassian.net/browse/HOTT-975)

### What?

I have added/removed/altered:

- [x] use the correct terminology for the the Rules of Origin agreements rather than always using UK

### Why?

I am doing this because:

- XI operates under EU agreements rather than UK agreements

### Notes

This has not yet been confirmed as a desired behaviour by Matt
