### PR TITLE
HOTT-1132 Service tags

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -90,7 +90,7 @@ module ServiceHelper
     t("service_banner.bottom.#{service_choice}")
   end
 
-  def region_name
+  def service_region
     t("title.region_name.#{service_choice}")
   end
 

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -94,6 +94,21 @@ module ServiceHelper
     t("title.region_name.#{service_choice}")
   end
 
+  def replace_service_tags(content)
+    content.gsub %r{\[\[SERVICE_[A-Z_]+\]\]} do |match|
+      case match
+      when '[[SERVICE_NAME]]'
+        service_name
+      when '[[SERVICE_PATH]]'
+        TradeTariffFrontend::ServiceChooser.xi? ? '/xi' : ''
+      when '[[SERVICE_REGION]]'
+        service_region
+      else
+        match
+      end
+    end
+  end
+
 private
 
   def service_name

--- a/app/views/find_commodities/show.html.erb
+++ b/app/views/find_commodities/show.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>find commodity codes for imports into or exports out of <%= region_name %></li>
+      <li>find commodity codes for imports into or exports out of <%= service_region %></li>
       <li>find the taxes and duties that apply to those imports</li>
       <li>find out which certificates and licences apply to the import of your goods</li>
     </ul>

--- a/app/views/news_items/_latest_news.html.erb
+++ b/app/views/news_items/_latest_news.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="govuk-notification-banner__content">
     <div class="tariff-markdown">
-      <%= govspeak news_item.paragraphs.first %>
+      <%= govspeak replace_service_tags news_item.paragraphs.first %>
 
       <%- if news_item.paragraphs.many? -%>
         <%= link_to 'Show more ...', news_item,

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -17,7 +17,7 @@
         </h2>
 
         <div class="tariff-markdown">
-          <%= govspeak replace_service_tags news_item.paragraphs.first %>
+          <%= govspeak replace_service_tags(news_item.paragraphs.first) %>
         </div>
 
         <%= link_to 'Show more ...', news_item if news_item.paragraphs.many? %>

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -17,7 +17,7 @@
         </h2>
 
         <div class="tariff-markdown">
-          <%= govspeak news_item.paragraphs.first %>
+          <%= govspeak replace_service_tags news_item.paragraphs.first %>
         </div>
 
         <%= link_to 'Show more ...', news_item if news_item.paragraphs.many? %>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -16,7 +16,7 @@
   </h3>
 
   <div class="tariff-markdown">
-    <%= govspeak replace_service_tags @news_item.content %>
+    <%= govspeak replace_service_tags(@news_item.content) %>
   </div>
 </article>
 

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -16,7 +16,7 @@
   </h3>
 
   <div class="tariff-markdown">
-    <%= govspeak @news_item.content %>
+    <%= govspeak replace_service_tags @news_item.content %>
   </div>
 </article>
 

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -206,8 +206,8 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
-  describe '#region_name' do
-    subject { region_name }
+  describe '#service_region' do
+    subject { service_region }
 
     context 'with UK service' do
       include_context 'with UK service'

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -222,6 +222,106 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
+  describe '.replace_service_tags' do
+    subject { replace_service_tags content }
+
+    context 'with UK service' do
+      include_context 'with UK service'
+
+      context 'without tags' do
+        let(:content) { 'this is some sample content' }
+
+        it { is_expected.to eql 'this is some sample content' }
+      end
+
+      context 'with SERVICE_NAME tag' do
+        let(:content) { 'You are on the [[SERVICE_NAME]]' }
+
+        it { is_expected.to eql 'You are on the UK Integrated Online Tariff' }
+      end
+
+      context 'with SERVICE_PATH tag' do
+        let(:content) { '<a href="[[SERVICE_PATH]]/browse">Browse</a>' }
+
+        it { is_expected.to eql '<a href="/browse">Browse</a>' }
+      end
+
+      context 'with SERVICE_REGION' do
+        let(:content) { 'within [[SERVICE_REGION]]' }
+
+        it { is_expected.to eql 'within the UK' }
+      end
+
+      context 'with multiple tags' do
+        let :content do
+          <<~END_OF_CONTENT
+            [[SERVICE_NAME]]
+            * [Find commodity]([[SERVICE_PATH]]/find_commodity)
+            * [Browse]([[SERVICE_PATH]]/browse)
+          END_OF_CONTENT
+        end
+
+        let :expected do
+          <<~END_OF_EXPECTED
+            UK Integrated Online Tariff
+            * [Find commodity](/find_commodity)
+            * [Browse](/browse)
+          END_OF_EXPECTED
+        end
+
+        it { is_expected.to eql expected }
+      end
+    end
+
+    context 'with XI service' do
+      include_context 'with XI service'
+
+      context 'without tags' do
+        let(:content) { 'this is some sample content' }
+
+        it { is_expected.to eql 'this is some sample content' }
+      end
+
+      context 'with SERVICE_NAME tag' do
+        let(:content) { 'You are on the [[SERVICE_NAME]]' }
+
+        it { is_expected.to eql 'You are on the Northern Ireland Online Tariff' }
+      end
+
+      context 'with SERVICE_PATH tag' do
+        let(:content) { '<a href="[[SERVICE_PATH]]/browse">Browse</a>' }
+
+        it { is_expected.to eql '<a href="/xi/browse">Browse</a>' }
+      end
+
+      context 'with SERVICE_REGION' do
+        let(:content) { 'within [[SERVICE_REGION]]' }
+
+        it { is_expected.to eql 'within Northern Ireland' }
+      end
+
+      context 'with multiple tags' do
+        let :content do
+          <<~END_OF_CONTENT
+            [[SERVICE_NAME]]
+            * [Find commodity]([[SERVICE_PATH]]/find_commodity)
+            * [Browse]([[SERVICE_PATH]]/browse)
+          END_OF_CONTENT
+        end
+
+        let :expected do
+          <<~END_OF_EXPECTED
+            Northern Ireland Online Tariff
+            * [Find commodity](/xi/find_commodity)
+            * [Browse](/xi/browse)
+          END_OF_EXPECTED
+        end
+
+        it { is_expected.to eql expected }
+      end
+    end
+  end
+
   describe '#import_export_date_title' do
     subject(:import_export_date_title) { helper.import_export_date_title }
 

