### PR TITLE
Changes logic on the supplementary unit in context tables.

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -11,8 +11,6 @@ class CommoditiesController < GoodsNomenclaturesController
     @chapter = commodity.chapter
     @section = commodity.section
 
-    @supplementary_unit = commodity.supplementary_unit(country: @search.country)
-
     if params[:country].present? && @search.geographical_area
       @rules_of_origin = commodity.rules_of_origin(params[:country])
     end

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -14,8 +14,6 @@ class HeadingsController < GoodsNomenclaturesController
     @section = heading.section
     @chapter = heading.chapter
 
-    @supplementary_unit = heading.supplementary_unit(country: @search.country)
-
     if params[:country].present? && @search.geographical_area
       @rules_of_origin = heading.rules_of_origin(params[:country])
     end

--- a/app/helpers/declarable_helper.rb
+++ b/app/helpers/declarable_helper.rb
@@ -59,6 +59,11 @@ module DeclarableHelper
     session[:declarable_code]
   end
 
+  # Supplementary unit measures treat no country specified in the search as the entire world
+  def supplementary_geographical_area_id(search)
+    search.country || GeographicalArea::ERGA_OMNES
+  end
+
   private
 
   def declarable_path_opts

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -57,23 +57,30 @@ module Declarable
     ).uniq(&:code)
   end
 
-  def supplementary_unit(country: nil)
-    supplementary_measures = import_measures.for_country(country).supplementary
+  def supplementary_unit_description(country:)
+    supplementary_measure(country)&.supplementary_unit_description || 'Supplementary unit'
+  end
 
-    case supplementary_measures.count
-    when 0
-      'No supplementary unit required.'
-    when 1
-      supplementary_measure = supplementary_measures.first
-      supplementary_measure_component = supplementary_measure.measure_components.first
+  def supplementary_unit(country:)
+    measure = supplementary_measure(country)
+    supplementary_component = measure&.measure_components&.first
 
-      "#{supplementary_measure_component.measurement_unit.description} (#{supplementary_measure.duty_expression.base})"
+    if supplementary_component
+      "#{supplementary_component.measurement_unit&.description} (#{measure.duty_expression&.base})"
     else
-      'There are multiple supplementary units for you trade. See measures below.'
+      'No supplementary unit required.'
     end
   end
 
   private
+
+  def supplementary_measure(country)
+    supplementary_measures(country).first
+  end
+
+  def supplementary_measures(country)
+    @supplementary_measures ||= import_measures.for_country(country).supplementary
+  end
 
   def no_heading?
     !heading?

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -9,6 +9,8 @@ class GeographicalArea
 
   has_many :children_geographical_areas, class_name: 'GeographicalArea'
 
+  ERGA_OMNES = '1011'.freeze # Entire world
+
   def self.by_long_description(term)
     lookup_regexp = /#{term}/i
 
@@ -48,5 +50,9 @@ class GeographicalArea
 
   def to_s
     description
+  end
+
+  def erga_omnes?
+    id == ERGA_OMNES
   end
 end

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -3,5 +3,16 @@ require 'api_entity'
 class MeasureType
   include ApiEntity
 
+  SUPPLEMENTARY_MEASURE_TYPES = %w[109 110 111].freeze
+  SUPPLEMENTARY_IMPORT_ONLY_MEASURE_TYPES = %w[110].freeze
+
   attr_accessor :id, :description
+
+  def supplementary?
+    id.in?(SUPPLEMENTARY_MEASURE_TYPES)
+  end
+
+  def supplementary_unit_import_only?
+    id.in?(SUPPLEMENTARY_IMPORT_ONLY_MEASURE_TYPES)
+  end
 end

--- a/app/views/shared/context_tables/_commodity.html.erb
+++ b/app/views/shared/context_tables/_commodity.html.erb
@@ -16,7 +16,7 @@
     </dd>
   </div>
   <% if @commodity.declarable? %>
-    <%= render 'shared/context_tables/supplementary_unit_row', supplementary_unit: @supplementary_unit %>
+    <%= render 'shared/context_tables/supplementary_unit_row', declarable: @commodity %>
   <% end %>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">

--- a/app/views/shared/context_tables/_heading.html.erb
+++ b/app/views/shared/context_tables/_heading.html.erb
@@ -16,7 +16,7 @@
     </dd>
   </div>
   <% if @heading.declarable? %>
