### PR TITLE
Reuse http client

### DIFF
--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -1,0 +1,23 @@
+class ClientBuilder
+  DEFAULT_VERSION = 'v2'.freeze
+  DEFAULT_FORMAT = 'jsonapi'.freeze
+
+  def initialize(service)
+    @service = service
+  end
+
+  def call
+    Faraday.new(host) do |conn|
+      conn.request :url_encoded
+      conn.adapter Faraday.default_adapter
+      conn.response :json, content_type: /\bjson$/
+      conn.headers['Accept'] = "application/vnd.uktt.v#{DEFAULT_VERSION}"
+    end
+  end
+
+  private
+
+  def host
+    TradeTariffFrontend::ServiceChooser.public_send("#{@service}_host")
+  end
+end

--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -2,11 +2,15 @@ class ClientBuilder
   DEFAULT_VERSION = 'v2'.freeze
   DEFAULT_FORMAT = 'jsonapi'.freeze
 
-  def initialize(service)
+  def initialize(service, forwarding: false)
     @service = service
+    @forwarding = forwarding
   end
 
   def call
+    return nil if TradeTariffFrontend::ServiceChooser.service_choices.blank?
+    return Faraday.new(host) if @forwarding
+
     Faraday.new(host) do |conn|
       conn.request :url_encoded
       conn.adapter Faraday.default_adapter

--- a/config/initializers/backend.rb
+++ b/config/initializers/backend.rb
@@ -1,0 +1,6 @@
+require 'client_builder'
+
+Rails.application.config.http_client_uk = ClientBuilder.new('uk').call
+Rails.application.config.http_client_xi = ClientBuilder.new('xi').call
+Rails.application.config.http_client_uk_forwarding = ClientBuilder.new('uk', forwarding: true).call
+Rails.application.config.http_client_xi_forwarding = ClientBuilder.new('xi', forwarding: true).call

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -175,14 +175,7 @@ module ApiEntity
     end
 
     def api
-      host = TradeTariffFrontend::ServiceChooser.api_host
-
-      Faraday.new(host) do |conn|
-        conn.request :url_encoded
-        conn.adapter Faraday.default_adapter
-        conn.response :json, content_type: /\bjson$/
-        conn.headers['Accept'] = "application/vnd.uktt.v#{Rails.configuration.x.backend.api_version}"
-      end
+      TradeTariffFrontend::ServiceChooser.api_client
     end
   end
 end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -3,6 +3,7 @@ require 'paas_config'
 module TradeTariffFrontend
   autoload :Presenter,      'trade_tariff_frontend/presenter'
   autoload :ViewContext,    'trade_tariff_frontend/view_context'
+  autoload :ServiceChooser, 'trade_tariff_frontend/service_chooser'
 
   module_function
 
@@ -91,80 +92,6 @@ module TradeTariffFrontend
 
   def revision
     `cat REVISION 2>/dev/null || git rev-parse --short HEAD`.strip
-  end
-
-  module ServiceChooser
-    SERVICE_CURRENCIES = {
-      'uk' => 'GBP',
-      'xi' => 'EUR',
-    }.freeze
-
-    module_function
-
-    def with_source(service_source)
-      original_service_source = service_choice
-
-      self.service_choice = service_source.to_s
-
-      result = yield
-
-      self.service_choice = original_service_source
-
-      result
-    rescue StandardError => e
-      # Restore the request's original service source
-      self.service_choice = original_service_source
-
-      raise e
-    end
-
-    def service_default
-      ENV.fetch('SERVICE_DEFAULT', 'uk')
-    end
-
-    def currency
-      SERVICE_CURRENCIES.fetch(service_choice, 'GBP')
-    end
-
-    def service_choices
-      @service_choices ||= begin
-        api_options = ENV.fetch('API_SERVICE_BACKEND_URL_OPTIONS', '{}')
-
-        JSON.parse(api_options)
-      end
-    end
-
-    def service_choice=(service_choice)
-      Thread.current[:service_choice] = service_choice
-    end
-
-    def service_choice
-      Thread.current[:service_choice]
-    end
-
-    def cache_with_service_choice(cache_key, options = {}, &block)
-      Rails.cache.fetch("#{cache_prefix}.#{cache_key}", options, &block)
-    end
-
-    def api_host
-      host = service_choices[service_choice]
-
-      return service_choices[service_default] if host.blank?
-
-      host
-    end
-
-    def cache_prefix
-      service_choice || service_default
-    end
-
-    def uk?
-      (service_choice || service_default) == 'uk'
-    end
-
-    def xi?
-      service_choice == 'xi'
-    end
   end
 
   class FilterBadURLEncoding

