### PR TITLE
HOTT-1001 Expose the RoO API

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -44,6 +44,7 @@ module TradeTariffFrontend
       certificate_types
       footnote_types
       changes
+      rules_of_origin_schemes
     ]
   end
 


### PR DESCRIPTION
### Jira link

[HOTT-1001](https://transformuk.atlassian.net/browse/HOTT-1001)

### What?

I have added/removed/altered:

- [x] Exposed the `rules_of_origin_schemes` api endpoint as part of the public API

### Why?

I am doing this because:

- We want to allow members of the public to query the Rules of Origin data