-    <%= render 'shared/context_tables/supplementary_unit_row', supplementary_unit: @supplementary_unit %>
+    <%= render 'shared/context_tables/supplementary_unit_row', declarable: @heading %>
   <% end %>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">

--- a/app/views/shared/context_tables/_supplementary_unit_row.html.erb
+++ b/app/views/shared/context_tables/_supplementary_unit_row.html.erb
@@ -1,17 +1,17 @@
 <div class="govuk-summary-list__row">
-  <dt class="govuk-summary-list__key">Supplementary unit</dt>
+  <dt class="govuk-summary-list__key"><%= declarable.supplementary_unit_description(country: supplementary_geographical_area_id(@search)) %></dt>
   <dd class="govuk-summary-list__value ">
-
-  <p><%= supplementary_unit %></p>
-
-  <details class="govuk-details" data-module="govuk-details">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">What are supplementary units?</span>
-    </summary>
-    <div class="govuk-details__text  govuk-!-font-size-16">
-      Supplementary units are used when an additional measurement unit is needed on customs declarations. For example: the quantity of the products as well as the weight in kilograms.<br>
-    </div>
-  </details>
+    <p>
+      <%= declarable.supplementary_unit(country: supplementary_geographical_area_id(@search)) %>
+    </p>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">What are supplementary units?</span>
+      </summary>
+      <div class="govuk-details__text  govuk-!-font-size-16">
+        Supplementary units are used when an additional measurement unit is needed on customs declarations. For example: the quantity of the products as well as the weight in kilograms.<br>
+      </div>
+    </details>
   </dd>
   <dd class="govuk-summary-list__actions"></dd>
 </div>

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -28,12 +28,6 @@ RSpec.describe CommoditiesController, type: :controller do
         expect(session[:declarable_code]).to eq('0101210000')
       end
 
-      it 'assigns a supplementary unit', vcr: { cassette_name: 'commodities#show_0101210000_xi' } do
-        get :show, params: { id: '0101210000' }
-
-        expect(assigns[:supplementary_unit]).to eq('Number of items (p/st)')
-      end
-
       context 'with existing commodity id provided' do
         subject { controller }
 

--- a/spec/controllers/headings_controller_spec.rb
+++ b/spec/controllers/headings_controller_spec.rb
@@ -26,12 +26,6 @@ RSpec.describe HeadingsController, type: :controller do
       expect(session[:declarable_code]).to eq('0501')
     end
 
-    it 'assigns a supplementary unit', vcr: { cassette_name: 'headings#show_0110' } do
-      get :show, params: { id: '0501' }
-
-      expect(assigns[:supplementary_unit]).to eq('No supplementary unit required.')
-    end
-
     context 'with existing heading id provided', vcr: { cassette_name: 'headings#show' } do
       let!(:heading) { Heading.new(attributes_for(:heading).stringify_keys) }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -120,6 +120,10 @@ FactoryBot.define do
       vat { true }
     end
 
+    trait :erga_omnes do
+      geographical_area { attributes_for(:geographical_area, :erga_omnes).stringify_keys }
+    end
+
     trait :vat_excise do
       measure_type do
         attributes_for(:measure_type, :vat_excise, description: measure_type_description).stringify_keys
@@ -154,12 +158,22 @@ FactoryBot.define do
       measure_type do
         attributes_for(:measure_type, :third_country, description: measure_type_description).stringify_keys
       end
-      geographical_area { attributes_for(:geographical_area, :third_country).stringify_keys }
+      geographical_area { attributes_for(:geographical_area, :erga_omnes).stringify_keys }
     end
 
-    trait :supplementary do
+    trait :import_export_supplementary do
       measure_type do
-        attributes_for(:measure_type, :supplementary, description: measure_type_description).stringify_keys
+        attributes_for(:measure_type, :import_export_supplementary, description: measure_type_description).stringify_keys
+      end
+
+      duty_expression do
+        attributes_for(:duty_expression, base: 'p/st')
+      end
+    end
+
+    trait :import_only_supplementary do
+      measure_type do
+        attributes_for(:measure_type, :import_only_supplementary, description: measure_type_description).stringify_keys
       end
 
       duty_expression do
@@ -197,6 +211,14 @@ FactoryBot.define do
       origin { 'eu' }
     end
 
+    trait :import do
+      import { true }
+    end
+
+    trait :export do
+      import { false }
+    end
+
     initialize_with do
       new(attributes.stringify_keys)
     end
