### PR TITLE
HOTT-1048: Add the find commodity page

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -4,6 +4,10 @@ class CommoditiesController < GoodsNomenclaturesController
   before_action :fetch_commodities, only: %i[show]
   before_action :set_session, only: %i[show]
 
+  def index
+    @no_shared_search = true
+  end
+
   def show
     @heading = commodity.heading
     @chapter = commodity.chapter

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,4 +1,6 @@
 class SectionsController < GoodsNomenclaturesController
+  prepend_before_action :redirect_to_find_commodity, only: :index
+
   def index
     @tariff_updates = TariffUpdate.all
     @sections = Section.all
@@ -14,5 +16,9 @@ class SectionsController < GoodsNomenclaturesController
 
   def find_relevant_goods_code_or_fallback
     redirect_to sections_url
+  end
+
+  def redirect_to_find_commodity
+    redirect_to find_commodity_path if TradeTariffFrontend.updated_navigation?
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,7 +41,8 @@ module ApplicationHelper
   end
 
   def search_active_class
-    'active' if controller_name == 'search' || (controller_name == 'sections' && action_name == 'index')
+    'active' if action_name == 'search' ||
+      (action_name == 'index' && %w[sections commodities].include?(controller_name))
   end
 
   def browse_active_class

--- a/app/views/commodities/index.html.erb
+++ b/app/views/commodities/index.html.erb
@@ -1,0 +1,139 @@
+<%= page_header 'Look up commodity codes, import duties, taxes and controls' %>
+
+<%= form_tag perform_search_path, method: :get, class: "tariff-search feature-panel last-feature-panel feature-panel--shaded", id: "new_search" do |f| %>
+  <div class="js-search-header">
+    <h2 class="govuk-heading-m">
+      Search for a commodity
+    </h2>
+
+    <p>
+      The UK Integrated Online Tariff helps you to:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>find commodity codes for imports into or exports out of the UK</li>
+      <li>find the taxes and duties that apply to those imports</li>
+      <li>find out which certificates and licences apply to the import of your goods</li>
+    </ul>
+
+    <p>
+      The first step is to find the commodity that you are importing or exporting.
+    </p>
+
+    <label class="govuk-label govuk-label--s" for="search_term">
+      Enter the name of the goods or a commodity code
+    </label>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="searchfield govuk-form-group">
+          <fieldset class="govuk-fieldset govuk-search-input" aria-describedby="q-hint">
+            <%= label_tag :q, search_label_text, class: 'govuk-label' %>
+
+            <div class="govuk-hint" id="q-hint">
+              Commodity codes are 10-digit numbers that classify goods so you can fill in declarations and other paperwork.
+              You must use the right commodity code.
+            </div>
+
+            <%= hidden_field_tag :q, @search.q, { class: "js-commodity-picker-target" } %>
+
+            <div class="js-commodity-picker-select js-show" data-nosubmit></div>
+            <noscript>
+              <%= text_field_tag(:q, @search.q, {class: "govuk-input", name: :q}) %>
+            </noscript>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+
+    <details class="govuk-details govuk-!-margin-top-2" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Enter date of import
+        </span>
+      </summary>
+
+      <div class="govuk-details__text">
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="find-commodity-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s b">
+              <h1 class="govuk-fieldset__heading">When are you planning to trade the goods?</h1>
+            </legend>
+
+            <div class="govuk-hint" id="find-commodity-hint">
+              As commodities, duties and quotas change over time, it may be important to enter the date you think
+              your goods will be traded. Use the format day, month, year, for example 27&nbsp;3&nbsp;2021.
+              If you don't enter a date, today's date will be used.
+            </div>
+
+            <div class="govuk-date-input">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="tariff_date_day">Day</label>
+                  <%= text_field_tag(:day,
+                         @search.date.day,
+                         {
+                           id: 'tariff_date_day',
+                           name: 'day',
+                           class: "govuk-input govuk-date-input__input govuk-input--width-2",
+                           maxlength: 2,
+                           placeholder: "DD",
+                           pattern: "[0-9]*",
+                           inputmode: :numeric
+                         }
+                        ) %>
+                </div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="tariff_date_month">Month</label>
+                  <%= text_field_tag(:month,
+                         @search.date.month,
+                         {
+                           id: 'tariff_date_month',
+                           name: 'month',
+                           class: "govuk-input govuk-date-input__input govuk-input--width-2",
+                           maxlength: 2,
+                           placeholder: "MM",
+                           pattern: "[0-9]*",
+                           inputmode: :numeric
+                         }
+                        ) %>
+                </div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="tariff_date_year">Year</label>
+                  <%= text_field_tag(:year,
+                         @search.date.year,
+                         {
+                           id: 'tariff_date_year',
+                           name: 'year',
+                           class: "govuk-input govuk-date-input__input govuk-input--width-4",
+                           maxlength: 4,
+                           placeholder: "YYYY",
+                           pattern: "[0-9]*",
+                           inputmode: :numeric
+                         }
+                        ) %>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </details>
+
+    <%= submit_tag 'Search for a commodity', class: 'govuk-button' %>
+  </div>
+
+  <p>
+    Alternatively, you can
+    <%= link_to 'browse the goods classification', browse_sections_path %>
+    or
+    <%= link_to 'look for your product in the A-Z', a_z_index_path('a') %>.
+  </p>
+<% end %>
+
+<%= render 'sections/stw_information' %>
+

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -22,12 +22,18 @@
     <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="proposition-links" aria-label="Show or hide Top Level Navigation">Menu</button>
     <nav id="proposition-menu"  aria-label="Top Level Navigation">
       <ul id="proposition-links" class="govuk-header__navigation ">
