### PR TITLE
Heading, chapter and quota search redirects relay the query params

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,17 +23,38 @@ Rails.application.routes.draw do
   get '/api/:version/commodities/:id', constraints: { id: /\d{2}00000000/ }, to: redirect { |_params, request|
     path = request.path.gsub('commodities', 'chapters').gsub('00000000', '')
     query = URI(request.url).query
-    "https://#{ENV['HOST']}#{path}?#{query}"
+
+    url = "https://#{ENV['HOST']}#{path}"
+
+    if query
+      "#{url}?#{query}" if query
+    else
+      url
+    end
   }
   get '/api/:version/commodities/:id', constraints: { id: /\d{4}000000/ }, to: redirect { |_params, request|
     path = request.path.gsub('commodities', 'headings').gsub('000000', '')
     query = URI(request.url).query
-    "https://#{ENV['HOST']}#{path}?#{query}"
+
+    url = "https://#{ENV['HOST']}#{path}"
+
+    if query
+      "#{url}?#{query}" if query
+    else
+      url
+    end
   }
   get '/api/v1/quotas/search', to: redirect { |_params, request|
     path = request.path.gsub('v1', 'v2')
     query = URI(request.url).query
-    "https://#{ENV['HOST']}#{path}?#{query}"
+
+    url = "https://#{ENV['HOST']}#{path}"
+
+    if query
+      "#{url}?#{query}" if query
+    else
+      url
+    end
   }
 
   get '/', to: redirect(TradeTariffFrontend.production? ? 'https://www.gov.uk/trade-tariff' : '/sections', status: 302)
@@ -84,11 +105,11 @@ Rails.application.routes.draw do
           )
   end
 
-  constraints(id: /[\d]{1,2}/) do
+  constraints(id: /\d{1,2}/) do
     resources :sections, only: %i[index show]
   end
 
-  constraints(id: /[\d]{2}/) do
+  constraints(id: /\d{2}/) do
     resources :chapters, only: %i[show] do
       resources :changes,
                 only: [:index],
@@ -97,7 +118,7 @@ Rails.application.routes.draw do
     end
   end
 
-  constraints(id: /[\d]{4}/) do
+  constraints(id: /\d{4}/) do
     resources :headings, only: %i[show] do
       resources :changes,
                 only: [:index],
@@ -106,7 +127,7 @@ Rails.application.routes.draw do
     end
   end
 
-  constraints(id: /[\d]{10}/) do
+  constraints(id: /\d{10}/) do
     resources :commodities, only: %i[show] do
       resources :changes,
                 only: [:index],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,17 +19,21 @@ Rails.application.routes.draw do
   }
   get '/v1/(*path)', to: redirect { |_params, request| "/api#{request.path}?#{request.query_string}" }
   get '/v2/(*path)', to: redirect { |_params, request| "/api#{request.path}?#{request.query_string}" }
+
   get '/api/:version/commodities/:id', constraints: { id: /\d{2}00000000/ }, to: redirect { |_params, request|
     path = request.path.gsub('commodities', 'chapters').gsub('00000000', '')
-    "https://#{ENV['HOST']}#{path}"
+    query = URI(request.url).query
+    "https://#{ENV['HOST']}#{path}?#{query}"
   }
   get '/api/:version/commodities/:id', constraints: { id: /\d{4}000000/ }, to: redirect { |_params, request|
     path = request.path.gsub('commodities', 'headings').gsub('000000', '')
-    "https://#{ENV['HOST']}#{path}"
+    query = URI(request.url).query
+    "https://#{ENV['HOST']}#{path}?#{query}"
   }
   get '/api/v1/quotas/search', to: redirect { |_params, request|
     path = request.path.gsub('v1', 'v2')
-    "https://#{ENV['HOST']}#{path}"
+    query = URI(request.url).query
+    "https://#{ENV['HOST']}#{path}?#{query}"
   }
 
   get '/', to: redirect(TradeTariffFrontend.production? ? 'https://www.gov.uk/trade-tariff' : '/sections', status: 302)

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe 'URL redirects', type: :request do
+  subject(:do_response) { get path }
+
+  describe '/api/:version/commodities/:id' do
+    let(:path) { "/api/v2/commodities/#{goods_nomenclature_item_id}?as_of=test&some=param" }
+
+    context 'when the id is a chapter id' do
+      let(:goods_nomenclature_item_id) { '9900000000' }
+
+      it { is_expected.to redirect_to 'https://www.example.com/api/v2/chapters/99?as_of=test&some=param' }
+    end
+
+    context 'when the id is a heading id' do
+      let(:goods_nomenclature_item_id) { '9999000000' }
+
+      it { is_expected.to redirect_to 'https://www.example.com/api/v2/headings/9999?as_of=test&some=param' }
+    end
+
+    context 'when the id is a commodity id' do
+      let(:goods_nomenclature_item_id) { '9999990000' }
+
+      before do
+        stub_request(:get, 'http://localhost:3018/commodities/9999990000?as_of=test&some=param')
+      end
+
+      it { is_expected.to eq(200) }
+    end
+  end
+
+  describe '/api/v1/quotas/search' do
+    context 'when a query is not supplied' do
+      let(:path) { '/api/v1/quotas/search' }
+
+      it { is_expected.to redirect_to 'https://www.example.com/api/v2/quotas/search' }
+    end
+
+    context 'when a query is supplied' do
+      let(:path) { '/api/v1/quotas/search?as_of=test&some=param' }
+
+      it { is_expected.to redirect_to 'https://www.example.com/api/v2/quotas/search?as_of=test&some=param' }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1013

### What?

I have added/removed/altered:

- [x] Supply query params when redirecting to a heading, chapter or quota version change

### Why?

I am doing this because:

- This is required by api users in order to preserve the experience with their previously specified query params
