### PR TITLE
HOTT-1020: Non preferential rules of origin

### DIFF
--- a/app/views/rules_of_origin/_non_preferential.html.erb
+++ b/app/views/rules_of_origin/_non_preferential.html.erb
@@ -1,0 +1,12 @@
+<div class="rules-of-origin__non-preferential">
+  <h2 class="govuk-heading-m">
+    Non-preferential rules of origin
+  </h2>
+
+  <p>
+    <%= link_to 'https://www.gov.uk/government/publications/reference-document-for-the-customs-origin-of-chargeable-goods-eu-exit-regulations-2020' do %>
+      Find out about the product-specific rules, to determine the origin of
+      imports outside of a preferential agreement.
+    <% end %>
+  </p>
+</div>

--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l rules-of-origin-heading">
-      Rules of origin for trading with <%= country_name %>
+    <h2 class="govuk-heading-m rules-of-origin-heading">
+      Preferential rules of origin for trading with <%= country_name %>
       <%= country_flag_tag country_code, alt: "Flag for #{country_name}" %>
     </h2>
 

--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -35,6 +35,8 @@
       </div>
     </div>
     <% end %>
+
+    <%= render 'rules_of_origin/non_preferential' %>
   </div>
 
   <% if rules_of_origin.flat_map(&:links).any? %>

--- a/app/views/rules_of_origin/_without_country.html.erb
+++ b/app/views/rules_of_origin/_without_country.html.erb
@@ -5,8 +5,9 @@
     </h2>
 
     <p>
-      To view rules of origin, select a country with which the <%= rules_of_origin_service_name %>
-      has a trade agreement from the list above
+      To view rules of origin, select a country with
+      which the <%= rules_of_origin_service_name %> has a trade agreement
+      from the list above
     </p>
 
     <% if TradeTariffFrontend::ServiceChooser.uk? %>
@@ -31,5 +32,7 @@
       </ul>
     </nav>
     <% end %>
+
+    <%= render 'rules_of_origin/non_preferential' %>
   </div>
 </div>

--- a/app/views/rules_of_origin/_without_country.html.erb
+++ b/app/views/rules_of_origin/_without_country.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">
-      Rules of origin
+      Preferential rules of origin
     </h2>
 
     <p>

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 RSpec.describe CommoditiesController, type: :controller do
   describe 'GET to #show' do
     context 'with XI site' do
+      include_context 'with XI service'
+
       before do
-        allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('xi')
         allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:xi).and_call_original
         allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:uk).and_call_original
-        TradeTariffFrontend::ServiceChooser.service_choice = 'xi'
       end
 
       it 'doesn\'t uses with_source to fetch the commodity from the XI service', vcr: { cassette_name: 'commodities#show_0101210000_2000-01-01' } do
@@ -77,8 +77,9 @@ RSpec.describe CommoditiesController, type: :controller do
     end
 
     context 'with UK site' do
+      include_context 'with UK service'
+
       before do
-        allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_call_original
         allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:xi).and_call_original
         allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:uk).and_call_original
       end

--- a/spec/helpers/rules_of_origin_helper_spec.rb
+++ b/spec/helpers/rules_of_origin_helper_spec.rb
@@ -4,19 +4,14 @@ RSpec.describe RulesOfOriginHelper, type: :helper do
   describe '#rules_of_origin_service_name' do
     subject { helper.rules_of_origin_service_name }
 
-    before do
-      allow(TradeTariffFrontend::ServiceChooser).to \
-        receive(:service_choice).and_return(service)
-    end
-
     context 'with uk service' do
-      let(:service) { 'uk' }
+      include_context 'with UK service'
 
       it { is_expected.to eql 'UK' }
     end
 
     context 'with xi service' do
-      let(:service) { 'xi' }
+      include_context 'with XI service'
 
       it { is_expected.to eql 'EU' }
     end

--- a/spec/support/shared_context/service_chooser.rb
+++ b/spec/support/shared_context/service_chooser.rb
@@ -1,0 +1,13 @@
+RSpec.shared_context 'with UK service' do
+  before do
+    allow(TradeTariffFrontend::ServiceChooser).to \
+      receive(:service_choice).and_return 'uk'
+  end
+end
+
+RSpec.shared_context 'with XI service' do
+  before do
+    allow(TradeTariffFrontend::ServiceChooser).to \
+      receive(:service_choice).and_return 'xi'
+  end
+end

--- a/spec/support/shared_context/service_chooser.rb
+++ b/spec/support/shared_context/service_chooser.rb
@@ -11,3 +11,10 @@ RSpec.shared_context 'with XI service' do
       receive(:service_choice).and_return 'xi'
   end
 end
+
+RSpec.shared_context 'with default service' do
+  before do
+    allow(TradeTariffFrontend::ServiceChooser).to \
+      receive(:service_choice).and_return nil
+  end
+end

--- a/spec/trade_tariff_frontend/service_chooser_spec.rb
+++ b/spec/trade_tariff_frontend/service_chooser_spec.rb
@@ -88,12 +88,8 @@ RSpec.describe TradeTariffFrontend::ServiceChooser do
   end
 
   describe '.currency' do
-    before do
-      allow(described_class).to receive(:service_choice).and_return(choice)
-    end
-
     context 'when the service is xi' do
-      let(:choice) { 'xi' }
+      include_context 'with XI service'
 
       it 'returns the correct currency' do
         expect(described_class.currency).to eq('EUR')
@@ -101,7 +97,7 @@ RSpec.describe TradeTariffFrontend::ServiceChooser do
     end
 
     context 'when the service is uk' do