@@ -217,6 +239,10 @@ FactoryBot.define do
   factory :duty_expression do
     base { '80.50 EUR / Hectokilogram' }
     formatted_base { "80.50 EUR / <abbr title='Hectokilogram'>Hectokilogram</abbr>" }
+
+    trait :supplementary do
+      description { 'Number of items' }
+    end
   end
 
   factory :measure_type do
@@ -251,15 +277,25 @@ FactoryBot.define do
       id { '103' }
     end
 
-    trait :supplementary do
+    trait :import_export_supplementary do
+      id { '109' }
+    end
+
+    trait :import_only_supplementary do
       id { '110' }
+    end
+
+    trait :export_only_supplementary do
+      id { '111' }
     end
   end
 
   factory :measure_component do
-    duty_expression
-
     trait :with_supplementary_measurement_unit do
+      duty_expression do
+        attributes_for(:duty_expression, base: 'p/st')
+      end
+
       measurement_unit do
         attributes_for(:measurement_unit, :supplementary).stringify_keys
       end
@@ -280,12 +316,12 @@ FactoryBot.define do
     id { Forgery(:basic).text(exactly: 2).upcase }
     description { Forgery(:basic).text }
 
-    trait :third_country do
-      id { '1011' }
-    end
-
     trait :specific_country do
       description { Forgery(:basic).text }
+    end
+
+    trait :erga_omnes do
+      id { '1011' }
     end
 
     initialize_with do

--- a/spec/helpers/declarable_helper_spec.rb
+++ b/spec/helpers/declarable_helper_spec.rb
@@ -171,4 +171,20 @@ RSpec.describe DeclarableHelper, type: :helper do
         .to eq('Fruits &mdash; Foo1 &mdash; Foo2 &mdash; <strong>Cherry tomatos</strong>')
     end
   end
+
+  describe '#supplementary_geographical_area_id' do
+    subject(:supplementary_geographical_area_id) { helper.supplementary_geographical_area_id(search) }
+
+    context 'when the country is present on the search' do
+      let(:search) { Search.new(country: 'IT') }
+
+      it { is_expected.to eq('IT') }
+    end
+
+    context 'when the country is not present on the search' do
+      let(:search) { Search.new(country: nil) }
+
+      it { is_expected.to eq('1011') }
+    end
+  end
 end

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -35,4 +35,18 @@ RSpec.describe GeographicalArea do
       expect(by_long_desc).to eq(expected_geographical_areas)
     end
   end
+
+  describe '#erga_omnes?' do
+    context 'when the geographical area is the world' do
+      subject(:geographical_area) { build(:geographical_area, :erga_omnes) }
+
+      it { is_expected.to be_erga_omnes }
+    end
+
+    context 'when the geographical area is not the world' do
+      subject(:geographical_area) { build(:geographical_area) }
+
+      it { is_expected.not_to be_erga_omnes }
+    end
+  end
 end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -159,4 +159,32 @@ RSpec.describe Measure do
       it { is_expected.not_to be_trade_remedies }
     end
   end
+
+  describe '#import?' do
+    context 'when the measure is an import measure' do
+      subject(:measure) { build(:measure, :import) }
+
+      it { is_expected.to be_import }
+    end
+
+    context 'when the measure is an export measure' do
+      subject(:measure) { build(:measure, :export) }
+
+      it { is_expected.not_to be_import }
+    end
+  end
+
+  describe '#export?' do
+    context 'when the measure is an export measure' do
+      subject(:measure) { build(:measure, :export) }
+
+      it { is_expected.to be_export }
+    end
+
+    context 'when the measure is an import measure' do
+      subject(:measure) { build(:measure, :import) }
+
+      it { is_expected.not_to be_export }
+    end
+  end
 end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -2,71 +2,48 @@ require 'spec_helper'
 
 RSpec.describe Measure do
   describe '#relevant_for_country?' do
-    it 'returns true when no geographical area is specified' do
-      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: { id: 'br',
-                                                                               description: 'Brazil' }).stringify_keys)
-      expect(
-        measure.relevant_for_country?(nil),
-      ).to eq true
+    context 'when the area is not present' do
+      subject(:measure) { build(:measure, :eu, geographical_area: { id: 'br', description: 'Brazil' }) }
+
+      it { expect(measure.relevant_for_country?(nil)).to eq true }
     end
 
