### PR TITLE
HOTT-1049: Use smokeTestCI.spec for smoketest runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
           command: 'echo "Testing: ${CYPRESS_BASE_URL}"'
       - run:
           name: "Cypress Smoke tests"
-          command: 'cd trade-tariff-testing && yarn install && yarn run cypress run --spec "/*/**/HOTT-Shared/smokeTestTradeTariff.spec.js"'
+          command: 'cd trade-tariff-testing && yarn install && yarn run cypress run --spec "/*/**/HOTT-Shared/smokeTestCI.spec.js"'
 
   smoketest_staging:
     <<: *smoketest


### PR DESCRIPTION
### Jira link

[HOTT-1049](https://transformuk.atlassian.net/browse/HOTT-1049)

### What?

I have added/removed/altered:

- [x] Change from using `smokeTestTradeTariff.spec.js` to using `smokeTestCI.spec.js`

### Why?

I am doing this because:

- we are currently using the wrong smoke test