-      let(:choice) { 'uk' }
+      include_context 'with UK service'
 
       it 'returns the correct currency' do
         expect(described_class.currency).to eq('GBP')
@@ -109,7 +105,7 @@ RSpec.describe TradeTariffFrontend::ServiceChooser do
     end
 
     context 'when the service is not set' do
-      let(:choice) { nil }
+      include_context 'with default service'
 
       it 'returns the correct currency' do
         expect(described_class.currency).to eq('GBP')

--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -54,14 +54,14 @@ RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
 
     context 'without country selected' do
       it_behaves_like 'measures with rules of origin tab'
-      it { is_expected.to have_css '#rules-of-origin h2', text: 'Rules of origin' }
+      it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin' }
     end
 
     context 'with country selected' do
       let(:search) { Search.new(q: '0101300000', 'country' => 'FR') }
 
       it_behaves_like 'measures with rules of origin tab'
-      it { is_expected.to have_css '#rules-of-origin h2', text: /Rules of origin for trading/ }
+      it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
     end
 
     context 'with RULES_OF_ORIGIN_ENABLED set to false' do
@@ -85,14 +85,14 @@ RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
 
     context 'without country selected' do
       it_behaves_like 'measures with rules of origin tab'
-      it { is_expected.to have_css '#rules-of-origin h2', text: 'Rules of origin' }
+      it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin' }
     end
 
     context 'with country selected' do
       let(:search) { Search.new(q: '0101300000', 'country' => 'FR') }
 
       it_behaves_like 'measures with rules of origin tab'
-      it { is_expected.to have_css '#rules-of-origin h2', text: /Rules of origin for trading/ }
+      it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
     end
 
     context 'with RULES_OF_ORIGIN_ENABLED set to false' do

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
 
   it 'includes the countries name in the title' do
     expect(rendered_page).to \
-      have_css 'h2', text: 'Rules of origin for trading with France'
+      have_css 'h2', text: 'Preferential rules of origin for trading with France'
   end
 
   it 'shows the flag' do

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -45,9 +45,7 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
   end
 
   context 'with UK service' do
-    before do
-      allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('uk')
-    end
+    include_context 'with UK service'
 
     it 'references the country in the introductory text' do
       expect(rendered_page).to \
@@ -56,9 +54,7 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
   end
 
   context 'with XI service' do
-    before do
-      allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('xi')
-    end
+    include_context 'with XI service'
 
     it 'references the country in the introductory text' do
       expect(rendered_page).to \

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -102,6 +102,10 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
       expect(rendered_page).to have_css 'details .tariff-markdown p',
                                         text: /Details of introductory notes/
     end
+
+    it 'includes the non-preferential bloc' do
+      expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
+    end
   end
 
   context 'without matched rules' do
@@ -119,6 +123,10 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
     it 'excludes the introductory_notes section' do
       expect(rendered_page).not_to have_css 'details .tariff-markdown'
     end
+
+    it 'includes the non-preferential bloc' do
+      expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
+    end
   end
 
   context 'with country specific scheme' do
@@ -133,6 +141,10 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
     let(:schemes) { [] }
 
     it { is_expected.to have_css '#rules-of-origin__intro--no-scheme' }
+
+    it 'includes the non-preferential bloc' do
+      expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
+    end
   end
 
   context 'with blank fta_intro field' do

--- a/spec/views/rules_of_origin/_without_country.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_without_country.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/_without_country.html.erb', type: :view do
+  subject(:rendered_page) { render && rendered }
+
+  context 'with UK service' do
+    include_context 'with UK service'
+
+    it 'references the correct service' do
+      expect(rendered_page).to have_css 'p', text: 'the UK has a trade agreement'
+    end
+
+    it 'includes additional links' do
+      expect(rendered_page).to have_css 'nav a', text: 'Check your goods meet the'
+    end
+
+    it 'includes the non-preferential bloc' do
+      expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
+    end
+  end
+
+  context 'with XI service' do
+    include_context 'with XI service'
+
+    it 'references the correct service' do
+      expect(rendered_page).to match 'the EU has a trade agreement'
+    end
+
+    it 'excludes additional links' do
+      expect(rendered_page).not_to have_css 'nav a', text: 'Check your goods meet the'
+    end
+
+    it 'includes the non-preferential bloc' do
+      expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
+    end
+  end
+end

--- a/spec/views/rules_of_origin/_without_country.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_without_country.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'rules_of_origin/_without_country.html.erb', type: :view do
   context 'with UK service' do
     include_context 'with UK service'
 
-    it 'references the correct service' do
+    it 'references the UK service' do
       expect(rendered_page).to have_css 'p', text: 'the UK has a trade agreement'
     end
 
@@ -22,7 +22,7 @@ RSpec.describe 'rules_of_origin/_without_country.html.erb', type: :view do
   context 'with XI service' do
     include_context 'with XI service'
 
-    it 'references the correct service' do
+    it 'references the XI service' do
       expect(rendered_page).to match 'the EU has a trade agreement'
     end
 


### PR DESCRIPTION
### Jira link

[HOTT-1020](https://transformuk.atlassian.net/browse/HOTT-1020)

### What?

I have added/removed/altered:

- [x] Added the non-preferential rules of Origin
- [x] Added a shared_context for selecting the service being tested, and updated existing specs to use this
- [x] Updated the main heading on the RoO tab to be smaller and reference 'Preferential rules of origin' instead of 'Rules of origin'

### Why?

I am doing this because:

- We wish to include detalis of the non-preferential rules for our users
