### PR TITLE
Lock Rails version to our current release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'rails', '~> 6'
+gem 'rails', '~> 6.1.4'
 
 gem 'addressable'
 gem 'faraday', '= 1.3.0' # TODO: Debug issue with newer versions of Faraday client under high loads

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,7 +469,7 @@ DEPENDENCIES
   puma
   rack-cors
   rack-test
-  rails (~> 6)
+  rails (~> 6.1.4)
   rails-controller-testing!
   redis-rails
   responders


### PR DESCRIPTION
### Jira link

[HOTT-981](https://transformuk.atlassian.net/browse/HOTT-981)

### What?

I have added/removed/altered:

- [x] Restricted the rails version definition in the Gemfile

### Why?

I am doing this because:

- The current definition accepts _any_ version of Rails but upgrading the rails gem should be done in lockstep with running the `rails app:update` command so we want to ensure the developer is doing a dedicated rails upgrade for anything other than patch level updates.

