### PR TITLE
HOTT-1050: Headings switcher

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
 
   before_action :set_cache
-  before_action :enable_switch_service_banner
   before_action :set_last_updated
   before_action :set_path_info
 
@@ -73,16 +72,12 @@ class ApplicationController < ActionController::Base
     # rubocop:enable Naming/MemoizedInstanceVariableName
   end
 
-  def enable_switch_service_banner
-    @switch_service_banner = true
-  end
-
-  def disable_switch_service_banner
-    @switch_service_banner = false
+  def disable_switch_service_banner!
+    @disable_switch_service_banner = true
   end
 
   def is_switch_service_banner_enabled?
-    @switch_service_banner == true
+    !@disable_switch_service_banner
   end
 
   def disable_search_form

--- a/app/controllers/find_commodities_controller.rb
+++ b/app/controllers/find_commodities_controller.rb
@@ -1,5 +1,5 @@
 class FindCommoditiesController < ApplicationController
-  before_action :disable_switch_service_banner, only: [:show]
+  before_action :disable_switch_service_banner!, only: [:show]
 
   def show
     @no_shared_search = true

--- a/app/controllers/import_export_dates_controller.rb
+++ b/app/controllers/import_export_dates_controller.rb
@@ -1,7 +1,7 @@
 class ImportExportDatesController < ApplicationController
   include GoodsNomenclatureHelper
 
-  before_action :disable_search_form, :disable_switch_service_banner do
+  before_action :disable_search_form, :disable_switch_service_banner! do
     @tariff_last_updated = nil
   end
 

--- a/app/controllers/meursing_lookup/steps_controller.rb
+++ b/app/controllers/meursing_lookup/steps_controller.rb
@@ -4,7 +4,7 @@ module MeursingLookup
       disable_search_form
       @tariff_last_updated = nil
 
-      disable_switch_service_banner
+      disable_switch_service_banner!
 
       clear_meursing_lookup_session
       store_meursing_lookup_result_on_session

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,7 +1,7 @@
 require 'addressable/uri'
 
 class SearchController < ApplicationController
-  before_action :disable_switch_service_banner, only: [:quota_search]
+  before_action :disable_switch_service_banner!, only: [:quota_search]
   before_action :disable_search_form, except: [:search]
 
   def search

--- a/app/controllers/trading_partners_controller.rb
+++ b/app/controllers/trading_partners_controller.rb
@@ -1,7 +1,7 @@
 class TradingPartnersController < ApplicationController
   include GoodsNomenclatureHelper
 
-  before_action :disable_search_form, :disable_switch_service_banner do
+  before_action :disable_search_form, :disable_switch_service_banner! do
     @tariff_last_updated = nil
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,10 @@ module ApplicationHelper
   def page_header(heading = nil, &block)
     extra_content = block_given? ? capture(&block) : nil
 
-    render 'shared/page_header', heading: heading, extra_content: extra_content
+    render 'shared/page_header',
+           heading: heading,
+           show_switch_service: is_switch_service_banner_enabled?,
+           extra_content: extra_content
   end
 
   def govuk_header_navigation_item(active_class: '', &block)

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -45,14 +45,19 @@ module ServiceHelper
     link_to(t('service_banner.service_name.uk'), current_path)
   end
 
-  def switch_service_bottom_link
+  def switch_service_button
     copy, link = if uk_service_choice?
                    [t('service_banner.service_name.xi'), "/xi#{current_path}"]
                  else
                    [t('service_banner.service_name.uk'), current_path]
                  end
 
-    link_to("Switch to the #{copy}", link, class: 'govuk-link--no-underline')
+    tag.span class: 'switch_control' do
+      safe_join [
+        tag.span(class: 'arrow'),
+        link_to("Switch to the #{copy}", link, class: 'govuk-link--no-underline'),
+      ], "\n"
+    end
   end
 
   def search_label_text

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -52,7 +52,7 @@ module ServiceHelper
                    [t('service_banner.service_name.uk'), current_path]
                  end
 
