### PR TITLE
HOTT-1139: Multiple Rules of Origin schemes

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -12,7 +12,7 @@ class CommoditiesController < GoodsNomenclaturesController
     @section = commodity.section
 
     if params[:country].present? && @search.geographical_area
-      @rules_of_origin = commodity.rules_of_origin(params[:country])
+      @rules_of_origin_schemes = commodity.rules_of_origin(params[:country])
     end
   end
 

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -15,7 +15,7 @@ class HeadingsController < GoodsNomenclaturesController
     @chapter = heading.chapter
 
     if params[:country].present? && @search.geographical_area
-      @rules_of_origin = heading.rules_of_origin(params[:country])
+      @rules_of_origin_schemes = heading.rules_of_origin(params[:country])
     end
   end
 

--- a/app/helpers/rules_of_origin_helper.rb
+++ b/app/helpers/rules_of_origin_helper.rb
@@ -8,22 +8,25 @@ module RulesOfOriginHelper
 
   def rules_of_origin_schemes_intro(country_name, schemes)
     if schemes.empty?
-      return render 'rules_of_origin/intros/no_scheme',
-                    country_name: country_name
-    end
-
-    schemes_intros = schemes.map do |scheme|
-      partial = if scheme.countries.one? then 'country'
-                elsif scheme.unilateral then 'unilateral_trade_bloc'
-                else 'trade_bloc'
-                end
-
-      render "rules_of_origin/intros/#{partial}",
+      render 'rules_of_origin/intros/no_scheme',
+             country_name: country_name
+    elsif schemes.many?
+      render 'rules_of_origin/intros/multiple_schemes',
              country_name: country_name,
-             scheme: scheme
+             schemes: schemes
+    elsif schemes.first.countries.one?
+      render 'rules_of_origin/intros/country',
+             country_name: country_name,
+             scheme: schemes.first
+    elsif schemes.first.unilateral
+      render 'rules_of_origin/intros/unilateral_trade_bloc',
+             country_name: country_name,
+             scheme: schemes.first
+    else
+      render 'rules_of_origin/intros/trade_bloc',
+             country_name: country_name,
+             scheme: schemes.first
     end
-
-    safe_join schemes_intros, "\n\n"
   end
 
   def rules_of_origin_tagged_descriptions(content)

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -15,4 +15,4 @@
            declarable: @commodity,
            xi_declarable: xi_commodity,
            uk_declarable: uk_commodity,
-           rules_of_origin: @rules_of_origin %>
+           rules_of_origin_schemes: @rules_of_origin_schemes %>

--- a/app/views/declarables/_declarable.html.erb
+++ b/app/views/declarables/_declarable.html.erb
@@ -6,5 +6,5 @@
              declarable: declarable,
              uk_declarable: uk_declarable,
              xi_declarable: xi_declarable,
-             rules_of_origin: rules_of_origin %>
+             rules_of_origin_schemes: rules_of_origin_schemes %>
 </article>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -18,7 +18,7 @@
              declarable: @heading,
              uk_declarable: uk_heading,
              xi_declarable: xi_heading,
-             rules_of_origin: @rules_of_origin %>
+             rules_of_origin_schemes: @rules_of_origin_schemes %>
 <% else %>
   <article class="tariff">
     <div class="commodity-tree">

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -124,7 +124,7 @@
                  country_code: @search.country,
                  country_name: @search.geographical_area.description,
                  commodity_code: declarable.code,
-                 rules_of_origin: rules_of_origin %>
+                 rules_of_origin_schemes: rules_of_origin_schemes %>
     <%- else -%>
       <%= render 'rules_of_origin/without_country' %>
     <%- end -%>

--- a/app/views/rules_of_origin/_introductory_notes.html.erb
+++ b/app/views/rules_of_origin/_introductory_notes.html.erb
@@ -34,21 +34,19 @@
       <li>check column 2 to find the description that applies to the product</li>
 
       <li>
-        check column 3 <!--(and 4 if present)//--> to see how the product must
+        check column 3 to see how the product must
         be worked or processed to gain country of origin status
       </li>
     </ul>
 
     <p>
-      Unless preceded by ‘ex’, the rules in column 3 <!--(or 4 if present)//-->
-      apply to all products that come under the headings and chapters in column
-      1.
+      Unless preceded by ‘ex’, the rules in column 3 apply to all products that
+      come under the headings and chapters in column 1.
     </p>
 
     <p>
       If the heading in column 1 starts with ‘ex’, the rules in column 3
