### PR TITLE
HOTT-984: Interpret placeholders

### DIFF
--- a/app/helpers/rules_of_origin_helper.rb
+++ b/app/helpers/rules_of_origin_helper.rb
@@ -1,4 +1,6 @@
 module RulesOfOriginHelper
+  ROO_TAGGED_DESCRIPTIONS = %w[CC CTH CTSH EXW WO].freeze
+
   def rules_of_origin_service_name
     TradeTariffFrontend::ServiceChooser.uk? ? 'UK' : 'EU'
   end
@@ -17,5 +19,17 @@ module RulesOfOriginHelper
     end
 
     safe_join schemes_intros, "\n\n"
+  end
+
+  def rules_of_origin_tagged_descriptions(content)
+    content.gsub(/\{\{([A-Z]+)\}\}/) do |_match|
+      matched_tag = Regexp.last_match(1)
+
+      if ROO_TAGGED_DESCRIPTIONS.include?(matched_tag)
+        render "rules_of_origin/tagged_descriptions/#{matched_tag.downcase}"
+      else
+        ''
+      end
+    end
   end
 end

--- a/app/views/rules_of_origin/_rules_table.html.erb
+++ b/app/views/rules_of_origin/_rules_table.html.erb
@@ -37,7 +37,7 @@
       </td>
 
       <td class="govuk-table__cell tariff-markdown responsive-full-width" data-label="Rule">
-        <%= govspeak rule.rule %>
+        <%= govspeak rules_of_origin_tagged_descriptions rule.rule %>
       </td>
     </tr>
     <% end %>

--- a/app/views/rules_of_origin/tagged_descriptions/_cc.html.erb
+++ b/app/views/rules_of_origin/tagged_descriptions/_cc.html.erb
@@ -1,6 +1,7 @@
-<span class='roo_explainer'>
-<b>CC rule - change of chapter</b><br>
-A product complies with the CC rule when all non-originating materials
-used in its production are classified in a different HS chapter
-than the product.
+<span class='rules-of-origin-explainer'>
+  <strong>CC rule - change of chapter</strong>
+  <br/>
+  A product complies with the CC rule when all non-originating materials
+  used in its production are classified in a different HS chapter
+  than the product.
 </span>

--- a/app/views/rules_of_origin/tagged_descriptions/_cc.html.erb
+++ b/app/views/rules_of_origin/tagged_descriptions/_cc.html.erb
@@ -1,0 +1,6 @@
+<span class='roo_explainer'>
+<b>CC rule - change of chapter</b><br>
+A product complies with the CC rule when all non-originating materials
+used in its production are classified in a different HS chapter
+than the product.
+</span>

--- a/app/views/rules_of_origin/tagged_descriptions/_cth.html.erb
+++ b/app/views/rules_of_origin/tagged_descriptions/_cth.html.erb
@@ -1,6 +1,7 @@
-<span class='roo_explainer'>
-<b>CTH rule - change in tariff heading</b><br>
-A product complies with the CTH rule when all non-originating materials
-used in its production are classified in a different HS heading
-than the product.
+<span class='rules-of-origin-explainer'>
+  <strong>CTH rule - change in tariff heading</strong>
+  <br />
+  A product complies with the CTH rule when all non-originating materials
+  used in its production are classified in a different HS heading
+  than the product.
 </span>

--- a/app/views/rules_of_origin/tagged_descriptions/_cth.html.erb
+++ b/app/views/rules_of_origin/tagged_descriptions/_cth.html.erb
@@ -1,0 +1,6 @@
+<span class='roo_explainer'>
+<b>CTH rule - change in tariff heading</b><br>
+A product complies with the CTH rule when all non-originating materials
+used in its production are classified in a different HS heading
+than the product.
+</span>

--- a/app/views/rules_of_origin/tagged_descriptions/_ctsh.html.erb
+++ b/app/views/rules_of_origin/tagged_descriptions/_ctsh.html.erb
@@ -1,6 +1,7 @@
-<span class='roo_explainer'>
-<b>CTSH rule - change in tariff subheading</b><br>
-A product complies with the CTSH rule when all of the non-originating
-materials used in its production are classified in a different
-HS subheading than the product.
+<span class='rules-of-origin-explainer'>
+  <strong>CTSH rule - change in tariff subheading</strong>
+  <br />
+  A product complies with the CTSH rule when all of the non-originating
+  materials used in its production are classified in a different
+  HS subheading than the product.
 </span>

--- a/app/views/rules_of_origin/tagged_descriptions/_ctsh.html.erb
+++ b/app/views/rules_of_origin/tagged_descriptions/_ctsh.html.erb
@@ -1,0 +1,6 @@
+<span class='roo_explainer'>
+<b>CTSH rule - change in tariff subheading</b><br>
+A product complies with the CTSH rule when all of the non-originating
+materials used in its production are classified in a different
+HS subheading than the product.
+</span>

--- a/app/views/rules_of_origin/tagged_descriptions/_exw.html.erb
+++ b/app/views/rules_of_origin/tagged_descriptions/_exw.html.erb
@@ -1,0 +1,8 @@
+<span class='roo_explainer'>
+<b>Ex-works price</b><br>
+When importing on Ex Works terms, the buyer is responsible for
+the whole shipment from door to door. All costs and liabilities
+are with the buyer. The only responsibility for a seller during
+the whole transportation process is to ensure that the goods they
+are selling are made available for collection at their premises.
+</span>

