### PR TITLE
HOTT-1173 Reinstated search form

### DIFF
--- a/app/controllers/browse_sections_controller.rb
+++ b/app/controllers/browse_sections_controller.rb
@@ -1,6 +1,4 @@
 class BrowseSectionsController < ApplicationController
-  before_action { disable_search_form }
-
   def index
     @sections = Section.all
   end

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -1,5 +1,4 @@
 class ChaptersController < GoodsNomenclaturesController
-  before_action { @no_shared_search = true }
   after_action :set_goods_nomenclature_code
 
   def show

--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -5,8 +5,6 @@ class CommoditiesController < GoodsNomenclaturesController
   before_action :set_goods_nomenclature_code, only: %i[show]
 
   def show
-    disable_search_form
-
     @heading = commodity.heading
     @chapter = commodity.chapter
     @section = commodity.section

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,5 @@
 class ErrorsController < ApplicationController
   before_action do
-    disable_search_form
     @tariff_last_updated = nil
   end
 

--- a/app/controllers/exchange_rates_controller.rb
+++ b/app/controllers/exchange_rates_controller.rb
@@ -1,6 +1,4 @@
 class ExchangeRatesController < ApplicationController
-  before_action { disable_search_form }
-
   def index
     all_rates = MonetaryExchangeRate.all
     @last_updated = all_rates.last.operation_date.strftime('%d %B %Y')

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,6 +1,5 @@
 class FeedbackController < ApplicationController
   before_action do
-    disable_search_form
     @tariff_last_updated = nil
   end
 

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -7,8 +7,6 @@ class HeadingsController < GoodsNomenclaturesController
   helper_method :uk_heading, :xi_heading
 
   def show
-    disable_search_form
-
     @commodities = HeadingCommodityPresenter.new(heading.commodities)
     @meursing_additional_code = session[:meursing_lookup].try(:[], 'result')
     @section = heading.section

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,7 +2,7 @@ require 'addressable/uri'
 
 class SearchController < ApplicationController
   before_action :disable_switch_service_banner, only: [:quota_search]
-  before_action { disable_search_form }
+  before_action :disable_search_form, except: [:search]
 
   def search
     @results = @search.perform

--- a/app/controllers/search_references_controller.rb
+++ b/app/controllers/search_references_controller.rb
@@ -1,6 +1,4 @@
 class SearchReferencesController < ApplicationController
-  before_action { disable_search_form }
-
   def show
     @search_references = SearchReferencesPresenter.new(
       SearchReference.all(query: { letter: letter })

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,8 +1,6 @@
 class SectionsController < GoodsNomenclaturesController
   prepend_before_action :redirect_to_find_commodity, only: :index
 
-  before_action :disable_search_form
-
   def index
     @tariff_updates = TariffUpdate.all
     @sections = Section.all

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,13 +70,6 @@
 
       <%= render 'shared/switch_banner' %>
 
-      <% # This is a patch to show the header and search in section until the updated_navigation feature flag is removed
-         # TODO: remove this after updated_navigation is removed
-       if (controller.controller_name == 'sections' && controller.action_name == 'index' && !TradeTariffFrontend.updated_navigation?) %>
-        <%= page_header heading_for(section: @section) %>
-        <%= render 'shared/search/search_form'%>
-      <% end %>
-
       <%= render 'shared/search/search_form' unless @no_shared_search %>
 
       <%= yield %>

--- a/app/views/sections/index.html.erb
+++ b/app/views/sections/index.html.erb
@@ -2,6 +2,8 @@
   <link rel='alternate' type='application/json' href='<%= sections_url(format: :json) %>' title='Section list in JSON format' />
 <% end %>
 
+<%= page_header heading_for(section: @section) %>
+
 <section class="sections">
   <table class="govuk-table">
     <caption class="govuk-table__caption govuk-table__caption--m">All sections</caption>


### PR DESCRIPTION
This re-instates the global search for on all pages which had it disable in PR398 and PR412

### Jira link

[HOTT-1173](https://transformuk.atlassian.net/browse/HOTT-1173)

### What?

I have added/removed/altered:

- [x]  Re-instate the global search for on all pages which had it disable in PR398 and PR412

### Why?

I am doing this because:

- Users are encountering inconvenience when performing repeated searches

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

