### PR TITLE
HOTT-979: Gracefully handle missing country flags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem 'newrelic_rpm'
 gem 'govuk_design_system_formbuilder'
 gem 'wizard_steps'
 
+# Sentry
+gem 'sentry-raven'
+
 group :development do
   gem 'letter_opener'
   gem 'rubocop-govuk'
@@ -78,8 +81,4 @@ group :test do
   gem 'vcr'
   gem 'webdrivers'
   gem 'webmock'
-end
-
-group :production do
-  gem 'sentry-raven'
 end

--- a/app/helpers/country_flag_helper.rb
+++ b/app/helpers/country_flag_helper.rb
@@ -2,5 +2,10 @@ module CountryFlagHelper
   def country_flag_tag(two_letter_country_code, **kwargs)
     image_pack_tag "flags/#{two_letter_country_code.downcase}.png",
                    **kwargs.merge(class: 'country-flag')
+  rescue Webpacker::Manifest::MissingEntryError
+    Raven.capture_message \
+      "Missing flag image file for #{two_letter_country_code.downcase}"
+
+    nil
   end
 end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,4 +1,4 @@
-if defined?(Raven)
+if defined?(Raven) && ENV['VCAP_APPLICATION'].present?
   tags = JSON.parse(ENV['VCAP_APPLICATION'])
              .except('application_uris', 'host', 'application_name', 'space_id', 'port', 'uris', 'application_version')
              .merge({ server_name: ENV['GOVUK_APP_DOMAIN'] })

--- a/spec/helpers/country_flag_helper_spec.rb
+++ b/spec/helpers/country_flag_helper_spec.rb
@@ -21,5 +21,19 @@ describe CountryFlagHelper, type: :helper do
           have_css('img.country-flag[alt="alt text"]')
       end
     end
+
+    context "with country which we don't have a flag for" do
+      subject(:rendered) { helper.country_flag_tag('A1') }
+
+      before { allow(Raven).to receive(:capture_message).and_return(true) }
+
+      it('returns nothing') { is_expected.to be_nil }
+
+      it 'notifies Sentry' do
+        rendered
+
+        expect(Raven).to have_received(:capture_message)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-979](https://transformuk.atlassian.net/browse/HOTT-979)

### What?

I have added/removed/altered:

- [x] Moved to load Sentry all the time - this allows testing using in Dev and Test but does nothing if the env var key is not set
- [x] Changed the country_flag helper to alert if a requested flag is missing and return no flag

### Why?

I am doing this because:

- Viewing the commodities page with RoO enabled for either XC or XL results in a 500 error