### PR TITLE
HOTT-1176 Faster autocomplete on home page

### DIFF
--- a/app/models/search_suggestion.rb
+++ b/app/models/search_suggestion.rb
@@ -2,21 +2,46 @@ require 'api_entity'
 
 class SearchSuggestion
   include ApiEntity
+  CACHE_VERSION = 'v1'.freeze
 
   collection_path '/search_suggestions'
 
   attr_accessor :value
 
-  def self.cached_suggestions
-    TradeTariffFrontend::ServiceChooser.cache_with_service_choice(
-      'cached_search_suggestions', expires_in: 24.hours
-    ) do
-      all
-    end
-  end
+  class << self
+    def cached_suggestions_for(term)
+      return [] if term.blank?
 
-  def self.start_with(term)
-    cached_suggestions.select { |s| s.value =~ /^#{term}/i }
-                      .first(TradeTariffFrontend.suggestions_count)
+      first_letter = term.slice(0, 1).downcase
+      cached_suggestions_for_letter first_letter
+    end
+
+    def start_with(term)
+      cached_suggestions_for(term).select { |s| s.value =~ /^#{term}/i }
+                                  .first(TradeTariffFrontend.suggestions_count)
+    end
+
+  private
+
+    def cached_suggestions_for_letter(first_letter)
+      results = Rails.cache.read_multi "#{cache_prefix}loaded",
+                                       "#{cache_prefix}#{first_letter}"
+
+      if results["#{cache_prefix}loaded"]
+        return results["#{cache_prefix}#{first_letter}"] || []
+      end
+
+      grouped_results = all.group_by { |r| r.value.to_s.downcase.slice(0, 1) }
+      grouped_results.transform_keys! { |letter| "#{cache_prefix}#{letter}" }
+      grouped_results["#{cache_prefix}loaded"] = true
+
+      Rails.cache.write_multi grouped_results, expires_in: 24.hours
+
+      grouped_results["#{cache_prefix}#{first_letter}"]
+    end
+
+    def cache_prefix
+      "#{TradeTariffFrontend::ServiceChooser.cache_prefix}.#{CACHE_VERSION}.search_suggestions_"
+    end
   end
 end

--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -840,7 +840,7 @@
                       populateResults([]);
                     }
                   });
-                }, 300, false)
+                }, 100, false)
               });
             })($(this));
           });

--- a/spec/models/search_suggestion_spec.rb
+++ b/spec/models/search_suggestion_spec.rb
@@ -2,12 +2,10 @@ require 'spec_helper'
 
 RSpec.describe SearchSuggestion do
   describe '.all', vcr: { cassette_name: 'search#suggestions', allow_playback_repeats: true } do
-    let(:suggestions) { SearchSuggestion.all }
+    subject(:suggestions) { described_class.all }
 
-    it 'fetches suggestions from the API' do
-      expect(suggestions).to be_kind_of Array
-      expect(suggestions).not_to be_blank
-    end
+    it { is_expected.to be_kind_of Array }
+    it { is_expected.not_to be_empty }
 
     it 'sorts suggestions by value' do
       expect(suggestions.first.value).to be < suggestions.last.value
@@ -15,13 +13,15 @@ RSpec.describe SearchSuggestion do
   end
 
   describe '.start_with', vcr: { cassette_name: 'search#suggestions', allow_playback_repeats: true } do
-    it 'invokes .cached_suggestions method' do
-      expect(described_class).to receive(:cached_suggestions).and_return([])
+    before { allow(Rails.cache).to receive(:write_multi).and_call_original }
+
+    it 'utilises Rails cache' do
       described_class.start_with('123')
+      expect(Rails.cache).to have_received(:write_multi)
     end
 
     it 'returns suggestions filtered by value' do
-      values = SearchSuggestion.all
+      values = described_class.all
       expect(described_class.start_with(values[0].value.first(4)).map(&:value)).to include(values[0].value)
     end
 


### PR DESCRIPTION
### Jira link

[HOTT-1176](https://transformuk.atlassian.net/browse/HOTT-1176)

### What?

I have added/removed/altered:

- [x] Made the frontend caching of search results more granular - now we have separate cache entries for each of the starting letters - this drops the time to get a search result from ~120ms locally to a consistent 17ms
- [x] Reduced the debounce timeout on the autocomplete field from 300ms to 100ms
- [x] Combined effect is to drop the time from finishing typing, to seeing autocomplete results from approx 420ms down to 120ms

### Why?

I am doing this because:

- The autocomplete search results feel slow and this is an quick win.

### Deployment risks (optional)

- Changes the caching behaviour on the search
- Will likely increase queries to the search suggestions endpoint - probably double (but they're taking quarter the time)
