### PR TITLE
Handle jsonapi metadata and update duty calculator business logic

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -24,7 +24,8 @@ module Declarable
                   :basic_duty_rate,
                   :meursing_code,
                   :producline_suffix,
-                  :declarable
+                  :declarable,
+                  :meta
 
     alias_method :declarable?, :declarable
 
@@ -32,24 +33,16 @@ module Declarable
     delegate :code, :short_code, to: :chapter, prefix: true
   end
 
-  def meursing_code?
-    meursing_code
-  end
-
   def calculate_duties?
-    no_meursing? && no_heading?
+    no_meursing? && no_heading? && no_entry_price_system?
   end
 
-  def no_meursing?
-    !meursing_code?
+  def meursing_code?
+    meta.dig('duty_calculator', 'meursing_code')
   end
 
   def heading?
     code && code.last(6) == Heading::HEADING_PATTERN
-  end
-
-  def no_heading?
-    !heading?
   end
 
   def code
@@ -62,5 +55,23 @@ module Declarable
       export_measures.map(&:footnotes).select(&:present?).flatten +
       import_measures.map(&:footnotes).select(&:present?).flatten
     ).uniq(&:code)
+  end
+
+  private
+
+  def no_meursing?
+    !meursing_code?
+  end
+
+  def no_heading?
+    !heading?
+  end
+
+  def no_entry_price_system?
+    !entry_price_system?
+  end
+
+  def entry_price_system?
+    meta.dig('duty_calculator', 'entry_price_system')
   end
 end

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -38,7 +38,7 @@ module Declarable
   end
 
   def meursing_code?
-    meta.dig('duty_calculator', 'meursing_code')
+    meta&.dig('duty_calculator', 'meursing_code')
   end
 
   def heading?
@@ -72,6 +72,6 @@ module Declarable
   end
 
   def entry_price_system?
-    meta.dig('duty_calculator', 'entry_price_system')
+    meta&.dig('duty_calculator', 'entry_price_system')
   end
 end

--- a/lib/tariff_jsonapi_parser.rb
+++ b/lib/tariff_jsonapi_parser.rb
@@ -32,8 +32,8 @@ class TariffJsonapiParser
     result = {}
 
     parse_top_level_attributes!(resource, result)
-
     parse_relationships!(resource['relationships'], result) if resource.key?('relationships')
+    parse_meta!(resource, result) if resource.key?('meta')
 
     result
   end
@@ -44,8 +44,8 @@ class TariffJsonapiParser
     end
   end
 
-  def parse_top_level_attributes!(attributes, parent)
-    parent.merge!(attributes['attributes'])
+  def parse_top_level_attributes!(resource, parent)
+    parent.merge!(resource['attributes'])
   end
 
   def parse_relationships!(relationships, parent)
@@ -73,19 +73,18 @@ class TariffJsonapiParser
   end
 
   def find_and_parse_included(name, id, type)
-    record = find_included(id, type)
-    parse_record(record)
+    found_resource = find_included(id, type)
+
+    return {} if found_resource.blank?
+
+    parse_resource(found_resource)
   rescue NoMethodError
     raise ParsingError,
           "Error finding relationship - '#{name}', '#{id}', '#{type}': #{record.inspect}"
   end
 
-  def parse_record(record)
-    record_attrs = record['attributes'].clone || {}
-    if record.key?('relationships')
-      parse_relationships!(record['relationships'], record_attrs)
-    end
-    record_attrs
+  def parse_meta!(resource, parent)
+    parent['meta'] = resource['meta']
   end
 
   def find_included(id, type)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -34,6 +34,22 @@ FactoryBot.define do
     goods_nomenclature_sid { Forgery(:basic).number }
     parent_sid { Forgery(:basic).number }
     meursing_code { false }
+    meta do
+      {
+        'duty_calculator' => {
+          'applicable_additional_codes' => {},
+          'applicable_measure_units' => {},
+          'applicable_vat_options' => {
+            'VATZ' => 'VAT zero rate',
+          },
+          'entry_price_system' => false,
+          'meursing_code' => false,
+          'source' => 'uk',
+          'trade_defence' => false,
+          'zero_mfn_duty' => false,
+        },
+      }
+    end
   end
 
   factory :monetary_exchange_rate do