-    it 'returns true if a national measure and geographical area code is equal to 1011' do
-      measure = Measure.new(attributes_for(:measure, :national, geographical_area: { id: '1011',
-                                                                                     description: 'ERGA OMNES' }).stringify_keys)
-      expect(
-        measure.relevant_for_country?('br'),
-      ).to eq true
+    context 'when the measure is a national measure that is erga omnes' do
+      subject(:measure) { build(:measure, :national, :erga_omnes) }
+
+      it { expect(measure.relevant_for_country?('br')).to eq true }
     end
 
-    it 'returns false if a national measure and it is an excluded country' do
-      measure = Measure.new(attributes_for(:measure, :national, geographical_area: { id: 'lt',
-                                                                                     description: 'Lithuania' },
-                                                                excluded_countries: [
-                                                                  { id: 'lt', description: 'Lithuania', geographical_area_id: 'lt' },
-                                                                ]).stringify_keys)
-      expect(
-        measure.relevant_for_country?('lt'),
-      ).to eq false
+    context 'when the area is an excluded geographical area' do
+      subject(:measure) do
+        build(:measure, geographical_area: { id: 'lt',
+                                             description: 'Lithuania' },
+                        excluded_countries: [
+                          { id: 'lt', description: 'Lithuania', geographical_area_id: 'lt' },
+                        ])
+      end
+
+      it { expect(measure.relevant_for_country?('lt')).to eq false }
     end
 
-    it 'returns true if geographical area code matches' do
-      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: { id: 'br',
-                                                                               description: 'Brazil' }).stringify_keys)
-      expect(
-        measure.relevant_for_country?('br'),
-      ).to eq true
-      expect(
-        measure.relevant_for_country?('fr'),
-      ).to eq false
+    context 'when an exact match on the geographical_area_id' do
+      subject(:measure) { build(:measure, :eu, geographical_area: { id: 'br' }) }
+
+      it { expect(measure.relevant_for_country?('br')).to eq true }
     end
 
-    it 'returns true if geographical area (group) contains matching code' do
-      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: { id: nil,
-                                                                               description: 'European Union',
-                                                                               children_geographical_areas: [
-                                                                                 { id: 'lt', description: 'Lithuania' },
-                                                                                 { id: 'fr', description: 'France' },
-                                                                               ] }).stringify_keys)
-      expect(
-        measure.relevant_for_country?('lt'),
-      ).to eq true
-      expect(
-        measure.relevant_for_country?('it'),
-      ).to eq false
-    end
+    context 'when a group match on the geographical_area_id' do
+      subject(:measure) do
+        build(:measure, :eu, geographical_area: { id: nil,
+                                                  description: 'European Union',
+                                                  children_geographical_areas: [
+                                                    { id: 'lt', description: 'Lithuania' },
+                                                    { id: 'fr', description: 'France' },
+                                                  ] })
+      end
 
-    it 'returns false if country code is among excluded countries for this measure' do
-      measure = Measure.new(attributes_for(:measure, :eu, geographical_area: { id: nil,
-                                                                               description: 'European Union',
-                                                                               children_geographical_areas: [
-                                                                                 { id: 'lt', description: 'Lithuania', geographical_area_id: 'lt' },
-                                                                               ] },
-                                                          excluded_countries: [
-                                                            { id: 'lt', description: 'Lithuania', geographical_area_id: 'lt' },
-                                                          ]).stringify_keys)
-      expect(
-        measure.relevant_for_country?('lt'),
-      ).to eq false
+      it { expect(measure.relevant_for_country?('lt')).to eq true }
+      it { expect(measure.relevant_for_country?('it')).to eq false }
     end
   end
 

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe MeasureType do
+  describe '#supplementary?' do
+    shared_examples_for 'a supplementary measure type' do |measure_type_id|
+      subject(:measure_type) { build(:measure_type, id: measure_type_id) }
+
+      it { is_expected.to be_a_supplementary }
+    end
+
+    it_behaves_like 'a supplementary measure type', '109'
+    it_behaves_like 'a supplementary measure type', '110'
+    it_behaves_like 'a supplementary measure type', '111'
+
+    context 'when the measure type id is a non supplementary measure type id' do
+      subject(:measure_type) { build(:measure_type, id: 'foo') }
+
+      it { is_expected.not_to be_a_supplementary }
+    end
+  end
+
+  describe '#supplementary_unit_import_only?' do
+    context 'when the measure type id is a supplementary id and import only' do
+      subject(:measure_type) { build(:measure_type, id: '110') }
+
+      it { is_expected.to be_a_supplementary_unit_import_only }
+    end
+
+    context 'when the measure type id is a supplementary id but not import only' do
+      subject(:measure_type) { build(:measure_type, id: '109') }
+
+      it { is_expected.not_to be_a_supplementary_unit_import_only }
+    end
+
+    context 'when the measure type id is not supplementary' do
+      subject(:measure_type) { build(:measure_type, id: 'foo') }
+
+      it { is_expected.not_to be_a_supplementary_unit_import_only }
+    end
+  end
+end

