### PR TITLE
HOTT-1094 Add Browse in to the breadcrumbs

### DIFF
--- a/app/views/shared/_top_breadcrumbs.html.erb
+++ b/app/views/shared/_top_breadcrumbs.html.erb
@@ -4,6 +4,13 @@
       <li class="govuk-breadcrumbs__list-item">
         <%= link_to "Home", sections_path, class:'govuk-breadcrumbs__link' %>
       </li>
+
+      <%- if TradeTariffFrontend.updated_navigation? -%>
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Browse', browse_sections_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <%- end -%>
+
       <li class="govuk-breadcrumbs__list-item">
         <%= breadcrumb_link_or_text(@section, @chapter, "Section #{@section.numeral}") %>
       </li>


### PR DESCRIPTION
### Jira link

[HOTT-1094](https://transformuk.atlassian.net/browse/HOTT-1094)

### What?

I have added/removed/altered:

- [x] Added a browse item to the breadcrumbs on the commodities, headings, chapters, and sections pages

### Why?

I am doing this because:

- Browse sections is no longer the same as home, under the new updated navigation 'home' points to the find_commodity page