--- a/lib/trade_tariff_frontend/request_forwarder.rb
+++ b/lib/trade_tariff_frontend/request_forwarder.rb
@@ -24,8 +24,7 @@ module TradeTariffFrontend
                              .split('/')
                              .reject { |p| p.empty? || p == 'api' }
                              .first || "v#{Rails.configuration.x.backend.api_version}"
-        conn = Faraday.new
-        response = conn.send(
+        response = api.send(
           rackreq.request_method.downcase,
           request_url_for(rackreq)
         ) do |req|
@@ -97,6 +96,10 @@ module TradeTariffFrontend
       prefix = "/#{choice}"
 
       rackreq.path_info = rackreq.path_info.sub(prefix, '') if choice.present?
+    end
+
+    def api
+      TradeTariffFrontend::ServiceChooser.api_client_with_forwarding
     end
   end
 end

--- a/lib/trade_tariff_frontend/service_chooser.rb
+++ b/lib/trade_tariff_frontend/service_chooser.rb
@@ -1,0 +1,99 @@
+module TradeTariffFrontend
+  module ServiceChooser
+    SERVICE_CURRENCIES = {
+      'uk' => 'GBP',
+      'xi' => 'EUR',
+    }.freeze
+
+    module_function
+
+    def with_source(service_source)
+      original_service_source = service_choice
+
+      self.service_choice = service_source.to_s
+
+      result = yield
+
+      self.service_choice = original_service_source
+
+      result
+    rescue StandardError => e
+      # Restore the request's original service source
+      self.service_choice = original_service_source
+
+      raise e
+    end
+
+    def service_default
+      ENV.fetch('SERVICE_DEFAULT', 'uk')
+    end
+
+    def currency
+      SERVICE_CURRENCIES.fetch(service_choice, 'GBP')
+    end
+
+    def service_choices
+      @service_choices ||= begin
+        api_options = ENV.fetch('API_SERVICE_BACKEND_URL_OPTIONS', '{}')
+
+        JSON.parse(api_options)
+      end
+    end
+
+    def service_choice=(service_choice)
+      Thread.current[:service_choice] = service_choice
+    end
+
+    def service_choice
+      Thread.current[:service_choice]
+    end
+
+    def cache_with_service_choice(cache_key, options = {}, &block)
+      Rails.cache.fetch("#{cache_prefix}.#{cache_key}", options, &block)
+    end
+
+    def xi_host
+      service_choices['xi']
+    end
+
+    def uk_host
+      service_choices['uk']
+    end
+
+    def api_client
+      if xi?
+        Rails.application.config.http_client_xi
+      else
+        Rails.application.config.http_client_uk
+      end
+    end
+
+    def api_client_with_forwarding
+      if xi?
+        Rails.application.config.http_client_xi_forwarding
+      else
+        Rails.application.config.http_client_uk_forwarding
+      end
+    end
+
+    def api_host
+      host = service_choices[service_choice]
+
+      return service_choices[service_default] if host.blank?
+
+      host
+    end
+
+    def cache_prefix
+      service_choice || service_default
+    end
+
+    def uk?
+      (service_choice || service_default) == 'uk'
+    end
+
+    def xi?
+      service_choice == 'xi'
+    end
+  end
+end

--- a/spec/services/client_builder_spec.rb
+++ b/spec/services/client_builder_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe ClientBuilder do
+  subject(:builder) { described_class.new(service) }
+
+  describe '#call' do
+    before do
+      allow(Faraday).to receive(:new)
+    end
+
+    context 'when the service is uk' do
+      let(:service) { :uk }
+
+      it 'passes the correct configuration' do
+        builder.call
+
+        expect(Faraday).to have_received(:new).with('http://localhost:3018')
+      end
+    end
+
+    context 'when the service is xi' do
+      let(:service) { :xi }
+
+      it 'passes the correct configuration' do
+        builder.call
+
+        expect(Faraday).to have_received(:new).with('http://localhost:3019')
+      end
+    end
+  end
+end

--- a/spec/services/client_builder_spec.rb
+++ b/spec/services/client_builder_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe ClientBuilder do
   subject(:builder) { described_class.new(service) }
 
+  let(:service) { :uk }
+
   describe '#call' do
     before do
       allow(Faraday).to receive(:new)
@@ -24,6 +26,20 @@ RSpec.describe ClientBuilder do
 
         expect(Faraday).to have_received(:new).with('http://localhost:3019')
       end
+    end
+
+    context 'when the services are not configured' do
+      before do
+        allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choices).and_return(nil)
+      end
+
+      it 'does not call Faraday' do
+        builder.call
+
+        expect(Faraday).not_to have_received(:new)
+      end
+
+      it { expect(builder.call).to be_nil }
     end
   end
 end

