### PR TITLE
Updates home path to find_commodity globally

### DIFF
--- a/app/controllers/cookies/hide_confirmations_controller.rb
+++ b/app/controllers/cookies/hide_confirmations_controller.rb
@@ -6,7 +6,7 @@ module Cookies
         expires: 1.year.from_now,
       }
 
-      redirect_back(fallback_location: sections_path)
+      redirect_back(fallback_location: find_commodity_path)
     end
   end
 end

--- a/app/controllers/cookies/hide_confirmations_controller.rb
+++ b/app/controllers/cookies/hide_confirmations_controller.rb
@@ -6,7 +6,7 @@ module Cookies
         expires: 1.year.from_now,
       }
 
-      redirect_back(fallback_location: find_commodity_path)
+      redirect_back(fallback_location: home_path)
     end
   end
 end

--- a/app/controllers/cookies/policies_controller.rb
+++ b/app/controllers/cookies/policies_controller.rb
@@ -14,7 +14,7 @@ module Cookies
       cookies_policy.mark_persisted!
 
       if policy_params.key? :acceptance
-        redirect_back(fallback_location: sections_path)
+        redirect_back(fallback_location: find_commodity_path)
       else
         @saved = true
         render :show

--- a/app/controllers/cookies/policies_controller.rb
+++ b/app/controllers/cookies/policies_controller.rb
@@ -14,7 +14,7 @@ module Cookies
       cookies_policy.mark_persisted!
 
       if policy_params.key? :acceptance
-        redirect_back(fallback_location: find_commodity_path)
+        redirect_back(fallback_location: home_path)
       else
         @saved = true
         render :show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,12 @@
 module ApplicationHelper
+  def home_path(*args, &block)
+    find_commodity_path(*args, &block)
+  end
+
+  def home_url(*args, &block)
+    find_commodity_url(*args, &block)
+  end
+
   def govspeak(text)
     text = text['content'] || text[:content] if text.is_a?(Hash)
     return '' if text.nil?

--- a/app/helpers/goods_nomenclature_helper.rb
+++ b/app/helpers/goods_nomenclature_helper.rb
@@ -8,7 +8,7 @@ module GoodsNomenclatureHelper
 
     case current_goods_nomenclature_code&.size
     when nil
-      find_commodity_path(path_opts)
+      home_path(path_opts)
     when Chapter::SHORT_CODE_LENGTH
       chapter_path(path_opts)
     when Heading::SHORT_CODE_LENGTH

--- a/app/helpers/goods_nomenclature_helper.rb
+++ b/app/helpers/goods_nomenclature_helper.rb
@@ -8,7 +8,7 @@ module GoodsNomenclatureHelper
 
     case current_goods_nomenclature_code&.size
     when nil
-      sections_path(path_opts)
+      find_commodity_path(path_opts)
     when Chapter::SHORT_CODE_LENGTH
       chapter_path(path_opts)
     when Heading::SHORT_CODE_LENGTH

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -85,12 +85,6 @@ module ServiceHelper
     service_choice == 'uk'
   end
 
-  def switch_banner_copy
-    copy = request.filtered_path == sections_path ? "service_banner.big.#{service_choice}" : 'service_banner.small'
-
-    t(copy, link: switch_service_link).html_safe
-  end
-
   def switch_banner_bottom_copy
     t("service_banner.bottom.#{service_choice}")
   end

--- a/app/views/browse_sections/index.html.erb
+++ b/app/views/browse_sections/index.html.erb
@@ -7,7 +7,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.browse'),
       [
-        [t('breadcrumb.home'), sections_path]
+        [t('breadcrumb.home'), find_commodity_path]
       ]
     )
   %>

--- a/app/views/browse_sections/index.html.erb
+++ b/app/views/browse_sections/index.html.erb
@@ -7,7 +7,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.browse'),
       [
-        [t('breadcrumb.home'), find_commodity_path]
+        [t('breadcrumb.home'), home_path]
       ]
     )
   %>

