### PR TITLE
HOTT-923: raise errors for unexpected responses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,12 +17,13 @@ class ApplicationController < ActionController::Base
 
   layout :set_layout
 
-  rescue_from ApiEntity::Error, Errno::ECONNREFUSED do
+  rescue_from ApiEntity::Error, Faraday::ServerError, Errno::ECONNREFUSED do
     request.format = :html
     render_500
   end
 
-  rescue_from(ApiEntity::NotFound, ActionView::MissingTemplate, ActionController::UnknownFormat,
+  rescue_from(ApiEntity::NotFound, Faraday::ResourceNotFound,
+              ActionView::MissingTemplate, ActionController::UnknownFormat,
               AbstractController::ActionNotFound, URI::InvalidURIError) do |_e|
     request.format = :html
     render_404

--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -1,5 +1,5 @@
 class GoodsNomenclaturesController < ApplicationController
-  rescue_from ApiEntity::NotFound, with: :find_relevant_goods_code_or_fallback
+  rescue_from ApiEntity::NotFound, Faraday::ResourceNotFound, with: :find_relevant_goods_code_or_fallback
 
   private
 

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,7 +1,7 @@
 require 'api_entity'
 
 class HealthcheckController < ActionController::Base
-  rescue_from ApiEntity::Error do |_e|
+  rescue_from ApiEntity::Error, Faraday::ServerError do |_e|
     render plain: '', status: :internal_server_error
   end
 

--- a/app/presenters/chemical_search_presenter.rb
+++ b/app/presenters/chemical_search_presenter.rb
@@ -5,7 +5,7 @@ class ChemicalSearchPresenter
     @with_errors = false
     @search_form = search_form
     @search_result = Chemical.search(search_form.to_params) if search_form.present?
-  rescue ApiEntity::NotFound
+  rescue ApiEntity::NotFound, Faraday::ResourceNotFound
     # noop - swallow a 404 here so that the UI can display a message to the user
   rescue StandardError
     @with_errors = true

--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -26,6 +26,7 @@ class ClientBuilder
   def resource_client
     Faraday.new(host) do |conn|
       conn.request :url_encoded
+      conn.response :raise_error
       conn.adapter :net_http_persistent
       conn.response :json, content_type: /\bjson$/
       conn.headers['Accept'] = "application/vnd.uktt.v#{DEFAULT_VERSION}"

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -102,14 +102,10 @@ module ApiEntity
         collection = collection.map { |entry_data| new(entry_data) }
         collection = paginate_collection(collection, resp.body.dig('meta', 'pagination')) if resp.body.is_a?(Hash) && resp.body.dig('meta', 'pagination').present?
         collection
-      rescue Faraday::Error => e
+      rescue Faraday::Error, ApiEntity::UnparseableResponseError
         if retries < Rails.configuration.x.http.max_retry
           retries += 1
           retry
-        elsif e.is_a? Faraday::ResourceNotFound
-          raise ApiEntity::NotFound
-        elsif e.is_a? Faraday::ServerError
-          raise ApiEntity::Error
         else
           raise
         end
@@ -121,14 +117,10 @@ module ApiEntity
       begin
         resp = api.get("/#{name.pluralize.parameterize}/#{id}", opts)
         new parse_jsonapi(resp)
-      rescue Faraday::Error => e
+      rescue Faraday::Error, ApiEntity::UnparseableResponseError
         if retries < Rails.configuration.x.http.max_retry
           retries += 1
           retry
-        elsif e.is_a? Faraday::ResourceNotFound
-          raise ApiEntity::NotFound
-        elsif e.is_a? Faraday::ServerError
-          raise ApiEntity::Error
         else
           raise
         end

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -98,22 +98,18 @@ module ApiEntity
       retries = 0
       begin
         resp = api.get(collection_path, opts)
-        case resp.status
-        when 404
-          raise ApiEntity::NotFound, TariffJsonapiParser.new(resp.body).errors
-        when 500
-          raise ApiEntity::Error, TariffJsonapiParser.new(resp.body).errors
-        when 502
-          raise ApiEntity::Error, '502 Bad Gateway'
-        end
         collection = parse_jsonapi(resp)
         collection = collection.map { |entry_data| new(entry_data) }
         collection = paginate_collection(collection, resp.body.dig('meta', 'pagination')) if resp.body.is_a?(Hash) && resp.body.dig('meta', 'pagination').present?
         collection
-      rescue StandardError
+      rescue Faraday::Error => e
         if retries < Rails.configuration.x.http.max_retry
           retries += 1
           retry
+        elsif e.is_a? Faraday::ResourceNotFound
+          raise ApiEntity::NotFound
+        elsif e.is_a? Faraday::ServerError
+          raise ApiEntity::Error
         else
           raise
         end
@@ -124,20 +120,15 @@ module ApiEntity
       retries = 0
       begin
         resp = api.get("/#{name.pluralize.parameterize}/#{id}", opts)
-        case resp.status
-        when 404
-          raise ApiEntity::NotFound
-        when 500
-          raise ApiEntity::Error, TariffJsonapiParser.new(resp.body).errors
-        when 502
-          raise ApiEntity::Error, TariffJsonapiParser.new(resp.body).errors
-        end
-        resp = parse_jsonapi(resp)
-        new(resp)
-      rescue StandardError
+        new parse_jsonapi(resp)
+      rescue Faraday::Error => e
         if retries < Rails.configuration.x.http.max_retry
           retries += 1
           retry
+        elsif e.is_a? Faraday::ResourceNotFound
+          raise ApiEntity::NotFound
+        elsif e.is_a? Faraday::ServerError
+          raise ApiEntity::Error
         else
           raise
         end

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe HealthcheckController, type: :controller do
 
   it 'throws a 500 on no API connection' do
     allow(Section).to receive(:all)
-                  .and_raise(ApiEntity::Error.new('502 Bad Gateway'))
+                      .and_raise(Faraday::ServerError, 'Bad request')
+
     get :check
     expect(response.status).to eq 500
   end

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe ApiEntity do
       it { is_expected.to have_attributes name: 'Joe', age: 21 }
     end
 
+    context 'with 400 response' do
+      let(:status) { 400 }
+      let(:body) { {}.to_json }
+
+      it { expect { request }.to raise_exception Faraday::BadRequestError }
+    end
+
     context 'with 404 response' do
       let(:status) { 404 }
       let(:body) { {}.to_json }
@@ -46,6 +53,13 @@ RSpec.describe ApiEntity do
 
     context 'with error response' do
       let(:status) { 500 }
+      let(:body) { {}.to_json }
+
+      it { expect { request }.to raise_exception described_class::Error }
+    end
+
+    context 'with 502 response' do
+      let(:status) { 502 }
       let(:body) { {}.to_json }
 
       it { expect { request }.to raise_exception described_class::Error }
@@ -85,6 +99,13 @@ RSpec.describe ApiEntity do
       it { expect(request.first).to have_attributes name: 'Joe', age: 21 }
     end
 
+    context 'with 400 response' do
+      let(:status) { 400 }
+      let(:body) { {}.to_json }
+
+      it { expect { request }.to raise_exception Faraday::BadRequestError }
+    end
+
     context 'with 404 response' do
       let(:status) { 404 }
       let(:body) { {}.to_json }
@@ -94,6 +115,13 @@ RSpec.describe ApiEntity do
 
     context 'with error response' do
       let(:status) { 500 }
+      let(:body) { {}.to_json }
+
+      it { expect { request }.to raise_exception described_class::Error }
+    end
+
+    context 'with 502 response' do
+      let(:status) { 502 }
       let(:body) { {}.to_json }
 
       it { expect { request }.to raise_exception described_class::Error }

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -48,21 +48,21 @@ RSpec.describe ApiEntity do
       let(:status) { 404 }
       let(:body) { {}.to_json }
 
-      it { expect { request }.to raise_exception described_class::NotFound }
+      it { expect { request }.to raise_exception Faraday::ResourceNotFound }
     end
 
     context 'with error response' do
       let(:status) { 500 }
       let(:body) { {}.to_json }
 
-      it { expect { request }.to raise_exception described_class::Error }
+      it { expect { request }.to raise_exception Faraday::ServerError }
     end
 
     context 'with 502 response' do
       let(:status) { 502 }
       let(:body) { {}.to_json }
 
-      it { expect { request }.to raise_exception described_class::Error }
+      it { expect { request }.to raise_exception Faraday::ServerError }
     end
 
     context 'with unparseable response' do
@@ -110,21 +110,21 @@ RSpec.describe ApiEntity do
       let(:status) { 404 }
       let(:body) { {}.to_json }
 
-      it { expect { request }.to raise_exception described_class::NotFound }
+      it { expect { request }.to raise_exception Faraday::ResourceNotFound }
     end
 
     context 'with error response' do
       let(:status) { 500 }
       let(:body) { {}.to_json }
 
-      it { expect { request }.to raise_exception described_class::Error }
+      it { expect { request }.to raise_exception Faraday::ServerError }
     end
 
     context 'with 502 response' do
       let(:status) { 502 }
       let(:body) { {}.to_json }
 
-      it { expect { request }.to raise_exception described_class::Error }
+      it { expect { request }.to raise_exception Faraday::ServerError }
     end
 
     context 'with unparseable response' do


### PR DESCRIPTION
### Jira link

[HOTT-923](https://transformuk.atlassian.net/browse/HOTT-923)

### What?

I have added/removed/altered:

- [x] Added in Faradays RaiseError middlewhere - this replaces `ApiEntity`'s error handling with a more complete alternative provided by Faraday

### Why?

I am doing this because:

- I'd observed odd errors from the Frontend - these are almost always of the form that Nil is missing a method - the underlying cause is error responses from the Backend which have status codes the Frontend is not checking for - at which point it is parsed as a successful response even though it isn't and produces a misleading error. Since Faraday provides its own very robust error handling I'm dropping our version.

### Notes

There are still some parts of the codebase raising ApiError's so I've left the existing errors in place and will remove all references in a subsequent PR.

### Deployment risks (optional)

- This is a fundamental change to our API error handling so requires a full regression run in Staging prior to any deployment to Production