--- a/spec/support/shared_examples/a_declarable.rb
+++ b/spec/support/shared_examples/a_declarable.rb
@@ -4,34 +4,57 @@ RSpec.shared_examples 'a declarable' do
   let(:measures) { [] }
 
   describe '#supplementary_unit' do
-    context 'when there there is one supplementary_measures' do
+    context 'when there is a supplementary measure' do
       let(:measures) do
         [
-          attributes_for(:measure, :supplementary, :with_supplementary_measure_components),
+          attributes_for(:measure, :import_export_supplementary, :erga_omnes, :with_supplementary_measure_components),
         ]
       end
 
-      it 'return appropriate notice message' do
-        expect(declarable.supplementary_unit).to eq('Number of items (p/st)')
+      it 'returns the appropriate supplementary unit' do
+        expect(declarable.supplementary_unit(country: '1011')).to eq('Number of items (p/st)')
       end
     end
 
-    context 'when there are not supplementary_measures' do
-      it 'return appropriate notice message' do
-        expect(declarable.supplementary_unit).to eq('No supplementary unit required.')
+    context 'when there are no supplementary measures' do
+      let(:measures) { [attributes_for(:measure)] }
+
+      it 'returns the appropriate supplementary unit' do
+        expect(declarable.supplementary_unit(country: '1011')).to eq('No supplementary unit required.')
       end
     end
+  end
 
-    context 'when there are more than one supplementary_measures' do
+  describe '#supplementary_unit_description' do
+    context 'when there is a supplementary measure and the measure is an import measure' do
       let(:measures) do
         [
-          attributes_for(:measure, :supplementary, :with_supplementary_measure_components),
-          attributes_for(:measure, :supplementary, :with_supplementary_measure_components),
+          attributes_for(:measure, :import_only_supplementary, :erga_omnes, :with_supplementary_measure_components),
         ]
       end
 
-      it 'return appropriate notice message' do
-        expect(declarable.supplementary_unit).to eq('There are multiple supplementary units for you trade. See measures below.')
+      it 'returns the appropriate description' do
+        expect(declarable.supplementary_unit_description(country: '1011')).to eq('Supplementary unit (import)')
+      end
+    end
+
+    context 'when there is a supplementary measure and the measure is an export measure' do
+      let(:measures) do
+        [
+          attributes_for(:measure, :import_export_supplementary, :erga_omnes, :with_supplementary_measure_components),
+        ]
+      end
+
+      it 'returns the appropriate description' do
+        expect(declarable.supplementary_unit_description(country: '1011')).to eq('Supplementary unit')
+      end
+    end
+
+    context 'when there are no supplementary measures' do
+      let(:measures) { [attributes_for(:measure)] }
+
+      it 'returns the appropriate description' do
+        expect(declarable.supplementary_unit_description(country: '1011')).to eq('Supplementary unit')
       end
     end
   end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1054

### What?
This PR changes the Business logic for the supplementary unit in context tables.

## New logic:
Depending on whether or not a country is selected in filter by country
- If a country is selected …

    Look for any current measures of type 109 or 110 applicable to that country (or a group that contains that country)

    All these measures will be brought back in the API anyway

    - If there is a measure of type 109, then show: in column 1, the words “Supplementary unit”
    - If there is a measure of type 110, then show: in column 1, the words “Supplementary unit (import)”

    In either case, in column 2, show the applicable description from the table measuremet_unit_descriptions that applies to the measurement unit

    If there is also a measurement unit qualifier, then also bring the qualifier back

        this in turn needs a fix making to the API, which is covered in ticket xyz

    Matt to complete this as and when possible

- If a country is not selected …

As above, but look for measures that are assigned to 1011 only - all other logic is identical
Where there is no supplementary unit

If there is no supplementary unit measure (109 or 110) on a commodity, then show this instead