--- a/spec/fixtures/jsonapi/multiple_invalid_relationship.json
+++ b/spec/fixtures/jsonapi/multiple_invalid_relationship.json
@@ -1,6 +1,7 @@
 {
   "data" : [
     {
+      "meta": { "foo": "bar" },
       "id": "123",
       "type": "mock_entity",
       "attributes": {
@@ -16,6 +17,7 @@
   ],
   "included": [
     {
+      "meta": { "foo": "bar" },
       "id": 456,
       "type": "part",
       "attributes": {

--- a/spec/fixtures/jsonapi/multiple_missing_relationship.json
+++ b/spec/fixtures/jsonapi/multiple_missing_relationship.json
@@ -1,6 +1,7 @@
 {
   "data" : [
     {
+      "meta": { "foo": "bar" },
       "id": "123",
       "type": "mock_entity",
       "attributes": {

--- a/spec/fixtures/jsonapi/multiple_no_relationship.json
+++ b/spec/fixtures/jsonapi/multiple_no_relationship.json
@@ -1,6 +1,7 @@
 {
-  "data" : [
+  "data": [
     {
+      "meta": { "foo": "bar" },
       "id": "123",
       "type": "mock_entity",
       "attributes": {

--- a/spec/fixtures/jsonapi/multiple_with_relationship.json
+++ b/spec/fixtures/jsonapi/multiple_with_relationship.json
@@ -1,6 +1,7 @@
 {
-  "data" : [
+  "data": [
     {
+      "meta": { "foo": "bar" },
       "id": "123",
       "type": "mock_entity",
       "attributes": {
@@ -21,6 +22,7 @@
   ],
   "included": [
     {
+      "meta": { "foo": "bar" },
       "id": 456,
       "type": "part",
       "attributes": {

--- a/spec/fixtures/jsonapi/singular_invalid_relationship.json
+++ b/spec/fixtures/jsonapi/singular_invalid_relationship.json
@@ -1,5 +1,6 @@
 {
   "data" : {
+    "meta": { "foo": "bar" },
     "id": "123",
     "type": "mock_entity",
     "attributes": {
@@ -14,6 +15,7 @@
   },
   "included": [
     {
+      "meta": { "foo": "bar" },
       "id": 456,
       "type": "part",
       "attributes": {

--- a/spec/fixtures/jsonapi/singular_missing_relationship.json
+++ b/spec/fixtures/jsonapi/singular_missing_relationship.json
@@ -1,5 +1,6 @@
 {
   "data" : {
+    "meta": { "foo": "bar" },
     "id": "123",
     "type": "mock_entity",
     "attributes": {

--- a/spec/fixtures/jsonapi/singular_no_relationship.json
+++ b/spec/fixtures/jsonapi/singular_no_relationship.json
@@ -1,5 +1,6 @@
 {
-  "data" : {
+  "data": {
+    "meta": { "foo": "bar" },
     "id": "123",
     "type": "mock_entity",
     "attributes": {

--- a/spec/fixtures/jsonapi/singular_with_relationship.json
+++ b/spec/fixtures/jsonapi/singular_with_relationship.json
@@ -1,5 +1,6 @@
 {
   "data" : {
+    "meta": { "foo": "bar" },
     "id": "123",
     "type": "mock_entity",
     "attributes": {
@@ -19,6 +20,7 @@
   },
   "included": [
     {
+      "meta": { "foo": "bar" },
       "id": 456,
       "type": "part",
       "attributes": {

--- a/spec/lib/tariff_jsonapi_parser_spec.rb
+++ b/spec/lib/tariff_jsonapi_parser_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe TariffJsonapiParser do
       context 'with valid' do
         let(:json_file) { 'singular_no_relationship' }
 
+        it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
       end
@@ -17,14 +18,16 @@ RSpec.describe TariffJsonapiParser do
       context 'with relationships' do
         let(:json_file) { 'singular_with_relationship' }
 
+        it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
-        it { is_expected.to include 'parts' => [{ 'part_name' => 'A part name' }] }
+        it { is_expected.to include 'parts' => [{ 'meta' => { 'foo' => 'bar' }, 'part_name' => 'A part name' }] }
       end
 
       context 'with missing relationships' do
         let(:json_file) { 'singular_missing_relationship' }
 
+        it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
         it { is_expected.to include 'parts' => [{}] }
@@ -47,6 +50,7 @@ RSpec.describe TariffJsonapiParser do
       context 'with valid' do
         let(:json_file) { 'multiple_no_relationship' }
 
+        it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
       end
@@ -54,14 +58,16 @@ RSpec.describe TariffJsonapiParser do
       context 'with relationships' do
         let(:json_file) { 'multiple_with_relationship' }
 
+        it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
-        it { is_expected.to include 'parts' => [{ 'part_name' => 'A part name' }] }
+        it { is_expected.to include 'parts' => [{ 'meta' => { 'foo' => 'bar' }, 'part_name' => 'A part name' }] }
       end
 
       context 'with missing relationships' do
         let(:json_file) { 'multiple_missing_relationship' }
 
+        it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
         it { is_expected.to include 'parts' => [{}] }

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -82,8 +82,16 @@ RSpec.describe Commodity do
     end
   end
 
+  describe '#heading?' do
+    it { is_expected.not_to be_heading }
+  end
+
   describe '#meursing_code?' do
-    subject(:commodity) { described_class.new(attributes_for(:commodity, meursing_code: meursing_code).stringify_keys) }
+    subject(:commodity) { described_class.new(attributes_for(:commodity, meta: commodity_metadata).stringify_keys) }
+
+    let(:commodity_metadata) do
+      { 'duty_calculator' => { 'meursing_code' => meursing_code } }
+    end
 
     context 'when the commodity has a meursing code' do
       let(:meursing_code) { true }
@@ -102,43 +110,37 @@ RSpec.describe Commodity do
     end
   end
 
-  describe '#no_meursing?' do
-    subject(:commodity) { described_class.new(attributes_for(:commodity, meursing_code: meursing_code).stringify_keys) }
+  describe '#calculate_duties?' do
+    subject(:commodity) { described_class.new(attributes_for(:commodity, meta: commodity_metadata).stringify_keys) }
 
-    context 'when the commodity has a meursing code' do
-      let(:meursing_code) { true }
-
-      it 'returns true' do
-        expect(commodity).not_to be_no_meursing
-      end
+    let(:commodity_metadata) do
+      {
+        'duty_calculator' => {
+          'entry_price_system' => entry_price_system,
+          'meursing_code' => meursing_code,
+        },
+      }
     end
+    let(:entry_price_system) { false }
+    let(:meursing_code) { false }
 
-    context 'when the commodity does not have a meursing code' do
+    context 'when the commodity should calculate duties' do
+      let(:entry_price_system) { false }
       let(:meursing_code) { false }
 
-      it 'returns false' do
-        expect(commodity).to be_no_meursing
-      end
+      it { is_expected.to be_calculate_duties }
     end
-  end
 
-  describe '#heading?' do
-    it { is_expected.not_to be_heading }
-  end
-
-  describe '#calculate_duties?' do
-    subject(:commodity) { described_class.new(attributes_for(:commodity, meursing_code: meursing_code).stringify_keys) }
-
-    context 'when the commodity has a meursing code' do
+    context 'when the commodity has measures that have meursing codes' do
       let(:meursing_code) { true }
 
       it { is_expected.not_to be_calculate_duties }
     end
 
-    context 'when the commodity does not have a meursing code' do
-      let(:meursing_code) { false }
+    context 'when the commodity has measures that use the Entry Price System' do
+      let(:entry_price_system) { true }
 
-      it { is_expected.to be_calculate_duties }
+      it { is_expected.not_to be_calculate_duties }
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1067

### What?

I have added/removed/altered:

- [x] Hides duty calculator link for EPS commodities
- [x] Removes duplicating parse_record method
- [x] Adds support for metadata attribute as per jsonapi spec

### Why?

I am doing this because:

- These currently aren't supported in the duty calculator
- This brings us closer to the UKTT implementation and means we can access data about commodities that reflect aggregated questions on measures