### PR TITLE
HOTT-1005: removed Rules of Origin feature flags

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -8,7 +8,6 @@ CURRENCY_PICKER=0
 FRONTEND_HOST=http://test.host
 HTTPARTY_READ_TIMEOUT=661
 NOTICE_BANNER="NOTICE|This service is currently being updated, some data might be missing."
-RULES_OF_ORIGIN_ENABLED=true
 SERVICE_DEFAULT=uk
 TARIFF_API_VERSION=2
 TARIFF_FROM_EMAIL=no-reply@example.com

--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -10,9 +10,7 @@ class CommoditiesController < GoodsNomenclaturesController
     @section = commodity.section
     @back_path = request.referer || heading_path(@heading.short_code)
 
-    if TradeTariffFrontend.rules_of_origin_api_requests_enabled? &&
-        params[:country].present? && @search.geographical_area
-
+    if params[:country].present? && @search.geographical_area
       @rules_of_origin = commodity.rules_of_origin(params[:country])
     end
   end

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -11,9 +11,7 @@ class HeadingsController < GoodsNomenclaturesController
     @back_path = request.referer || chapter_path(heading.chapter.short_code)
     @meursing_additional_code = session[:meursing_lookup].try(:[], 'result')
 
-    if TradeTariffFrontend.rules_of_origin_api_requests_enabled? &&
-        params[:country].present? && @search.geographical_area
-
+    if params[:country].present? && @search.geographical_area
       @rules_of_origin = heading.rules_of_origin(params[:country])
     end
   end

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -9,11 +9,9 @@
     <li class="govuk-tabs__list-item">
       <a class="govuk-tabs__tab" href="#export">Export</a>
     </li>
-    <% if TradeTariffFrontend.rules_of_origin_enabled? %>
-      <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="#rules-of-origin">Rules of origin</a>
-      </li>
-    <% end %>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#rules-of-origin">Rules of origin</a>
+    </li>
     <li class="govuk-tabs__list-item">
       <a class="govuk-tabs__tab" href="#footnotes">Footnotes</a>
     </li>
@@ -137,19 +135,17 @@
   </div>
 
   <!-- Rules of Origin tab -->
-  <% if TradeTariffFrontend.rules_of_origin_enabled? %>
-    <div class="govuk-tabs__panel" id="rules-of-origin">
-      <%- if @search.filtered_by_country? && @search.geographical_area -%>
-        <%= render 'rules_of_origin/tab',
-                   country_code: @search.country,
-                   country_name: @search.geographical_area.description,
-                   commodity_code: declarable.code,
-                   rules_of_origin: rules_of_origin %>
-      <%- else -%>
-        <%= render 'rules_of_origin/without_country' %>
-      <%- end -%>
-    <div>
-  <% end %>
+  <div class="govuk-tabs__panel" id="rules-of-origin">
+    <%- if @search.filtered_by_country? && @search.geographical_area -%>
+      <%= render 'rules_of_origin/tab',
+                 country_code: @search.country,
+                 country_name: @search.geographical_area.description,
+                 commodity_code: declarable.code,
+                 rules_of_origin: rules_of_origin %>
+    <%- else -%>
+      <%= render 'rules_of_origin/without_country' %>
+    <%- end -%>
+  <div>
 
   <!-- Footnotes tab -->
   <div class="govuk-tabs__panel" id="footnotes">

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -80,15 +80,6 @@ module TradeTariffFrontend
     ENV.fetch('JS_SENTRY_DSN', '')
   end
 
-  def rules_of_origin_enabled?
-    ENV['RULES_OF_ORIGIN_ENABLED'].to_s.downcase == 'true'
-  end
-
-  def rules_of_origin_api_requests_enabled?
-    rules_of_origin_enabled? ||
-      ENV['RULES_OF_ORIGIN_API_REQUESTS_ENABLED'].to_s.downcase == 'true'
-  end
-
   def revision
     `cat REVISION 2>/dev/null || git rev-parse --short HEAD`.strip
   end

--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -34,15 +34,6 @@ RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
     it { is_expected.to have_css '.govuk-tabs__panel#footnotes', count: 1 }
   end
 
-  shared_examples 'measures without rules of origin tab' do
-    it { is_expected.to have_css '.govuk-tabs .govuk-tabs__tab', count: 4 }
-    it { is_expected.to have_css '.govuk-tabs__panel#overview', count: 1 }
-    it { is_expected.to have_css '.govuk-tabs__panel#import', count: 1 }
-    it { is_expected.to have_css '.govuk-tabs__panel#export', count: 1 }
-    it { is_expected.not_to have_css '.govuk-tabs__panel#rules-of-origin' }
-    it { is_expected.to have_css '.govuk-tabs__panel#footnotes', count: 1 }
-  end
-
   context 'with uk service' do
     let :render_page do
       render 'measures/measures',
@@ -62,15 +53,6 @@ RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
 
       it_behaves_like 'measures with rules of origin tab'
       it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
-    end
-
-    context 'with RULES_OF_ORIGIN_ENABLED set to false' do
-      before do
-        allow(TradeTariffFrontend).to \
-          receive(:rules_of_origin_enabled?).and_return false
-      end
-
-      it_behaves_like 'measures without rules of origin tab'
     end
   end
 
@@ -93,15 +75,6 @@ RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
 
       it_behaves_like 'measures with rules of origin tab'
       it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
-    end
-
-    context 'with RULES_OF_ORIGIN_ENABLED set to false' do
-      before do
-        allow(TradeTariffFrontend).to \
-          receive(:rules_of_origin_enabled?).and_return false
-      end
-
-      it_behaves_like 'measures without rules of origin tab'
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1005](https://transformuk.atlassian.net/browse/HOTT-1005)

### What?

I have added/removed/altered:

- [x] Removed the RULES_OF_ORIGIN_API_REQUESTS_ENABLED feature flag and its dependencies
- [x] Removed the RULES_OF_ORIGIN_ENABLED feature flag and its dependencies

### Why?

I am doing this because:

- We now have Rules of Origin fully live and the feature flags complicate the codebase

