### PR TITLE
Configure maxlength on date inputs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'aws-sdk-rails'
 gem 'newrelic_rpm'
 
 # For MeursingLookup functionality
-gem 'govuk_design_system_formbuilder'
+gem 'govuk_design_system_formbuilder', github: 'willfish/govuk-formbuilder', branch: 'support-maxlength'
 gem 'wizard_steps'
 
 # Sentry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,17 @@ GIT
       actionpack (>= 6.1)
       activesupport (>= 6.1)
 
+GIT
+  remote: https://github.com/willfish/govuk-formbuilder.git
+  revision: 1c0727d18f8373cc3faba439f03e7713b35ec000
+  branch: support-maxlength
+  specs:
+    govuk_design_system_formbuilder (2.8.0)
+      actionview (>= 6.0)
+      activemodel (>= 6.0)
+      activesupport (>= 6.0)
+      deep_merge (~> 1.2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -174,11 +185,6 @@ GEM
       sentry-ruby (~> 4.5.0)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
-    govuk_design_system_formbuilder (2.7.6)
-      actionview (>= 6.0)
-      activemodel (>= 6.0)
-      activesupport (>= 6.0)
-      deep_merge (~> 1.2.1)
     govuk_personalisation (0.10.0)
       plek (>= 1.9.0)
       rails (~> 6)
@@ -458,7 +464,7 @@ DEPENDENCIES
   faraday_middleware
   forgery
   govspeak
-  govuk_design_system_formbuilder
+  govuk_design_system_formbuilder!
   kaminari
   letter_opener
   lograge

--- a/app/views/import_export_dates/show.html.erb
+++ b/app/views/import_export_dates/show.html.erb
@@ -15,7 +15,8 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_date_field :import_date,
         legend: { text: t('import_export_date.form.legend_text'), size: 'xl', tag: 'h1' },
-        hint: { text: t('import_export_date.form.hint_text_html') } %>
+        hint: { text: t('import_export_date.form.hint_text_html') },
+        maxlength_enabled: true %>
 
       <div class="govuk-button-group">
         <%= f.govuk_submit('Update date') %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1172

### What?

We've recently opened a PR to enable this functionality on the
GOVUKDesignSystemFormBuilder gem: https://github.com/DFE-Digital/govuk-formbuilder/pull/329

Once/if this is merged we can push for the master branch of the unforked gem.

I have added/removed/altered:

- [x] Added the keyword arg param maxlength_enabled: true to the govuk_date_field invocation

### Why?

I am doing this because:

- This is required to restrict user input failures