--- a/app/views/cookies/policies/show.html.erb
+++ b/app/views/cookies/policies/show.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
           "Cookies on UK Integrated Online Tariff",
           [
-              [t('breadcrumb.home'), sections_path],
+              [t('breadcrumb.home'), find_commodity_path],
           ]
       )
   %>

--- a/app/views/cookies/policies/show.html.erb
+++ b/app/views/cookies/policies/show.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
           "Cookies on UK Integrated Online Tariff",
           [
-              [t('breadcrumb.home'), find_commodity_path],
+              [t('breadcrumb.home'), home_path],
           ]
       )
   %>

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -16,14 +16,14 @@
 <% content_for :header_class, 'with-proposition' %>
 <% content_for :proposition_header do %>
   <div class="govuk-header__content">
-    <a href="<%= find_commodity_path %>" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">
+    <a href="<%= home_path %>" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">
       <%= trade_tariff_heading %>
     </a>
     <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="proposition-links" aria-label="Show or hide Top Level Navigation">Menu</button>
     <nav id="proposition-menu"  aria-label="Top Level Navigation">
       <ul id="proposition-links" class="govuk-header__navigation ">
         <%= govuk_header_navigation_item(active_class: search_active_class) do %>
-          <%= link_to 'Search', find_commodity_path, class: "govuk-header__link" %>
+          <%= link_to 'Search', home_path, class: "govuk-header__link" %>
         <% end %>
         <%= govuk_header_navigation_item(active_class: browse_active_class) do %>
           <%= link_to 'Browse', browse_sections_path, class: "govuk-header__link" %>

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -16,7 +16,7 @@
 <% content_for :header_class, 'with-proposition' %>
 <% content_for :proposition_header do %>
   <div class="govuk-header__content">
-    <a href="<%= sections_path %>" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">
+    <a href="<%= find_commodity_path %>" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">
       <%= trade_tariff_heading %>
     </a>
     <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="proposition-links" aria-label="Show or hide Top Level Navigation">Menu</button>

--- a/app/views/meursing_lookup/steps/_start.html.erb
+++ b/app/views/meursing_lookup/steps/_start.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.meursing_lookup'),
       [
-        [t('breadcrumb.home'), sections_path],
+        [t('breadcrumb.home'), find_commodity_path],
         [t('breadcrumb.tools'), tools_path]
       ]
     )

--- a/app/views/meursing_lookup/steps/_start.html.erb
+++ b/app/views/meursing_lookup/steps/_start.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.meursing_lookup'),
       [
-        [t('breadcrumb.home'), find_commodity_path],
+        [t('breadcrumb.home'), home_path],
         [t('breadcrumb.tools'), tools_path]
       ]
     )

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -1,7 +1,7 @@
 <%= page_header 'Latest news' %>
 
 <% content_for :top_breadcrumbs do %>
-  <%= generate_breadcrumbs t('breadcrumb.news'), [[t('breadcrumb.home'), find_commodity_path]] %>
+  <%= generate_breadcrumbs t('breadcrumb.news'), [[t('breadcrumb.home'), home_path]] %>
 <% end %>
 
 <section class="news-items">

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -1,7 +1,7 @@
 <%= page_header 'Latest news' %>
 
 <% content_for :top_breadcrumbs do %>