--- a/app/views/rules_of_origin/tagged_descriptions/_exw.html.erb
+++ b/app/views/rules_of_origin/tagged_descriptions/_exw.html.erb
@@ -1,8 +1,9 @@
-<span class='roo_explainer'>
-<b>Ex-works price</b><br>
-When importing on Ex Works terms, the buyer is responsible for
-the whole shipment from door to door. All costs and liabilities
-are with the buyer. The only responsibility for a seller during
-the whole transportation process is to ensure that the goods they
-are selling are made available for collection at their premises.
+<span class='rules-of-origin-explainer'>
+  <strong>Ex-works price</strong>
+  <br />
+  When importing on Ex Works terms, the buyer is responsible for
+  the whole shipment from door to door. All costs and liabilities
+  are with the buyer. The only responsibility for a seller during
+  the whole transportation process is to ensure that the goods they
+  are selling are made available for collection at their premises.
 </span>

--- a/app/views/rules_of_origin/tagged_descriptions/_wo.html.erb
+++ b/app/views/rules_of_origin/tagged_descriptions/_wo.html.erb
@@ -1,0 +1,9 @@
+<span class='roo_explainer'>
+<b>Wholly obtained</b><br>
+The 'wholly obtained' rule applies mainly to basic agricultural products,
+fishery products, minerals, or waste and scrap.
+<br><br>
+Wholly obtained products are goods obtained entirely in the
+territory of one country without the addition of any non-originating
+materials.
+</span>

--- a/app/views/rules_of_origin/tagged_descriptions/_wo.html.erb
+++ b/app/views/rules_of_origin/tagged_descriptions/_wo.html.erb
@@ -1,9 +1,10 @@
-<span class='roo_explainer'>
-<b>Wholly obtained</b><br>
-The 'wholly obtained' rule applies mainly to basic agricultural products,
-fishery products, minerals, or waste and scrap.
-<br><br>
-Wholly obtained products are goods obtained entirely in the
-territory of one country without the addition of any non-originating
-materials.
+<span class='rules-of-origin-explainer'>
+  <strong>Wholly obtained</strong>
+  <br />
+  The 'wholly obtained' rule applies mainly to basic agricultural products,
+  fishery products, minerals, or waste and scrap.
+  <br /><br />
+  Wholly obtained products are goods obtained entirely in the
+  territory of one country without the addition of any non-originating
+  materials.
 </span>

--- a/app/webpacker/src/stylesheets/_rules_of_origin.scss
+++ b/app/webpacker/src/stylesheets/_rules_of_origin.scss
@@ -10,3 +10,14 @@
     margin-left: 0.5em;
   }
 }
+
+.rules-of-origin-explainer {
+  display            : block;
+  margin             : 1em 0px 0.5em 0px;
+  border-left        : 8px #098DC1 solid;
+  padding            : 0.25em 0.25em 0.25em 0.5em;
+  color              : #000;
+  background-color   : #E9F4F9;
+  font-size          : 16px;
+  line-height        : 1.5em;
+}

--- a/spec/helpers/rules_of_origin_helper_spec.rb
+++ b/spec/helpers/rules_of_origin_helper_spec.rb
@@ -51,4 +51,31 @@ RSpec.describe RulesOfOriginHelper, type: :helper do
       it { is_expected.to have_css '#rules-of-origin__intro--country-scheme' }
     end
   end
+
+  describe '#rules_of_origin_tagged_descriptions' do
+    subject { helper.rules_of_origin_tagged_descriptions(content) }
+
+    context 'without tagged descriptions' do
+      let(:content) { 'Some sample content' }
+
+      it { is_expected.to eql content }
+    end
+
+    context 'with matching tagged descriptions' do
+      let(:content) { "With two tags in\n\n{{CC}}{{CTSH}}" }
+
+      it { is_expected.to start_with 'With two tags in' }
+      it { is_expected.to match 'change of chapter' }
+      it { is_expected.to match 'change in tariff subheading' }
+    end
+
+    context 'with unmatched tagged descriptions' do
+      let(:content) { "With two tags in\n\n{{UNKNOWN}}{{CTSH}}" }
+
+      it { is_expected.to start_with 'With two tags in' }
+      it { is_expected.not_to match '{{CC}}' }
+      it { is_expected.not_to match 'change of chapter' }
+      it { is_expected.to match 'change in tariff subheading' }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[HOTT-984](https://transformuk.atlassian.net/browse/HOTT-984)

### What?

I have added/removed/altered:

- [x] Added a helper to substitute the tagged placeholders in the rule descriptions
- [x] Use this placeholder in the table for showing Rules of Origin

### Why?

I am doing this because:

- We should be showing these markers in a manner friendly to our users

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Notes

The implementation is decidly non optimal - the CSS needs work and using `<span>`s is not great - _but_ kramdown wont pass block level html elements through if we process before HTML conversion, and if we do it after we are stuck trying to fixup HTML nesting problems negating the advantage of markdown. 

This can be thought of as a strategic solution since it needs sorting for tomorrow but I'll iterate on it later.