### PR TITLE
HOTT-1060: Cache node modules for smoketest runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,36 @@ commands:
           event: pass
           template: basic_success_1
 
+  smoketest:
+    parameters:
+      url:
+        type: string
+    steps:
+      - run:
+          name: "Checkout tests repo"
+          command: git clone --depth=1 "https://github.com/trade-tariff/trade-tariff-testing/"
+      - run:
+          name: "Check environment being tested"
+          environment:
+            CYPRESS_BASE_URL: '<< parameters.url >>'
+          command: 'echo "Testing: ${CYPRESS_BASE_URL}"'
+      - restore_cache:
+          keys:
+            - v2-smoketest-deps-{{ checksum "trade-tariff-testing/yarn.lock" }}
+      - run:
+          name: "Install NPM packages"
+          command: 'cd trade-tariff-testing && yarn install'
+      - save_cache:
+          key: v2-smoketest-deps-{{ checksum "trade-tariff-testing/yarn.lock" }}
+          paths:
+            - trade-tariff-testing/node_modules
+            - /root/.cache/Cypress
+      - run:
+          name: "Cypress Smoke tests"
+          environment:
+            CYPRESS_BASE_URL: '<< parameters.url >>'
+          command: 'cd trade-tariff-testing && yarn run cypress run --spec "/*/**/HOTT-Shared/devSmokeTestCI.spec.js"'
+
   sentry-release:
     steps:
       - checkout
@@ -167,26 +197,19 @@ jobs:
             docker tag $IMAGE_NAME:$DOCKER_TAG $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
             docker push $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
 
-  smoketest_dev: &smoketest
+  smoketest_dev:
     docker:
       - image: 'cypress/base:latest'
-    environment:
-      CYPRESS_BASE_URL: https://dev.trade-tariff.service.gov.uk
     steps:
-      - run:
-          name: "Checkout tests repo"
-          command: git clone --depth=1 "https://github.com/trade-tariff/trade-tariff-testing/"
-      - run:
-          name: "Check environment being tested"
-          command: 'echo "Testing: ${CYPRESS_BASE_URL}"'
-      - run:
-          name: "Cypress Smoke tests"
-          command: 'cd trade-tariff-testing && yarn install && yarn run cypress run --spec "/*/**/HOTT-Shared/devSmokeTestCI.spec.js"'
+      - smoketest:
+          url: https://dev.trade-tariff.service.gov.uk
 
   smoketest_staging:
-    <<: *smoketest
-    environment:
-      CYPRESS_BASE_URL: https://staging.trade-tariff.service.gov.uk
+    docker:
+      - image: 'cypress/base:latest'
+    steps:
+      - smoketest:
+          url: https://staging.trade-tariff.service.gov.uk
 
   jest-tests:
     docker:


### PR DESCRIPTION
### Jira link

[HOTT-1060](https://transformuk.atlassian.net/browse/HOTT-1060)

### What?

I have added/removed/altered:

- [x] Cache npm modules in CI
### Why?

I am doing this because:

- because these change infrequently and this should speed up runs when yarn.lock has not changed