-  <%= generate_breadcrumbs t('breadcrumb.news'), [[t('breadcrumb.home'), sections_path]] %>
+  <%= generate_breadcrumbs t('breadcrumb.news'), [[t('breadcrumb.home'), find_commodity_path]] %>
 <% end %>
 
 <section class="news-items">

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs truncate(@news_item.title),
-                           [ [t('breadcrumb.home'), find_commodity_path],
+                           [ [t('breadcrumb.home'), home_path],
                              [t('breadcrumb.news'), news_items_path] ] %>
 <% end %>
 

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs truncate(@news_item.title),
-                           [ [t('breadcrumb.home'), sections_path],
+                           [ [t('breadcrumb.home'), find_commodity_path],
                              [t('breadcrumb.news'), news_items_path] ] %>
 <% end %>
 

--- a/app/views/pages/cn2021_cn2022.html.erb
+++ b/app/views/pages/cn2021_cn2022.html.erb
@@ -4,7 +4,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.help_goods_classification'),
       [
-        [t('breadcrumb.home'), sections_path],
+        [t('breadcrumb.home'), find_commodity_path],
         [t('breadcrumb.help'), help_path]
       ]
     )

--- a/app/views/pages/cn2021_cn2022.html.erb
+++ b/app/views/pages/cn2021_cn2022.html.erb
@@ -4,7 +4,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.help_goods_classification'),
       [
-        [t('breadcrumb.home'), find_commodity_path],
+        [t('breadcrumb.home'), home_path],
         [t('breadcrumb.help'), help_path]
       ]
     )

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
     t('breadcrumb.help'),
     [
-      [t('breadcrumb.home'), find_commodity_path]
+      [t('breadcrumb.home'), home_path]
     ]
   ) %>
 <% end %>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
     t('breadcrumb.help'),
     [
-      [t('breadcrumb.home'), sections_path]
+      [t('breadcrumb.home'), find_commodity_path]
     ]
   ) %>
 <% end %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -8,7 +8,7 @@
         <li>check if there’s duty or VAT to pay</li>
         <li>find out about duty reliefs</li>
       </ul>
-      <a class="button button-start" href="<%= find_commodity_path %>" role="button">Start now</a>
+      <a class="button button-start" href="<%= home_path %>" role="button">Start now</a>
     </section>
     <section class="more content-block">
       <h2 id="if-youre-not-sure-how-to-classify-your-goods">If you’re not sure how to classify your goods</h2>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -8,7 +8,7 @@
         <li>check if there’s duty or VAT to pay</li>
         <li>find out about duty reliefs</li>
       </ul>
-      <a class="button button-start" href="<%= sections_path %>" role="button">Start now</a>
+      <a class="button button-start" href="<%= find_commodity_path %>" role="button">Start now</a>
     </section>
     <section class="more content-block">
       <h2 id="if-youre-not-sure-how-to-classify-your-goods">If you’re not sure how to classify your goods</h2>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.privacy'),
       [
-        [t('breadcrumb.home'), sections_path]
+        [t('breadcrumb.home'), find_commodity_path]
       ]
     )
   %>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.privacy'),
       [
-        [t('breadcrumb.home'), find_commodity_path]
+        [t('breadcrumb.home'), home_path]
       ]
     )
   %>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.terms'),
       [
-        [t('breadcrumb.home'), sections_path]
+        [t('breadcrumb.home'), find_commodity_path]
       ]
     )
   %>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.terms'),
       [
-        [t('breadcrumb.home'), find_commodity_path]
+        [t('breadcrumb.home'), home_path]
       ]
     )
   %>

--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.tools'),
       [
-        [t('breadcrumb.home'), find_commodity_path]
+        [t('breadcrumb.home'), home_path]
       ]
     )
   %>

--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.tools'),
       [
-        [t('breadcrumb.home'), sections_path]
+        [t('breadcrumb.home'), find_commodity_path]
       ]
     )
   %>

--- a/app/views/search/additional_code_search.erb
+++ b/app/views/search/additional_code_search.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.additional_codes'),
       [
-        [t('breadcrumb.home'), sections_path],
+        [t('breadcrumb.home'), find_commodity_path],
         [t('breadcrumb.tools'), tools_path]
       ]
     )

--- a/app/views/search/certificate_search.erb
+++ b/app/views/search/certificate_search.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.certificates'),
       [
-        [t('breadcrumb.home'), sections_path],
+        [t('breadcrumb.home'), find_commodity_path],
         [t('breadcrumb.tools'), tools_path]
       ]
     )

