### PR TITLE
HOTT-1144 Fix breadcrumb alignment

### DIFF
--- a/app/webpacker/src/stylesheets/tariff-custom.scss
+++ b/app/webpacker/src/stylesheets/tariff-custom.scss
@@ -38,22 +38,6 @@
   }
 }
 
-#content,
-#global-header-bar,
-#global-cookie-message p,
-#footer > .govuk-width-container,
-.tariff.service.govuk-width-container {
-  max-width: 1140px !important;
-
-  @media (min-width: 1020px) {
-    margin: 0 30px !important;
-  }
-
-  @media (min-width: 1190px) {
-    margin: 0 auto !important;
-  }
-}
-
 .govuk-heading-l a {
   text-decoration: none;
   &:hover {


### PR DESCRIPTION
On displays between 1020px and 1190px

### Jira link

[HOTT-1144](https://transformuk.atlassian.net/browse/HOTT-1144)

### What?

I have added/removed/altered:

- [x] Removed the custom margins on displays between 1020px and 1190px wide

### Why?

I am doing this because:

- It will fix the alignment of breadcrumbs
- It will simplify the change of page width back to the default 960px in the future

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes
