### PR TITLE
HOTT-1076 Show commodity code in 4 4 2 pattern

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -144,4 +144,14 @@ module CommoditiesHelper
         tag.p(commodity.to_s.html_safe)
     end
   end
+
+  def four_four_two_commodity_code(code)
+    return if code.blank?
+
+    parts = code.to_s.gsub(/[^\d]/, '').split('').each_slice(4).map(&:join)
+
+    tag.span class: 'commodity-code-4-4-2' do
+      safe_join parts.map(&tag.method(:span)), "\n"
+    end
+  end
 end

--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -145,12 +145,12 @@ module CommoditiesHelper
     end
   end
 
-  def four_four_two_commodity_code(code)
+  def segmented_commodity_code(code)
     return if code.blank?
 
     parts = code.to_s.gsub(/[^\d]/, '').split('').each_slice(4).map(&:join)
 
-    tag.span class: 'commodity-code-4-4-2' do
+    tag.span class: 'segmented-commodity-code' do
       safe_join parts.map(&tag.method(:span)), "\n"
     end
   end

--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -151,7 +151,7 @@ module CommoditiesHelper
     parts = code.to_s.gsub(/[^\d]/, '').split('').each_slice(4).map(&:join)
 
     tag.span class: 'segmented-commodity-code' do
-      safe_join parts.map(&tag.method(:span)), "\n"
+      safe_join parts.map(&tag.method(:span))
     end
   end
 end

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -2,7 +2,7 @@
   <% if (controller_name == 'commodities' && action_name == 'show') || (controller_name == 'headings' && action_name == 'show' && @heading&.declarable?) %>
     <header>
       <h1 class="govuk-heading-l commodity-header" data-comm-code="<%= commodity_code %>">
-        Commodity information for <%= segmented_commodity_code commodity_code %>
+        Commodity <%= segmented_commodity_code commodity_code %>
         <div class="copy_code" id="copy_code">
           <span id="copy_comm_code" class="pseudo-link govuk-link">Copy commodity code</span><br>
           <span class="copied">Code copied</span>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -2,7 +2,7 @@
   <% if (controller_name == 'commodities' && action_name == 'show') || (controller_name == 'headings' && action_name == 'show' && @heading&.declarable?) %>
     <header>
       <h1 class="govuk-heading-l commodity-header" data-comm-code="<%= commodity_code %>">
-        Commodity information for <%= four_four_two_commodity_code commodity_code %>
+        Commodity information for <%= segmented_commodity_code commodity_code %>
         <div class="copy_code" id="copy_code">
           <span id="copy_comm_code" class="pseudo-link govuk-link">Copy commodity code</span><br>
           <span class="copied">Code copied</span>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -2,7 +2,7 @@
   <% if (controller_name == 'commodities' && action_name == 'show') || (controller_name == 'headings' && action_name == 'show' && @heading&.declarable?) %>
     <header>
       <h1 class="govuk-heading-l commodity-header" data-comm-code="<%= commodity_code %>">
-        Commodity information for <%= commodity_code %>
+        Commodity information for <%= four_four_two_commodity_code commodity_code %>
         <div class="copy_code" id="copy_code">
           <span id="copy_comm_code" class="pseudo-link govuk-link">Copy commodity code</span><br>
           <span class="copied">Code copied</span>

--- a/app/webpacker/src/stylesheets/_commodity-codes.scss
+++ b/app/webpacker/src/stylesheets/_commodity-codes.scss
@@ -69,7 +69,7 @@
   }
 }
 