-      <!--(and 4 if present)//--> will only apply to the product as described
-      in column 2.
+      will only apply to the product as described in column 2.
     </p>
 
     <h2 class="govuk-heading-m">Introductory notes</h2>

--- a/app/views/rules_of_origin/_proofs.html.erb
+++ b/app/views/rules_of_origin/_proofs.html.erb
@@ -1,5 +1,11 @@
 <div class="rules-of-origin__proofs">
   <% if proofs.any? %>
+    <% if scheme_title %>
+      <span class="govuk-caption-l">
+        <%= scheme_title %>
+      </span>
+    <% end %>
+
     <h3 class="govuk-heading-m">
       Proving originating status and claiming preferential treatment
     </h3>

--- a/app/views/rules_of_origin/_scheme.html.erb
+++ b/app/views/rules_of_origin/_scheme.html.erb
@@ -1,0 +1,27 @@
+<div class="rules-of-origin__scheme govuk-!-margin-bottom-7">
+  <h3 class="govuk-heading-m">
+    <% if multiple_schemes %>
+      <span class="govuk-caption-l">
+        <%= scheme.title %>
+      </span>
+    <% end %>
+
+    Product-specific rules for commodity <%= commodity_code %>
+  </h3>
+
+  <%- if scheme.rules.any? -%>
+    <%= render 'rules_of_origin/rules_table', country_name: country_name,
+                                              rules: scheme.rules %>
+
+    <%= render 'rules_of_origin/introductory_notes',
+               introductory_notes: scheme.introductory_notes %>
+  <%- else -%>
+    <p>
+      There are no product-specific rules for commodity <%= commodity_code %>
+    </p>
+  <%- end -%>
+
+  <%= render 'rules_of_origin/proofs',
+              proofs: scheme.proofs,
+              scheme_title: (multiple_schemes ? scheme.title : nil) %>
+</div>

--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -5,20 +5,20 @@
       <%= country_flag_tag country_code, alt: "Flag for #{country_name}" %>
     </h2>
 
-    <%= rules_of_origin_schemes_intro country_name, rules_of_origin %>
+    <%= rules_of_origin_schemes_intro country_name, rules_of_origin_schemes %>
 
     <%= render partial: 'rules_of_origin/scheme',
-               collection: rules_of_origin,
+               collection: rules_of_origin_schemes,
                locals: {
                  country_name: country_name,
                  commodity_code: commodity_code,
-                 multiple_schemes: rules_of_origin.many?
+                 multiple_schemes: rules_of_origin_schemes.many?
                } %>
 
     <%= render 'rules_of_origin/non_preferential' %>
   </div>
 
-  <% if rules_of_origin.flat_map(&:links).any? %>
+  <% if rules_of_origin_schemes.flat_map(&:links).any? %>
   <div class="govuk-grid-column-one-third" id="rules-of-origin__related-content">
     <h2 class="govuk-heading-m">
       Related content
@@ -26,7 +26,7 @@
 
     <nav role="navigation">
       <ul class="govuk-list govuk-list-s">
-        <% rules_of_origin.flat_map(&:links).each do |link| %>
+        <% rules_of_origin_schemes.flat_map(&:links).each do |link| %>
           <li>
             <%= link_to link.text, link.url %>
           </li>

--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -15,18 +15,6 @@
                  multiple_schemes: rules_of_origin.many?
                } %>
 
-    <% rules_of_origin.map(&:fta_intro).map(&:presence).compact.each do |fta_intro| %>
-    <div class="rules-of-origin-fta">
-      <h3 class="govuk-heading-m">
-        Trading relationship with <%= country_name %>
-      </h3>
-
-      <div class="tariff-markdown">
-        <%= govspeak fta_intro %>
-      </div>
-    </div>
-    <% end %>
-
     <%= render 'rules_of_origin/non_preferential' %>
   </div>
 

--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -7,25 +7,13 @@
 
     <%= rules_of_origin_schemes_intro country_name, rules_of_origin %>
 