--- a/spec/views/news_items/_latest_news.html.erb_spec.rb
+++ b/spec/views/news_items/_latest_news.html.erb_spec.rb
@@ -3,10 +3,11 @@ require 'spec_helper'
 RSpec.describe 'news_items/latest_news.html.erb', type: :view do
   subject { render 'news_items/latest_news', news_item: news_item }
 
-  let(:news_item) { build :news_item }
+  let(:news_item) { build :news_item, content: "[[SERVICE_NAME]]\n\nFirst para" }
 
   it { is_expected.to have_css '.latest-news-banner.govuk-notification-banner' }
   it { is_expected.to have_css '.latest-news-banner h2', text: news_item.title }
   it { is_expected.to have_css '.latest-news-banner .tariff-markdown p' }
+  it { is_expected.to have_css '.latest-news-banner p', text: /#{I18n.t('title.service_name.uk')}/ }
   it { is_expected.to have_link 'Show more ...', href: news_item_path(news_item) }
 end

--- a/spec/views/news_items/index.html.erb_spec.rb
+++ b/spec/views/news_items/index.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'news_items/index.html.erb', type: :view do
 
   before { assign :news_items, news_items }
 
-  let(:news_items) { build_list :news_item, 3 }
+  let(:news_items) { build_list :news_item, 3, content: "[[SERVICE_NAME]]\n\nFirst para" }
   let(:date_format) { /\d\d? [A-Z][a-z]{2} [12]\d{3}/ }
 
   it { is_expected.to have_css 'section.news-items' }
@@ -13,6 +13,7 @@ RSpec.describe 'news_items/index.html.erb', type: :view do
   it { is_expected.to have_css 'section.news-items article.news-item', count: 3 }
   it { is_expected.to have_css 'section article h2', count: 3 }
   it { is_expected.to have_css 'section article .tariff-markdown p', count: 3 }
+  it { is_expected.to have_css '.news-item p', text: /#{I18n.t('title.service_name.uk')}/ }
   it { is_expected.to have_link 'Show more ...', href: %r{/news/\d+} }
 
   context 'with single paragraph news items' do

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe 'news_items/show.html.erb', type: :view do
 
   before { assign :news_item, news_item }
 
-  let(:news_item) { build :news_item }
+  let(:news_item) { build :news_item, content: 'Welcome to [[SERVICE_NAME]]' }
   let(:expected_date) { news_item.start_date.to_formatted_s :long }
 
   it { is_expected.to have_css 'article.news-item' }
   it { is_expected.to have_css 'article h2', text: news_item.title }
   it { is_expected.to have_css 'article h3', text: /published.*#{expected_date}/i }
   it { is_expected.to have_css 'article .tariff-markdown p' }
+  it { is_expected.to have_css 'p', text: /Welcome to #{I18n.t('title.service_name.uk')}/ }
 end


### PR DESCRIPTION
### Jira link

[HOTT-1132](https://transformuk.atlassian.net/browse/HOTT-1132)

### What?

I have added/removed/altered:

- [x] Renamed the `region_name` helper to `service_region` to clarify usage
- [x] Added a `replace_service_tags` helper to allow inserting the service name/region into the News Item content
- [x] Used the helper on the various places news items are rendered

### Why?

I am doing this because:

- We want a way to insert the Service name into news item content shown on the frontend
