### PR TITLE
HOTT-1094 add breadcrumbs to the new browse page

### DIFF
--- a/app/views/browse_sections/index.html.erb
+++ b/app/views/browse_sections/index.html.erb
@@ -3,6 +3,16 @@
                                href: sections_url(format: :json),
                                title: 'Section list in JSON format') %>
 
+<% content_for :before_main_content do %>
+  <%= generate_breadcrumbs(
+      t('breadcrumb.browse'),
+      [
+        [t('breadcrumb.home'), sections_path]
+      ]
+    )
+  %>
+<% end %>
+
 <%= page_header 'Browse the tariff' %>
 
 <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
     home: Home
     privacy: Privacy Notice
     help: Help
+    browse: Browse
     tools: Tools
     quotas: Quotas
     certificates: Certificate


### PR DESCRIPTION
### Jira link

[HOTT-1094](https://transformuk.atlassian.net/browse/HOTT-1094)

### What?

I have added/removed/altered:

- [x] Added breadcrumbs on the Browse page

### Why?

I am doing this because:

- it was missed from the initial breadcrumbs PR because its feature flagged off at the moment