-        <%= govuk_header_navigation_item(active_class: search_active_class) do %>
-          <%= link_to 'Search or browse the Tariff', sections_path, class: "govuk-header__link" %>
+        <% if TradeTariffFrontend.updated_navigation? %>
+          <%= govuk_header_navigation_item(active_class: search_active_class) do %>
+            <%= link_to 'Search', find_commodity_path, class: "govuk-header__link" %>
+          <% end %>
+          <%= govuk_header_navigation_item(active_class: browse_active_class) do %>
+            <%= link_to 'Browse', browse_sections_path, class: "govuk-header__link" %>
+          <% end %>
+        <% else %>
+          <%= govuk_header_navigation_item(active_class: search_active_class) do %>
+            <%= link_to 'Search or browse the Tariff', sections_path, class: "govuk-header__link" %>
+          <% end %>
         <% end %>
-        <%= govuk_header_navigation_item(active_class: browse_active_class) do %>
-          <%= link_to 'Browse', browse_sections_path, class: "govuk-header__link" %>
-        <% end if TradeTariffFrontend.updated_navigation? %>
         <%= govuk_header_navigation_item(active_class: a_z_active_class) do %>
           <%= link_to "A-Z", a_z_index_path(letter: "a"), class: "govuk-header__link" %>
         <% end %>

