### PR TITLE
Hott 1156 dynamic heading size

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,11 +31,11 @@ module ApplicationHelper
     end
   end
 
-  def page_header(heading = nil, &block)
+  def page_header(heading_text = nil, &block)
     extra_content = block_given? ? capture(&block) : nil
 
     render 'shared/page_header',
-           heading: heading,
+           heading_text: heading_text,
            show_switch_service: is_switch_service_banner_enabled?,
            extra_content: extra_content
   end
@@ -96,6 +96,16 @@ module ApplicationHelper
       link_to(caption, parent, class: 'govuk-breadcrumbs__link')
     else
       caption
+    end
+  end
+
+  def css_heading_size(text)
+    if text.length >= 400
+      'govuk-heading-s'
+    elsif text.length >= 120
+      'govuk-heading-m'
+    else
+      'govuk-heading-l'
     end
   end
 end

--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -7,9 +7,9 @@
     <%= switch_service_button if show_switch_service %>
   </span>
 
-  <% if heading.present? %>
-    <h1 class="govuk-heading-l">
-      <%= heading %>
+  <% if heading_text.present? %>
+    <h1 class="<%= css_heading_size(heading_text) %>">
+      <%= heading_text %>
     </h1>
   <% end %>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -250,4 +250,26 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { is_expected.not_to have_css 'span.switch-service-control' }
     end
   end
+
+  describe '#css_heading_size' do
+    subject { helper.css_heading_size(text) }
+
+    context 'when text length is greater than or equal to 400 chars' do
+      let(:text) { 'X' * 400 }
+
+      it { is_expected.to eq 'govuk-heading-s' } # Small text
+    end
+
+    context 'when text length is between 120 and 400 chars' do
+      let(:text) { 'X' * 150 }
+
+      it { is_expected.to eq 'govuk-heading-m' } # Medium text
+    end
+
+    context 'when text length is smaller than 120 chars' do
+      let(:text) { 'X' * 119 }
+
+      it { is_expected.to eq 'govuk-heading-l' } # Large text
+    end
+  end
 end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1156

### What?
set the size of the heading dynamically

<img width="665" alt="Screenshot 2021-11-30 at 12 07 59" src="https://user-images.githubusercontent.com/58971/144044726-616d3a2d-5013-465c-bbb2-b0c13765fbeb.png">

### Why?
to improve UI/Usability
