### PR TITLE
Hott 1138 fix breadcrumbs aria role

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,16 +15,20 @@ module ApplicationHelper
   end
 
   def generate_breadcrumbs(current_page, previous_pages)
-    crumbs = [
-      previous_pages.map do |title, link|
-        tag.li(nil, class: 'govuk-breadcrumbs__list-item') do
-          link_to(title, link, class: 'govuk-breadcrumbs__link')
-        end
-      end,
-      tag.li(current_page, class: 'govuk-breadcrumbs__list-item', aria: { current: 'page' }),
-    ]
+    breadcrumbs = previous_pages.map do |title, link|
+      tag.li class: 'govuk-breadcrumbs__list-item' do
+        link_to title, link, class: 'govuk-breadcrumbs__link'
+      end
+    end
 
-    tag.div(class: 'govuk-breadcrumbs') { tag.ol(crumbs.join('').html_safe, class: 'govuk-breadcrumbs__list', role: 'breadcrumbs') }
+    breadcrumbs << tag.li(current_page, class: 'govuk-breadcrumbs__list-item',
+                                        aria: { current: 'page' })
+
+    tag.div class: 'govuk-breadcrumbs' do
+      tag.ol class: 'govuk-breadcrumbs__list', role: 'breadcrumbs' do
+        safe_join breadcrumbs, "\n"
+      end
+    end
   end
 
   def page_header(heading, &block)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,8 +24,8 @@ module ApplicationHelper
     breadcrumbs << tag.li(current_page, class: 'govuk-breadcrumbs__list-item',
                                         aria: { current: 'page' })
 
-    tag.div class: 'govuk-breadcrumbs' do
-      tag.ol class: 'govuk-breadcrumbs__list', role: 'breadcrumbs' do
+    tag.nav class: 'govuk-breadcrumbs', aria: { label: 'Breadcrumb' } do
+      tag.ol class: 'govuk-breadcrumbs__list' do
         safe_join breadcrumbs, "\n"
       end
     end

--- a/app/views/shared/_top_breadcrumbs.html.erb
+++ b/app/views/shared/_top_breadcrumbs.html.erb
@@ -1,5 +1,5 @@
 <% if @section %>
-  <div class="govuk-breadcrumbs">
+  <nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <%= link_to "Home", sections_path, class:'govuk-breadcrumbs__link' %>
@@ -27,13 +27,13 @@
         <% end %>
 
         <% if @commodity %>
-          <li class="govuk-breadcrumbs__list-item">
+          <li class="govuk-breadcrumbs__list-item" aria-current="page">
             Commodity <%= @commodity.short_code %>
           </li>
         <% end %>
       <% end %>
     </ol>
-  </div>
+  </nav>
 <% end %>
 
 <%= yield :top_breadcrumbs %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe ApplicationHelper, type: :helper do
     context 'with single page' do
       subject { generate_breadcrumbs 'Current Page', [] }
 
-      it { is_expected.to have_css 'div.govuk-breadcrumbs ol.govuk-breadcrumbs__list' }
+      it { is_expected.to have_css 'nav.govuk-breadcrumbs[aria-label="Breadcrumb"]' }
+      it { is_expected.to have_css 'nav ol.govuk-breadcrumbs__list' }
       it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item', count: 1 }
       it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item a.govuk-breadcrumbs__link', count: 0 }
       it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item', text: 'Current Page' }
@@ -64,7 +65,8 @@ RSpec.describe ApplicationHelper, type: :helper do
     context 'with nested pages' do
       subject { generate_breadcrumbs 'Current Page', [['Previous Page', '/']] }
 
-      it { is_expected.to have_css 'div.govuk-breadcrumbs ol.govuk-breadcrumbs__list' }
+      it { is_expected.to have_css 'nav.govuk-breadcrumbs[aria-label="Breadcrumb"]' }
+      it { is_expected.to have_css 'nav ol.govuk-breadcrumbs__list' }
       it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item', count: 2 }
       it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item a.govuk-breadcrumbs__link', count: 1 }
       it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item', text: 'Current Page' }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -52,12 +52,23 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe '.generate_breadcrumbs' do
-    it 'returns current page list item' do
-      expect(helper.generate_breadcrumbs('Current Page', [])).to match(/Current Page/)
+    context 'with single page' do
+      subject { generate_breadcrumbs 'Current Page', [] }
+
+      it { is_expected.to have_css 'div.govuk-breadcrumbs ol.govuk-breadcrumbs__list' }
+      it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item', count: 1 }
+      it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item a.govuk-breadcrumbs__link', count: 0 }
+      it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item', text: 'Current Page' }
     end
 
-    it 'returns previous pages breadcrumbs' do
-      expect(helper.generate_breadcrumbs('Current Page', [['Previous Page', '/']])).to match(/Previous Page/)
+    context 'with nested pages' do
+      subject { generate_breadcrumbs 'Current Page', [['Previous Page', '/']] }
+
+      it { is_expected.to have_css 'div.govuk-breadcrumbs ol.govuk-breadcrumbs__list' }
+      it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item', count: 2 }
+      it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item a.govuk-breadcrumbs__link', count: 1 }
+      it { is_expected.to have_css 'ol li.govuk-breadcrumbs__list-item', text: 'Current Page' }
+      it { is_expected.to have_link 'Previous Page', href: '/' }
     end
   end
 


### PR DESCRIPTION
### Jira link

[HOTT-1138](https://transformuk.atlassian.net/browse/HOTT-1138)

### What?

I have added/removed/altered:

- [x] Refactored the breadcrumbs generator and improved specs
- [x] Changed the generator to produce aria compliant breadcrumbs (according to the [W3C recommendations](https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html))
- [x] Added ARIA labelling to the breadcrumbs on the Commodities and Headings pages

### Why?

I am doing this because:

- the aXe tool identifed our breadcrumbs were using invalid markup

