### PR TITLE
HOTT-1140 Revert to default GovUK page width

### DIFF
--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -1,38 +1,34 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m rules-of-origin-heading">
-      Preferential rules of origin for trading with <%= country_name %>
-      <%= country_flag_tag country_code, alt: "Flag for #{country_name}" %>
-    </h2>
+<h2 class="govuk-heading-m rules-of-origin-heading">
+  Preferential rules of origin for trading with <%= country_name %>
+  <%= country_flag_tag country_code, alt: "Flag for #{country_name}" %>
+</h2>
 
-    <%= rules_of_origin_schemes_intro country_name, rules_of_origin_schemes %>
+<%= rules_of_origin_schemes_intro country_name, rules_of_origin_schemes %>
 
-    <%= render partial: 'rules_of_origin/scheme',
-               collection: rules_of_origin_schemes,
-               locals: {
-                 country_name: country_name,
-                 commodity_code: commodity_code,
-                 multiple_schemes: rules_of_origin_schemes.many?
-               } %>
+<%= render partial: 'rules_of_origin/scheme',
+           collection: rules_of_origin_schemes,
+           locals: {
+             country_name: country_name,
+             commodity_code: commodity_code,
+             multiple_schemes: rules_of_origin_schemes.many?
+           } %>
 
-    <%= render 'rules_of_origin/non_preferential' %>
-  </div>
+<%= render 'rules_of_origin/non_preferential' %>
 
-  <% if rules_of_origin_schemes.flat_map(&:links).any? %>
-  <div class="govuk-grid-column-one-third" id="rules-of-origin__related-content">
-    <h2 class="govuk-heading-m">
-      Related content
-    </h2>
+<% if rules_of_origin_schemes.flat_map(&:links).any? %>
+<div id="rules-of-origin__related-content">
+  <h2 class="govuk-heading-m">
+    Related content
+  </h2>
 
-    <nav role="navigation">
-      <ul class="govuk-list govuk-list-s">
-        <% rules_of_origin_schemes.flat_map(&:links).uniq(&:id).each do |link| %>
-          <li>
-            <%= link_to link.text, link.url %>
-          </li>
-        <% end %>
-      </ul>
-    </nav>
-  </div>
-  <% end %>
+  <nav role="navigation">
+    <ul class="govuk-list govuk-list-s">
+      <% rules_of_origin_schemes.flat_map(&:links).uniq(&:id).each do |link| %>
+        <li>
+          <%= link_to link.text, link.url %>
+        </li>
+      <% end %>
+    </ul>
+  </nav>
 </div>
+<% end %>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -1,6 +1,5 @@
 $govuk-global-styles: true;
 $govuk-use-legacy-palette: false;
-$govuk-page-width: 1140px;
 $govuk-fonts-path: '~govuk-frontend/govuk/assets/fonts/';
 $govuk-images-path: '~govuk-frontend/govuk/assets/images/';
 

--- a/app/webpacker/src/stylesheets/_tables.scss
+++ b/app/webpacker/src/stylesheets/_tables.scss
@@ -23,6 +23,12 @@ table.small-table {
       }
     }
 
+    @media (min-width: $small-table-breakpoint) {
+      .measure-type-col {
+        width: 40%;
+      }
+    }
+
     @media (max-width: $small-table-breakpoint - 1) {
       caption,
       thead,

--- a/app/webpacker/src/stylesheets/tariff-custom.scss
+++ b/app/webpacker/src/stylesheets/tariff-custom.scss
@@ -13,7 +13,6 @@
 
 .header-wrapper {
   @media (min-width: 1200px) {
-    max-width: 1140px !important;
     padding-bottom: 8px;
   }
 }


### PR DESCRIPTION
### Jira link

[HOTT-1140](https://transformuk.atlassian.net/browse/HOTT-1140)

### What?

I have added/removed/altered:

- [x] Removed the custom override on the page width - fall back to GovUK Design System defaults
- [x] Moved the sidebar of links to below the main content on the RoO tab - because the table was too cramped at 960px
- [x] Set a width for the measures column to prevent it from using all available width on the  imports/exports tables - this becomes much more prominent at 960px

### Why?

I am doing this because:

- We should be following the GovUK Design System whenever possible and the additional width is no longer required

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

