### PR TITLE
HOTT-1097 test loading of accessible autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,11 @@
     "webpack-cli": "^3.3.12"
   },
   "scripts": {
+    "spec": "jest",
     "test": "jest"
   },
   "jest": {
+    "testEnvironment": "jsdom",
     "setupFiles": [
       "./spec/javascript/setup.js"
     ],

--- a/spec/javascript/commodities.spec.js
+++ b/spec/javascript/commodities.spec.js
@@ -1,6 +1,7 @@
 // There are tests for commodities.js
 // To run them: 'yarn test' .
 
+global.accessibleAutocomplete = require('accessible-autocomplete');
 require('commodities.js');
 
 test('GOVUK.tariff public has expected public methods', () => {
@@ -21,5 +22,32 @@ test('GOVUK.tariff public has expected public methods', () => {
 
   items.forEach( (item) => {
     expect(GOVUK.tariff).toHaveProperty(item);
+  });
+});
+
+describe('searchForm', () => {
+  const autocompleteSelector = '.autocomplete__wrapper input';
+
+  const commodityPickerTemplate = `
+    <div class="search-header js-search-header">
+      <input type="text" name="q" class="js-commodity-picker-target" />
+      <div class='js-commodity-picker-select js-show'></div>
+
+      <input type="input" name="day" id="tariff_date_day" />
+      <input type="input" name="month" id="tariff_date_month" />
+      <input type="input" name="year" id="tariff_date_year" />
+
+      <input type="submit" value="Search" />
+    </div>
+  `;
+
+  beforeEach(() => {
+    document.body.innerHTML = commodityPickerTemplate;
+    GOVUK.tariff.selectBoxes.initialize(document.body);
+  });
+
+  it('loads the autocomplete', () => {
+    const autocompleteWidgets = document.querySelectorAll(autocompleteSelector);
+    expect(autocompleteWidgets.length).toBe(1);
   });
 });

--- a/spec/javascript/setup.js
+++ b/spec/javascript/setup.js
@@ -1,2 +1,1 @@
-var jsdom = require('jsdom');
-global.$ = require('jquery')(new jsdom.JSDOM().window);
+global.$ = require('jquery');


### PR DESCRIPTION
### Jira link

HOTT-1097

### What?

I have added/removed/altered:

- [x] Added a spec to check initialization of the commodity picker
- [x] Fixed integration between JSDOM context and the test suite context - before document and window didn't seem to work in the documents

### Why?

I am doing this because:

- we want to increase our javascript test coverage

