### PR TITLE
HOTT-687 Allign Export table to the import ones.

### DIFF
--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -1,5 +1,5 @@
 <tr id="measure-<%= measure.id %>" class="<%= measure.geo_class %>" tabIndex="-1">
-  <td>
+  <td class="country-col">
     <% if measure.has_children_geographical_areas? %>
       <dl>
         <dt class="has_children" role="button" aria-expanded="false" aria-controls="measure-<%= measure.id %>-children-geographical-areas">
@@ -18,7 +18,7 @@
     <% end %>
   </td>
 
-  <td class="<%= measure.measure_type.id %>">
+  <td class="measure-type-col <%= measure.measure_type.id %>">
     <span class='table-line'><%= measure.measure_type.description %></span>
     <% if measure.order_number.present? %>
       <span class='table-line'>
@@ -39,7 +39,7 @@
   </td>
 
   <% unless local_assigns[:hide_duty_rate] %>
-    <td class="numerical">
+    <td class="duty-rate-col numerical">
       <%= filter_duty_expression(measure) %>
 
       <% if measure.resolved_duty_expression.present? %>
@@ -52,19 +52,19 @@
     </td>
   <% end %>
 
-  <td>
+  <td class="conditions-col">
     <% if measure.has_measure_conditions? %>
       <%= link_to "Conditions",  "#", class: 'reference', 'data-popup-ref' => "#{measure.destination}-#{measure.id}-conditions", "aria-label": "Click to open a dialog with the conditions for this measure", role: "button" %>
     <% end %>
   </td>
 
-  <td><%= measure.excluded_country_list %></td>
+  <td class="exclusions-col"><%= measure.excluded_country_list %></td>
 
-  <td class="numerical">
+  <td class="legal-base-col numerical">
     <%= legal_act_regulation_url_link_for(measure) %>
   </td>
 
-  <td class="numerical">
+  <td class="dates-col numerical">
     <%= pretty_date_range(measure.effective_start_date, measure.effective_end_date) %>
 
     <% if measure.suspension_legal_act.present? %>
@@ -80,7 +80,7 @@
     <% end %>
   </td>
 
-  <td class="numerical">
+  <td class="footnotes-col numerical">
     <% if measure.has_measure_footnotes? %>
       <%= link_to measure.footnotes.size == 1 ? measure.footnotes.first.code : "Footnotes",  "#", class: 'reference', 'data-popup-ref' => "#{measure.destination}-#{measure.id}-footnotes", "aria-label": "Click to open a dialog with the footnotes for this measure", role: "button" %>
     <% end %>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -102,33 +102,16 @@
     <%= render partial: 'declarables/filtered', locals: { search: @search } %>
 
     <% if declarable.export_measures.for_country(@search.country).any? %>
-
       <%= render "shared/measure_types_help", anchor: "export" %>
 
-      <table class="small-table measures govuk-table">
-        <% if @search.filtered_by_country? %>
-          <caption class="govuk-table__caption">Measures for <%= @search.geographical_area %></caption>
-        <% else %>
-          <caption class="govuk-table__caption">Measures for all countries</caption>
-        <% end %>
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-3">
+        <%= @search.filtered_by_country? ? "Measures for #{@search.geographical_area}" : "Measures for all countries" %>
+      </h3>
 
-        <thead>
-        <tr>
-          <th>Country</th>
-          <th>Measure</th>
-          <th>Value</th>
-          <th>Conditions that apply</th>
-          <th>Exclusions</th>
-          <th title="Opens in a new window">Legal base</th>
-          <th>Start date<br>(End date, if any)</th>
-          <th>Footnotes</th>
-        </tr>
-        </thead>
-
-        <tbody>
-          <%= render partial: 'measures/measure', collection: declarable.export_measures.for_country(@search.country).sort_by(&:key) %>
-        </tbody>
-      </table>
+      <%= render partial: 'measures/grouped/table', locals: {
+        collection: declarable.export_measures.for_country(@search.country).sort_by(&:key),
+        hide_duty_rate: true }
+      %>
     <% else %>
       <p>There are no export measures for this commodity on this date.</p>
     <% end %>

--- a/app/views/measures/grouped/_table.html.erb
+++ b/app/views/measures/grouped/_table.html.erb
@@ -10,7 +10,7 @@
 
       <th>Conditions</th>
       <th>Exclusions</th>
-      <th title="Opens in a new window">Legal base</th>
+      <th class="legal-base-col" title="Opens in a new window">Legal base</th>
       <th>Date(s)</th>
       <th>Footnotes</th>
     </tr>

--- a/app/webpacker/src/stylesheets/_tables.scss
+++ b/app/webpacker/src/stylesheets/_tables.scss
@@ -101,14 +101,14 @@ table.small-table {
         }
       }
 
-      td:nth-of-type(1):before { content: 'Country'; }
-      td:nth-of-type(2):before { content: 'Measure type'; }
-      td:nth-of-type(3):before { content: 'Duty rate'; }
-      td:nth-of-type(4):before { content: 'Conditions'; }
-      td:nth-of-type(5):before { content: 'Exclusions'; }
-      td:nth-of-type(6):before { content: 'Legal base'; }
-      td:nth-of-type(7):before { content: 'Date(s)'; }
-      td:nth-of-type(8):before { content: 'Footnotes'; }
+      td.country-col:before { content: 'Country'; }
+      td.measure-type-col:before { content: 'Measure type'; }
+      td.duty-rate-col:before { content: 'Duty rate'; }
+      td.conditions-col:before { content: 'Conditions'; }
+      td.exclusions-col:before { content: 'Exclusions'; }
+      td.legal-base-col:before { content: 'Legal base'; }
+      td.dates-col:before { content: 'Date(s)'; }
+      td.footnotes-col:before { content: 'Footnotes'; }
     }
 
     @media (min-width: $small-table-breakpoint) {

--- a/app/webpacker/src/stylesheets/_uk_overrides.scss
+++ b/app/webpacker/src/stylesheets/_uk_overrides.scss
@@ -1,10 +1,10 @@
 body.uk-service {
   table.measures {
-    th:nth-of-type(6) {
+    th.legal-base-col {
       display: none;
     }
 
-    td:nth-of-type(6) {
+    td.legal-base-col {
       display: none;
     }
   }


### PR DESCRIPTION
### What?
Allign Export table to the import ones.
This also allow to reuse the existing partial for the table,
and fix the "Legal base" column (not visible on UK).

### Why?
This is something that was missing from the HOTT-687,
it was confirmed after I merged the PR, so this PR is complementary to the `HOTT-687-improve-commodities-table`.