### PR TITLE
HOTT-976: Embolden trade agreement title

### DIFF
--- a/app/views/rules_of_origin/_intro_country.html.erb
+++ b/app/views/rules_of_origin/_intro_country.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-inset-text" id="rules-of-origin__intro--country-scheme">
   <p>
     In order to qualify for the lower or zero preferential tariff under the
-    <%= scheme.title %>, the product must originate in the
+    <strong><%= scheme.title %></strong>, the product must originate in the
     <%= rules_of_origin_service_name %> or <%= country_name %>.
   </p>
 

--- a/app/views/rules_of_origin/_intro_trade_bloc.html.erb
+++ b/app/views/rules_of_origin/_intro_trade_bloc.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-inset-text" id="rules-of-origin__intro--bloc-scheme">
   <p>
     In order to qualify for the lower or zero preferential tariff under the
-    <%= scheme.title %>, the product must originate in the
+    <strong><%= scheme.title %></strong>, the product must originate in the
     <%= rules_of_origin_service_name %> or one of the partner countries.
   </p>
 


### PR DESCRIPTION
### Jira link

[HOTT-976](https://transformuk.atlassian.net/browse/HOTT-976)

### What?

I have added/removed/altered:

- [x] Added bold formatting to the trade agreement title when there is either a per-country or per-trade-bloc agreement

### Why?

I am doing this because:

- it is improves readability of the content shown to the user

