### PR TITLE
Adds GoodsNomenclatureHelper

### DIFF
--- a/app/controllers/import_export_dates_controller.rb
+++ b/app/controllers/import_export_dates_controller.rb
@@ -1,5 +1,5 @@
 class ImportExportDatesController < ApplicationController
-  include DeclarableHelper
+  include GoodsNomenclatureHelper
 
   before_action :disable_search_form, :disable_switch_service_banner do
     @tariff_last_updated = nil

--- a/app/controllers/meursing_lookup/results_controller.rb
+++ b/app/controllers/meursing_lookup/results_controller.rb
@@ -1,6 +1,6 @@
 module MeursingLookup
   class ResultsController < ApplicationController
-    include DeclarableHelper
+    include GoodsNomenclatureHelper
 
     def show
       session.delete(Result::CURRENT_MEURSING_ADDITIONAL_CODE_KEY)

--- a/app/controllers/meursing_lookup/steps_controller.rb
+++ b/app/controllers/meursing_lookup/steps_controller.rb
@@ -10,7 +10,7 @@ module MeursingLookup
       store_meursing_lookup_result_on_session
     end
 
-    include DeclarableHelper
+    include GoodsNomenclatureHelper
     include WizardSteps
 
     self.wizard_class = MeursingLookup::Wizard

--- a/app/controllers/trading_partners_controller.rb
+++ b/app/controllers/trading_partners_controller.rb
@@ -1,5 +1,5 @@
 class TradingPartnersController < ApplicationController
-  include DeclarableHelper
+  include GoodsNomenclatureHelper
 
   before_action :disable_search_form, :disable_switch_service_banner do
     @tariff_last_updated = nil

--- a/app/helpers/declarable_helper.rb
+++ b/app/helpers/declarable_helper.rb
@@ -47,33 +47,6 @@ module DeclarableHelper
     )
   end
 
-  def goods_nomenclature_back_link
-    link_to('Back', goods_nomenclature_path, class: 'govuk-back-link')
-  end
-
-  def declarable_link
-    link_to("Return to #{current_goods_nomenclature_code}", goods_nomenclature_path, class: 'govuk-link')
-  end
-
-  def goods_nomenclature_path(path_opts = {})
-    path_opts = goods_nomenclature_path_opts.merge(path_opts) if current_goods_nomenclature_code.present?
-
-    case current_goods_nomenclature_code&.size
-    when nil
-      sections_path(path_opts)
-    when Chapter::SHORT_CODE_LENGTH
-      chapter_path(path_opts)
-    when Heading::SHORT_CODE_LENGTH
-      heading_path(path_opts)
-    else
-      commodity_path(path_opts)
-    end
-  end
-
-  def current_goods_nomenclature_code
-    session[:goods_nomenclature_code]
-  end
-
   # Supplementary unit measures treat no country specified in the search as the entire world
   def supplementary_geographical_area_id(search)
     search.country || GeographicalArea::ERGA_OMNES
@@ -96,21 +69,6 @@ module DeclarableHelper
   end
 
   private
-
-  def goods_nomenclature_path_opts
-    url_options.merge(
-      id: current_goods_nomenclature_code,
-      anchor: anchor,
-    )
-  end
-
-  def anchor
-    referer&.fragment
-  end
-
-  def referer
-    @referer ||= Addressable::URI.parse(request.referer) if request.referer.present?
-  end
 
   def boldify_last(items)
     starting_items = items[..-2]

