### PR TITLE
Rearrange measure table ordering

### DIFF
--- a/app/views/measures/grouped/_uk.html.erb
+++ b/app/views/measures/grouped/_uk.html.erb
@@ -1,9 +1,3 @@
-<!-- VAT & EXCISE -->
-<% if (collection = uk_declarable.import_measures.vat_excise.for_country(@search.country)).present? %>
-  <%= render 'measures/grouped/shared/vat_excise_heading' %>
-  <%= render partial: 'measures/grouped/table', locals: { collection: collection.sort_by(&:key) } %>
-<% end %>
-
 <!-- CUSTOMS DUTIES -->
 <% if (collection = uk_declarable.import_measures.customs_duties.for_country(@search.country)).present? %>
   <%= render 'measures/grouped/shared/customs_duties_heading' %>
@@ -19,6 +13,12 @@
 <!-- TRADE REMEDIES -->
 <% if (collection = uk_declarable.import_measures.trade_remedies.for_country(@search.country)).present? %>
   <%= render 'measures/grouped/shared/trade_remedies_heading' %>
+  <%= render partial: 'measures/grouped/table', locals: { collection: collection.sort_by(&:key) } %>
+<% end %>
+
+<!-- VAT & EXCISE -->
+<% if (collection = uk_declarable.import_measures.vat_excise.for_country(@search.country)).present? %>
+  <%= render 'measures/grouped/shared/vat_excise_heading' %>
   <%= render partial: 'measures/grouped/table', locals: { collection: collection.sort_by(&:key) } %>
 <% end %>
 

--- a/app/views/measures/grouped/_uk_navigation.html.erb
+++ b/app/views/measures/grouped/_uk_navigation.html.erb
@@ -1,23 +1,32 @@
-<% if declarable.import_measures.vat_excise.for_country(@search.country).present? %>
-  <li class="govuk-!-margin-bottom-2">
-    <%= link_to('VAT and excise', '#vat_excise', class: 'govuk-link') %>
-  </li>
-<% end %>
+<!-- CUSTOMS DUTIES -->
 <% if declarable.import_measures.customs_duties.for_country(@search.country).present? %>
   <li class="govuk-!-margin-bottom-2">
   <%= link_to('Customs duties', '#customs_duties', class: 'govuk-link') %>
   </li>
 <% end %>
+
+<!-- QUOTAS -->
 <% if declarable.import_measures.quotas.for_country(@search.country).present? %>
   <li class="govuk-!-margin-bottom-2">
   <%= link_to('Quotas', '#quotas', class: 'govuk-link') %>
   </li>
 <% end %>
+
+<!-- TRADE REMEDIES -->
 <% if declarable.import_measures.trade_remedies.for_country(@search.country).present? %>
   <li class="govuk-!-margin-bottom-2">
     <%= link_to('Trade Remedies, safeguards and retaliatory duties', '#trade_remedies', class: 'govuk-link') %>
   </li>
 <% end %>
+
+<!-- VAT & EXCISE -->
+<% if declarable.import_measures.vat_excise.for_country(@search.country).present? %>
+  <li class="govuk-!-margin-bottom-2">
+    <%= link_to('VAT and excise', '#vat_excise', class: 'govuk-link') %>
+  </li>
+<% end %>
+
+<!-- UK IMPORT CONTROLS -->
 <% if declarable.import_measures.import_controls.for_country(@search.country).present? %>
   <li class="govuk-!-margin-bottom-2">
     <%= link_to('Import controls', '#uk_import_controls', class: 'govuk-link') %>

--- a/app/views/measures/grouped/_xi.html.erb
+++ b/app/views/measures/grouped/_xi.html.erb
@@ -1,9 +1,3 @@
-<!-- VAT & EXCISE -->
-<% if (collection = uk_declarable.import_measures.vat_excise.for_country(@search.country)).present? %>
-  <%= render 'measures/grouped/shared/vat_excise_heading' %>
-  <%= render partial: 'measures/grouped/table', locals: { collection: collection.sort_by(&:key) } %>
-<% end %>
-
 <!-- CUSTOMS DUTIES -->
 <% if (collection = xi_declarable.import_measures.customs_duties.for_country(@search.country)).present? %>
   <%= render 'measures/grouped/shared/customs_duties_heading' %>
