### PR TITLE
HOTT-1108 Display comm code when no match rules

### DIFF
--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -20,7 +20,7 @@
                  collection: rules_of_origin.map(&:introductory_notes) %>
     <%- else -%>
       <p>
-        There are no product-specific rules for commodity <% commodity_code %>
+        There are no product-specific rules for commodity <%= commodity_code %>
       </p>
     <%- end -%>
 

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
 
     it 'shows no matched rules message' do
       expect(rendered_page).to \
-        have_css 'p', text: /no product-specific rules/
+        have_css 'p', text: /no product-specific rules for commodity \d{10}/
     end
 
     it 'excludes the introductory_notes section' do


### PR DESCRIPTION
### Jira link

HOTT-1108

### What?

I have added/removed/altered:

- [x] Fixed displaying the comm code when there are no matching rules of origin

### Why?

I am doing this because:

- I spotted the typo whilst doing another change, unfortunately my view spec was a bit too flexible and wasn't checking for the comm codes presence

