### PR TITLE
HOTT-990: Removed the alerting for missing flags

### DIFF
--- a/app/helpers/country_flag_helper.rb
+++ b/app/helpers/country_flag_helper.rb
@@ -1,10 +1,16 @@
 module CountryFlagHelper
+  COUNTRY_FLAG_IGNORE = %w[xi xc xl].freeze
+
   def country_flag_tag(two_letter_country_code, **kwargs)
-    image_pack_tag "flags/#{two_letter_country_code.downcase}.png",
+    two_letter_country_code = two_letter_country_code.downcase
+
+    image_pack_tag "flags/#{two_letter_country_code}.png",
                    **kwargs.merge(class: 'country-flag')
   rescue Webpacker::Manifest::MissingEntryError
-    Raven.capture_message \
-      "Missing flag image file for #{two_letter_country_code.downcase}"
+    unless CountryFlagHelper::COUNTRY_FLAG_IGNORE.include?(two_letter_country_code)
+      Raven.capture_message \
+        "Missing flag image file for #{two_letter_country_code}"
+    end
 
     nil
   end

--- a/spec/helpers/country_flag_helper_spec.rb
+++ b/spec/helpers/country_flag_helper_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 RSpec.describe CountryFlagHelper, type: :helper do
   describe '#country_flag_tag' do
+    before { allow(Raven).to receive(:capture_message).and_return(true) }
+
     context 'with GB' do
       subject(:rendered) { helper.country_flag_tag('GB') }
 
@@ -25,14 +27,24 @@ RSpec.describe CountryFlagHelper, type: :helper do
     context "with country which we don't have a flag for" do
       subject(:rendered) { helper.country_flag_tag('A1') }
 
-      before { allow(Raven).to receive(:capture_message).and_return(true) }
-
       it('returns nothing') { is_expected.to be_nil }
 
       it 'notifies Sentry' do
         rendered
 
         expect(Raven).to have_received(:capture_message)
+      end
+    end
+
+    context "with country which we don't have a flag which is in ignore list" do
+      subject(:rendered) { helper.country_flag_tag('XI') }
+
+      it('returns nothing') { is_expected.to be_nil }
+
+      it 'does not notify Sentry' do
+        rendered
+
+        expect(Raven).not_to have_received(:capture_message)
       end
     end
   end


### PR DESCRIPTION
### Jira link

[HOTT-990](https://transformuk.atlassian.net/browse/HOTT-990)

### What?

I have added/removed/altered:

- [x] Removed the alerting for missing flag images

### Why?

I am doing this because:

- GeographicalArea's like XI don't actually have flags so this will just alert indefinitely without being fixable.