-    <h3 class="govuk-heading-m">
-      Product-specific rules for commodity <%= commodity_code %>
-    </h3>
-
-    <%- if (rules = rules_of_origin.flat_map(&:rules)).any? -%>
-      <%= render 'rules_of_origin/rules_table',
+    <%= render partial: 'rules_of_origin/scheme',
+               collection: rules_of_origin,
+               locals: {
                  country_name: country_name,
-                 rules: rules %>
-
-      <%= render partial: 'rules_of_origin/introductory_notes',
-                 collection: rules_of_origin.map(&:introductory_notes) %>
-    <%- else -%>
-      <p>
-        There are no product-specific rules for commodity <%= commodity_code %>
-      </p>
-    <%- end -%>
-
-    <%= render partial: 'rules_of_origin/proofs',
-               collection: rules_of_origin.map(&:proofs) %>
+                 commodity_code: commodity_code,
+                 multiple_schemes: rules_of_origin.many?
+               } %>
 
     <% rules_of_origin.map(&:fta_intro).map(&:presence).compact.each do |fta_intro| %>
     <div class="rules-of-origin-fta">

--- a/app/views/rules_of_origin/intros/_multiple_schemes.html.erb
+++ b/app/views/rules_of_origin/intros/_multiple_schemes.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-inset-text" id="rules-of-origin__intro--multiple-schemes">
+  <p>
+    Your trade may qualify for preferential rates with <%= country_name %>
+    through <%= schemes.length %> agreements. Check the rules of origin
+    applicable to each of these agreements.
+  </p>
+
+  <ul>
+    <% schemes.each do |scheme| %>
+      <li><%= scheme.title %></li>
+    <% end %>
+  </ul>
+</div>

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CommoditiesController, type: :controller do
         it { expect(assigns(:chapter)).to be_present }
         it { expect(assigns(:heading)).to be_present }
         it { expect(assigns(:commodity)).to be_present }
-        it { expect(assigns(:rules_of_origin)).to be_nil }
+        it { expect(assigns(:rules_of_origin_schemes)).to be_nil }
       end
 
       context 'with non-existant commodity id provided', vcr: { cassette_name: 'commodities#show_0101999999' } do

--- a/spec/controllers/headings_controller_spec.rb
+++ b/spec/controllers/headings_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe HeadingsController, type: :controller do
       it { is_expected.to respond_with(:success) }
       it { expect(assigns(:heading)).to be_a(HeadingPresenter) }
       it { expect(assigns(:commodities)).to be_a(HeadingCommodityPresenter) }
-      it { expect(assigns(:rules_of_origin)).to be_nil }
+      it { expect(assigns(:rules_of_origin_schemes)).to be_nil }
     end
 
     context 'with non-existent chapter id provided', vcr: { cassette_name: 'headings#show_0110' } do

--- a/spec/helpers/rules_of_origin_helper_spec.rb
+++ b/spec/helpers/rules_of_origin_helper_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe RulesOfOriginHelper, type: :helper do
       it { is_expected.not_to have_css '#rules-of-origin__intro--country-scheme' }
       it { is_expected.to have_css '#rules-of-origin__intro--unilateral-scheme' }
     end
+
+    context 'with multiple schemes' do
+      let(:schemes) { build_list :rules_of_origin_scheme, 2, countries: %w[FR ES] }
+
+      it { is_expected.not_to have_css '#rules-of-origin__intro--no-scheme' }
+      it { is_expected.not_to have_css '#rules-of-origin__intro--block-scheme' }
+      it { is_expected.not_to have_css '#rules-of-origin__intro--country-scheme' }
+      it { is_expected.not_to have_css '#rules-of-origin__intro--unilateral-scheme' }
+      it { is_expected.to have_css '#rules-of-origin__intro--multiple-schemes' }
+      it { is_expected.to have_css '#rules-of-origin__intro--multiple-schemes li', count: 2 }
+    end
   end
 
   describe '#rules_of_origin_tagged_descriptions' do

--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
              declarable: presented_commodity,
              uk_declarable: presented_commodity,
              xi_declarable: nil,
-             rules_of_origin: []
+             rules_of_origin_schemes: []
     end
 
     context 'without country selected' do
@@ -63,7 +63,7 @@ RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
              declarable: presented_commodity,
              uk_declarable: presented_commodity,
              xi_declarable: presented_commodity,
-             rules_of_origin: []
+             rules_of_origin_schemes: []
     end
 
     context 'without country selected' do

