### PR TITLE
HOTT-493 Avoid duplicate ids on the search fields

### DIFF
--- a/app/views/find_commodities/show.html.erb
+++ b/app/views/find_commodities/show.html.erb
@@ -37,11 +37,11 @@
               You must use the right commodity code.
             </div>
 
-            <%= hidden_field_tag :q, @search.q, { class: "js-commodity-picker-target" } %>
+            <%= hidden_field_tag :q, @search.q, id: 'q-hidden', class: "js-commodity-picker-target" %>
 
             <div class="js-commodity-picker-select js-show" data-nosubmit></div>
             <noscript>
-              <%= text_field_tag(:q, @search.q, {class: "govuk-input", name: :q}) %>
+              <%= text_field_tag :q, @search.q, class: "govuk-input" %>
             </noscript>
           </fieldset>
         </div>

--- a/app/views/shared/search/_search_form.html.erb
+++ b/app/views/shared/search/_search_form.html.erb
@@ -5,7 +5,7 @@
         <div class="searchfield govuk-form-group">
           <fieldset class="govuk-fieldset govuk-search-input">
             <%= label_tag :q, search_label_text, class: 'govuk-label' %>
-            <%= hidden_field_tag :q, @search.q, { class: "js-commodity-picker-target" } %>
+            <%= hidden_field_tag :q, @search.q, { class: "js-commodity-picker-target", id: 'q-hidden' } %>
             <div class='js-commodity-picker-select js-show'></div>
             <noscript>
               <%= text_field_tag(:q, @search.q, {class: "govuk-input", name: :q}) %>


### PR DESCRIPTION
### Jira link

[HOTT-493](https://transformuk.atlassian.net/browse/HOTT-493)

### What?

I have added/removed/altered:

- [x] Changed the id of the hidden field in the commodity search forms

### Why?

I am doing this because:

- Currently we have duplicate ids - the hidden field is never referred to by id and the duplicate id may cause accessibility problems

### Deployment risks (optional)

- This does change the code around one of the key entry points to our site - but the change should be safe from a 'logical' perspective and still works correctly in manual testing on both new and old commodity search forms
