### PR TITLE
This fix the Header for the old navigation. It is a tempoary patch, m…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,7 +52,7 @@ class ApplicationController < ActionController::Base
                 :is_switch_service_banner_enabled?
 
   def render_500
-    @no_shared_search = true
+    disable_search_form
     render template: 'errors/internal_server_error',
            status: :internal_server_error,
            formats: :html
@@ -60,7 +60,7 @@ class ApplicationController < ActionController::Base
   end
 
   def render_404
-    @no_shared_search = true
+    disable_search_form
     render template: 'errors/not_found',
            status: :not_found,
            formats: :html
@@ -83,6 +83,10 @@ class ApplicationController < ActionController::Base
 
   def is_switch_service_banner_enabled?
     @switch_service_banner == true
+  end
+
+  def disable_search_form
+    @no_shared_search = true
   end
 
   def search_invoked?

--- a/app/controllers/browse_sections_controller.rb
+++ b/app/controllers/browse_sections_controller.rb
@@ -1,5 +1,5 @@
 class BrowseSectionsController < ApplicationController
-  before_action { @no_shared_search = true }
+  before_action { disable_search_form }
 
   def index
     @sections = Section.all

--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -5,7 +5,7 @@ class CommoditiesController < GoodsNomenclaturesController
   before_action :set_session, only: %i[show]
 
   def show
-    @no_shared_search = true
+    disable_search_form
 
     @heading = commodity.heading
     @chapter = commodity.chapter

--- a/app/controllers/cookies/policies_controller.rb
+++ b/app/controllers/cookies/policies_controller.rb
@@ -1,6 +1,6 @@
 module Cookies
   class PoliciesController < ApplicationController
-    before_action { @no_shared_search = true }
+    before_action { disable_search_form }
 
     def show; end
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,6 @@
 class ErrorsController < ApplicationController
   before_action do
-    @no_shared_search = true
+    disable_search_form
     @tariff_last_updated = nil
   end
 

--- a/app/controllers/exchange_rates_controller.rb
+++ b/app/controllers/exchange_rates_controller.rb
@@ -1,5 +1,5 @@
 class ExchangeRatesController < ApplicationController
-  before_action { @no_shared_search = true }
+  before_action { disable_search_form }
 
   def index
     all_rates = MonetaryExchangeRate.all

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,6 +1,6 @@
 class FeedbackController < ApplicationController
   before_action do
-    @no_shared_search = true
+    disable_search_form
     @tariff_last_updated = nil
   end
 

--- a/app/controllers/geographical_areas_controller.rb
+++ b/app/controllers/geographical_areas_controller.rb
@@ -1,6 +1,6 @@
 class GeographicalAreasController < ApplicationController
   def show
-    @no_shared_search = true
+    disable_search_form
     @tariff_last_updated = nil
     @geographical_area = GeographicalArea.find(params[:id], query_params)
   end

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -7,7 +7,7 @@ class HeadingsController < GoodsNomenclaturesController
   helper_method :uk_heading, :xi_heading
 
   def show
-    @no_shared_search = true
+    disable_search_form
 
     @commodities = HeadingCommodityPresenter.new(heading.commodities)
     @meursing_additional_code = session[:meursing_lookup].try(:[], 'result')

--- a/app/controllers/meursing_lookup/steps_controller.rb
+++ b/app/controllers/meursing_lookup/steps_controller.rb
@@ -1,7 +1,7 @@
 module MeursingLookup
   class StepsController < ApplicationController
     before_action do
-      @no_shared_search = true
+      disable_search_form
       @tariff_last_updated = nil
 
       disable_switch_service_banner

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < ApplicationController
   before_action do
-    @no_shared_search = true
+    disable_search_form
     @tariff_last_updated = nil
   end
 
@@ -16,6 +16,6 @@ class PagesController < ApplicationController
   end
 
   def tools
-    @no_shared_search = true
+    disable_search_form
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,7 +2,7 @@ require 'addressable/uri'
 
 class SearchController < ApplicationController
   before_action :disable_switch_service_banner, only: [:quota_search]
-  before_action { @no_shared_search = true }
+  before_action { disable_search_form }
 
   def search
     @results = @search.perform

--- a/app/controllers/search_references_controller.rb
+++ b/app/controllers/search_references_controller.rb
@@ -1,5 +1,5 @@
 class SearchReferencesController < ApplicationController
-  before_action { @no_shared_search = true }
+  before_action { disable_search_form }
 
   def show
     @search_references = SearchReferencesPresenter.new(

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,6 +1,8 @@
 class SectionsController < GoodsNomenclaturesController
   prepend_before_action :redirect_to_find_commodity, only: :index
 
+  before_action :disable_search_form
+
   def index
     @tariff_updates = TariffUpdate.all
     @sections = Section.all

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -3,7 +3,7 @@ module ServiceHelper
     t('title.default', service_name: service_name, service_description: service_description)
   end
 
-  def heading_for(section:, chapter:, heading:, commodity:)
+  def heading_for(section:, chapter: nil, heading: nil, commodity: nil)
     item = commodity || heading || chapter || section
 
     item ? item.page_heading : t('h1.service_description')

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,6 +70,13 @@
 
       <%= render 'shared/switch_banner' %>
 
+      <% # This is a patch to show the header and search in section until the updated_navigation feature flag is removed
+         # TODO: remove this after updated_navigation is removed
+       if (controller.controller_name == 'sections' && controller.action_name == 'index' && !TradeTariffFrontend.updated_navigation?) %>
+        <%= page_header heading_for(section: @section) %>
+        <%= render 'shared/search/search_form'%>
+      <% end %>
+
       <%= render 'shared/search/search_form' unless @no_shared_search %>
 
       <%= yield %>


### PR DESCRIPTION
### What?

This fixes the Header for the old navigation. It is a temporary patch, made to be removed after the new navigation is released.

- [x] Show the header and search form only in /sections page
- [x] tiny refactor on disable_search_form


### Why?

to fix the missing header in /sections