@@ -11,20 +5,23 @@
   <%= render partial: 'measures/grouped/table', locals: { collection: collection.sort_by(&:key) } %>
 <% end %>
 
-
 <!-- TRADE REMEDIES -->
 <% if (collection = xi_declarable.import_measures.trade_remedies.for_country(@search.country)).present? %>
   <%= render 'measures/grouped/shared/trade_remedies_heading' %>
   <%= render partial: 'measures/grouped/table', locals: { collection: collection.sort_by(&:key) } %>
 <% end %>
 
+<!-- VAT & EXCISE -->
+<% if (collection = uk_declarable.import_measures.vat_excise.for_country(@search.country)).present? %>
+  <%= render 'measures/grouped/shared/vat_excise_heading' %>
+  <%= render partial: 'measures/grouped/table', locals: { collection: collection.sort_by(&:key) } %>
+<% end %>
 
 <!-- XI IMPORT CONTROLS -->
 <% if (collection = xi_declarable.import_measures.import_controls.for_country(@search.country)).present? %>
   <%= render 'measures/grouped/shared/xi_import_controls_heading' %>
   <%= render partial: 'measures/grouped/table', locals: { collection: collection.sort_by(&:key) } %>
 <% end %>
-
 
 <!-- UK IMPORT CONTROLS -->
 <% if (collection = uk_declarable.import_measures.import_controls.for_country(@search.country)).present? %>

--- a/app/views/measures/grouped/_xi_navigation.html.erb
+++ b/app/views/measures/grouped/_xi_navigation.html.erb
@@ -1,23 +1,32 @@
-<% if uk_declarable.import_measures.vat_excise.for_country(@search.country).present? %>
-  <li class="govuk-!-margin-bottom-2">
-    <%= link_to('VAT and excise', '#vat_excise', class: 'govuk-link') %>
-  </li>
-<% end %>
+<!-- CUSTOMS DUTIES -->
 <% if xi_declarable.import_measures.customs_duties.for_country(@search.country).present? %>
   <li class="govuk-!-margin-bottom-2">
   <%= link_to('Customs duties', '#customs_duties', class: 'govuk-link') %>
   </li>
 <% end %>
+
+<!-- TRADE REMEDIES -->
 <% if xi_declarable.import_measures.trade_remedies.for_country(@search.country).present? %>
   <li class="govuk-!-margin-bottom-2">
     <%= link_to('Trade Remedies, safeguards and retaliatory duties', '#trade_remedies', class: 'govuk-link') %>
   </li>
 <% end %>
+
+<!-- VAT & EXCISE -->
+<% if uk_declarable.import_measures.vat_excise.for_country(@search.country).present? %>
+  <li class="govuk-!-margin-bottom-2">
+    <%= link_to('VAT and excise', '#vat_excise', class: 'govuk-link') %>
+  </li>
+<% end %>
+
+<!-- XI IMPORT CONTROLS -->
 <% if xi_declarable.import_measures.import_controls.for_country(@search.country).present? %>
   <li class="govuk-!-margin-bottom-2">
     <%= link_to('EU import controls', '#xi_import_controls', class: 'govuk-link') %>
   </li>
 <% end %>
+
+<!-- UK IMPORT CONTROLS -->
 <% if uk_declarable.import_measures.import_controls.for_country(@search.country).present? %>
   <li class="govuk-!-margin-bottom-2">
     <%= link_to('UK import controls', '#uk_import_controls', class: 'govuk-link') %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1016

### What?

I have added/removed/altered:

- [x] Rearrange xi table and navigation partial ordering
- [x] Rearrange uk table and navigation partial ordering

![image](https://user-images.githubusercontent.com/8156884/136978554-5a588816-649b-4dfc-9e68-3b9d1c2fda7e.png)


### Why?

I am doing this because:

- The measure positions don't reflect their use/interest
