### PR TITLE
HOTT-994: Fixed css class for 'related content' on RoO tab

### DIFF
--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -38,7 +38,7 @@
   </div>
 
   <% if rules_of_origin.flat_map(&:links).any? %>
-  <div class="grid-column-one-third" id="rules-of-origin__related-content">
+  <div class="govuk-grid-column-one-third" id="rules-of-origin__related-content">
     <h2 class="govuk-heading-m">
       Related content
     </h2>


### PR DESCRIPTION
### Jira link

[HOTT-994](https://transformuk.atlassian.net/browse/HOTT-994)

### What?

I have added/removed/altered:

- [x] Fixed the CSS layout class on the 'Related content' section of the Rules of Origin tab

### Why?

I am doing this because:

- Its not showing correctly on mobile

### Before

![Screenshot from 2021-10-01 10-44-13](https://user-images.githubusercontent.com/10818/135600048-776c9838-535c-4855-a1a8-6640981206a1.png)

### After

![Screenshot from 2021-10-01 10-43-47](https://user-images.githubusercontent.com/10818/135600066-22bf41c4-ee4d-4c2b-8b4b-1d8c02638475.png)

