### PR TITLE
HOTT-1143: Migrate to sentry-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'govuk_design_system_formbuilder', github: 'DFE-Digital/govuk-formbuilder'
 gem 'wizard_steps'
 
 # Sentry
-gem 'sentry-raven'
+gem 'sentry-rails'
 
 group :development do
   gem 'letter_opener'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,8 +385,6 @@ GEM
     sentry-rails (4.5.2)
       railties (>= 5.0)
       sentry-ruby-core (~> 4.5.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
     sentry-ruby (4.5.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
@@ -487,7 +485,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop-govuk
   selenium-webdriver
-  sentry-raven
+  sentry-rails
   shoulda-matchers
   simplecov
   timecop

--- a/app/helpers/country_flag_helper.rb
+++ b/app/helpers/country_flag_helper.rb
@@ -8,7 +8,7 @@ module CountryFlagHelper
                    **kwargs.merge(class: 'country-flag')
   rescue Webpacker::Manifest::MissingEntryError
     unless CountryFlagHelper::COUNTRY_FLAG_IGNORE.include?(two_letter_country_code)
-      Raven.capture_message \
+      Sentry.capture_message \
         "Missing flag image file for #{two_letter_country_code}"
     end
 

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,8 +1,0 @@
-if defined?(Raven) && ENV['VCAP_APPLICATION'].present?
-  tags = JSON.parse(ENV['VCAP_APPLICATION'])
-             .except('application_uris', 'host', 'application_name', 'space_id', 'port', 'uris', 'application_version')
-             .merge({ server_name: ENV['GOVUK_APP_DOMAIN'] })
-  Raven.configure do |config|
-    config.tags = tags
-  end
-end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,5 @@
+Sentry.init do |config|
+  config.rails.report_rescued_exceptions = false
+
+  config.breadcrumbs_logger = [:active_support_logger]
+end

--- a/lib/sentry/rails/background_worker.rb
+++ b/lib/sentry/rails/background_worker.rb
@@ -1,0 +1,7 @@
+module Sentry
+  class BackgroundWorker
+    def _perform(&block)
+      block.call
+    end
+  end
+end

--- a/spec/helpers/country_flag_helper_spec.rb
+++ b/spec/helpers/country_flag_helper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe CountryFlagHelper, type: :helper do
   describe '#country_flag_tag' do
-    before { allow(Raven).to receive(:capture_message).and_return(true) }
+    before { allow(Sentry).to receive(:capture_message).and_return(true) }
 
     context 'with GB' do
       subject(:rendered) { helper.country_flag_tag('GB') }
@@ -32,7 +32,7 @@ RSpec.describe CountryFlagHelper, type: :helper do
       it 'notifies Sentry' do
         rendered
 
-        expect(Raven).to have_received(:capture_message)
+        expect(Sentry).to have_received(:capture_message)
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe CountryFlagHelper, type: :helper do
       it 'does not notify Sentry' do
         rendered
 
-        expect(Raven).not_to have_received(:capture_message)
+        expect(Sentry).not_to have_received(:capture_message)
       end
     end
   end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1143

### What?

I have added/removed/altered:

- [x] Added monkey patch for sentry rails
- [x] Added config initializer
- [x] Added sentry-rails gem
- [x] Fixed broken specs

### Why?

I am doing this because:

- The sentry-raven gem is now out of support
