### PR TITLE
HOTT-1087: Support calculating duties on commodities with meursing

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -34,7 +34,7 @@ module Declarable
   end
 
   def calculate_duties?
-    no_meursing? && no_heading? && no_entry_price_system?
+    no_heading? && no_entry_price_system?
   end
 
   def meursing_code?
@@ -58,10 +58,6 @@ module Declarable
   end
 
   private
-
-  def no_meursing?
-    !meursing_code?
-  end
 
   def no_heading?
     !heading?

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -113,28 +113,13 @@ RSpec.describe Commodity do
   describe '#calculate_duties?' do
     subject(:commodity) { described_class.new(attributes_for(:commodity, meta: commodity_metadata).stringify_keys) }
 
-    let(:commodity_metadata) do
-      {
-        'duty_calculator' => {
-          'entry_price_system' => entry_price_system,
-          'meursing_code' => meursing_code,
-        },
-      }
-    end
+    let(:commodity_metadata) { { 'duty_calculator' => { 'entry_price_system' => entry_price_system } } }
     let(:entry_price_system) { false }
-    let(:meursing_code) { false }
 
     context 'when the commodity should calculate duties' do
       let(:entry_price_system) { false }
-      let(:meursing_code) { false }
 
       it { is_expected.to be_calculate_duties }
-    end
-
-    context 'when the commodity has measures that have meursing codes' do
-      let(:meursing_code) { true }
-
-      it { is_expected.not_to be_calculate_duties }
     end
 
     context 'when the commodity has measures that use the Entry Price System' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1087

### What?

I have added/removed/altered:

- [x] Removed block on meursing commodities being able to calculate duties

### Why?

I am doing this because:

- We now support this feature in the DC