--- a/app/views/sections/_stw_information.html.erb
+++ b/app/views/sections/_stw_information.html.erb
@@ -1,0 +1,39 @@
+<div class="feature-panel">
+  <h2 class="govuk-heading-m">Advance tariff rulings</h2>
+  <p class="govuk-body">
+    For more help in classifying your commodity, you can
+    <%= link_to('search for advance tariff rulings', 'https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search', target: '_blank', class: 'govuk-link') %>
+  </p>
+  <p class="govuk-body">
+    Advance tariff rulings allow you to get a legally binding decision on the
+    commodity code to use when importing into or exporting goods.
+  </p>
+
+  <p class="govuk-body">
+    Find out more about
+    <%= link_to('advance tariff rulings', 'https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling', target: '_blank', class: 'govuk-link') %>.
+  </p>
+
+  <p class="govuk-body">
+    <%= link_to('Contact HMRC if you need help finding the right commodity code for your
+      goods','https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', target: '_blank', class: 'govuk-link') %>.
+  </p>
+</div>
+
+<div class="feature-panel last-feature-panel">
+  <h2 class="govuk-heading-m">Check how to import or export goods</h2>
+
+  <p class="govuk-body">
+    Use the
+    '<%= link_to('Check how to import or export goods', 'https://www.gov.uk/check-how-to-import-export', target: '_blank', class: 'govuk-link') %>'
+    service to get information about importing and exporting, including:
+  </p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>how to register your business for trading</li>
+    <li>which licences and certificates you need for your goods</li>
+    <li>paying the right tax and duty for your goods</li>
+    <li>how to make declarations for your goods to clear the UK border</li>
+    <li>which paperwork you need to keep</li>
+  </ul>
+</div>

--- a/app/views/sections/index.html.erb
+++ b/app/views/sections/index.html.erb
@@ -20,45 +20,7 @@
   </table>
 </section>
 
-<div class="feature-panel">
-  <h2 class="govuk-heading-m">Advance tariff rulings</h2>
-  <p class="govuk-body">
-    For more help in classifying your commodity, you can
-    <%= link_to('search for advance tariff rulings', 'https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search', target: '_blank', class: 'govuk-link') %>
-  </p>
-  <p class="govuk-body">
-    Advance tariff rulings allow you to get a legally binding decision on the
-    commodity code to use when importing into or exporting goods.
-  </p>
-
-  <p class="govuk-body">
-    Find out more about
-    <%= link_to('advance tariff rulings', 'https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling', target: '_blank', class: 'govuk-link') %>.
-  </p>
-
-  <p class="govuk-body">
-    <%= link_to('Contact HMRC if you need help finding the right commodity code for your
-      goods','https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', target: '_blank', class: 'govuk-link') %>.
-  </p>
-</div>
-
-<div class="feature-panel last-feature-panel">
-  <h2 class="govuk-heading-m">Check how to import or export goods</h2>
-
-  <p class="govuk-body">
-    Use the
-    '<%= link_to('Check how to import or export goods', 'https://www.gov.uk/check-how-to-import-export', target: '_blank', class: 'govuk-link') %>'
-    service to get information about importing and exporting, including:
-  </p>
-
-  <ul class="govuk-list govuk-list--bullet">
-    <li>how to register your business for trading</li>
-    <li>which licences and certificates you need for your goods</li>
-    <li>paying the right tax and duty for your goods</li>
-    <li>how to make declarations for your goods to clear the UK border</li>
-    <li>which paperwork you need to keep</li>
-  </ul>
-</div>
+<%= render 'sections/stw_information' %>
 
 <!--
 Tariff Updates:

--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -798,7 +798,10 @@
                         data: obj
                       }
                     }]);
