### PR TITLE
HOTT-1135 Removed reference to UK in browse page copy

### DIFF
--- a/app/views/browse_sections/index.html.erb
+++ b/app/views/browse_sections/index.html.erb
@@ -16,7 +16,7 @@
 <%= page_header 'Browse the tariff' %>
 
 <p>
-  The UK goods classification contains <%= pluralize @sections.length, 'section' %>,
+  The goods classification contains <%= pluralize @sections.length, 'section' %>,
   listed below. Choose the section that best matches your goods to see the
   <abbr title="Harmonised System">HS</abbr> chapters that are contained in the
   section.


### PR DESCRIPTION
### Jira link

[HOTT-11035](https://transformuk.atlassian.net/browse/HOTT-1135)

### What?

I have added/removed/altered:

- [x] Updated copy on the browse page to remove reference to the UK service

### Why?

I am doing this because:

- Previously the copy was always referring to the UK service, even on the XI service

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None