--- a/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 RSpec.describe 'rules_of_origin/_proofs.html.erb', type: :view do
   subject(:rendered_page) { render_page && rendered }
 
-  let(:render_page) { render 'rules_of_origin/proofs', proofs: proofs }
+  let(:render_page) do
+    render 'rules_of_origin/proofs', proofs: proofs, scheme_title: nil
+  end
 
   context 'with no proofs' do
     let(:proofs) { [] }

--- a/spec/views/rules_of_origin/_rules_table.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_rules_table.html.erb_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/_rules_table.html.erb', type: :view do
+  subject(:rendered_page) { render_page && rendered }
+
+  let(:country_name) { 'Kenya' }
+  let(:scheme) { build :rules_of_origin_scheme }
+
+  let :rules do
+    build_list :rules_of_origin_rule, 3, rule: "Manufacture\n\n* From materials"
+  end
+
+  let :render_page do
+    render 'rules_of_origin/rules_table', rules: rules,
+                                          country_name: country_name
+  end
+
+  it 'shows rules table' do
+    expect(rendered_page).to have_css 'table.govuk-table'
+  end
+
+  it 'shows row per rule' do
+    expect(rendered_page).to have_css 'tbody tr', count: 3
+  end
+
+  it 'show rule heading' do
+    expect(rendered_page).to \
+      have_css 'tbody tr td', text: rules.first.heading
+  end
+
+  it 'shows rule description' do
+    expect(rendered_page).to \
+      have_css 'tbody tr td', text: rules.first.description
+  end
+
+  it 'formats the rule detail markdown' do
+    expect(rendered_page).to \
+      have_css '.tariff-markdown ul li', text: 'From materials'
+  end
+
+  context 'with UK service' do
+    include_context 'with UK service'
+
+    it 'references the country in the introductory text' do
+      expect(rendered_page).to \
+        have_css 'p', text: /originating in the UK or #{country_name}/
+    end
+  end
+
+  context 'with XI service' do
+    include_context 'with XI service'
+
+    it 'references the country in the introductory text' do
+      expect(rendered_page).to \
+        have_css 'p', text: /originating in the EU or #{country_name}/
+    end
+  end
+end

--- a/spec/views/rules_of_origin/_scheme.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_scheme.html.erb_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/_scheme.html.erb', type: :view do
+  subject(:rendered_page) { render_page && rendered }
+
+  let(:country_name) { 'Kenya' }
+  let(:commodity_code) { '0302111000' }
+  let(:multiple_schemes) { true }
+  let(:scheme) { build :rules_of_origin_scheme }
+
+  let :render_page do
+    render 'rules_of_origin/scheme', scheme: scheme,
+                                     country_name: country_name,
+                                     commodity_code: commodity_code,
+                                     multiple_schemes: multiple_schemes
+  end
+
+  it 'includes comm code' do
+    expect(rendered_page).to have_css '.rules-of-origin__scheme h3',
+                                      text: /rules for commodity 0302111000/
+  end
+
+  describe 'scheme caption' do
+    context 'with single scheme' do
+      let(:multiple_schemes) { false }
+
+      it { is_expected.not_to have_css 'h3 span' }
+    end
+
+    context 'with multiple schemes' do
+      it { is_expected.to have_css 'h3 span' }
+    end
+  end
+
+  it { is_expected.to have_css 'table.commodity-rules-of-origin' }
+  it { is_expected.not_to have_css 'p', text: /no product-specific rules/ }
+
+  it 'includes the introductory_notes section' do
+    expect(rendered_page).to have_css 'details .tariff-markdown p',
+                                      text: /Details of introductory notes/
+  end
+
+  context 'with no rules' do
+    let(:scheme) { build :rules_of_origin_scheme, rule_count: 0 }
+
+    it { is_expected.not_to have_css 'table.commodity-rules-of-origin' }
+    it { is_expected.not_to have_css 'details.govuk-details' }
+    it { is_expected.to have_css 'p', text: /no product-specific rules/ }
+  end
+end

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
            country_code: 'FR',
            country_name: 'France',
            commodity_code: '2203000100',
-           rules_of_origin: schemes
+           rules_of_origin_schemes: schemes
   end
 
   let :rules_data do

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -44,26 +44,8 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
     expect(rendered_page).to have_css '#rules-of-origin__intro--bloc-scheme'
   end
 