--- a/app/views/search/chemical_search.html.erb
+++ b/app/views/search/chemical_search.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.chemicals'),
       [
-        [t('breadcrumb.home'), sections_path],
+        [t('breadcrumb.home'), find_commodity_path],
         [t('breadcrumb.tools'), tools_path]
       ]
     )

--- a/app/views/search/footnote_search.erb
+++ b/app/views/search/footnote_search.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.footnote_search'),
       [
-        [t('breadcrumb.home'), sections_path],
+        [t('breadcrumb.home'), find_commodity_path],
         [t('breadcrumb.tools'), tools_path]
       ]
     )

--- a/app/views/search/quota_search.html.erb
+++ b/app/views/search/quota_search.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.quotas'),
       [
-        [t('breadcrumb.home'), sections_path],
+        [t('breadcrumb.home'), find_commodity_path],
         [t('breadcrumb.tools'), tools_path]
       ]
     )

--- a/app/views/search_references/show.html.erb
+++ b/app/views/search_references/show.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.az'),
       [
-        [t('breadcrumb.home'), find_commodity_path],
+        [t('breadcrumb.home'), home_path],
       ]
     )
   %>

--- a/app/views/search_references/show.html.erb
+++ b/app/views/search_references/show.html.erb
@@ -2,7 +2,7 @@
   <%= generate_breadcrumbs(
       t('breadcrumb.az'),
       [
-        [t('breadcrumb.home'), sections_path],
+        [t('breadcrumb.home'), find_commodity_path],
       ]
     )
   %>

--- a/app/views/shared/_top_breadcrumbs.html.erb
+++ b/app/views/shared/_top_breadcrumbs.html.erb
@@ -2,7 +2,7 @@
   <nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
-        <%= link_to "Home", find_commodity_path, class:'govuk-breadcrumbs__link' %>
+        <%= link_to "Home", home_path, class:'govuk-breadcrumbs__link' %>
       </li>
 
       <li class="govuk-breadcrumbs__list-item">

--- a/app/views/shared/_top_breadcrumbs.html.erb
+++ b/app/views/shared/_top_breadcrumbs.html.erb
@@ -2,7 +2,7 @@
   <nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
-        <%= link_to "Home", sections_path, class:'govuk-breadcrumbs__link' %>
+        <%= link_to "Home", find_commodity_path, class:'govuk-breadcrumbs__link' %>
       </li>
 
       <li class="govuk-breadcrumbs__list-item">

--- a/spec/controllers/import_export_dates_controller_spec.rb
+++ b/spec/controllers/import_export_dates_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ImportExportDatesController, type: :controller do
         it { is_expected.to redirect_to(public_send(path_method, day: '1', month: '2', year: '2021', id: goods_nomenclature_code)) }
       end
 
-      it_behaves_like 'a valid date redirect', :sections_path, nil
+      it_behaves_like 'a valid date redirect', :find_commodity_path, nil
       it_behaves_like 'a valid date redirect', :chapter_path, '01'
       it_behaves_like 'a valid date redirect', :heading_path, '1501'
       it_behaves_like 'a valid date redirect', :commodity_path, '2402201000'

--- a/spec/controllers/trading_partners_controller_spec.rb
+++ b/spec/controllers/trading_partners_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe TradingPartnersController, type: :controller do
         it { is_expected.to redirect_to(public_send(path_method, country: 'IT', id: goods_nomenclature_code)) }
       end
 
-      it_behaves_like 'a valid trading partner redirect', :sections_path, nil
+      it_behaves_like 'a valid trading partner redirect', :find_commodity_path, nil
       it_behaves_like 'a valid trading partner redirect', :chapter_path, '01'
       it_behaves_like 'a valid trading partner redirect', :heading_path, '1501'
       it_behaves_like 'a valid trading partner redirect', :commodity_path, '2402201000'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,18 @@
 require 'spec_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
+  describe '#home_path' do
+    subject(:home_path) { helper.home_path }
+
+    it { is_expected.to eq(find_commodity_path) }
+  end
+
+  describe '#home_url' do
+    subject(:home_url) { helper.home_url }
+
+    it { is_expected.to eq(find_commodity_url) }
+  end
+
   describe '#govspeak' do
     context 'with string without HTML code' do
       let(:string) { '**hello**' }

