### PR TITLE
HOTT-1107: Migrate to context tables to summary list

### DIFF
--- a/app/views/shared/context_tables/_chapter.html.erb
+++ b/app/views/shared/context_tables/_chapter.html.erb
@@ -1,21 +1,28 @@
-<table class="govuk-table">
-  <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">Chapter</th>
-      <td class="govuk-table__cell"><%= @chapter.short_code %></td>
-      <td class="govuk-table__cell"/>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Classification</th>
-      <td class="govuk-table__cell"><%= @chapter.to_s %></td>
-      <td class="govuk-table__cell"/>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Date of trade</th>
-      <td class="govuk-table__cell">
-        <%= @search.date.to_formatted_s(:long) %>
-      </td>
-      <td class="govuk-table__cell"></td>
-    </tr>
-  </tbody>
-</table>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Chapter
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @chapter.short_code %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Classification
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @chapter.to_s %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Date of trade
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @search.date.to_formatted_s(:long) %>
+    </dd>
+    <dd class="govuk-summary-list__actions">
+    </dd>
+  </div>
+</dl>

--- a/app/views/shared/context_tables/_commodity.html.erb
+++ b/app/views/shared/context_tables/_commodity.html.erb
@@ -1,24 +1,31 @@
-<table class="govuk-table">
-  <tbody class="govuk-table__body">
-    <tr class="govuk-table__row ">
-      <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">Commodity</th>
-      <td class="govuk-table__cell"><%= segmented_commodity_code(@commodity.short_code) %></td>
-      <td class="govuk-table__cell"/>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Classification</th>
-      <td class="govuk-table__cell"><%= classification_description(@commodity) %></td>
-      <td class="govuk-table__cell"/>
-    </tr>
-    <% if @commodity.declarable? %>
-      <%= render 'shared/context_tables/supplementary_unit_row', supplementary_unit: @supplementary_unit %>
-    <% end %>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Date of trade</th>
-      <td class="govuk-table__cell">
-        <%= @search.date.to_formatted_s(:long) %>
-      </td>
-      <td class="govuk-table__cell"></td>
-    </tr>
-  </tbody>
-</table>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Commodity
+    </dt>
+    <dd class="govuk-summary-list__value">
+    <%= segmented_commodity_code(@commodity.short_code) %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Classification
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= classification_description(@commodity) %>
+    </dd>
+  </div>
+  <% if @commodity.declarable? %>
+    <%= render 'shared/context_tables/supplementary_unit_row', supplementary_unit: @supplementary_unit %>
+  <% end %>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Date of trade
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @search.date.to_formatted_s(:long) %>
+    </dd>
+    <dd class="govuk-summary-list__actions">
+    </dd>
+  </div>
+</dl>

--- a/app/views/shared/context_tables/_heading.html.erb
+++ b/app/views/shared/context_tables/_heading.html.erb
@@ -1,24 +1,31 @@
-<table class="govuk-table">
-  <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">Heading</th>
-      <td class="govuk-table__cell"><%= @heading.short_code %></td>
-      <td class="govuk-table__cell"/>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Classification</th>
-      <td class="govuk-table__cell"><%= @heading.to_s %></td>
-      <td class="govuk-table__cell"/>
-    </tr>
-    <% if @heading.declarable? %>
-      <%= render 'shared/context_tables/supplementary_unit_row', supplementary_unit: @supplementary_unit %>
-    <% end %>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Date of trade</th>
-      <td class="govuk-table__cell">
-        <%= @search.date.to_formatted_s(:long) %>
-      </td>
-      <td class="govuk-table__cell"></td>
-    </tr>
-  </tbody>
-</table>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Heading
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @heading.short_code %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Classification
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @heading.to_s %>
+    </dd>
+  </div>
+  <% if @heading.declarable? %>
+    <%= render 'shared/context_tables/supplementary_unit_row', supplementary_unit: @supplementary_unit %>
+  <% end %>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Date of trade
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @search.date.to_formatted_s(:long) %>
+    </dd>
+    <dd class="govuk-summary-list__actions">
+    </dd>
+  </div>
+</dl>

--- a/app/views/shared/context_tables/_supplementary_unit_row.html.erb
+++ b/app/views/shared/context_tables/_supplementary_unit_row.html.erb
@@ -1,18 +1,17 @@
-<tr class="govuk-table__row">
-  <th scope="row" class="govuk-table__header">Supplementary unit</th>
-  <td class="govuk-table__cell">
-    <%= supplementary_unit %>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">Supplementary unit</dt>
+  <dd class="govuk-summary-list__value ">
 
-    <details class="govuk-details" data-module="govuk-details">
+  <p><%= supplementary_unit %></p>
+
+  <details class="govuk-details" data-module="govuk-details">
     <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-        What are supplementary units?
-      </span>
+      <span class="govuk-details__summary-text">What are supplementary units?</span>
     </summary>
-    <div class="govuk-details__text">
-      Supplementary units are used when an additional measurement unit is needed on customs declarations. For example the quantity of the products as well as the weight in Kilograms.
+    <div class="govuk-details__text  govuk-!-font-size-16">
+      Supplementary units are used when an additional measurement unit is needed on customs declarations. For example: the quantity of the products as well as the weight in kilograms.<br>
     </div>
-    </details>
-  </td>
-  <td class="govuk-table__cell"/>
-</tr>
+  </details>
+  </dd>
+  <dd class="govuk-summary-list__actions"></dd>
+</div>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1107

### What?

See https://design-system.service.gov.uk/components/summary-list/

I have added/removed/altered:

- [x] Migrate context tables to summary list

### Why?

I am doing this because:

- This is required for compliance and so that we can easily add the properly-formatted actions as part of the date work (see linked ticket)