-    tag.span class: 'switch_control' do
+    tag.span class: 'switch-service-control' do
       safe_join [
         tag.span(class: 'arrow'),
         link_to("Switch to the #{copy}", link, class: 'govuk-link--no-underline'),

--- a/app/views/commodities/_header.html.erb
+++ b/app/views/commodities/_header.html.erb
@@ -1,6 +1,7 @@
 <header>
-  <span class="govuk-caption-m">
+  <span class="govuk-caption-xl">
     <%= trade_tariff_heading %>
+    <%= switch_service_button %>
   </span>
 
   <h1 class="govuk-heading-l commodity-header" data-comm-code="<%= commodity_code %>">

--- a/app/views/cookies/policies/show.html.erb
+++ b/app/views/cookies/policies/show.html.erb
@@ -10,26 +10,26 @@
 
 <%= form_for cookies_policy do |form| %>
   <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+    <% if @saved %>
+      <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Success
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <h3 class="govuk-notification-banner__heading">
+            Your cookie settings were saved
+          </h3>
+          <p>You can update these settings at any time.</p>
+        </div>
+      </div>
+    <% end %>
+
+    <%= page_header "Cookies on the #{service_name}" %>
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <% if @saved %>
-          <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-            <div class="govuk-notification-banner__header">
-              <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Success
-              </h2>
-            </div>
-            <div class="govuk-notification-banner__content">
-              <h3 class="govuk-notification-banner__heading">
-                Your cookie settings were saved
-              </h3>
-              <p>You can update these settings at any time.</p>
-            </div>
-          </div>
-        <% end %>
-        <h1 class="govuk-heading-l">
-          Cookies on the UK Integrated Online Tariff
-        </h1>
         <p>Cookies are files saved on your phone, tablet or computer when you visit a website.
         We use cookies to store information about how you use this website, such as the pages you visit.
         </p>

--- a/app/views/exchange_rates/index.html.erb
+++ b/app/views/exchange_rates/index.html.erb
@@ -1,5 +1,6 @@
 <div class="exchange-rate-page">
-  <h1 class="govuk-heading-l">Exchange rates</h1>
+  <%= page_header 'Exchange rates' %>
+
   <div class="govuk-grid-row sidebar-with-body" data-module="sticky-element-container" id="contents">
     <div class="column-full-mobile-only column-one-quarter-desktop-only">
       <nav role="navigation" class="contents-list" data-module="track-click" aria-labelledby="exchange-rates-contents-title">

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag feedback_path, class: 'feedback-form' do %>
-  <h1 class="govuk-heading-l">Send your feedback</h1>
+  <%= page_header 'Send your feedback' %>
 
   <p class="form-hint govuk-hint">
     Don't include any personal information. This form is for submitting feedback on the website. If you have a question

--- a/app/views/feedback/thanks.html.erb
+++ b/app/views/feedback/thanks.html.erb
@@ -1,3 +1,3 @@
 <div>
-  <h1 class="govuk-heading-l thanks"><%= flash[:alert] %></h1>
+  <%= page_header flash[:alert] %>
 </div>

--- a/app/views/geographical_areas/show.html.erb
+++ b/app/views/geographical_areas/show.html.erb
@@ -6,8 +6,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <span class="govuk-caption-xl"><%= trade_tariff_heading %></span>
-    <h1 class="govuk-heading-l">Geographical area <%= @geographical_area.id %> - <%= @geographical_area.description %></h1>
+    <%= page_header "Geographical area #{@geographical_area.id} - #{@geographical_area.description}" %>
+
     <p>Geographical area <%= @geographical_area.id %>, <strong><%= @geographical_area.description %></strong>,
       includes the following <%= @geographical_area.children_geographical_areas.count %> countries / regions.</p>
     <table class="govuk-table">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,8 +68,6 @@
       <%= render 'shared/phase_banner' if ENV['NOTICE_BANNER'] %>
       <%= yield :before_main_content %>
 
-      <%= render 'shared/switch_banner' %>
-
       <%= render 'shared/search/search_form' unless @no_shared_search %>
 
       <%= yield %>

--- a/app/views/meursing_lookup/steps/_start.html.erb
+++ b/app/views/meursing_lookup/steps/_start.html.erb
@@ -10,8 +10,9 @@
 <% end %>
 
 <div class="govuk-grid-row">
+  <%= page_header 'Look up a Meursing code' %>
+
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Look up a Meursing code</h1>
     <p>
       If you are moving a product into Northern Ireland or the European Union
       that is subject to duties which are dependent on the percentage content of

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -9,8 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl govuk-!-margin-top-0"><%= trade_tariff_heading %></span>
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">Help on using the tariff</h1>
+    <%= page_header 'Help on using the tariff' %>
 
     <p class="govuk-body-l">If you would like to leave feedback on this service or request additional help with your trade, then use the following links.</p>
   </div>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -8,8 +8,7 @@
   %>
 <% end %>
 
-<span class="govuk-caption-xl govuk-!-margin-top-0"><%= trade_tariff_heading %></span>
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-5">Privacy notice</h1>
+<%= page_header 'Privacy notice' %>
 
 <p class="govuk-body-l">
   This notice sets out how we will use your personal data, and your rights.

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -8,8 +8,7 @@
   %>
 <% end %>
 
-<span class="govuk-caption-xl govuk-!-margin-top-0"><%= trade_tariff_heading %></span>
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-5">Terms and conditions</h1>
+<%= page_header 'Terms and conditions' %>
 
 <h2 class="govuk-heading-m">Wrong codes and penalties</h2>
 

--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -10,8 +10,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <span class="govuk-caption-xl govuk-!-margin-top-0"><%= trade_tariff_heading %></span>
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">Tariff tools</h1>
+    <%= page_header 'Tariff tools' %>
 
     <ul class="govuk-list">
       <% if TradeTariffFrontend::ServiceChooser.uk? %>

--- a/app/views/search/additional_codes/_form.erb
+++ b/app/views/search/additional_codes/_form.erb
@@ -1,5 +1,5 @@
 <%= form_tag additional_code_search_path, method: :get, class: "tariff-search quota-search #{@section_css}", id: 'new_search' do |f| %>
-  <h1 class="govuk-heading-l">Search by Additional Code</h1>
+  <%= page_header 'Search by Additional Code' %>
 
   <div class="govuk-form-group">
     <%= label_tag :type, 'Type', class: 'govuk-label' %>

--- a/app/views/search/certificate/_form.erb
+++ b/app/views/search/certificate/_form.erb
@@ -1,5 +1,5 @@
 <%= form_tag certificate_search_path, method: :get, class: "tariff-search quota-search #{@section_css}", id: 'new_search' do |f| %>
-  <h1 class="govuk-heading-l">Search by Certificate</h1>
+  <%= page_header 'Search by Certificate' %>
 
   <div class="govuk-form-group">
     <%= label_tag :type, 'Type', class: 'govuk-label' %>

--- a/app/views/search/chemicals/_form.erb
+++ b/app/views/search/chemicals/_form.erb
@@ -1,5 +1,5 @@
 <%= form_tag chemical_search_path, method: :get, class: "tariff-search quota-search #{@section_css}", id: 'new_search' do |f| %>
-  <h1 class="govuk-heading-l">Search by Chemical</h1>
+  <%= page_header 'Search by Chemical' %>
 
   <div class="govuk-form-group">
     <%= label_tag :type, 'CAS number', class: 'govuk-label' %>

--- a/app/views/search/footnotes/_form.erb
+++ b/app/views/search/footnotes/_form.erb
@@ -1,5 +1,6 @@
 <%= form_tag footnote_search_path, method: :get, class: "tariff-search quota-search #{@section_css}", id: 'new_search' do |f| %>
-  <h1 class="govuk-heading-l">Search by Footnote</h1>
+  <%= page_header 'Search by Footnote' %>
+
   <div class="govuk-form-group">
     <%= label_tag :type, 'Type', class: 'govuk-label' %>
     <%= select_tag :type, options_for_select(search_form.footnote_types, search_form.type), include_blank: true, class: "custom-select" %>

--- a/app/views/search/quotas/_form.html.erb
+++ b/app/views/search/quotas/_form.html.erb
@@ -1,6 +1,5 @@
 <%= form_tag quota_search_path, method: :get, class: "tariff-search quota-search #{@section_css}", id: 'new_search' do |f| %>
-  <span class="govuk-caption-xl govuk-!-margin-top-0"><%= trade_tariff_heading %></span>
-  <h1 class="govuk-heading-l">Search for quotas</h1>
+  <%= page_header 'Search for quotas' %>
 
   <div class="govuk-form-group">
     <div class="govuk-inset-text govuk-grid-column-one-half govuk-!-margin-top-0 govuk-!-margin-bottom-0">

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-l">Search results for &lsquo;<%= @search.q %>&rsquo;</h1>
+<%= page_header "Search results for &lsquo;#{h @search.q}&rsquo;".html_safe %>
 <article class="search-results govuk-!-padding-top-1">
   <% if @results.any? %>
     <% if @results.reference_match.commodities.any? %>

--- a/app/views/search_references/show.html.erb
+++ b/app/views/search_references/show.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <section class="a-z">
-  <h1 class="govuk-heading-l">A&ndash;Z of Classified Goods</h1>
+  <%= page_header 'A&ndash;Z of Classified Goods'.html_safe %>
 
   <div class="inner">
     <ol class="index govuk-list govuk-!-margin-bottom-8">

--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -4,7 +4,7 @@
       <%= trade_tariff_heading %>
     </span>
 
-    <%= switch_service_button %>
+    <%= switch_service_button if show_switch_service %>
   </span>
 
   <% if heading.present? %>

--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -1,6 +1,7 @@
 <header>
   <span class="govuk-caption-xl">
     <%= trade_tariff_heading %>
+    <%= switch_service_button %>
   </span>
 
   <% if heading.present? %>

--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <span class="govuk-caption-m">
+  <span class="govuk-caption-xl">
     <%= trade_tariff_heading %>
   </span>
 

--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -1,6 +1,9 @@
 <header>
   <span class="govuk-caption-xl">
-    <%= trade_tariff_heading %>
+    <span class="switch-service-control__caption">
+      <%= trade_tariff_heading %>
+    </span>
+
     <%= switch_service_button %>
   </span>
 

--- a/app/views/shared/_switch_banner.html.erb
+++ b/app/views/shared/_switch_banner.html.erb
@@ -1,7 +1,0 @@
-<% if is_switch_service_banner_enabled? %>
-  <div class="tariff-breadcrumbs js-tariff-breadcrumbs clt">
-    <nav>
-      <p><%= switch_banner_copy %></p>
-    </nav>
-  </div>
-<% end %>

--- a/app/views/shared/_switch_banner_bottom.html.erb
+++ b/app/views/shared/_switch_banner_bottom.html.erb
@@ -1,8 +1,6 @@
-<% if is_switch_service_banner_enabled? %>
-  <div class="tariff-breadcrumbs js-tariff-breadcrumbs clt">
-    <nav>
-      <p><%= switch_banner_bottom_copy %></p>
-      <%= switch_service_button %>
-    </nav>
-  </div>
-<% end %>
+<div class="tariff-breadcrumbs js-tariff-breadcrumbs clt">
+  <nav>
+    <p><%= switch_banner_bottom_copy %></p>
+    <%= switch_service_button %>
+  </nav>
+</div>

--- a/app/views/shared/_switch_banner_bottom.html.erb
+++ b/app/views/shared/_switch_banner_bottom.html.erb
@@ -2,10 +2,7 @@
   <div class="tariff-breadcrumbs js-tariff-breadcrumbs clt">
     <nav>
       <p><%= switch_banner_bottom_copy %></p>
-      <span class="switch_control">
-        <span class="arrow" />
-        <%= switch_service_bottom_link %>
-      </span>
+      <%= switch_service_button %>
     </nav>
   </div>
 <% end %>

--- a/app/webpacker/src/stylesheets/_feedback.scss
+++ b/app/webpacker/src/stylesheets/_feedback.scss
@@ -1,8 +1,4 @@
 .feedback-form {
-  h1 {
-    margin-top: 20px;
-  }
-
   .form-hint {
     margin-bottom: 20px;
     width: 75%;

--- a/app/webpacker/src/stylesheets/_switch_uk_xi_panel.scss
+++ b/app/webpacker/src/stylesheets/_switch_uk_xi_panel.scss
@@ -26,14 +26,22 @@
   }
 }
 
-header .switch-service-control {
-  @include govuk-media-query($from: tablet) {
-    margin-left: 2.4em;
+header {
+  .switch-service-control__caption {
+    @include govuk-media-query($from: tablet) {
+      margin-right: 1.2em;
+    }
   }
 
-  @include govuk-media-query($until: tablet) {
-    display: block;
-    padding: 0;
-    margin: 1em 0;
+  .switch-service-control {
+    @include govuk-media-query($from: tablet) {
+      margin-top: 0.8em;
+    }
+
+    @include govuk-media-query($until: tablet) {
+      display: block;
+      padding: 0;
+      margin: 1em 0;
+    }
   }
 }

--- a/app/webpacker/src/stylesheets/_switch_uk_xi_panel.scss
+++ b/app/webpacker/src/stylesheets/_switch_uk_xi_panel.scss
@@ -1,30 +1,39 @@
-.switch_control {
-    font-size: 14px;
-    position: relative;
-    top: -0.4em;
-    white-space: nowrap;
-    padding: 0.2em 1em 0.3em 0.75em;
-    padding-top: 0.2em;
-    border-radius: 4px;
+.switch-service-control {
+  @include govuk-font($size: 14);
+  position: relative;
+  top: -0.4em;
+  white-space: nowrap;
+  padding: 0.2em 1em 0.2em 0;
+  border-radius: 4px;
 
-    @media (min-width: $desktop-min-width) {
-      a {
-        color: govuk-colour("white");
-      }
-      background-color: #1D70B8;
+  .arrow:before {
+    content: "\2192";
+    color: govuk-colour("blue");
+  }
 
-      .arrow:before {
-        content: "\2192";
-        color: govuk-colour("white");
-      }
+  @include govuk-media-query($from: tablet) {
+    display: inline-block;
+    padding-left: 0.75em;
+    background-color: govuk-colour("blue");
+
+    a {
+      color: govuk-colour("white");
     }
 
-    @media (max-width: $small-table-breakpoint - 1) {
-      .arrow:before {
-        content: "\2192";
-        color: govuk-colour("blue");
-      }
-
-      padding-left: 0;
+    .arrow:before {
+      color: govuk-colour("white");
     }
+  }
+}
+
+header .switch-service-control {
+  @include govuk-media-query($from: tablet) {
+    margin-left: 2.4em;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    display: block;
+    padding: 0;
+    margin: 1em 0;
+  }
 }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -215,7 +215,8 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       it { is_expected.to have_css 'header span.govuk-caption-xl', text: I18n.t('title.service_name.uk') }
       it { is_expected.to have_css 'header h1.govuk-heading-l', text: 'Test header' }
-      it { is_expected.to have_css 'header *', count: 2 }
+      it { is_expected.to have_css 'header > *', count: 2 }
+      it { is_expected.to have_css 'header span.switch-service-control' }
     end
 
     context 'with block' do
@@ -223,7 +224,8 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       it { is_expected.to have_css 'header span.govuk-caption-xl', text: I18n.t('title.service_name.uk') }
       it { is_expected.to have_css 'header h1.govuk-heading-l', text: 'Second header' }
-      it { is_expected.to have_css 'header *', count: 3 }
+      it { is_expected.to have_css 'header > *', count: 3 }
+      it { is_expected.to have_css 'header span.switch-service-control' }
       it { is_expected.to have_css 'header em', text: 'additional content' }
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     context 'without block' do
       subject { helper.page_header 'Test header' }
 
-      it { is_expected.to have_css 'header span.govuk-caption-m', text: I18n.t('title.service_name.uk') }
+      it { is_expected.to have_css 'header span.govuk-caption-xl', text: I18n.t('title.service_name.uk') }
       it { is_expected.to have_css 'header h1.govuk-heading-l', text: 'Test header' }
       it { is_expected.to have_css 'header *', count: 2 }
     end
@@ -221,7 +221,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     context 'with block' do
       subject { helper.page_header('Second header') { tag.em 'additional content' } }
 
-      it { is_expected.to have_css 'header span.govuk-caption-m', text: I18n.t('title.service_name.uk') }
+      it { is_expected.to have_css 'header span.govuk-caption-xl', text: I18n.t('title.service_name.uk') }
       it { is_expected.to have_css 'header h1.govuk-heading-l', text: 'Second header' }
       it { is_expected.to have_css 'header *', count: 3 }
       it { is_expected.to have_css 'header em', text: 'additional content' }
@@ -232,7 +232,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       include_context 'with XI service'
 
-      it { is_expected.to have_css 'header span.govuk-caption-m', text: I18n.t('title.service_name.xi') }
+      it { is_expected.to have_css 'header span.govuk-caption-xl', text: I18n.t('title.service_name.xi') }
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -210,6 +210,13 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe '#page_header' do
+    before do
+      allow(helper).to receive(:is_switch_service_banner_enabled?)
+                         .and_return switch_banner
+    end
+
+    let(:switch_banner) { true }
+
     context 'without block' do
       subject { helper.page_header 'Test header' }
 
@@ -235,6 +242,12 @@ RSpec.describe ApplicationHelper, type: :helper do
       include_context 'with XI service'
 
       it { is_expected.to have_css 'header span.govuk-caption-xl', text: I18n.t('title.service_name.xi') }
+    end
+
+    context 'with switch banner disabled' do
+      let(:switch_banner) { false }
+
+      it { is_expected.not_to have_css 'span.switch-service-control' }
     end
   end
 end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -137,6 +137,28 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
+  describe '#switch_service_button' do
+    subject { helper.switch_service_button }
+
+    before { allow(helper).to receive(:current_path).and_return '/some_path' }
+
+    context 'with UK service' do
+      include_context 'with UK service'
+
+      it { is_expected.to have_css 'span.switch_control span.arrow', text: nil }
+      it { is_expected.to have_css 'span.switch_control a.govuk-link--no-underline' }
+      it { is_expected.to have_link 'Switch to the Northern Ireland Online Tariff', href: '/xi/some_path' }
+    end
+
+    context 'with XI' do
+      include_context 'with XI service'
+
+      it { is_expected.to have_css 'span.switch_control span.arrow', text: nil }
+      it { is_expected.to have_css 'span.switch_control a.govuk-link--no-underline' }
+      it { is_expected.to have_link 'Switch to the UK Integrated Online Tariff', href: '/some_path' }
+    end
+  end
+
   describe '#switch_banner_copy' do
     before do
       helper.request.path = path

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -145,16 +145,16 @@ RSpec.describe ServiceHelper, type: :helper do
     context 'with UK service' do
       include_context 'with UK service'
 
-      it { is_expected.to have_css 'span.switch_control span.arrow', text: nil }
-      it { is_expected.to have_css 'span.switch_control a.govuk-link--no-underline' }
+      it { is_expected.to have_css 'span.switch-service-control span.arrow', text: nil }
+      it { is_expected.to have_css 'span.switch-service-control a.govuk-link--no-underline' }
       it { is_expected.to have_link 'Switch to the Northern Ireland Online Tariff', href: '/xi/some_path' }
     end
 
     context 'with XI' do
       include_context 'with XI service'
 
-      it { is_expected.to have_css 'span.switch_control span.arrow', text: nil }
-      it { is_expected.to have_css 'span.switch_control a.govuk-link--no-underline' }
+      it { is_expected.to have_css 'span.switch-service-control span.arrow', text: nil }
+      it { is_expected.to have_css 'span.switch-service-control a.govuk-link--no-underline' }
       it { is_expected.to have_link 'Switch to the UK Integrated Online Tariff', href: '/some_path' }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,8 @@ RSpec.configure do |config|
   config.include Capybara::DSL
   config.include ApiResponsesHelper
 
+  config.include_context 'with switch service banner', type: :view
+
   config.before do
     allow(TariffUpdate).to receive(:all).and_return([OpenStruct.new(updated_at: Time.zone.today)])
     allow(NewsItem).to receive(:any_updates?).and_return true

--- a/spec/support/shared_context/service_chooser.rb
+++ b/spec/support/shared_context/service_chooser.rb
@@ -18,3 +18,12 @@ RSpec.shared_context 'with default service' do
       receive(:service_choice).and_return nil
   end
 end
+
+RSpec.shared_context 'with switch service banner' do
+  before do
+    allow(view).to receive(:is_switch_service_banner_enabled?)
+                     .and_return(show_switch_service_banner)
+  end
+
+  let(:show_switch_service_banner) { true }
+end


### PR DESCRIPTION
### Jira link

[HOTT-1050](https://transformuk.atlassian.net/browse/HOTT-1050)

### What?

I have added/removed/altered:

- [x] Fixed the size of the caption in headings generated by the `page_header` helper
- [x] Refactored the switch service button to allow for reuse in the header
- [x] Added the switch service button into headings generated by the `page_header` helper method
- [x] Switch all applicable pages to use the `page_header` helper rather than coding their own page headings
- [x] Removed use of the old switch service banner
- [x] Refactored the switch_service_banner configuration to default to on, but still allow turning it off

### Why?

I am doing this because:

- We want to use the new style switch service link and want it to be part of the page heading

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, potentially there may be a page missing a switch service link but I can't find any

### Before

![Screenshot from 2021-11-26 15-03-49](https://user-images.githubusercontent.com/10818/143600636-8a6f9850-198d-4fcb-b55a-3da48e0b7cd7.png)

### After

![Screenshot from 2021-11-26 15-08-46](https://user-images.githubusercontent.com/10818/143600657-3fc310f4-7340-40ef-9071-854d619c4952.png)

