### PR TITLE
HOTT-1180 Fixed spacing on commodities page header

### DIFF
--- a/app/views/commodities/_header.html.erb
+++ b/app/views/commodities/_header.html.erb
@@ -1,9 +1,4 @@
-<header>
-  <span class="govuk-caption-xl">
-    <%= trade_tariff_heading %>
-    <%= switch_service_button %>
-  </span>
-
+<%= page_header do %>
   <h1 class="govuk-heading-l commodity-header" data-comm-code="<%= commodity_code %>">
     Commodity <%= segmented_commodity_code commodity_code %>
     <div class="copy_code" id="copy_code">
@@ -11,4 +6,4 @@
       <span class="copied">Code copied</span>
     </div>
   </h1>
-</header>
+<% end %>


### PR DESCRIPTION
### Jira link

[HOTT-1180](https://transformuk.atlassian.net/browse/HOTT-1180)

### What?

I have added/removed/altered:

- [x] Switched to use the same `page_header` helper on commodities#show as other pages are using

### Why?

I am doing this because:

- The spacing was incorrect in the caption on Commodities#show next to the switch service button, this was caused by use an older version of the markup as a result of a merge issue.

### Have you? (optional)

- [x] Validated mobile responsive behaviour of view changes

