### PR TITLE
HOTT-1169 Fix search submitting the wrong value

### DIFF
--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -767,6 +767,10 @@
             (function(element) {
               var options = [];
 
+              $(element).on('change', 'input[type="text"]', function(ev) {
+                $('.js-commodity-picker-target').val($(ev.target).val());
+              }) ;
+
               accessibleAutocomplete({
                 element: element[0],
                 id: "q",


### PR DESCRIPTION
Original issue:

Search for a heading or product and select from the autocomplete, then amend the input field, then submit

The autocompleted value is submitted, rather than the value typed in the input.

### Jira link

[HOTT-1169](https://transformuk.atlassian.net/browse/HOTT-1169)

### What?

I have added/removed/altered:

- [x] Changed the autocomplete field copy its value over to the hidden field whenever it is changed

### Why?

I am doing this because:

- We have a bug where if the user searches, chooses an autocomplete option, then amends the search value - then submits before the autocomplete loads a second time - the original autocomplete value is submitted instead of the users modified query

### Deployment risks (optional)

- This is a change to the core search mechanism so should be well tested
