### PR TITLE
HOTT-1121 use null cache store and massively speed up tests 

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,6 +19,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
+  config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/spec/controllers/search_additional_code_search_controller_spec.rb
+++ b/spec/controllers/search_additional_code_search_controller_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 RSpec.describe SearchController, 'GET to #additional_code_search', type: :controller,
   slow: true, vcr: { cassette_name: 'search#additional_code_search' } do
 
-  before do
-    Rails.cache.clear
-  end
-
   context 'without search params' do
     render_views
 

--- a/spec/controllers/search_additional_code_search_controller_spec.rb
+++ b/spec/controllers/search_additional_code_search_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SearchController, 'GET to #additional_code_search', type: :controller,
-  slow: true, vcr: { cassette_name: 'search#additional_code_search' } do
+  vcr: { cassette_name: 'search#additional_code_search' } do
 
   context 'without search params' do
     render_views

--- a/spec/controllers/search_certificate_search_controller_spec.rb
+++ b/spec/controllers/search_certificate_search_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SearchController, 'GET to #certificate_search', type: :controller,
-  slow: true, vcr: { cassette_name: 'search#certificate_search' } do
+  vcr: { cassette_name: 'search#certificate_search' } do
 
   context 'without search params' do
     render_views

--- a/spec/controllers/search_certificate_search_controller_spec.rb
+++ b/spec/controllers/search_certificate_search_controller_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 RSpec.describe SearchController, 'GET to #certificate_search', type: :controller,
   slow: true, vcr: { cassette_name: 'search#certificate_search' } do
 
-  before do
-    Rails.cache.clear
-  end
-
   context 'without search params' do
     render_views
 

--- a/spec/controllers/search_chemical_search_controller_spec.rb
+++ b/spec/controllers/search_chemical_search_controller_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 RSpec.describe SearchController, 'GET to #chemical_search', type: :controller,
   slow: true, vcr: { cassette_name: 'search#chemical_search' } do
 
-  before do
-    Rails.cache.clear
-  end
-
   context 'without search params' do
     render_views
 

--- a/spec/controllers/search_chemical_search_controller_spec.rb
+++ b/spec/controllers/search_chemical_search_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SearchController, 'GET to #chemical_search', type: :controller,
-  slow: true, vcr: { cassette_name: 'search#chemical_search' } do
+  vcr: { cassette_name: 'search#chemical_search' } do
 
   context 'without search params' do
     render_views

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
   end
 end
 
-RSpec.describe SearchController, 'GET to #codes', type: :controller, slow: true do
+RSpec.describe SearchController, 'GET to #codes', type: :controller do
   describe 'GET to #suggestions', vcr: { cassette_name: 'search#suggestions', allow_playback_repeats: true } do
     let!(:suggestions) { SearchSuggestion.all }
     let!(:suggestion) { suggestions[0] }
@@ -350,7 +350,7 @@ RSpec.describe SearchController, 'GET to #codes', type: :controller, slow: true 
   end
 end
 
-RSpec.describe SearchController, 'GET to #quota_search', type: :controller, slow: true, vcr: { cassette_name: 'search#quota_search', allow_playback_repeats: true } do
+RSpec.describe SearchController, 'GET to #quota_search', type: :controller, vcr: { cassette_name: 'search#quota_search', allow_playback_repeats: true } do
   context 'with xi as the service choice' do
     before do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:xi?).and_return(true)
@@ -460,7 +460,7 @@ RSpec.describe SearchController, 'GET to #quota_search', type: :controller, slow
   end
 end
 
-RSpec.describe SearchController, 'GET to #additional_code_search', slow: true, type: :controller, vcr: { cassette_name: 'search#additional_code_search' } do
+RSpec.describe SearchController, 'GET to #additional_code_search', type: :controller, vcr: { cassette_name: 'search#additional_code_search' } do
   context 'without search params' do
     render_views
 
@@ -518,7 +518,7 @@ RSpec.describe SearchController, 'GET to #additional_code_search', slow: true, t
   end
 end
 
-RSpec.describe SearchController, 'GET to #footnote_search', slow: true, type: :controller do
+RSpec.describe SearchController, 'GET to #footnote_search', type: :controller do
   context 'without search params', vcr: { cassette_name: 'search#footnote_search_without_params' } do
     render_views
 
@@ -576,7 +576,7 @@ RSpec.describe SearchController, 'GET to #footnote_search', slow: true, type: :c
   end
 end
 
