### PR TITLE
Make meursing measures accessible via the frontend

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -19,6 +19,7 @@ module TradeTariffFrontend
       goods_nomenclatures
       search_references
       geographical_areas
+      meursing_measures
     ]
   end
 
@@ -43,6 +44,7 @@ module TradeTariffFrontend
       certificate_types
       footnote_types
       changes
+      meursing_measures
     ]
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-801

### What?

I have added/removed/altered:

- [x] Make meursing measures accessible to and from the frontend

### Why?

I am doing this because:

- This is needed for debug and future use in the frontend