--- a/spec/helpers/goods_nomenclature_helper_spec.rb
+++ b/spec/helpers/goods_nomenclature_helper_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe GoodsNomenclatureHelper, type: :helper do
     it_behaves_like 'a goods_nomenclature_path', '1901200000', '/commodities/1901200000?country=AR&day=01&month=01&year=2021#export'
     it_behaves_like 'a goods_nomenclature_path', '1901', '/headings/1901?country=AR&day=01&month=01&year=2021#export'
     it_behaves_like 'a goods_nomenclature_path', '19', '/chapters/19?country=AR&day=01&month=01&year=2021#export'
-    it_behaves_like 'a goods_nomenclature_path', nil, '/sections?country=AR&day=01&month=01&year=2021'
+    it_behaves_like 'a goods_nomenclature_path', nil, '/find_commodity?country=AR&day=01&month=01&year=2021'
   end
 
   describe '#current_goods_nomenclature_code' do

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -183,31 +183,6 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
-  describe '#switch_banner_copy' do
-    before do
-      helper.request.path = path
-      assign(:enable_service_switch_banner_in_action, true)
-    end
-
-    include_context 'with XI service'
-
-    context 'when on sections page' do
-      let(:path) { '/xi/sections' }
-
-      it 'returns the full banner that allows users to toggle between the services' do
-        expect(helper.switch_banner_copy).to include(t('service_banner.big.xi', link: helper.switch_service_link))
-      end
-    end
-
-    context 'when not on sections page' do
-      let(:path) { '/xi/foo' }
-
-      it 'returns the subtle banner that allows users to toggle between the services' do
-        expect(helper.switch_banner_copy).to include(t('service_banner.small', link: helper.switch_service_link))
-      end
-    end
-  end
-
   describe '#service_choice' do
     context 'when there is a service choice set' do
       include_context 'with XI service'

--- a/spec/requests/cookies/hide_confirmations_controller_spec.rb
+++ b/spec/requests/cookies/hide_confirmations_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Cookies::HideConfirmationsController, type: :request do
     end
 
     it 'redirects to the correct fallback location' do
-      expect(response).to redirect_to(sections_path)
+      expect(response).to redirect_to(find_commodity_path)
     end
   end
 end

--- a/spec/requests/cookies/policies_controller_spec.rb
+++ b/spec/requests/cookies/policies_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Cookies::PoliciesController, type: :request do
       end
 
       it 'redirects to the correct fallback location' do
-        expect(response).to redirect_to(sections_path)
+        expect(response).to redirect_to(find_commodity_path)
       end
     end
 
@@ -86,7 +86,7 @@ RSpec.describe Cookies::PoliciesController, type: :request do
       end
 
       it 'redirects to the correct fallback location' do
-        expect(response).to redirect_to(sections_path)
+        expect(response).to redirect_to(find_commodity_path)
       end
     end
 

--- a/spec/routing/service_path_prefix_handling_spec.rb
+++ b/spec/routing/service_path_prefix_handling_spec.rb
@@ -136,15 +136,15 @@ RSpec.describe RoutingFilter::ServicePathPrefixHandler, type: :routing do
       let(:choice) { 'xi' }
 
       it 'prepends the choice to the path' do
-        result = sections_path
+        result = find_commodity_path
 
-        expect(result).to eq('/xi/sections')
+        expect(result).to eq('/xi/find_commodity')
       end
 
       it 'prepends the choice to the url' do
-        result = sections_url
+        result = find_commodity_url
 
-        expect(result).to eq('http://test.host/xi/sections')
+        expect(result).to eq('http://test.host/xi/find_commodity')
       end
     end
   end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Altered references to sections_path to be browse_sections_path

### Why?

I am doing this because:

- Avoids unnecessary redirects
- Cleans up references to an unused path we might get rid of later
