### PR TITLE
HOTT-1106 Added header banner for global notifications

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,6 +57,8 @@
       <%= render 'shared/govuk_logo' %>
       <%= yield :proposition_header %>
     </div>
+
+    <%= render 'shared/header_banner' %>
   </header>
 
   <div class="tariff service govuk-width-container">

--- a/app/views/shared/_header_banner.html.erb
+++ b/app/views/shared/_header_banner.html.erb
@@ -1,0 +1,10 @@
+<div class="hott-header-banner">
+  <div class="govuk-width-container">
+    <p>
+      From 1 Jan 2022, businesses moving goods into GB from the EU need to
+      submit customs declarations as goods move through ports. They also may
+      need to pre-notify imports of foods, plants and plant products from
+      the EU.
+    </p>
+  </div>
+</div>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -52,3 +52,4 @@ $govuk-images-path: '~govuk-frontend/govuk/assets/images/';
 @import '../src/stylesheets/uk_overrides';
 @import '../src/stylesheets/feature-panel';
 @import '../src/stylesheets/switch_uk_xi_panel';
+@import '../src/stylesheets/header_banner';

--- a/app/webpacker/src/stylesheets/_header_banner.scss
+++ b/app/webpacker/src/stylesheets/_header_banner.scss
@@ -1,0 +1,30 @@
+.govuk-header .hott-header-banner {
+  padding: govuk-spacing(2) 0;
+  border-top: govuk-spacing(2) solid $govuk-brand-colour;
+
+  p, div, h1, h2, h3 {
+    color: govuk-colour("white");
+  }
+
+  p {
+    @include govuk-font($size: 16);
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
+
+  a {
+    @include govuk-link-style-inverse;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    .govuk-width-container {
+      padding: govuk-spacing(3) 0 ;
+    }
+
+    p {
+      @include govuk-typography-weight-bold;
+    }
+  }
+}

--- a/spec/views/layout/application.html.erb_spec.rb
+++ b/spec/views/layout/application.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe 'layouts/application.html.erb', type: :view do
+  subject { render }
+
+  before do
+    allow(view).to receive(:cookies_policy).and_return cookies_policy
+    allow(view).to receive(:is_switch_service_banner_enabled?).and_return true
+
+    assign :search, Search.new
+  end
+
+  let(:cookies_policy) { Cookies::Policy.new }
+
+  context 'with header banner' do
+    it { is_expected.to have_css 'header.govuk-header > .hott-header-banner' }
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-1106](https://transformuk.atlassian.net/browse/HOTT-1106)

### What?

I have added/removed/altered:

- [x] Added a global banner displaying a message about upcoming declarations

### Why?

I am doing this because:

- we need to notify our users of upcoming changes to the declarations they are required to make

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None

### Screenshots

![Screenshot from 2021-11-11 11-17-42](https://user-images.githubusercontent.com/10818/141289214-e8f77b98-d266-45e8-89ab-b3a54b308a3b.png)
![Screenshot from 2021-11-11 11-17-23](https://user-images.githubusercontent.com/10818/141289224-2752cfc3-65b6-44c7-a1b5-f96d676520ff.png)