-.commodity-code-4-4-2 {
+.segmented-commodity-code {
   @include govuk-media-query($from: tablet) {
     span {
       padding: 0 0.12em;

--- a/app/webpacker/src/stylesheets/_commodity-codes.scss
+++ b/app/webpacker/src/stylesheets/_commodity-codes.scss
@@ -68,3 +68,11 @@
     width: 35%;
   }
 }
+
+.commodity-code-4-4-2 {
+  @include govuk-media-query($from: tablet) {
+    span {
+      padding: 0 0.12em;
+    }
+  }
+}

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -49,39 +49,41 @@ RSpec.describe CommoditiesHelper, type: :helper do
     end
   end
 
-  describe '#four_four_two_commodity_code' do
-    subject { four_four_two_commodity_code '0123456789' }
+  describe '#segmented_commodity_code' do
+    subject { segmented_commodity_code comm_code }
 
-    it { is_expected.to have_css 'span.commodity-code-4-4-2 span', count: 3 }
+    let(:comm_code) { '0123456789' }
+
+    it { is_expected.to have_css 'span.segmented-commodity-code span', count: 3 }
     it { is_expected.to have_css 'span span:nth-of-type(1)', text: '0123' }
     it { is_expected.to have_css 'span span:nth-of-type(2)', text: '4567' }
     it { is_expected.to have_css 'span span:nth-of-type(3)', text: '89' }
 
     context 'with already segmented code' do
-      subject { four_four_two_commodity_code '0123 4567 89' }
+      let(:comm_code) { '0123 4567 89' }
 
-      it { is_expected.to have_css 'span.commodity-code-4-4-2 span', count: 3 }
+      it { is_expected.to have_css 'span.segmented-commodity-code span', count: 3 }
       it { is_expected.to have_css 'span span:nth-of-type(1)', text: '0123' }
       it { is_expected.to have_css 'span span:nth-of-type(2)', text: '4567' }
       it { is_expected.to have_css 'span span:nth-of-type(3)', text: '89' }
     end
 
     context 'with a heading' do
-      subject { four_four_two_commodity_code '0123' }
+      let(:comm_code) { '0123' }
 
-      it { is_expected.to have_css 'span.commodity-code-4-4-2 span', count: 1 }
+      it { is_expected.to have_css 'span.segmented-commodity-code span', count: 1 }
       it { is_expected.to have_css 'span span:nth-of-type(1)', text: '0123' }
     end
 
     context 'with a chapter' do
-      subject { four_four_two_commodity_code '01' }
+      let(:comm_code) { '01' }
 
-      it { is_expected.to have_css 'span.commodity-code-4-4-2 span', count: 1 }
+      it { is_expected.to have_css 'span.segmented-commodity-code span', count: 1 }
       it { is_expected.to have_css 'span span:nth-of-type(1)', text: '01' }
     end
 
     context 'with nothing' do
-      subject { four_four_two_commodity_code '' }
+      let(:comm_code) { '' }
 
       it { is_expected.to be_nil }
     end

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -48,4 +48,42 @@ RSpec.describe CommoditiesHelper, type: :helper do
       end
     end
   end
+
+  describe '#four_four_two_commodity_code' do
+    subject { four_four_two_commodity_code '0123456789' }
+
+    it { is_expected.to have_css 'span.commodity-code-4-4-2 span', count: 3 }
+    it { is_expected.to have_css 'span span:nth-of-type(1)', text: '0123' }
+    it { is_expected.to have_css 'span span:nth-of-type(2)', text: '4567' }
+    it { is_expected.to have_css 'span span:nth-of-type(3)', text: '89' }
+
+    context 'with already segmented code' do
+      subject { four_four_two_commodity_code '0123 4567 89' }
+
+      it { is_expected.to have_css 'span.commodity-code-4-4-2 span', count: 3 }
+      it { is_expected.to have_css 'span span:nth-of-type(1)', text: '0123' }
+      it { is_expected.to have_css 'span span:nth-of-type(2)', text: '4567' }
+      it { is_expected.to have_css 'span span:nth-of-type(3)', text: '89' }
+    end
+
+    context 'with a heading' do
+      subject { four_four_two_commodity_code '0123' }
+
+      it { is_expected.to have_css 'span.commodity-code-4-4-2 span', count: 1 }
+      it { is_expected.to have_css 'span span:nth-of-type(1)', text: '0123' }
+    end
+
+    context 'with a chapter' do
+      subject { four_four_two_commodity_code '01' }
+
+      it { is_expected.to have_css 'span.commodity-code-4-4-2 span', count: 1 }
+      it { is_expected.to have_css 'span span:nth-of-type(1)', text: '01' }
+    end
+
+    context 'with nothing' do
+      subject { four_four_two_commodity_code '' }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1076](https://transformuk.atlassian.net/browse/HOTT-1076)

### What?

I have added/removed/altered:

- [x] Added a helper for format the commodity code into a 4 4 2 split, this will also handle heading or chapter codes if handed those
- [x] Changed the _search partial to use the helper when formatting the heading

### Why?

I am doing this because:

- We want to visually break up the commodity code

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None

### Notes

This conflicts with the refactor of the `_search` partial in #393 - it should be rebased and merged after that PR.

### Before

![Screenshot from 2021-11-10 11-10-49](https://user-images.githubusercontent.com/10818/141103438-ba710ba4-73d8-4aab-af5f-abbcc9dfe310.png)

### After

![Screenshot from 2021-11-10 11-10-10](https://user-images.githubusercontent.com/10818/141103458-7318c657-5ad4-4268-9b89-c2b5f5b8a50e.png)

