### PR TITLE
HOTT-1048: refactored page header handling

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,12 @@ module ApplicationHelper
     tag.div(class: 'govuk-breadcrumbs') { tag.ol(crumbs.join('').html_safe, class: 'govuk-breadcrumbs__list', role: 'breadcrumbs') }
   end
 
+  def page_header(heading, &block)
+    extra_content = block_given? ? capture(&block) : nil
+
+    render 'shared/page_header', heading: heading, extra_content: extra_content
+  end
+
   def govuk_header_navigation_item(active_class: '', &block)
     base_class_name = 'govuk-header__navigation-item'
     active_class_name = active_class.present? ? "#{base_class_name}--active" : ''

--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -1,0 +1,11 @@
+<header>
+  <span class="govuk-caption-m">
+    <%= trade_tariff_heading %>
+  </span>
+
+  <h1 class="govuk-heading-l">
+    <%= heading %>
+  </h1>
+
+  <%= extra_content %>
+</header>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -28,14 +28,10 @@
     <% end %>
   </header>
 <% elsif %w(search search_references exchange_rates pages errors feedback).exclude?(controller_name) && action_name != 'quota_search' %>
-  <header>
-    <span class="govuk-caption-m"><%= trade_tariff_heading %></span>
-    <h1 class="govuk-heading-l">
-      <%= default_heading(section: @section) %>
-    </h1>
-
+  <%= page_header default_heading(section: @section) do %>
     <%= render 'shared/switch_banner' %>
-  </header>
+  <% end %>
+
   <%= form_tag perform_search_path, method: :get, class: "tariff-search #{@section_css}", id: "new_search" do |f| %>
     <div class="search-header js-search-header">
       <div class="govuk-grid-row">

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
   describe '#govspeak' do
-    context 'string without HTML code' do
+    context 'with string without HTML code' do
       let(:string) { '**hello**' }
 
       it 'renders string in Markdown as HTML' do
@@ -12,7 +12,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
 
-    context 'string contains Javascript code' do
+    context 'when string contains Javascript code' do
       let(:string) { "<script type='text/javascript'>alert('hello');</script>" }
 
       it '<script> tags with a content are filtered' do
@@ -102,6 +102,33 @@ RSpec.describe ApplicationHelper, type: :helper do
       it 'returns nil' do
         expect(helper.help_active_class).to be_nil
       end
+    end
+  end
+
+  describe '#page_header' do
+    context 'without block' do
+      subject { helper.page_header 'Test header' }
+
+      it { is_expected.to have_css 'header span.govuk-caption-m', text: I18n.t('title.service_name.uk') }
+      it { is_expected.to have_css 'header h1.govuk-heading-l', text: 'Test header' }
+      it { is_expected.to have_css 'header *', count: 2 }
+    end
+
+    context 'with block' do
+      subject { helper.page_header('Second header') { tag.em 'additional content' } }
+
+      it { is_expected.to have_css 'header span.govuk-caption-m', text: I18n.t('title.service_name.uk') }
+      it { is_expected.to have_css 'header h1.govuk-heading-l', text: 'Second header' }
+      it { is_expected.to have_css 'header *', count: 3 }
+      it { is_expected.to have_css 'header em', text: 'additional content' }
+    end
+
+    context 'with XI service' do
+      subject { helper.page_header 'Test header' }
+
+      include_context 'with XI service'
+
+      it { is_expected.to have_css 'header span.govuk-caption-m', text: I18n.t('title.service_name.xi') }
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1048](https://transformuk.atlassian.net/browse/HOTT-1048)

### What?

I have added/removed/altered:

- [x] Generalised the page header handling

### Why?

I am doing this because:

- I'll want to use this on pages which don't have the existing search section on