-RSpec.describe SearchController, 'GET to #certificate_search', slow: true, type: :controller, vcr: { cassette_name: 'search#certificate_search' } do
+RSpec.describe SearchController, 'GET to #certificate_search', type: :controller, vcr: { cassette_name: 'search#certificate_search' } do
   context 'without search params' do
     render_views
 
@@ -634,7 +634,7 @@ RSpec.describe SearchController, 'GET to #certificate_search', slow: true, type:
   end
 end
 
-RSpec.describe SearchController, 'GET to #chemical_search', slow: true, type: :controller, vcr: { cassette_name: 'search#chemical_search' } do
+RSpec.describe SearchController, 'GET to #chemical_search', type: :controller, vcr: { cassette_name: 'search#chemical_search' } do
   context 'without search params' do
     render_views
 

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -351,10 +351,6 @@ RSpec.describe SearchController, 'GET to #codes', type: :controller, slow: true 
 end
 
 RSpec.describe SearchController, 'GET to #quota_search', type: :controller, slow: true, vcr: { cassette_name: 'search#quota_search', allow_playback_repeats: true } do
-  before do
-    Rails.cache.clear
-  end
-
   context 'with xi as the service choice' do
     before do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:xi?).and_return(true)
@@ -465,10 +461,6 @@ RSpec.describe SearchController, 'GET to #quota_search', type: :controller, slow
 end
 
 RSpec.describe SearchController, 'GET to #additional_code_search', slow: true, type: :controller, vcr: { cassette_name: 'search#additional_code_search' } do
-  before do
-    Rails.cache.clear
-  end
-
   context 'without search params' do
     render_views
 
@@ -527,10 +519,6 @@ RSpec.describe SearchController, 'GET to #additional_code_search', slow: true, t
 end
 
 RSpec.describe SearchController, 'GET to #footnote_search', slow: true, type: :controller do
-  before do
-    Rails.cache.clear
-  end
-
   context 'without search params', vcr: { cassette_name: 'search#footnote_search_without_params' } do
     render_views
 
@@ -589,10 +577,6 @@ RSpec.describe SearchController, 'GET to #footnote_search', slow: true, type: :c
 end
 
 RSpec.describe SearchController, 'GET to #certificate_search', slow: true, type: :controller, vcr: { cassette_name: 'search#certificate_search' } do
-  before do
-    Rails.cache.clear
-  end
-
   context 'without search params' do
     render_views
 
@@ -651,10 +635,6 @@ RSpec.describe SearchController, 'GET to #certificate_search', slow: true, type:
 end
 
 RSpec.describe SearchController, 'GET to #chemical_search', slow: true, type: :controller, vcr: { cassette_name: 'search#chemical_search' } do
-  before do
-    Rails.cache.clear
-  end
-
   context 'without search params' do
     render_views
 

--- a/spec/controllers/search_footnote_search_controller_spec.rb
+++ b/spec/controllers/search_footnote_search_controller_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe SearchController, 'GET to #footnote_search', type: :controller, slow: true do
-  before do
-    Rails.cache.clear
-  end
-
   context 'without search params', vcr: { cassette_name: 'search#footnote_search_without_params' } do
     render_views
 

--- a/spec/controllers/search_footnote_search_controller_spec.rb
+++ b/spec/controllers/search_footnote_search_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe SearchController, 'GET to #footnote_search', type: :controller, slow: true do
+RSpec.describe SearchController, 'GET to #footnote_search', type: :controller do
   context 'without search params', vcr: { cassette_name: 'search#footnote_search_without_params' } do
     render_views
 

--- a/spec/controllers/search_quotas_controller_spec.rb
+++ b/spec/controllers/search_quotas_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe SearchController, '#quota_search', type: :controller, slow: true,
+RSpec.describe SearchController, '#quota_search', type: :controller,
   vcr: { cassette_name: 'search#quota_search', allow_playback_repeats: true } do
 
   before { TradeTariffFrontend::ServiceChooser.service_choice = nil }

--- a/spec/controllers/search_quotas_controller_spec.rb
+++ b/spec/controllers/search_quotas_controller_spec.rb
@@ -3,10 +3,7 @@ require 'spec_helper'
 RSpec.describe SearchController, '#quota_search', type: :controller, slow: true,
   vcr: { cassette_name: 'search#quota_search', allow_playback_repeats: true } do
 
-  before do
-    Rails.cache.clear
-    TradeTariffFrontend::ServiceChooser.service_choice = nil
-  end
+  before { TradeTariffFrontend::ServiceChooser.service_choice = nil }
 
   context 'with xi as the service choice' do
     before do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -230,19 +230,21 @@ RSpec.describe 'Search', js: true, slow: true do
 
     context 'when getting back some additional code search results' do
       it 'performs search and render results' do
