### PR TITLE
Remove breadcrumbs from meursing lookup steps

### DIFF
--- a/app/views/meursing_lookup/steps/_form.html.erb
+++ b/app/views/meursing_lookup/steps/_form.html.erb
@@ -1,14 +1,3 @@
-<% content_for :before_main_content do %>
-  <%= generate_breadcrumbs(
-      t('breadcrumb.meursing_lookup'),
-      [
-        [t('breadcrumb.home'), sections_path],
-        [t('breadcrumb.tools'), tools_path]
-      ]
-    )
-  %>
-<% end %>
-
 <%= back_link %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1078

### What?

I have added/removed/altered:

- [x] Removed breadcrumbs from meursing lookup form steps

### Why?

I am doing this because:

- This looks weird when combined with a back button