--- a/app/helpers/goods_nomenclature_helper.rb
+++ b/app/helpers/goods_nomenclature_helper.rb
@@ -1,0 +1,45 @@
+module GoodsNomenclatureHelper
+  def goods_nomenclature_back_link
+    link_to('Back', goods_nomenclature_path, class: 'govuk-back-link')
+  end
+
+  def goods_nomenclature_path(path_opts = {})
+    path_opts = goods_nomenclature_path_opts.merge(path_opts) if current_goods_nomenclature_code.present?
+
+    case current_goods_nomenclature_code&.size
+    when nil
+      sections_path(path_opts)
+    when Chapter::SHORT_CODE_LENGTH
+      chapter_path(path_opts)
+    when Heading::SHORT_CODE_LENGTH
+      heading_path(path_opts)
+    else
+      commodity_path(path_opts)
+    end
+  end
+
+  def goods_nomenclature_link
+    link_to("Return to #{current_goods_nomenclature_code}", goods_nomenclature_path, class: 'govuk-link')
+  end
+
+  def current_goods_nomenclature_code
+    session[:goods_nomenclature_code]
+  end
+
+  private
+
+  def anchor
+    referer&.fragment
+  end
+
+  def referer
+    @referer ||= Addressable::URI.parse(request.referer) if request.referer.present?
+  end
+
+  def goods_nomenclature_path_opts
+    url_options.merge(
+      id: current_goods_nomenclature_code,
+      anchor: anchor,
+    )
+  end
+end

--- a/app/views/meursing_lookup/steps/_end.html.erb
+++ b/app/views/meursing_lookup/steps/_end.html.erb
@@ -23,7 +23,7 @@
     <% if current_goods_nomenclature_code.present? %>
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <%= declarable_link %>
+          <%= goods_nomenclature_link %>
         </li>
         <li>
           <%= link_to('Start again', meursing_lookup_step_path(:start)) %>

--- a/spec/helpers/declarable_helper_spec.rb
+++ b/spec/helpers/declarable_helper_spec.rb
@@ -1,15 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe DeclarableHelper, type: :helper do
-  before do
-    session[:goods_nomenclature_code] = session_goods_nomenclature_code
-    allow(helper).to receive(:url_options).and_return(url_options)
-    allow(helper.request).to receive(:referer).and_return('http://example.com/commodities/2402201000?country=AE&day=25&month=12&year=2021#export')
-  end
-
-  let(:session_goods_nomenclature_code) { '1901200000' }
-  let(:url_options) { { country: 'AR', year: '2021', month: '01', day: '01' } }
-
   describe '#declarable_stw_link' do
     subject(:declarable_stw_link) { helper.declarable_stw_link(declarable, search) }
 
@@ -80,59 +71,6 @@ RSpec.describe DeclarableHelper, type: :helper do
       it { is_expected.to include('rel="noopener"') }
       it { is_expected.to include('class="govuk-link"') }
     end
-  end
-
-  describe '#goods_nomenclature_back_link' do
-    let(:session_goods_nomenclature_code) { '1901200000' }
-
-    it 'returns the correct link html' do
-      expected_link = '<a class="govuk-back-link" href="/commodities/1901200000?country=AR&amp;day=01&amp;month=01&amp;year=2021#export">Back</a>'
-
-      expect(helper.goods_nomenclature_back_link).to eq(expected_link)
-    end
-  end
-
-  describe '#declarable_link' do
-    context 'when the session goods_nomenclature_code is a commodity code' do
-      let(:session_goods_nomenclature_code) { '1901200000' }
-
-      it 'returns a return link for the commodity' do
-        expected_link = '<a class="govuk-link" href="/commodities/1901200000?country=AR&amp;day=01&amp;month=01&amp;year=2021#export">Return to 1901200000</a>'
-
-        expect(helper.declarable_link).to eq(expected_link)
-      end
-    end
-
-    context 'when the session goods_nomenclature_code is a heading code' do
-      let(:session_goods_nomenclature_code) { '1901' }
-
-      it 'returns a return link for the heading' do
-        expected_link = '<a class="govuk-link" href="/headings/1901?country=AR&amp;day=01&amp;month=01&amp;year=2021#export">Return to 1901</a>'
-
-        expect(helper.declarable_link).to eq(expected_link)
-      end
-    end
-  end
-
-  describe '#goods_nomenclature_path' do
-    shared_examples_for 'a goods_nomenclature_path' do |goods_nomenclature_code, expected_path|
-      let(:session_goods_nomenclature_code) { goods_nomenclature_code }
-
-      it { expect(helper.goods_nomenclature_path).to eq(expected_path) }
-    end
-
-    it_behaves_like 'a goods_nomenclature_path', '1901200000', '/commodities/1901200000?country=AR&day=01&month=01&year=2021#export'
-    it_behaves_like 'a goods_nomenclature_path', '1901', '/headings/1901?country=AR&day=01&month=01&year=2021#export'
-    it_behaves_like 'a goods_nomenclature_path', '19', '/chapters/19?country=AR&day=01&month=01&year=2021#export'
-    it_behaves_like 'a goods_nomenclature_path', nil, '/sections?country=AR&day=01&month=01&year=2021'
-  end
-
-  describe '#current_goods_nomenclature_code' do
-    before do
-      session[:goods_nomenclature_code] = '1901200000'
-    end
-
-    it { expect(helper.current_goods_nomenclature_code).to eq('1901200000') }
   end
 
   describe '#classification_description' do

