### PR TITLE
HOTT-980: RoO reduce text when no country chosen

### DIFF
--- a/app/views/rules_of_origin/_without_country.html.erb
+++ b/app/views/rules_of_origin/_without_country.html.erb
@@ -9,6 +9,7 @@
       has a trade agreement from the list above
     </p>
 
+    <% if TradeTariffFrontend::ServiceChooser.uk? %>
     <p>
       You can also find out about rules of origin
     <p>
@@ -29,5 +30,6 @@
         </li>
       </ul>
     </nav>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Jira link

[HOTT-980](https://transformuk.atlassian.net/browse/HOTT-980)

### What?

I have added/removed/altered:

- [x] Show reduced content when no country chose on the RoO tab for XI service

### Why?

I am doing this because:

- We don't have XI relevant content to show
