### PR TITLE
Namespace all describes

### DIFF
--- a/spec/models/rules_of_origin/proof_spec.rb
+++ b/spec/models/rules_of_origin/proof_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RulesOfOrigin::Proof do
+RSpec.describe RulesOfOrigin::Proof do
   it { is_expected.to respond_to :summary }
   it { is_expected.to respond_to :url }
   it { is_expected.to respond_to :subtext }

--- a/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'rules_of_origin/_proofs.html.erb', type: :view do
+RSpec.describe 'rules_of_origin/_proofs.html.erb', type: :view do
   subject(:rendered_page) { render_page && rendered }
 
   let(:render_page) { render 'rules_of_origin/proofs', proofs: proofs }


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Namespace all RSpec.describes 

### Why?

I am doing this because:

- For consistency
