### PR TITLE
HOTT-977: Show proofs

### DIFF
--- a/app/models/rules_of_origin/proof.rb
+++ b/app/models/rules_of_origin/proof.rb
@@ -1,0 +1,7 @@
+require 'api_entity'
+
+class RulesOfOrigin::Proof
+  include ApiEntity
+
+  attr_accessor :summary, :content
+end

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -10,6 +10,7 @@ class RulesOfOrigin::Scheme
 
   has_many :rules, class_name: 'RulesOfOrigin::Rule'
   has_many :links, class_name: 'RulesOfOrigin::Link'
+  has_many :proofs, class_name: 'RulesOfOrigin::Proof'
 
   class << self
     def all(heading_code, country_code, opts = {})

--- a/app/views/rules_of_origin/_proofs.html.erb
+++ b/app/views/rules_of_origin/_proofs.html.erb
@@ -1,0 +1,37 @@
+<div class="rules-of-origin__proofs">
+  <% if proofs.any? %>
+    <h3 class="govuk-heading-m">
+      Proving originating status and claiming preferential treatment
+    </h3>
+
+    <p>
+      The customs authority of the importing party will grant preferential
+      tariff treatment, based on a claim made by the importer, to goods that
+      originate in the other party that meet the conditions of the Trade
+      Agreement
+    </p>
+
+    <% if proofs.many? %>
+      <p>
+        A claim can be made if the importer has one of the following proofs of
+        origin:
+      </p>
+    <% else %>
+      <p>
+        A claim can be made if the importer has the following proof of origin:
+      </p>
+    <% end %>
+  <% end %>
+
+  <% proofs.each do |proof| %>
+    <div class="rules-of-origin__proofs__content">
+      <h3 class="govuk-heading-s">
+        <%= proof.summary %>
+      </h3>
+
+      <div class="tariff-markdown">
+        <%= govspeak proof.content %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -24,6 +24,9 @@
       </p>
     <%- end -%>
 
+    <%= render partial: 'rules_of_origin/proofs',
+               collection: rules_of_origin.map(&:proofs) %>
+
     <% rules_of_origin.map(&:fta_intro).map(&:presence).compact.each do |fta_intro| %>
     <div class="rules-of-origin-fta">
       <h3 class="govuk-heading-m">

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -251,16 +251,21 @@ FactoryBot.define do
     end
   end
 
+  factory :rules_of_origin_link, class: 'RulesOfOrigin::Link' do
+    sequence(:text) { |n| "GovUK page #{n}" }
+    url { 'https://www.gov.uk' }
+  end
+
+  factory :rules_of_origin_proof, class: 'RulesOfOrigin::Proof' do
+    sequence(:summary) { |n| "Proof summary #{n}" }
+    sequence(:content) { |n| "Proof content #{n}" }
+  end
+
   factory :rules_of_origin_rule, class: 'RulesOfOrigin::Rule' do
     sequence(:id_rule) { |n| n }
     sequence(:heading) { |n| "Chapter #{n}" }
     description { 'Description' }
     rule { 'Rule' }
-  end
-
-  factory :rules_of_origin_link, class: 'RulesOfOrigin::Link' do
-    sequence(:text) { |n| "GovUK page #{n}" }
-    url { 'https://www.gov.uk' }
   end
 
   factory :rules_of_origin_scheme, class: 'RulesOfOrigin::Scheme' do

--- a/spec/models/rules_of_origin/proof_spec.rb
+++ b/spec/models/rules_of_origin/proof_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe RulesOfOrigin::Proof do
+  it { is_expected.to respond_to :summary }
+  it { is_expected.to respond_to :content }
+end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -47,6 +47,14 @@ describe RulesOfOrigin::Scheme do
                   },
                 ],
               },
+              proofs: {
+                data: [
+                  {
+                    id: 'proof-1',
+                    type: 'rules_of_origin_proof',
+                  },
+                ],
+              },
             },
           },
         ],
@@ -67,6 +75,14 @@ describe RulesOfOrigin::Scheme do
             attributes: {
               text: 'GovUK',
               url: 'https://www.gov.uk',
+            },
+          },
+          {
+            id: 'proof-1',
+            type: 'rules_of_origin_proof',
+            attributes: {
+              summary: 'proof',
+              content: 'content',
             },
           },
         ],
@@ -206,11 +222,24 @@ describe RulesOfOrigin::Scheme do
 
       it { expect(schemes.first.links.length).to be 1 }
 
-      context 'with single link' do
+      context 'with first link' do
         subject { schemes.first.links.first }
 
         it { is_expected.to have_attributes text: 'GovUK' }
         it { is_expected.to have_attributes url: 'https://www.gov.uk' }
+      end
+    end
+
+    describe 'proofs' do
+      include_context 'with mocked response'
+
+      it { expect(schemes.first.proofs.length).to be 1 }
+
+      context 'with first proof' do
+        subject { schemes.first.proofs.first }
+
+        it { is_expected.to have_attributes summary: 'proof' }
+        it { is_expected.to have_attributes content: 'content' }
       end
     end
   end

--- a/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'rules_of_origin/_proofs.html.erb', type: :view do
+  subject(:rendered_page) { render_page && rendered }
+
+  let(:render_page) { render 'rules_of_origin/proofs', proofs: proofs }
+
+  context 'with no proofs' do
+    let(:proofs) { [] }
+
+    it { is_expected.to have_css '.rules-of-origin__proofs', text: '' }
+    it { is_expected.not_to have_css '.rules-of-origin__proofs__content' }
+  end
+
+  context 'with 1 proof' do
+    let(:proofs) { build_list :rules_of_origin_proof, 1 }
+
+    it { is_expected.to have_css '.rules-of-origin__proofs' }
+    it { is_expected.to have_css 'p', text: /has the following proof/ }
+    it { is_expected.to have_css '.rules-of-origin__proofs__content', count: 1 }
+  end
+
+  context 'with multiple proofs' do
+    let(:proofs) { build_list :rules_of_origin_proof, 3 }
+
+    it { is_expected.to have_css '.rules-of-origin__proofs' }
+    it { is_expected.to have_css 'p', text: /has one of the following proofs/ }
+    it { is_expected.to have_css '.rules-of-origin__proofs__content', count: 3 }
+  end
+end

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -44,6 +44,10 @@ describe 'rules_of_origin/_tab.html.erb', type: :view do
     expect(rendered_page).to have_css '#rules-of-origin__intro--bloc-scheme'
   end
 
+  it 'includes the proofs' do
+    expect(rendered_page).to have_css '.rules-of-origin__proofs'
+  end
+
   context 'with UK service' do
     before do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('uk')


### PR DESCRIPTION
### Jira link

[HOTT-977](https://transformuk.atlassian.net/browse/HOTT-977)

### What?

I have added/removed/altered:

- [x] Added an API client for the Proofs data
- [x] Render any retrieved proofs content on the Rules of Origin tab
- [x] Added view specs for the new partial

### Why?

I am doing this because:

- We wish to expose Proofs information to our users

### Deployment notes (optional)

- The proofs information will only show up when both frontend and backend PRs are merged - they are safe to merge in either order
