### PR TITLE
HOTT-1133-dynamic-trading-partner-title

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -26,6 +26,14 @@ module ServiceHelper
     )
   end
 
+  def import_export_date_title
+    t('title.import_export_date', service_name: service_name)
+  end
+
+  def trading_partner_title
+    t('title.trading_partner', service_name: service_name)
+  end
+
   def trade_tariff_heading
     t("trade_tariff_heading.#{service_choice}")
   end

--- a/app/views/import_export_dates/show.html.erb
+++ b/app/views/import_export_dates/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'UK Integrated Online Tariff - When will your goods be traded' %>
+<% content_for :title, import_export_date_title %>
 
 <% if current_goods_nomenclature_code %>
   <%= goods_nomenclature_back_link %>

--- a/app/views/trading_partners/show.html.erb
+++ b/app/views/trading_partners/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'UK Integrated Online Tariff - Set country filter' %>
+<% content_for :title, trading_partner_title %>
 
 <% if current_goods_nomenclature_code %>
   <%= goods_nomenclature_back_link %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,8 @@ en:
   title:
     default: "%{service_name}: %{service_description} - GOV.UK"
     goods_nomenclature: "%{goods_description} - %{service_name} - GOV.UK"
+    trading_partner: "%{service_name} - Set country filter - GOV.UK"
+    import_export_date: "%{service_name} - When will your goods be traded - GOV.UK"
     commodity:
       uk: "Commodity code %{commodity_code}: %{commodity_description} - %{service_name} - GOV.UK"
       xi: "Commodity code %{commodity_code}: %{commodity_description} - %{service_name} - GOV.UK"

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -221,4 +221,36 @@ RSpec.describe ServiceHelper, type: :helper do
       it { is_expected.to eql 'Northern Ireland' }
     end
   end
+
+  describe '#import_export_date_title' do
+    subject(:import_export_date_title) { helper.import_export_date_title }
+
+    context 'when the selected service choice is xi' do
+      include_context 'with XI service'
+
+      it { is_expected.to eq('Northern Ireland Online Tariff - When will your goods be traded - GOV.UK') }
+    end
+
+    context 'when the selected service choice is nil' do
+      include_context 'with default service'
+
+      it { is_expected.to eq('UK Integrated Online Tariff - When will your goods be traded - GOV.UK') }
+    end
+  end
+
+  describe '#trading_partner_title' do
+    subject(:trading_partner_title) { helper.trading_partner_title }
+
+    context 'when the selected service choice is xi' do
+      include_context 'with XI service'
+
+      it { is_expected.to eq('Northern Ireland Online Tariff - Set country filter - GOV.UK') }
+    end
+
+    context 'when the selected service choice is nil' do
+      include_context 'with default service'
+
+      it { is_expected.to eq('UK Integrated Online Tariff - Set country filter - GOV.UK') }
+    end
+  end
 end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -1,15 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe ServiceHelper, type: :helper do
-  before do
-    allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return(choice)
-  end
-
-  let(:choice) { 'xi' }
-
   describe '.default_title' do
     context 'when the selected service choice is xi' do
-      let(:choice) { 'xi' }
+      include_context 'with XI service'
 
       it 'returns the title for the current service choice' do
         expect(helper.default_title).to eq('Northern Ireland Online Tariff: Look up commodity codes, duty and VAT rates - GOV.UK')
@@ -17,7 +11,7 @@ RSpec.describe ServiceHelper, type: :helper do
     end
 
     context 'when the selected service choice is nil' do
-      let(:choice) { nil }
+      include_context 'with default service'
 
       it 'returns the title for the current service choice' do
         expect(helper.default_title).to eq('UK Integrated Online Tariff: Look up commodity codes, duty and VAT rates - GOV.UK')
@@ -25,7 +19,7 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
-  describe '.heading_for' do
+  describe '#heading_for' do
     subject { helper.heading_for(section: section, chapter: chapter, heading: heading, commodity: commodity) }
 
     let(:section) { instance_double('Section', page_heading: 'Section AAA') }
@@ -59,11 +53,11 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
-  describe '.goods_nomenclature_title' do
+  describe '#goods_nomenclature_title' do
     let(:commodity) { build(:commodity, formatted_description: 'Live horses, asses, mules and hinnies') }
 
     context 'when the selected service choice is xi' do
-      let(:choice) { 'xi' }
+      include_context 'with XI service'
 
       it 'returns the correct title for the current goods nomenclature' do
         expect(helper.goods_nomenclature_title(commodity)).to eq('Live horses, asses, mules and hinnies - Northern Ireland Online Tariff - GOV.UK')
@@ -71,7 +65,7 @@ RSpec.describe ServiceHelper, type: :helper do
     end
 
     context 'when the selected service choice is nil' do
-      let(:choice) { nil }
+      include_context 'with default service'
 
       it 'returns the correct title for the current goods nomenclature' do
         expect(helper.goods_nomenclature_title(commodity)).to eq('Live horses, asses, mules and hinnies - UK Integrated Online Tariff - GOV.UK')
@@ -79,11 +73,11 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
-  describe '.commodity_title' do
+  describe '#commodity_title' do
     let(:commodity) { build(:commodity, formatted_description: 'Pure-bred breeding animals', goods_nomenclature_item_id: '0101300000') }
 
     context 'when the selected service choice is xi' do