--- a/spec/trade_tariff_frontend/service_chooser_spec.rb
+++ b/spec/trade_tariff_frontend/service_chooser_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe TradeTariffFrontend::ServiceChooser do
   describe '.service_choices' do
     it 'returns a Hash of url options for the services' do
@@ -84,6 +82,54 @@ RSpec.describe TradeTariffFrontend::ServiceChooser do
 
         expect(Rails.cache).to have_received(:fetch).with('xi.foo', options)
       end
+    end
+  end
+
+  describe '.xi_host' do
+    it { expect(described_class.xi_host).to eq('http://localhost:3019') }
+  end
+
+  describe '.uk_host' do
+    it { expect(described_class.uk_host).to eq('http://localhost:3018') }
+  end
+
+  describe '.api_client' do
+    before do
+      Thread.current[:service_choice] = choice
+    end
+
+    context 'when the service choice is xi' do
+      let(:choice) { 'xi' }
+
+      it { expect(described_class.api_client).to eq(Rails.application.config.http_client_xi) }
+      it { expect(described_class.api_client).to be_a(Faraday::Connection) }
+    end
+
+    context 'when the service choice is not xi' do
+      let(:choice) { nil }
+
+      it { expect(described_class.api_client).to eq(Rails.application.config.http_client_uk) }
+      it { expect(described_class.api_client).to be_a(Faraday::Connection) }
+    end
+  end
+
+  describe '.api_client_with_forwarding' do
+    before do
+      Thread.current[:service_choice] = choice
+    end
+
+    context 'when the service choice is xi' do
+      let(:choice) { 'xi' }
+
+      it { expect(described_class.api_client_with_forwarding).to eq(Rails.application.config.http_client_xi_forwarding) }
+      it { expect(described_class.api_client_with_forwarding).to be_a(Faraday::Connection) }
+    end
+
+    context 'when the service choice is not xi' do
+      let(:choice) { nil }
+
+      it { expect(described_class.api_client_with_forwarding).to eq(Rails.application.config.http_client_uk_forwarding) }
+      it { expect(described_class.api_client_with_forwarding).to be_a(Faraday::Connection) }
     end
   end
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds client builder service
- [x] Extract service chooser
- [x] Initialize client on application start
- [x] Make api entity and request forwarder use reusable client
- [x] Adds missing test coverage
- [x] Adds specs for request forwarder

### Why?

I am doing this because:

- Consolidate the initialisation of the client (easier substitution later).
- Massively reduce the process of instantiatiating and configuring an api client
- Enables the use of persistent connections
