### PR TITLE
HOTT-334 Commodity picker: prevent duplicate entries

### DIFF
--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -814,13 +814,6 @@
                       let exactMatch = false;
                       options = [];
 
-                      newSource.push(query.toLowerCase());
-                      options.push({
-                        id: query.toLowerCase(),
-                        text: query.toLowerCase(),
-                        newOption: true
-                      });
-
                       results.forEach(function(result) {
                         newSource.push(result.text);
                         options.push(result);
@@ -829,6 +822,15 @@
                           exactMatch = true;
                         }
                       });
+
+                      if ($.inArray(query.toLowerCase(), newSource) < 0) {
+                        newSource.unshift(query.toLowerCase());
+                        options.unshift({
+                          id: query.toLowerCase(),
+                          text: query.toLowerCase(),
+                          newOption: true
+                        });
+                      }
 
                       populateResults(newSource);
 


### PR DESCRIPTION
### Jira link

[HOTT-334](https://transformuk.atlassian.net/browse/HOTT-334)

### What?

I have added/removed/altered:

- [x] Refactored the commodity picker auto complete to only add the typed query if its not already in the list

### Why?

I am doing this because:

- If the user types a search term which we find an exact match for, they will see duplicate results for the query they typed. This is both confusing for the user and unnecessary.
