### PR TITLE
HOTT-982: Don't show RoO for invalid country selection

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -10,7 +10,9 @@ class CommoditiesController < GoodsNomenclaturesController
     @section = commodity.section
     @back_path = request.referer || heading_path(@heading.short_code)
 
-    if params[:country].present? && TradeTariffFrontend.rules_of_origin_api_requests_enabled?
+    if TradeTariffFrontend.rules_of_origin_api_requests_enabled? &&
+        params[:country].present? && @search.geographical_area
+
       @rules_of_origin = commodity.rules_of_origin(params[:country])
     end
   end

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -8,7 +8,9 @@ class HeadingsController < GoodsNomenclaturesController
     @commodities = HeadingCommodityPresenter.new(heading.commodities)
     @back_path = request.referer || chapter_path(heading.chapter.short_code)
 
-    if params[:country].present? && TradeTariffFrontend.rules_of_origin_api_requests_enabled?
+    if TradeTariffFrontend.rules_of_origin_api_requests_enabled? &&
+        params[:country].present? && @search.geographical_area
+
       @rules_of_origin = heading.rules_of_origin(params[:country])
     end
   end

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -143,7 +143,7 @@
   <!-- Rules of Origin tab -->
   <% if TradeTariffFrontend.rules_of_origin_enabled? %>
     <div class="govuk-tabs__panel" id="rules-of-origin">
-      <%- if @search.filtered_by_country? -%>
+      <%- if @search.filtered_by_country? && @search.geographical_area -%>
         <%= render 'rules_of_origin/tab',
                    country_code: @search.country,
                    country_name: @search.geographical_area.description,


### PR DESCRIPTION
### Jira link

[HOTT-982](https://transformuk.atlassian.net/browse/HOTT-982)

### What?

I have added/removed/altered:

- [x] Ensure we don't try to show the rules data if the user has managed to select an invalid country

### Why?

I am doing this because:

- If the user chooses XI as the country, whilst on the XI service (achieved by selecting it on the UK service, then switching to the XI service) the users sees a 500 error page

