### PR TITLE
HOTT-1046 Remove Back link from heading and commodity page

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -8,7 +8,6 @@ class CommoditiesController < GoodsNomenclaturesController
     @heading = commodity.heading
     @chapter = commodity.chapter
     @section = commodity.section
-    @back_path = request.referer || heading_path(@heading.short_code)
 
     if params[:country].present? && @search.geographical_area
       @rules_of_origin = commodity.rules_of_origin(params[:country])

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -8,7 +8,6 @@ class HeadingsController < GoodsNomenclaturesController
 
   def show
     @commodities = HeadingCommodityPresenter.new(heading.commodities)
-    @back_path = request.referer || chapter_path(heading.chapter.short_code)
     @meursing_additional_code = session[:meursing_lookup].try(:[], 'result')
     @section = heading.section
 

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -10,9 +10,7 @@
 <% end %>
 
 <% if controller_name == 'commodities' && action_name == 'show' || controller_name == 'headings' && action_name == 'show' && @heading&.declarable? %>
-  <% content_for :before_main_content do %>
-    <a class="govuk-back-link" href="<%= @back_path %>">Back <span class="govuk-visually-hidden"> to the list of commodities</span></a>
-  <% end %>
+  <% content_for :before_main_content %>
 <% end %>
 
 <% content_for :header_class, 'with-proposition' %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1046

### What?

remove Back button link on commodity / headings page to make it consistent with other pages sections /chapters / headings /commodities