-      let(:choice) { 'xi' }
+      include_context 'with XI service'
 
       it 'returns the correct title for the current goods nomenclature' do
         expect(helper.commodity_title(commodity)).to eq('Commodity code 0101300000: Pure-bred breeding animals - Northern Ireland Online Tariff - GOV.UK')
@@ -91,7 +85,7 @@ RSpec.describe ServiceHelper, type: :helper do
     end
 
     context 'when the selected service choice is nil' do
-      let(:choice) { nil }
+      include_context 'with default service'
 
       it 'returns the correct title for the current goods nomenclature' do
         expect(helper.commodity_title(commodity)).to eq('Commodity code 0101300000: Pure-bred breeding animals - UK Integrated Online Tariff - GOV.UK')
@@ -99,9 +93,9 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
-  describe '.trade_tariff_heading' do
+  describe '#trade_tariff_heading' do
     context 'when the selected service choice is uk' do
-      let(:choice) { 'uk' }
+      include_context 'with UK service'
 
       it 'returns UK Integrated Online Tariff' do
         expect(trade_tariff_heading).to eq('UK Integrated Online Tariff')
@@ -109,7 +103,7 @@ RSpec.describe ServiceHelper, type: :helper do
     end
 
     context 'when the selected service choice is xi' do
-      let(:choice) { 'xi' }
+      include_context 'with XI service'
 
       it 'returns Northern Ireland Online Tariff' do
         expect(trade_tariff_heading).to eq('Northern Ireland Online Tariff')
@@ -117,14 +111,15 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
-  describe '.switch_service_link' do
+  describe '#switch_service_link' do
     before do
       helper.request.path = path
     end
 
     context 'when the selected service choice is uk' do
+      include_context 'with UK service'
+
       let(:path) { '/uk/sections/1' }
-      let(:choice) { 'uk' }
 
       it 'returns the link to the XI service' do
         expect(helper.switch_service_link).to eq(link_to('Northern Ireland Online Tariff', '/xi/sections/1'))
@@ -132,8 +127,9 @@ RSpec.describe ServiceHelper, type: :helper do
     end
 
     context 'when the selected service choice is xi' do
+      include_context 'with XI service'
+
       let(:path) { '/xi/sections/1' }
-      let(:choice) { 'xi' }
 
       it 'returns the link to the current UK service' do
         expect(helper.switch_service_link).to eq(link_to('UK Integrated Online Tariff', '/sections/1'))
@@ -141,17 +137,19 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
-  describe '.switch_banner_copy' do
+  describe '#switch_banner_copy' do
     before do
       helper.request.path = path
       assign(:enable_service_switch_banner_in_action, true)
     end
 
-    context 'when on xi sections page' do
+    include_context 'with XI service'
+
+    context 'when on sections page' do
       let(:path) { '/xi/sections' }
 
       it 'returns the full banner that allows users to toggle between the services' do
-        expect(helper.switch_banner_copy).to include(t("service_banner.big.#{choice}", link: helper.switch_service_link))
+        expect(helper.switch_banner_copy).to include(t('service_banner.big.xi', link: helper.switch_service_link))
       end
     end
 
@@ -164,43 +162,35 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
-  describe '.service_choice' do
+  describe '#service_choice' do
     context 'when there is a service choice set' do
-      let(:choice) { 'xi' }
+      include_context 'with XI service'
 
-      it 'returns xi' do
-        expect(helper.service_choice).to eq(choice)
-      end
+      it { expect(helper.service_choice).to eq('xi') }
     end
 
     context 'when the selected service choice is nil' do
-      let(:choice) { nil }
+      include_context 'with default service'
 
-      it 'returns the default service which is uk' do
-        expect(helper.service_choice).to eq('uk')
-      end
+      it { expect(helper.service_choice).to eq('uk') }
     end
   end
 
-  describe '.import_destination' do
+  describe '#import_destination' do
     context 'when there is a service choice is xi' do
-      let(:choice) { 'xi' }
+      include_context 'with XI service'
 
-      it 'returns Northern Ireland' do
-        expect(helper.import_destination).to eq('Northern Ireland')
-      end
+      it { expect(helper.import_destination).to eq('Northern Ireland') }
     end
 
     context 'when the selected service choice is uk' do
-      let(:choice) { 'uk' }
+      include_context 'with UK service'
 
-      it 'returns United Kingdom' do
-        expect(helper.import_destination).to eq('United Kingdom')
-      end
+      it { expect(helper.import_destination).to eq('United Kingdom') }
     end
   end
 
-  describe '.service_name' do
+  describe '#service_name' do
     subject { service_name }
 
     context 'with UK service' do
@@ -216,7 +206,7 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
-  describe '.region_name' do
+  describe '#region_name' do
     subject { region_name }
 
     context 'with UK service' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1133

### What?

I have added/removed/altered:

- [x] Make trading partner and import export date titles reflect the current service
- [x] Tidy up ServiceHelper spec
- [x] Extend ServiceHelper spec to include new title methods

### Why?

I am doing this because:

- This is a requirement for the service and is consistent with other page titles