-                    $('.js-commodity-picker-select').parents('form:first').trigger("submit");
+
+                    if (typeof($(element).data('nosubmit')) == 'undefined') {
+                      $('.js-commodity-picker-select').parents('form:first').trigger("submit");
+                    }
                   }
                 },
                 source: debounce(function(query, populateResults) {

--- a/app/webpacker/src/stylesheets/_feature-panel.scss
+++ b/app/webpacker/src/stylesheets/_feature-panel.scss
@@ -9,4 +9,8 @@ $feature-panel-border-colour: #333;
   &.last-feature-panel {
     border: 0;
   }
+
+  &--shaded {
+    background-color: #f0f4f5;
+  }
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,11 @@ Rails.application.routes.draw do
     query ? "#{url}?#{query}" : url
   }
 
-  get '/', to: redirect(TradeTariffFrontend.production? ? 'https://www.gov.uk/trade-tariff' : '/sections', status: 302)
+  if TradeTariffFrontend.updated_navigation?
+    get '/', to: redirect(TradeTariffFrontend.production? ? 'https://www.gov.uk/trade-tariff' : '/find_commodity', status: 302)
+  else
+    get '/', to: redirect(TradeTariffFrontend.production? ? 'https://www.gov.uk/trade-tariff' : '/sections', status: 302)
+  end
   get 'healthcheck', to: 'healthcheck#check'
   get 'opensearch', to: 'pages#opensearch', constraints: { format: :xml }
   get 'terms', to: 'pages#terms'
@@ -128,7 +132,7 @@ Rails.application.routes.draw do
                 module: 'commodities'
     end
   end
-  get '/find_commodity', to: 'commodities#index'
+  get '/find_commodity', to: 'commodities#index' if TradeTariffFrontend.updated_navigation?
 
   constraints TradeTariffFrontend::ApiPubConstraints.new(TradeTariffFrontend.public_api_endpoints) do
     scope 'api' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
                 module: 'commodities'
     end
   end
+  get '/find_commodity', to: 'commodities#index'
 
   constraints TradeTariffFrontend::ApiPubConstraints.new(TradeTariffFrontend.public_api_endpoints) do
     scope 'api' do

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe CommoditiesController, type: :controller do
+  describe 'GET #index' do
+    subject { get :index }
+
+    it { is_expected.to have_http_status :success }
+  end
+
   describe 'GET to #show' do
     context 'with XI site' do
       include_context 'with XI service'

--- a/spec/features/date_currency_change_spec.rb
+++ b/spec/features/date_currency_change_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe 'Date & Currency change', js: true, vcr: {
   record: :once,
   match_requests_on: %i[path query],
 } do
+  before do
+    allow(TradeTariffFrontend).to receive(:updated_navigation?).and_return false
+  end
+
   it 'displays the current date' do
     visit sections_path(day: 0o1, month: 0o2, year: 2019)
 
@@ -31,8 +35,8 @@ RSpec.describe 'Date & Currency change', js: true, vcr: {
   end
 
   it 'displays the searched-for date, if the searched-for date is past BREXIT_DATE, and the current date is past BREXIT_DATE' do
-    post_eu_exit_date = DateTime.new(2021, 1, 2, 12, 0, 0)
-    searched_for_date = DateTime.new(2021, 2, 2, 12, 0, 0)
+    post_eu_exit_date = Time.zone.parse('2021-01-02 12:00:00')
+    searched_for_date = Time.zone.parse('2021-02-02 12:00:00')
 
     Timecop.freeze(post_eu_exit_date) do
       visit sections_path

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -5,72 +5,151 @@ RSpec.describe 'Search', js: true, slow: true do
     TradeTariffFrontend::ServiceChooser.service_choice = nil
   end
 
-  context 'when reaching the search page' do
-    it 'renders the search container properly' do
-      VCR.use_cassette('search#check') do
-        visit sections_path
-
-        expect(page).to have_content('UK Integrated Online Tariff')
-        expect(page).to have_content('Look up commodity codes, duty and VAT rates')
-        expect(page).to have_content('Search or browse the Tariff')
-        expect(page).to have_content('Browse')
-
-        expect(page.find('.autocomplete__input#q')).to be_present
-      end
+  context 'with existing sections page' do
+    before do
+      allow(TradeTariffFrontend).to receive(:updated_navigation?).and_return false
     end
-  end
 
-  context 'when hitting the autocomplete fields' do
-    it 'fetches data from the server as we type' do
-      VCR.use_cassette('search#gold') do
-        visit sections_path
+    context 'when reaching the search page' do
+      it 'renders the search container properly' do
+        VCR.use_cassette('search#check') do
+          visit sections_path
 
-        page.find('.autocomplete__input#q').click
+          expect(page).to have_content('UK Integrated Online Tariff')
+          expect(page).to have_content('Look up commodity codes, duty and VAT rates')
+          expect(page).to have_content('Search or browse the Tariff')
 
-        page.find('.autocomplete__input#q').set('gold')
-        sleep 1
-
-        expect(page.find('.autocomplete__option--focused').text).to eq('gold')
-
-        using_wait_time 1 do
-          expect(page.find_all('.autocomplete__option').length).to be > 1
+          expect(page.find('.autocomplete__input#q')).to be_present
         end
+      end
+    end
 
-        expect(page.find('.autocomplete__option--focused').text).to eq('gold')
-        expect(page).to have_content('gold - gold coin')
+    context 'when hitting the autocomplete fields' do
+      it 'fetches data from the server as we type' do
+        VCR.use_cassette('search#gold') do
+          visit sections_path
 
-        page.find('.autocomplete__option--focused').click
+          page.find('.autocomplete__input#q').click
 
-        # trying to see if redirect done by JS needs some sleep to be caught up
-        sleep 1
+          page.find('.autocomplete__input#q').set('gold')
+          sleep 1
 
-        expect(page).to have_content('Search results for ‘gold’')
+          expect(page.find('.autocomplete__option--focused').text).to eq('gold')
+
+          using_wait_time 1 do
+            expect(page.find_all('.autocomplete__option').length).to be > 1
+          end
+
+          expect(page.find('.autocomplete__option--focused').text).to eq('gold')
+          expect(page).to have_content('gold - gold coin')
+
+          page.find('.autocomplete__option--focused').click
+
+          # trying to see if redirect done by JS needs some sleep to be caught up
+          sleep 1
+
+          expect(page).to have_content('Search results for ‘gold’')
+        end
+      end
+    end
+
+    context 'when no result can be found' do
+      it 'handles no results found' do
+        VCR.use_cassette('search#gibberish') do
+          visit sections_path
+
+          page.find('.autocomplete__input#q').click
+
+          page.find('.autocomplete__input#q').set('dsauidoasuiodsa')
+
+          sleep 1
+
+          expect(page.find_all('.autocomplete__option').length).to eq(1)
+          expect(page.find('.autocomplete__option--focused').text).to eq('dsauidoasuiodsa')
+          sleep 1
+
+          page.find('.autocomplete__option--focused').click
+
+          # trying to see if redirect done by JS needs some sleep to be caught up
+          sleep 1
+
+          expect(page).to have_content('Search results for ‘dsauidoasuiodsa’')
+          expect(page).to have_content('There are no results matching your query.')
+        end
       end
     end
   end
 
-  context 'when no result can be found' do
-    it 'handles no results found' do
-      VCR.use_cassette('search#gibberish') do
-        visit sections_path
+  context 'with find_commodity page' do
+    context 'when reaching the search page' do
+      it 'renders the search container properly' do
+        VCR.use_cassette('search#check') do
+          visit find_commodity_path
 
-        page.find('.autocomplete__input#q').click
+          expect(page).to have_content('UK Integrated Online Tariff')
+          expect(page).to have_content('Look up commodity codes, duty and VAT rates')
+          expect(page).to have_content('Search')
+          expect(page).to have_content('Browse')
 
-        page.find('.autocomplete__input#q').set('dsauidoasuiodsa')
+          expect(page.find('.autocomplete__input#q')).to be_present
+        end
+      end
+    end
 
-        sleep 1
+    context 'when hitting the autocomplete fields' do
+      it 'fetches data from the server as we type' do
+        VCR.use_cassette('search#gold') do
+          visit find_commodity_path
 
-        expect(page.find_all('.autocomplete__option').length).to eq(1)
-        expect(page.find('.autocomplete__option--focused').text).to eq('dsauidoasuiodsa')
-        sleep 1
+          page.find('.autocomplete__input#q').click
 
-        page.find('.autocomplete__option--focused').click
+          page.find('.autocomplete__input#q').set('gold')
+          sleep 1
 
-        # trying to see if redirect done by JS needs some sleep to be caught up
-        sleep 1
+          expect(page.find('.autocomplete__option--focused').text).to eq('gold')
 
-        expect(page).to have_content('Search results for ‘dsauidoasuiodsa’')
-        expect(page).to have_content('There are no results matching your query.')
+          using_wait_time 1 do
+            expect(page.find_all('.autocomplete__option').length).to be > 1
+          end
+
+          expect(page.find('.autocomplete__option--focused').text).to eq('gold')
+          expect(page).to have_content('gold - gold coin')
+
+          page.find('.autocomplete__option--focused').click
+          page.click_on 'Search for a commodity'
+
+          # trying to see if redirect done by JS needs some sleep to be caught up
+          sleep 1
+
+          expect(page).to have_content('Search results for ‘gold’')
+        end
+      end
+    end
+
+    context 'when no result can be found' do
+      it 'handles no results found' do
+        VCR.use_cassette('search#gibberish') do
+          visit find_commodity_path
+
+          page.find('.autocomplete__input#q').click
+
+          page.find('.autocomplete__input#q').set('dsauidoasuiodsa')
+
+          sleep 1
+
+          expect(page.find_all('.autocomplete__option').length).to eq(1)
+          expect(page.find('.autocomplete__option--focused').text).to eq('dsauidoasuiodsa')
+          sleep 1
+
+          page.find('.autocomplete__option--focused').click
+          page.click_on 'Search for a commodity'
+
+          # trying to see if redirect done by JS needs some sleep to be caught up
+          sleep 1
+
+          expect(page).to have_content('Search results for ‘dsauidoasuiodsa’')
+          expect(page).to have_content('There are no results matching your query.')
+        end
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -76,6 +76,13 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { is_expected.to eq 'active' }
     end
 
+    context 'with find_commodity page' do
+      let(:controller_name) { 'commodities' }
+      let(:action) { 'index' }
+
+      it { is_expected.to eq 'active' }
+    end
+
     context 'with search results page' do
       let(:controller_name) { 'search' }
       let(:action) { 'search' }

--- a/spec/requests/sections_spec.rb
+++ b/spec/requests/sections_spec.rb
@@ -1,157 +1,159 @@
 require 'spec_helper'
 
-RSpec.describe 'Sections Index page', type: :request do
-  context 'when requesting as HTML' do
-    before do
-      allow(TradeTariffFrontend).to receive(:updated_navigation?).and_return false
+RSpec.describe 'SectionsController', type: :request do
+  describe 'GET #index' do
+    context 'when requesting as HTML' do
+      before do
+        allow(TradeTariffFrontend).to receive(:updated_navigation?).and_return false
 
-      VCR.use_cassette('geographical_areas#countries') do
-        VCR.use_cassette('sections#index') do
-          visit sections_path
+        VCR.use_cassette('geographical_areas#countries') do
+          VCR.use_cassette('sections#index') do
+            visit sections_path
+          end
         end
+      end
+
+      it 'displays the first section as a link' do
+        expect(page).to have_link 'Live animals; animal products'
+      end
+
+      it 'displays the second section as a link' do
+        expect(page).to have_link 'Vehicles, aircraft'
+      end
+
+      it 'displays the third section as a link' do
+        expect(page).to have_link 'Privacy'
       end
     end
 
-    it 'displays the first section as a link' do
-      expect(page).to have_link 'Live animals; animal products'
+    context 'when HTML with updated_navigation? enabled' do
+      let :visit_page do
+        VCR.use_cassette('geographical_areas#countries') do
+          VCR.use_cassette('sections#index') do
+            get sections_path
+          end
+        end
+      end
+
+      context 'with UK service' do
+        include_context 'with UK service'
+
+        before { visit_page }
+
+        it { expect(response).to redirect_to '/find_commodity' }
+      end
+
+      context 'with XI service' do
+        include_context 'with XI service'
+
+        before { visit_page }
+
+        it { expect(response).to redirect_to '/xi/find_commodity' }
+      end
     end
 
-    it 'displays the second section as a link' do
-      expect(page).to have_link 'Vehicles, aircraft'
-    end
+    context 'when requesting as JSON' do
+      context 'when requested with json format' do
+        before do
+          VCR.use_cassette('sections#index_api_json_format') do
+            get '/sections.json'
+          end
+        end
 
-    it 'displays the third section as a link' do
-      expect(page).to have_link 'Privacy'
+        let(:json) { JSON.parse(response.body) }
+
+        it 'renders direct API response' do
+          expect(json).to be_kind_of Array
+        end
+
+        it 'renders the correct title for the first element' do
+          expect(json.first['title']).to eq 'Live animals; animal products'
+        end
+      end
+
+      context 'when requested with json HTTP Accept header' do
+        before do
+          VCR.use_cassette('sections#index_api_json_content_type') do
+            get '/sections', headers: { 'HTTP_ACCEPT' => 'application/json' }
+          end
+        end
+
+        let(:json) { JSON.parse(response.body) }
+
+        it 'renders direct API response' do
+          expect(json).to be_kind_of Array
+        end
+
+        it 'renders the correct title for the first element' do
+          expect(json.first['title']).to eq 'Live animals; animal products'
+        end
+      end
     end
   end
 
-  context 'when HTML with updated_navigation? enabled' do
-    let :visit_page do
-      VCR.use_cassette('geographical_areas#countries') do
-        VCR.use_cassette('sections#index') do
-          get sections_path
-        end
-      end
-    end
-
-    context 'with UK service' do
-      include_context 'with UK service'
-
-      before { visit_page }
-
-      it { expect(response).to redirect_to '/find_commodity' }
-    end
-
-    context 'with XI service' do
-      include_context 'with XI service'
-
-      before { visit_page }
-
-      it { expect(response).to redirect_to '/xi/find_commodity' }
-    end
-  end
-
-  context 'when requesting as JSON' do
-    context 'when requested with json format' do
+  describe 'GET #show' do
+    context 'when requested as HTML' do
       before do
-        VCR.use_cassette('sections#index_api_json_format') do
-          get '/sections.json'
+        VCR.use_cassette('geographical_areas#countries') do
+          VCR.use_cassette('sections#show') do
+            visit section_path(1)
+          end
         end
       end
 
-      let(:json) { JSON.parse(response.body) }
-
-      it 'renders direct API response' do
-        expect(json).to be_kind_of Array
+      it 'displays the link to all sections' do
+        expect(page).to have_link 'All sections',
+                                  href: '/sections'
       end
 
-      it 'renders the correct title for the first element' do
-        expect(json.first['title']).to eq 'Live animals; animal products'
+      it 'displays section name' do
+        expect(page).to have_content 'Live animals; animal products'
+      end
+
+      it 'displays the first chapter in the section' do
+        expect(page).to have_content 'Live animals'
+      end
+
+      it 'displays the second chapter in the section' do
+        expect(page).to have_content 'Meat and edible meat offal'
       end
     end
 
-    context 'when requested with json HTTP Accept header' do
-      before do
-        VCR.use_cassette('sections#index_api_json_content_type') do
-          get '/sections', headers: { 'HTTP_ACCEPT' => 'application/json' }
+    context 'when requested as JSON' do
+      context 'when requested with json format' do
+        before do
+          VCR.use_cassette('sections#show_1_api_json_format') do
+            get '/sections/1.json'
+          end
+        end
+
+        let(:json) { JSON.parse(response.body) }
+
+        it 'renders the correct title' do
+          expect(json['title']).to eq 'Live animals; animal products'
+        end
+
+        it 'renders direct API response' do
+          expect(json['chapters']).to be_kind_of Array
         end
       end
 
-      let(:json) { JSON.parse(response.body) }
-
-      it 'renders direct API response' do
-        expect(json).to be_kind_of Array
-      end
-
-      it 'renders the correct title for the first element' do
-        expect(json.first['title']).to eq 'Live animals; animal products'
-      end
-    end
-  end
-end
-
-RSpec.describe 'Section page', type: :request do
-  context 'when requested as HTML' do
-    before do
-      VCR.use_cassette('geographical_areas#countries') do
-        VCR.use_cassette('sections#show') do
-          visit section_path(1)
+      context 'when requested with json HTTP Accept header' do
+        before do
+          VCR.use_cassette('sections#show_1_api_json_content_type') do
+            get '/sections/1', headers: { 'HTTP_ACCEPT' => 'application/json' }
+          end
         end
-      end
-    end
 
-    it 'displays the link to all sections' do
-      expect(page).to have_link 'All sections',
-                                href: '/sections'
-    end
+        let(:json) { JSON.parse(response.body) }
 
-    it 'displays section name' do
-      expect(page).to have_content 'Live animals; animal products'
-    end
-
-    it 'displays the first chapter in the section' do
-      expect(page).to have_content 'Live animals'
-    end
-
-    it 'displays the second chapter in the section' do
-      expect(page).to have_content 'Meat and edible meat offal'
-    end
-  end
-
-  context 'when requested as JSON' do
-    context 'when requested with json format' do
-      before do
-        VCR.use_cassette('sections#show_1_api_json_format') do
-          get '/sections/1.json'
+        it 'renders the correct title' do
+          expect(json['title']).to eq 'Live animals; animal products'
         end
-      end
 
-      let(:json) { JSON.parse(response.body) }
-
-      it 'renders the correct title' do
-        expect(json['title']).to eq 'Live animals; animal products'
-      end
-
-      it 'renders direct API response' do
-        expect(json['chapters']).to be_kind_of Array
-      end
-    end
-
-    context 'when requested with json HTTP Accept header' do
-      before do
-        VCR.use_cassette('sections#show_1_api_json_content_type') do
-          get '/sections/1', headers: { 'HTTP_ACCEPT' => 'application/json' }
+        it 'renders direct API response' do
+          expect(json['chapters']).to be_kind_of Array
         end
-      end
-
-      let(:json) { JSON.parse(response.body) }
-
-      it 'renders the correct title' do
-        expect(json['title']).to eq 'Live animals; animal products'
-      end
-
-      it 'renders direct API response' do
-        expect(json['chapters']).to be_kind_of Array
       end
     end
   end

--- a/spec/requests/sections_spec.rb
+++ b/spec/requests/sections_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 RSpec.describe 'Sections Index page', type: :request do
   context 'when requesting as HTML' do
     before do
+      allow(TradeTariffFrontend).to receive(:updated_navigation?).and_return false
+
       VCR.use_cassette('geographical_areas#countries') do
         VCR.use_cassette('sections#index') do
           visit sections_path
@@ -20,6 +22,32 @@ RSpec.describe 'Sections Index page', type: :request do
 
     it 'displays the third section as a link' do
       expect(page).to have_link 'Privacy'
+    end
+  end
+
+  context 'when HTML with updated_navigation? enabled' do
+    let :visit_page do
+      VCR.use_cassette('geographical_areas#countries') do
+        VCR.use_cassette('sections#index') do
+          get sections_path
+        end
+      end
+    end
+
+    context 'with UK service' do
+      include_context 'with UK service'
+
+      before { visit_page }
+
+      it { expect(response).to redirect_to '/find_commodity' }
+    end
+
+    context 'with XI service' do
+      include_context 'with XI service'
+
+      before { visit_page }
+
+      it { expect(response).to redirect_to '/xi/find_commodity' }
     end
   end
 

--- a/spec/views/commodities/index.html.erb_spec.rb
+++ b/spec/views/commodities/index.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe 'commodities/index.html.erb', type: :view do
+  subject { render }
+
+  before { assign :search, search }
+
+  let(:as_of) { Time.zone.today }
+  let(:q) { nil }
+  let(:search) { Search.new q: q, as_of: as_of }
+
+  describe 'header' do
+    it { is_expected.to have_css 'header h1', text: /commodity codes, import duties/ }
+  end
+
+  describe 'search form' do
+    it { is_expected.to have_css 'form input[name="q"]' }
+    it { is_expected.to have_css 'form details .govuk-details__text' }
+
+    context 'without preset date' do
+      it { is_expected.to have_css %(.govuk-details__text input[name="day"][value="#{as_of.day}"]) }
+      it { is_expected.to have_css %(.govuk-details__text input[name="month"][value="#{as_of.month}"]) }
+      it { is_expected.to have_css %(.govuk-details__text input[name="year"][value="#{as_of.year}"]) }
+    end
+
+    context 'with preset date' do
+      let(:as_of) { 3.days.ago }
+
+      it { is_expected.to have_css %(.govuk-details__text input[name="day"][value="#{as_of.day}"]) }
+      it { is_expected.to have_css %(.govuk-details__text input[name="month"][value="#{as_of.month}"]) }
+      it { is_expected.to have_css %(.govuk-details__text input[name="year"][value="#{as_of.year}"]) }
+    end
+  end
+
+  describe 'STW links' do
+    it { is_expected.to have_css 'h2', text: 'Advance tariff rulings' }
+    it { is_expected.to have_css 'h2', text: 'Check how to import or export goods' }
+  end
+end

--- a/spec/views/commodities/index.html.erb_spec.rb
+++ b/spec/views/commodities/index.html.erb_spec.rb
@@ -17,18 +17,20 @@ RSpec.describe 'commodities/index.html.erb', type: :view do
     it { is_expected.to have_css 'form input[name="q"]' }
     it { is_expected.to have_css 'form details .govuk-details__text' }
 
-    context 'without preset date' do
+    shared_examples 'a populated date input' do
       it { is_expected.to have_css %(.govuk-details__text input[name="day"][value="#{as_of.day}"]) }
       it { is_expected.to have_css %(.govuk-details__text input[name="month"][value="#{as_of.month}"]) }
       it { is_expected.to have_css %(.govuk-details__text input[name="year"][value="#{as_of.year}"]) }
     end
 
-    context 'with preset date' do
+    context 'with default date' do
+      it_behaves_like 'a populated date input'
+    end
+
+    context 'with selected date' do
       let(:as_of) { 3.days.ago }
 
-      it { is_expected.to have_css %(.govuk-details__text input[name="day"][value="#{as_of.day}"]) }
-      it { is_expected.to have_css %(.govuk-details__text input[name="month"][value="#{as_of.month}"]) }
-      it { is_expected.to have_css %(.govuk-details__text input[name="year"][value="#{as_of.year}"]) }
+      it_behaves_like 'a populated date input'
     end
   end
 


### PR DESCRIPTION
### Jira link

[HOTT-1048](https://transformuk.atlassian.net/browse/HOTT-1048)

### What?

I have added/removed/altered:

- [x] Added a find commodity page
- [x] Redirect the existing sections page to the find commodity page when the feature flag is enabled
- [x] Updated various specs to test with both the feature flag off and on

### Why?

I am doing this because:

- We want to provide separate Find and Browse pages whilst keeping all existing links working

### Notes

Switch service banner is currently missing because that is being worked on separately and this is hidden behind a feature flag

### Screenshot

![Screenshot from 2021-10-28 16-25-20](https://user-images.githubusercontent.com/10818/139287335-0d461663-47fa-4fcd-ab7b-79f5a815ab54.png)
