### PR TITLE
HOTT-1034: Upgrade Puma to 5.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
-    puma (5.5.0)
+    puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)


### PR DESCRIPTION
### Jira link

[HOTT-1034](https://transformuk.atlassian.net/browse/HOTT-1034)

### What?

I have added/removed/altered:

- [x] Upgraded the puma gem to 5.5.2

### Why?

I am doing this because:

- we currently have 5.5.0 which has a minor security issue in it

