### PR TITLE
HOTT-1136 Show XI content on find commodity page

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -82,6 +82,10 @@ module ServiceHelper
     t("service_banner.bottom.#{service_choice}")
   end
 
+  def region_name
+    t("title.region_name.#{service_choice}")
+  end
+
 private
 
   def service_name

--- a/app/views/find_commodities/show.html.erb
+++ b/app/views/find_commodities/show.html.erb
@@ -9,11 +9,11 @@
     </h2>
 
     <p>
-      The UK Integrated Online Tariff helps you to:
+      The <%= service_name %> helps you to:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>find commodity codes for imports into or exports out of the UK</li>
+      <li>find commodity codes for imports into or exports out of <%= region_name %></li>
       <li>find the taxes and duties that apply to those imports</li>
       <li>find out which certificates and licences apply to the import of your goods</li>
     </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,9 @@ en:
     service_name:
       uk: "UK Integrated Online Tariff"
       xi: "Northern Ireland Online Tariff"
+    region_name:
+      uk: the UK
+      xi: Northern Ireland
   h1:
     service_description: "Look up commodity codes, duty and VAT rates"
     service_name:

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -199,4 +199,36 @@ RSpec.describe ServiceHelper, type: :helper do
       end
     end
   end
+
+  describe '.service_name' do
+    subject { service_name }
+
+    context 'with UK service' do
+      include_context 'with UK service'
+
+      it { is_expected.to eql 'UK Integrated Online Tariff' }
+    end
+
+    context 'with XI service' do
+      include_context 'with XI service'
+
+      it { is_expected.to eql 'Northern Ireland Online Tariff' }
+    end
+  end
+
+  describe '.region_name' do
+    subject { region_name }
+
+    context 'with UK service' do
+      include_context 'with UK service'
+
+      it { is_expected.to eql 'the UK' }
+    end
+
+    context 'with XI service' do
+      include_context 'with XI service'
+
+      it { is_expected.to eql 'Northern Ireland' }
+    end
+  end
 end


### PR DESCRIPTION
Previously we were referring to the UK service whilst on the XI version of the find commodity page

### Jira link

[HOTT-1136](https://transformuk.atlassian.net/browse/HOTT-1136)

### What?

I have added/removed/altered:

- [x] Updated the copy on the find commodity page for the XI service
- [x] Added a `region_name` helper for the above
- [x] Added some missing specs to the existing `service_name` helper

### Why?

I am doing this because:

- We should be referring to Northern Ireland on the XI service
