### PR TITLE
HOTT-988: Retry downloads of cf.deb file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,8 @@ commands:
       - run:
           name: "Setup CF CLI"
           command: |
-            curl -L -o cf.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=7.2.0&source=github-rel'
+            curl -L -o cf.deb --retry 3 'https://packages.cloudfoundry.org/stable?release=debian64&version=7.2.0&source=github-rel'
+            file cf.deb
             sudo dpkg -i cf.deb
             cf -v
             cf api "$CF_ENDPOINT"


### PR DESCRIPTION
### Jira link

[HOTT-988](https://transformuk.atlassian.net/browse/HOTT-988)

### What?

I have added/removed/altered:

- [x] Added `--retry 3` to the curl command
- [x] Added `file cf.deb`

### Why?

I am doing this because:

- I _think_ this is failing because flaky network means curl is creating an empty file and then deb is trying to install it
- The retry will hopefully solve the issue
- If it doesn't the `file cf.deb` should mean we can see what `cf.deb` is and why its not installable