### PR TITLE
HOTT-1045: better error reporting from unparseable response

### DIFF
--- a/spec/features/commodities_spec.rb
+++ b/spec/features/commodities_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'Commodity show page', js: true do
   before do
-    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', 'spec/fixtures/measure_condition_dialog_config.yaml')
+    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
 
     TradeTariffFrontend::ServiceChooser.service_choice = 'xi'
     VCR.use_cassette('headings#show_0201', record: :new_episodes) do

--- a/spec/fixtures/jsonapi/multiple_invalid_relationship.json
+++ b/spec/fixtures/jsonapi/multiple_invalid_relationship.json
@@ -1,0 +1,26 @@
+{
+  "data" : [
+    {
+      "id": "123",
+      "type": "mock_entity",
+      "attributes": {
+        "name": "Joe",
+        "age": 21
+      },
+      "relationships": {
+        "parts": {
+          "data": [null]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": 456,
+      "type": "part",
+      "attributes": {
+        "part_name": "A part name"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/jsonapi/multiple_missing_relationship.json
+++ b/spec/fixtures/jsonapi/multiple_missing_relationship.json
@@ -1,0 +1,23 @@
+{
+  "data" : [
+    {
+      "id": "123",
+      "type": "mock_entity",
+      "attributes": {
+        "name": "Joe",
+        "age": 21
+      },
+      "relationships": {
+        "parts": {
+          "data": [
+            {
+              "id": 456,
+              "type": "part"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "included": []
+}

--- a/spec/fixtures/jsonapi/multiple_no_relationship.json
+++ b/spec/fixtures/jsonapi/multiple_no_relationship.json
@@ -1,0 +1,13 @@
+{
+  "data" : [
+    {
+      "id": "123",
+      "type": "mock_entity",
+      "attributes": {
+        "name": "Joe",
+        "age": 21
+      }
+    }
+  ],
+  "included": []
+}

--- a/spec/fixtures/jsonapi/multiple_with_relationship.json
+++ b/spec/fixtures/jsonapi/multiple_with_relationship.json
@@ -1,0 +1,31 @@
+{
+  "data" : [
+    {
+      "id": "123",
+      "type": "mock_entity",
+      "attributes": {
+        "name": "Joe",
+        "age": 21
+      },
+      "relationships": {
+        "parts": {
+          "data": [
+            {
+              "id": 456,
+              "type": "part"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": 456,
+      "type": "part",
+      "attributes": {
+        "part_name": "A part name"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/jsonapi/singular_invalid_relationship.json
+++ b/spec/fixtures/jsonapi/singular_invalid_relationship.json
@@ -1,0 +1,24 @@
+{
+  "data" : {
+    "id": "123",
+    "type": "mock_entity",
+    "attributes": {
+      "name": "Joe",
+      "age": 21
+    },
+    "relationships": {
+      "parts": {
+        "data": [null]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": 456,
+      "type": "part",
+      "attributes": {
+        "part_name": "A part name"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/jsonapi/singular_missing_relationship.json
+++ b/spec/fixtures/jsonapi/singular_missing_relationship.json
@@ -1,0 +1,21 @@
+{
+  "data" : {
+    "id": "123",
+    "type": "mock_entity",
+    "attributes": {
+      "name": "Joe",
+      "age": 21
+    },
+    "relationships": {
+      "parts": {
+        "data": [
+          {
+            "id": 456,
+            "type": "part"
+          }
+        ]
+      }
+    }
+  },
+  "included": []
+}

--- a/spec/fixtures/jsonapi/singular_no_relationship.json
+++ b/spec/fixtures/jsonapi/singular_no_relationship.json
@@ -1,0 +1,11 @@
+{
+  "data" : {
+    "id": "123",
+    "type": "mock_entity",
+    "attributes": {
+      "name": "Joe",
+      "age": 21
+    }
+  },
+  "included": []
+}

--- a/spec/fixtures/jsonapi/singular_with_relationship.json
+++ b/spec/fixtures/jsonapi/singular_with_relationship.json
@@ -1,0 +1,29 @@
+{
+  "data" : {
+    "id": "123",
+    "type": "mock_entity",
+    "attributes": {
+      "name": "Joe",
+      "age": 21
+    },
+    "relationships": {
+      "parts": {
+        "data": [
+          {
+            "id": 456,
+            "type": "part"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": 456,
+      "type": "part",
+      "attributes": {
+        "part_name": "A part name"
+      }
+    }
+  ]
+}

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ApiEntity do
         file_fixture('jsonapi/singular_invalid_relationship.json').read
       end
 
-      it { expect { request }.to raise_exception NoMethodError }
+      it { expect { request }.to raise_exception TariffJsonapiParser::ParsingError }
     end
   end
 
@@ -100,7 +100,7 @@ RSpec.describe ApiEntity do
         file_fixture('jsonapi/multiple_invalid_relationship.json').read
       end
 
-      it { expect { request }.to raise_exception NoMethodError }
+      it { expect { request }.to raise_exception TariffJsonapiParser::ParsingError }
     end
   end
 end

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+RSpec.describe ApiEntity do
+  let :mock_entity do
+    Class.new do
+      include ApiEntity
+
+      collection_path '/mockentities'
+
+      attr_accessor :name, :age
+
+      has_many :parts, class_name: 'Part'
+
+      def self.name
+        'MockEntity'
+      end
+    end
+  end
+
+  describe '#find' do
+    subject(:request) { mock_entity.find(123) }
+
+    before do
+      stub_request(:get, "#{api_endpoint}/mockentities/123").and_return \
+        status: status,
+        headers: headers,
+        body: body
+    end
+
+    let(:api_endpoint) { TradeTariffFrontend::ServiceChooser.uk_host }
+    let(:status) { 200 }
+    let(:headers) { { 'content-type' => 'application/json; charset=utf-8' } }
+
+    context 'with valid response' do
+      let(:body) { file_fixture('jsonapi/singular_no_relationship.json').read }
+
+      it { is_expected.to have_attributes name: 'Joe', age: 21 }
+    end
+
+    context 'with 404 response' do
+      let(:status) { 404 }
+      let(:body) { {}.to_json }
+
+      it { expect { request }.to raise_exception ApiEntity::NotFound }
+    end
+
+    context 'with error response' do
+      let(:status) { 500 }
+      let(:body) { {}.to_json }
+
+      it { expect { request }.to raise_exception ApiEntity::Error }
+    end
+
+    context 'with unparseable response' do
+      let :body do
+        file_fixture('jsonapi/singular_invalid_relationship.json').read
+      end
+
+      it { expect { request }.to raise_exception NoMethodError }
+    end
+  end
+
+  describe '#all' do
+    subject(:request) { mock_entity.all }
+
+    before do
+      stub_request(:get, "#{api_endpoint}/mockentities").and_return \
+        status: status,
+        headers: headers,
+        body: body
+    end
+
+    let(:api_endpoint) { TradeTariffFrontend::ServiceChooser.uk_host }
+    let(:status) { 200 }
+    let(:headers) { { 'content-type' => 'application/json; charset=utf-8' } }
+
+    context 'with valid response' do
+      let(:body) { file_fixture('jsonapi/multiple_no_relationship.json').read }
+
+      it { is_expected.to have_attributes length: 1 }
+      it { expect(request.first).to have_attributes name: 'Joe', age: 21 }
+    end
+
+    context 'with 404 response' do
+      let(:status) { 404 }
+      let(:body) { {}.to_json }
+
+      it { expect { request }.to raise_exception ApiEntity::NotFound }
+    end
+
+    context 'with error response' do
+      let(:status) { 500 }
+      let(:body) { {}.to_json }
+
+      it { expect { request }.to raise_exception ApiEntity::Error }
+    end
+
+    context 'with unparseable response' do
+      let :body do
+        file_fixture('jsonapi/multiple_invalid_relationship.json').read
+      end
+
+      it { expect { request }.to raise_exception NoMethodError }
+    end
+  end
+end

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -41,14 +41,14 @@ RSpec.describe ApiEntity do
       let(:status) { 404 }
       let(:body) { {}.to_json }
 
-      it { expect { request }.to raise_exception ApiEntity::NotFound }
+      it { expect { request }.to raise_exception described_class::NotFound }
     end
 
     context 'with error response' do
       let(:status) { 500 }
       let(:body) { {}.to_json }
 
-      it { expect { request }.to raise_exception ApiEntity::Error }
+      it { expect { request }.to raise_exception described_class::Error }
     end
 
     context 'with unparseable response' do
@@ -56,7 +56,11 @@ RSpec.describe ApiEntity do
         file_fixture('jsonapi/singular_invalid_relationship.json').read
       end
 
-      it { expect { request }.to raise_exception TariffJsonapiParser::ParsingError }
+      it 'raises descriptive exception' do
+        expect { request }.to raise_exception \
+          described_class::UnparseableResponseError,
+          %r{Error parsing #{api_endpoint}/mockentities/123 with headers:}
+      end
     end
   end
 
@@ -85,14 +89,14 @@ RSpec.describe ApiEntity do
       let(:status) { 404 }
       let(:body) { {}.to_json }
 
-      it { expect { request }.to raise_exception ApiEntity::NotFound }
+      it { expect { request }.to raise_exception described_class::NotFound }
     end
 
     context 'with error response' do
       let(:status) { 500 }
       let(:body) { {}.to_json }
 
-      it { expect { request }.to raise_exception ApiEntity::Error }
+      it { expect { request }.to raise_exception described_class::Error }
     end
 
     context 'with unparseable response' do
@@ -100,7 +104,11 @@ RSpec.describe ApiEntity do
         file_fixture('jsonapi/multiple_invalid_relationship.json').read
       end
 
-      it { expect { request }.to raise_exception TariffJsonapiParser::ParsingError }
+      it 'raises descriptive exception' do
+        expect { request }.to raise_exception \
+          described_class::UnparseableResponseError,
+          %r{Error parsing #{api_endpoint}/mockentities with headers:}
+      end
     end
   end
 end

--- a/spec/lib/tariff_jsonapi_parser_spec.rb
+++ b/spec/lib/tariff_jsonapi_parser_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+RSpec.describe TariffJsonapiParser do
+  describe '#parse' do
+    let(:json) { JSON.parse file_fixture("jsonapi/#{json_file}.json").read }
+
+    context 'with singular resource' do
+      subject(:parse) { described_class.new(json).parse }
+
+      context 'with valid' do
+        let(:json_file) { 'singular_no_relationship' }
+
+        it { is_expected.to include 'name' => 'Joe' }
+        it { is_expected.to include 'age' => 21 }
+      end
+
+      context 'with relationships' do
+        let(:json_file) { 'singular_with_relationship' }
+
+        it { is_expected.to include 'name' => 'Joe' }
+        it { is_expected.to include 'age' => 21 }
+        it { is_expected.to include 'parts' => [{ 'part_name' => 'A part name' }] }
+      end
+
+      context 'with missing relationships' do
+        let(:json_file) { 'singular_missing_relationship' }
+
+        it { is_expected.to include 'name' => 'Joe' }
+        it { is_expected.to include 'age' => 21 }
+        it { is_expected.to include 'parts' => [{}] }
+      end
+
+      context 'with invalid relationships' do
+        let(:json_file) { 'singular_invalid_relationship' }
+
+        it { expect { parse }.to raise_exception NoMethodError }
+      end
+    end
+
+    context 'with array resource' do
+      subject(:parse) { described_class.new(json).parse.first }
+
+      context 'with valid' do
+        let(:json_file) { 'multiple_no_relationship' }
+
+        it { is_expected.to include 'name' => 'Joe' }
+        it { is_expected.to include 'age' => 21 }
+      end
+
+      context 'with relationships' do
+        let(:json_file) { 'multiple_with_relationship' }
+
+        it { is_expected.to include 'name' => 'Joe' }
+        it { is_expected.to include 'age' => 21 }
+        it { is_expected.to include 'parts' => [{ 'part_name' => 'A part name' }] }
+      end
+
+      context 'with missing relationships' do
+        let(:json_file) { 'multiple_missing_relationship' }
+
+        it { is_expected.to include 'name' => 'Joe' }
+        it { is_expected.to include 'age' => 21 }
+        it { is_expected.to include 'parts' => [{}] }
+      end
+
+      context 'with invalid relationships' do
+        let(:json_file) { 'multiple_invalid_relationship' }
+
+        it { expect { parse }.to raise_exception NoMethodError }
+      end
+    end
+  end
+end

--- a/spec/lib/tariff_jsonapi_parser_spec.rb
+++ b/spec/lib/tariff_jsonapi_parser_spec.rb
@@ -33,7 +33,11 @@ RSpec.describe TariffJsonapiParser do
       context 'with invalid relationships' do
         let(:json_file) { 'singular_invalid_relationship' }
 
-        it { expect { parse }.to raise_exception NoMethodError }
+        it 'raises a description exception' do
+          expect { parse }.to raise_exception \
+            described_class::ParsingError,
+            "Error finding relationship 'parts': nil"
+        end
       end
     end
 
@@ -66,7 +70,11 @@ RSpec.describe TariffJsonapiParser do
       context 'with invalid relationships' do
         let(:json_file) { 'multiple_invalid_relationship' }
 
-        it { expect { parse }.to raise_exception NoMethodError }
+        it 'raises a description exception' do
+          expect { parse }.to raise_exception \
+            described_class::ParsingError,
+            "Error finding relationship 'parts': nil"
+        end
       end
     end
   end

--- a/spec/models/measure_condition_dialog_spec.rb
+++ b/spec/models/measure_condition_dialog_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MeasureConditionDialog do
   subject(:dialog) { described_class.build(declarable, measure) }
 
   before do
-    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', 'spec/fixtures/measure_condition_dialog_config.yaml')
+    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
   end
 
   describe '#build' do

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'Commodity page', type: :request do
   before do
-    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', 'spec/fixtures/measure_condition_dialog_config.yaml')
+    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
 
     allow(RulesOfOrigin::Scheme).to receive(:all).and_return([])
     TradeTariffFrontend::ServiceChooser.service_choice = nil

--- a/spec/requests/heading_spec.rb
+++ b/spec/requests/heading_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'Heading page', type: :request do
   before do
-    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', 'spec/fixtures/measure_condition_dialog_config.yaml')
+    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
 
     allow(RulesOfOrigin::Scheme).to receive(:all).and_return([])
     TradeTariffFrontend::ServiceChooser.service_choice = nil

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe 'Search page', type: :request do
   describe 'search results' do
     before do
-      stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', 'spec/fixtures/measure_condition_dialog_config.yaml')
+      stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
       allow(Section).to receive(:all).and_return([])
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,7 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+  config.file_fixture_path = 'spec/fixtures'
 
   config.include FactoryBot::Syntax::Methods
   config.include Rails.application.routes.url_helpers

--- a/spec/views/measures/_measure.html.erb_spec.rb
+++ b/spec/views/measures/_measure.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'measures/_measure.html.erb', type: :view do
   end
 
   before do
-    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', 'spec/fixtures/measure_condition_dialog_config.yaml')
+    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
 
     render 'measures/measure', measure: MeasurePresenter.new(measure)
   end

--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
   subject { render_page && rendered }
 
   before do
-    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', 'spec/fixtures/measure_condition_dialog_config.yaml')
+    stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
 
     allow(search).to receive(:countries).and_return all_countries
 


### PR DESCRIPTION
### Jira link

[HOTT-1045](https://transformuk.atlassian.net/browse/HOTT-1045)

### What?

I have added/removed/altered:

- [x] Added a spec for the existing implementation of `TariffJsonapiParser`
- [x] Added a spec for the existing implementation of `ApiEntity`
- [x] Changed TariffJsonapiParser to catch missing keys and raise its own `ParsingError` with more debug info in
- [x] Changed ApiEntity to catch `ParsingError`s and raise `UnparseableResponseError` - this includes the URL which could not be parsed together with the request headers (to find out APIv1 vs APIv2) - the `ParsingError` will continue to be available in `UnparseableResponseError#cause` and Sentry should record this info.

### Why?

I am doing this because:

- I struggled to debug the issue this relates to yesterday and also found we were short of specs around this.

### Deployment risks (optional)

- Makes minor syntactic changes our `ApiEntity` client - which has historically been untested and unchanged accordingly
