### PR TITLE
HOTT-1078: Remove breadcrumbs from meursing lookup end step

### DIFF
--- a/app/views/meursing_lookup/steps/_end.html.erb
+++ b/app/views/meursing_lookup/steps/_end.html.erb
@@ -1,14 +1,3 @@
-<% content_for :before_main_content do %>
-  <%= generate_breadcrumbs(
-      t('breadcrumb.meursing_lookup'),
-      [
-        [t('breadcrumb.home'), sections_path],
-        [t('breadcrumb.tools'), tools_path]
-      ]
-    )
-  %>
-<% end %>
-
 <%= back_link %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1078

### What?

I have added/removed/altered:

- [x] Removes breadcrumbs from end step in meursing lookup

### Why?

I am doing this because:

- With the back link this looks strange
