### PR TITLE
HOTT-1007: Non breaking space

### DIFF
--- a/app/helpers/rules_of_origin_helper.rb
+++ b/app/helpers/rules_of_origin_helper.rb
@@ -38,7 +38,7 @@ module RulesOfOriginHelper
     content.gsub('&nbsp;', ' ')
   end
 
-  def prevent_breaking_heading_components(content)
+  def restrict_wrapping(content)
     safe_content = html_escape(content)
 
     safe_content.gsub(ROO_NON_BREAKING_HEADING) { |match|

--- a/app/helpers/rules_of_origin_helper.rb
+++ b/app/helpers/rules_of_origin_helper.rb
@@ -1,5 +1,6 @@
 module RulesOfOriginHelper
   ROO_TAGGED_DESCRIPTIONS = %w[CC CTH CTSH EXW WO].freeze
+  ROO_NON_BREAKING_HEADING = /\w+\s+\d+/
 
   def rules_of_origin_service_name
     TradeTariffFrontend::ServiceChooser.uk? ? 'UK' : 'EU'
@@ -31,5 +32,17 @@ module RulesOfOriginHelper
         ''
       end
     end
+  end
+
+  def replace_non_breaking_space(content)
+    content.gsub('&nbsp;', ' ')
+  end
+
+  def prevent_breaking_heading_components(content)
+    safe_content = html_escape(content)
+
+    safe_content.gsub(ROO_NON_BREAKING_HEADING) { |match|
+      tag.span match, class: 'rules-of-origin__non-breaking-heading'
+    }.html_safe
   end
 end

--- a/app/views/rules_of_origin/_rules_table.html.erb
+++ b/app/views/rules_of_origin/_rules_table.html.erb
@@ -12,7 +12,7 @@
 <table class="govuk-table govuk-table--responsive commodity-rules-of-origin">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">
+      <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">
         Heading
       </th>
 
@@ -29,7 +29,7 @@
     <% rules.each do |rule| %>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell" data-label="Heading">
-        <%= rule.heading %>
+        <%= prevent_breaking_heading_components replace_non_breaking_space(rule.heading) %>
       </td>
 
       <td class="govuk-table__cell" data-label="Description">

--- a/app/views/rules_of_origin/_rules_table.html.erb
+++ b/app/views/rules_of_origin/_rules_table.html.erb
@@ -29,7 +29,7 @@
     <% rules.each do |rule| %>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell" data-label="Heading">
-        <%= prevent_breaking_heading_components replace_non_breaking_space(rule.heading) %>
+        <%= restrict_wrapping replace_non_breaking_space(rule.heading) %>
       </td>
 
       <td class="govuk-table__cell" data-label="Description">

--- a/app/webpacker/src/stylesheets/_rules_of_origin.scss
+++ b/app/webpacker/src/stylesheets/_rules_of_origin.scss
@@ -21,3 +21,9 @@
   font-size          : 16px;
   line-height        : 1.5em;
 }
+
+.rules-of-origin {
+  &__non-breaking-heading {
+    white-space: nowrap;
+  }
+}

--- a/spec/helpers/rules_of_origin_helper_spec.rb
+++ b/spec/helpers/rules_of_origin_helper_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe RulesOfOriginHelper, type: :helper do
     it { is_expected.to eql 'With space and non-breaking space' }
   end
 
-  describe '#prevent_breaking_heading_components' do
-    subject { helper.prevent_breaking_heading_components content }
+  describe '#restrict_wrapping' do
+    subject { helper.restrict_wrapping content }
 
     let(:span) { '<span class="rules-of-origin__non-breaking-heading">' }
 

--- a/spec/helpers/rules_of_origin_helper_spec.rb
+++ b/spec/helpers/rules_of_origin_helper_spec.rb
@@ -73,4 +73,34 @@ RSpec.describe RulesOfOriginHelper, type: :helper do
       it { is_expected.to match 'change in tariff subheading' }
     end
   end
+
+  describe '#replace_non_breaking_space' do
+    subject { helper.replace_non_breaking_space content }
+
+    let(:content) { 'With space and&nbsp;non-breaking&nbsp;space' }
+
+    it { is_expected.to eql 'With space and non-breaking space' }
+  end
+
+  describe '#prevent_breaking_heading_components' do
+    subject { helper.prevent_breaking_heading_components content }
+
+    let(:span) { '<span class="rules-of-origin__non-breaking-heading">' }
+
+    context 'with single replacement' do
+      let(:content) { 'ex Chapter 123 456' }
+
+      it { is_expected.to eql "ex #{span}Chapter 123</span> 456" }
+    end
+
+    context 'with multiple replacements' do
+      let(:content) { 'ex 123, ex 456 and ex 789' }
+
+      let :expected do
+        "#{span}ex 123</span>, #{span}ex 456</span> and #{span}ex 789</span>"
+      end
+
+      it { is_expected.to eql expected }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1007](https://transformuk.atlassian.net/jira/software/projects/HOTT/boards/96)

### What?

I have added/removed/altered:

- [x] Added a helper to filter out `nbsp;` tags from the headings content (this will get removed from the source data, at which point this can be dropped)
- [x] Set an explicit width on the heading column, on the normal desktop use case this should avoid wrapping in almost all scenarios
- [x] Added a helper to mark `(word) (number)` sections of headings as unbreakable, which should help the browser to make smarter choices on the break points

### Why?

I am doing this because:

- Currently we have `&nbsp;` tags showing through on the headings for some commodities rules of origin
- These were added to avoid breaking headings at in appropriate points but are simply getting escaped by the frontend
- We do want to avoid breaking at inconvenient points but also want to avoid having presentational markup in the headings in the API response

