### PR TITLE
HOTT-1077 Moved breadcrumbs further up page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,12 +59,13 @@
     </div>
   </header>
 
-  <main id="content" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" role="main">
-    <div class="tariff service govuk-width-container">
+  <div class="tariff service govuk-width-container">
+    <%= render 'shared/top_breadcrumbs' %>
+
+    <main id="content" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" role="main">
       <%= render 'shared/phase_banner' if ENV['NOTICE_BANNER'] %>
       <%= yield :before_main_content %>
 
-      <%= render 'shared/top_breadcrumbs' %>
       <%= render 'shared/switch_banner' %>
       <%= render 'shared/search' %>
 
@@ -78,8 +79,8 @@
       <% if content_for? (:commodity_pagination) %>
         <%= yield :commodity_pagination %>
       <% end %>
-    </div>
-  </main>
+    </main>
+  </div>
 
   <footer id="footer" class="govuk-footer" role="contentinfo">
     <div class="govuk-width-container">


### PR DESCRIPTION
Previously they were spaced away from the header bar. This was caused by the .govuk-width-container being inside the main element rather then outside as recommended by the GovUK Design System.

I've inverted the ordering to match the GovUK pattern and move the breadcrumbs to sit directly below the header, outside of main.

### Jira link

[HOTT-1077](https://transformuk.atlassian.net/browse/HOTT-1077)

### What?

I have added/removed/altered:

- [x] Adjusted the application.html.erb to invert the nesting of `<main>` and `.govuk-width-container`
- [x] Moved the breadcrumbs up out of main so they sit directly below the header

### Why?

I am doing this because:

- We want the breadcrumbs to show below the header bar
- This change is a prerequisite for [HOTT-1106](https://transformuk.atlassian.net/browse/HOTT-1106)

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Unexpected CSS impacts from something checking specifically for nesting of `main .govuk-width-container` as opposed to `.govuk-width-container main`

### Before

![Screenshot from 2021-11-10 11-56-03](https://user-images.githubusercontent.com/10818/141109033-95c84c72-53bb-46d7-a22c-a43b33f6288f.png)

### After

![Screenshot from 2021-11-10 11-56-52](https://user-images.githubusercontent.com/10818/141109126-7ccb5a3e-735e-47c8-a56f-5936ec7eca58.png)
![Screenshot from 2021-11-10 11-55-35](https://user-images.githubusercontent.com/10818/141109129-941a01ee-9b26-4bf4-841a-1ad3a465de49.png)