-        VCR.use_cassette('search#additional_code_search_results') do
-          visit additional_code_search_path
+        VCR.use_cassette('search#additional_code_search_form') do
+          VCR.use_cassette('search#additional_code_search_results') do
+            visit additional_code_search_path
 
-          expect(page).to have_content('Additional code')
+            expect(page).to have_content('Additional code')
 
-          page.find('#code').set('119')
-          page.find('input[name="new_search"]').click
+            page.find('#code').set('119')
+            page.find('input[name="new_search"]').click
 
-          using_wait_time 1 do
-            expect(page).to have_content('Additional code search results')
-            expect(page).to have_content('B119')
-            expect(page).to have_content('Wenzhou Jiangnan Steel Pipe Manufacturing, Co. Ltd., Yongzhong')
-            expect(page).to have_content('Of stainless steel')
+            using_wait_time 1 do
+              expect(page).to have_content('Additional code search results')
+              expect(page).to have_content('B119')
+              expect(page).to have_content('Wenzhou Jiangnan Steel Pipe Manufacturing, Co. Ltd., Yongzhong')
+              expect(page).to have_content('Of stainless steel')
+            end
           end
         end
       end
@@ -273,19 +275,21 @@ RSpec.describe 'Search', js: true, slow: true do
 
     context 'when getting back some certificate search results' do
       it 'performs search and render results' do
-        VCR.use_cassette('search#certificate_search_results') do
-          visit certificate_search_path
+        VCR.use_cassette('search#certificate_search_form') do
+          VCR.use_cassette('search#certificate_search_results') do
+            visit certificate_search_path
 
-          expect(page).to have_content('Certificate')
+            expect(page).to have_content('Certificate')
 
-          page.find('#code').set('119')
-          page.find('input[name="new_search"]').click
+            page.find('#code').set('119')
+            page.find('input[name="new_search"]').click
 
-          using_wait_time 1 do
-            expect(page).to have_content('Certificate search results')
-            expect(page).to have_content('C119')
-            expect(page).to have_content('Authorised Release Certificate — EASA Form 1 (Appendix I to Annex I to Regulation (EU) No 748/2012), or equivalent certificate')
-            expect(page).to have_content('Carbon dioxide')
+            using_wait_time 1 do
+              expect(page).to have_content('Certificate search results')
+              expect(page).to have_content('C119')
+              expect(page).to have_content('Authorised Release Certificate — EASA Form 1 (Appendix I to Annex I to Regulation (EU) No 748/2012), or equivalent certificate')
+              expect(page).to have_content('Carbon dioxide')
+            end
           end
         end
       end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'Search', js: true, slow: true do
+RSpec.describe 'Search', js: true do
   before do
     TradeTariffFrontend::ServiceChooser.service_choice = nil
   end

--- a/spec/presenters/measure_presenter_spec.rb
+++ b/spec/presenters/measure_presenter_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe MeasurePresenter do
   subject(:presented_measure) { described_class.new(measure) }
 

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe 'Commodity page', type: :request do
   before do
     stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))

--- a/spec/requests/heading_spec.rb
+++ b/spec/requests/heading_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe 'Heading page', type: :request do
   before do
     stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))

--- a/spec/services/client_builder_spec.rb
+++ b/spec/services/client_builder_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe ClientBuilder do
   subject(:builder) { described_class.new(service) }
 

--- a/spec/trade_tariff_frontend/service_chooser_spec.rb
+++ b/spec/trade_tariff_frontend/service_chooser_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe TradeTariffFrontend::ServiceChooser do
   describe '.service_choices' do
     it 'returns a Hash of url options for the services' do

--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
   cassette_name: 'geographical_areas_countries',
 } do


### PR DESCRIPTION
### Jira link

[HOTT-1121](https://transformuk.atlassian.net/browse/HOTT-1121)

### What?

I have added/removed/altered:

- [x] Changed the cache store in the test environment to be the null store
- [x] Fixed specs failing because they were reliant on cached results from other specs
- [x] Removed redundant calls to `Rails.cache.clear` in specs
- [x] Added missing `require 'spec_helper'` lines

### Why?

I am doing this because:

- it is necessary to avoid tests relying upon the output from other tests
- it massively reduces the run time of the tests - I'd hypothesis we're writing large amounts of cache data as part of the specs, the circle machines are on slow cheap disks, and using the `:null_store` bypasses that
- The spec helper fixes are a drive by fix for what were existing flaky specs - because some spec files were loading the helper, they could only pass if they weren't the first specs to be run.