### PR TITLE
HOTT-1077 Moved breadcrumbs on non-commodity pages

### DIFF
--- a/app/views/browse_sections/index.html.erb
+++ b/app/views/browse_sections/index.html.erb
@@ -3,7 +3,7 @@
                                href: sections_url(format: :json),
                                title: 'Section list in JSON format') %>
 
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
       t('breadcrumb.browse'),
       [

--- a/app/views/cookies/policies/show.html.erb
+++ b/app/views/cookies/policies/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
           "Cookies on UK Integrated Online Tariff",
           [

--- a/app/views/meursing_lookup/steps/_start.html.erb
+++ b/app/views/meursing_lookup/steps/_start.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
       t('breadcrumb.meursing_lookup'),
       [

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -1,6 +1,6 @@
 <%= page_header 'Latest news' %>
 
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs t('breadcrumb.news'), [[t('breadcrumb.home'), sections_path]] %>
 <% end %>
 

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -1,6 +1,6 @@
 <%= page_header 'Latest news' %>
 
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs truncate(@news_item.title),
                            [ [t('breadcrumb.home'), sections_path],
                              [t('breadcrumb.news'), news_items_path] ] %>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
     t('breadcrumb.help'),
     [

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
       t('breadcrumb.privacy'),
       [

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
       t('breadcrumb.terms'),
       [

--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
       t('breadcrumb.tools'),
       [

--- a/app/views/search/additional_code_search.erb
+++ b/app/views/search/additional_code_search.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
       t('breadcrumb.additional_codes'),
       [

--- a/app/views/search/certificate_search.erb
+++ b/app/views/search/certificate_search.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
       t('breadcrumb.certificates'),
       [

--- a/app/views/search/chemical_search.html.erb
+++ b/app/views/search/chemical_search.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
       t('breadcrumb.chemicals'),
       [

--- a/app/views/search/footnote_search.erb
+++ b/app/views/search/footnote_search.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
       t('breadcrumb.footnote_search'),
       [

--- a/app/views/search/quota_search.html.erb
+++ b/app/views/search/quota_search.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
       t('breadcrumb.quotas'),
       [

--- a/app/views/search_references/show.html.erb
+++ b/app/views/search_references/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_main_content do %>
+<% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(
       t('breadcrumb.az'),
       [

--- a/app/views/shared/_top_breadcrumbs.html.erb
+++ b/app/views/shared/_top_breadcrumbs.html.erb
@@ -28,3 +28,5 @@
     </ol>
   </div>
 <% end %>
+
+<%= yield :top_breadcrumbs %>


### PR DESCRIPTION
### Jira link

[HOTT-1077](https://transformuk.atlassian.net/browse/HOTT-1077)

### What?

I have added/removed/altered:

- [x] Added a new `content_for` location in the page template for breadcrumbs under the top banner  
- [x] Changed breadcrumbs on all content pages to render into that location 

### Why?

I am doing this because:

- When I'd updated the commodities pages earlier I'd not realised we had multiple mechanisms for rendering the breadcrumbs and this hadn't moved other breadcrumbs up under the banner

### Before

![Screenshot from 2021-11-19 10-10-15](https://user-images.githubusercontent.com/10818/142613184-e9dbecdb-cc49-4a9f-92cd-8f346bafb4e5.png)

### After

![Screenshot from 2021-11-19 11-09-55](https://user-images.githubusercontent.com/10818/142613221-aabff151-aa41-4004-a376-b3ba2c2879ca.png)