-  it 'includes the proofs' do
-    expect(rendered_page).to have_css '.rules-of-origin__proofs'
-  end
-
-  context 'with UK service' do
-    include_context 'with UK service'
-
-    it 'references the country in the introductory text' do
-      expect(rendered_page).to \
-        have_css 'p', text: /originating in the UK or France/
-    end
-  end
-
-  context 'with XI service' do
-    include_context 'with XI service'
-
-    it 'references the country in the introductory text' do
-      expect(rendered_page).to \
-        have_css 'p', text: /originating in the EU or France/
-    end
+  it 'includes the schemes' do
+    expect(rendered_page).to have_css '.rules-of-origin__scheme', count: 1
   end
 
   context 'with matched rules of origin' do
@@ -73,34 +55,10 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
       expect(rendered_page).to have_css 'table.govuk-table'
     end
 
-    it 'shows row per rule' do
-      expect(rendered_page).to have_css 'tbody tr', count: 1
-    end
-
-    it 'show rule heading' do
-      expect(rendered_page).to \
-        have_css 'tbody tr td', text: first_rule.heading
-    end
-
-    it 'shows rule description' do
-      expect(rendered_page).to \
-        have_css 'tbody tr td', text: first_rule.description
-    end
-
-    it 'formats the rule detail markdown' do
-      expect(rendered_page).to \
-        have_css '.tariff-markdown ul li', text: 'From materials'
-    end
-
     it 'formats the scheme fta_intro markdown' do
       expect(rendered_page).to \
         have_css '.rules-of-origin-fta .tariff-markdown h2',
                  text: 'Free Trade Agreement'
-    end
-
-    it 'includes the introductory_notes section' do
-      expect(rendered_page).to have_css 'details .tariff-markdown p',
-                                        text: /Details of introductory notes/
     end
 
     it 'includes the non-preferential bloc' do
@@ -120,10 +78,6 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
         have_css 'p', text: /no product-specific rules for commodity \d{10}/
     end
 
-    it 'excludes the introductory_notes section' do
-      expect(rendered_page).not_to have_css 'details .tariff-markdown'
-    end
-
     it 'includes the non-preferential bloc' do
       expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
     end
@@ -141,9 +95,23 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
     let(:schemes) { [] }
 
     it { is_expected.to have_css '#rules-of-origin__intro--no-scheme' }
+    it { is_expected.not_to have_css '.rules-of-origin__scheme' }
 
     it 'includes the non-preferential bloc' do
       expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
+    end
+  end
+
+  context 'with multiple schemes' do
+    let(:schemes) do
+      build_list :rules_of_origin_scheme, 3, rules: rules_data,
+                                             fta_intro: fta_intro
+    end
+
+    it { is_expected.to have_css '.rules-of-origin__scheme', count: 3 }
+
+    it 'includes one non-preferential bloc' do
+      expect(rendered_page).to have_css '.rules-of-origin__non-preferential', count: 1
     end
   end
 

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -55,12 +55,6 @@ RSpec.describe 'rules_of_origin/_tab.html.erb', type: :view do
       expect(rendered_page).to have_css 'table.govuk-table'
     end
 
-    it 'formats the scheme fta_intro markdown' do
-      expect(rendered_page).to \
-        have_css '.rules-of-origin-fta .tariff-markdown h2',
-                 text: 'Free Trade Agreement'
-    end
-
     it 'includes the non-preferential bloc' do
       expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
     end


### PR DESCRIPTION
### Jira link

[HOTT-1139](https://transformuk.atlassian.net/browse/HOTT-1139)

### What?

I have added/removed/altered:

- [x] Added a new intro text for when there are multiple available Rules of Origin schemes
- [x] Grouped the rules and intro text blocks together
- [x] Show captions on the sections headings when there are multiple schemes
- [x] Dropped the fta_intro content from the RoO tab
- [x] Refactored some of the view specs to make it clearer and easier to update in the future
- [x] Renamed the `rules_of_origin` variable to `rules_of_origin_schemes` to remove potential confusion for future developers

### Why?

I am doing this because:

- The previous layout did not allow for when there were multiple RoO schemes - the new layout explicitly takes account of that scenario

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- The variable name change could cause errors if any usages have been missed