--- a/spec/helpers/goods_nomenclature_helper_spec.rb
+++ b/spec/helpers/goods_nomenclature_helper_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+RSpec.describe GoodsNomenclatureHelper, type: :helper do
+  before do
+    session[:goods_nomenclature_code] = session_goods_nomenclature_code
+    allow(helper).to receive(:url_options).and_return(url_options)
+    allow(helper.request).to receive(:referer).and_return('http://example.com/commodities/2402201000?country=AE&day=25&month=12&year=2021#export')
+  end
+
+  let(:session_goods_nomenclature_code) { '1901200000' }
+  let(:url_options) { { country: 'AR', year: '2021', month: '01', day: '01' } }
+
+  describe '#goods_nomenclature_back_link' do
+    let(:session_goods_nomenclature_code) { '1901200000' }
+
+    it 'returns the correct link html' do
+      expected_link = '<a class="govuk-back-link" href="/commodities/1901200000?country=AR&amp;day=01&amp;month=01&amp;year=2021#export">Back</a>'
+
+      expect(helper.goods_nomenclature_back_link).to eq(expected_link)
+    end
+  end
+
+  describe '#goods_nomenclature_link' do
+    context 'when the session goods_nomenclature_code is a commodity code' do
+      let(:session_goods_nomenclature_code) { '1901200000' }
+
+      it 'returns a return link for the commodity' do
+        expected_link = '<a class="govuk-link" href="/commodities/1901200000?country=AR&amp;day=01&amp;month=01&amp;year=2021#export">Return to 1901200000</a>'
+
+        expect(helper.goods_nomenclature_link).to eq(expected_link)
+      end
+    end
+
+    context 'when the session goods_nomenclature_code is a heading code' do
+      let(:session_goods_nomenclature_code) { '1901' }
+
+      it 'returns a return link for the heading' do
+        expected_link = '<a class="govuk-link" href="/headings/1901?country=AR&amp;day=01&amp;month=01&amp;year=2021#export">Return to 1901</a>'
+
+        expect(helper.goods_nomenclature_link).to eq(expected_link)
+      end
+    end
+  end
+
+  describe '#goods_nomenclature_path' do
+    shared_examples_for 'a goods_nomenclature_path' do |goods_nomenclature_code, expected_path|
+      let(:session_goods_nomenclature_code) { goods_nomenclature_code }
+
+      it { expect(helper.goods_nomenclature_path).to eq(expected_path) }
+    end
+
+    it_behaves_like 'a goods_nomenclature_path', '1901200000', '/commodities/1901200000?country=AR&day=01&month=01&year=2021#export'
+    it_behaves_like 'a goods_nomenclature_path', '1901', '/headings/1901?country=AR&day=01&month=01&year=2021#export'
+    it_behaves_like 'a goods_nomenclature_path', '19', '/chapters/19?country=AR&day=01&month=01&year=2021#export'
+    it_behaves_like 'a goods_nomenclature_path', nil, '/sections?country=AR&day=01&month=01&year=2021'
+  end
+
+  describe '#current_goods_nomenclature_code' do
+    before do
+      session[:goods_nomenclature_code] = '1901200000'
+    end
+
+    it { expect(helper.current_goods_nomenclature_code).to eq('1901200000') }
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

The DeclarableHelper is meant for headings and commodities that are
declarable. Some of the functionality in there was really built for all
goods nomenclature so this extracts that behaviour into its own helper

### Why?

I am doing this because:

- This makes way more sense conceptually
