### PR TITLE
Move to using short code when setting goods_nomenclature_code

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -11,6 +11,6 @@ class ChaptersController < GoodsNomenclaturesController
   private
 
   def set_goods_nomenclature_code
-    session[:goods_nomenclature_code] = @chapter.code
+    session[:goods_nomenclature_code] = @chapter.short_code
   end
 end

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe ChaptersController, type: :controller, vcr: { cassette_name: 'cha
     it { is_expected.to respond_with(:success) }
     it { expect(assigns(:chapter)).to be_a(Chapter) }
     it { expect(assigns(:headings)).to be_a(Array) }
-    it { expect(session[:goods_nomenclature_code]).to eq(chapter.code) }
+    it { expect(session[:goods_nomenclature_code]).to eq('01') }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Updates setting of goods nomenclature code on session for a chapter to use Chapter#short_code

### Why?

I am doing this because:

- This fixes a bug where the redirect to a chapter after a date change does not work
