### PR TITLE
HOTT-1166: Updates shared stw link copy

### DIFF
--- a/app/helpers/declarable_helper.rb
+++ b/app/helpers/declarable_helper.rb
@@ -17,7 +17,7 @@ module DeclarableHelper
       .html_safe
   end
 
-  def declarable_stw_link(declarable, search)
+  def declarable_stw_link(declarable, search, anchor = 'import')
     geographical_area = GeographicalArea.find(search.country)
     declarable_type = declarable.heading? ? 'heading' : 'commodity'
     today = Time.zone.today
@@ -37,9 +37,8 @@ module DeclarableHelper
     }
 
     stw_link = "#{TradeTariffFrontend.single_trade_window_url}?#{CGI.unescape(stw_options.to_query)}"
-
     link_to(
-      "Check how to import #{declarable_type} #{declarable.code} from #{geographical_area&.description}.",
+      "check how to #{anchor} #{declarable_type} #{declarable.code} from #{geographical_area&.description}.",
       stw_link,
       target: '_blank',
       class: 'govuk-link',

--- a/app/views/measures/_meursing_form.html.erb
+++ b/app/views/measures/_meursing_form.html.erb
@@ -1,7 +1,7 @@
 <% meursing_finder_link = link_to 'Meursing code finder', meursing_lookup_step_path('start'), class: 'govuk-link' %>
 <% meursing_clear_link = link_to 'Clear additional code', meursing_lookup_result_path, class: 'govuk-link meursing-form-textual-button' %>
 
-<div id="meursing" class="govuk-inset-text govuk-inset-text--s no-inset tariff-inset">
+<div id="meursing" class="govuk-inset-text govuk-inset-text--s no-inset tariff-inset-meursing">
   <%= form_for MeursingLookup::Result.new, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
     <h4 class="govuk-heading-s">Enter a 'Meursing code' to work out applicable duties</h4>
     <p class="govuk-body">This commodity code features duties which may be dependent on the <b>sugar, flour, milk fat and milk protein</b> content. To fully define the applicable duties, you need to specify the additional code that defines the content of these ingredients.</p>

--- a/app/views/measures/grouped/_table.html.erb
+++ b/app/views/measures/grouped/_table.html.erb
@@ -2,15 +2,7 @@
   <%= local_assigns[:caption] %>
 </h3>
 
-<% if local_assigns[:show_stw_text] %> 
-  <p class= "govuk-body">
-    <% if search.country.present? %>
-      <%= declarable_stw_link(declarable, search) %>
-    <% else %>
-      To use the new 'Check how to import or export goods' service to find out which licences and certificates you need to import commodity code <%= declarable.code %>, select the country of origin from the dropdown above.
-    <% end %>
-  </p>
-<% end %>
+<%= render 'shared/stw_link', declarable: declarable, search: search, anchor: anchor if local_assigns[:show_stw_text]  %>
 
 <table class="small-table measures govuk-table"  >
   <thead class="govuk-table__head">

--- a/app/views/measures/grouped/_uk.html.erb
+++ b/app/views/measures/grouped/_uk.html.erb
@@ -10,6 +10,7 @@
     hide_duty_rate: true,
     search: @search,
     show_stw_text: true,
+    anchor: 'import'
   }
 %>
 <% end %>

--- a/app/views/shared/_stw_link.html.erb
+++ b/app/views/shared/_stw_link.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-inset-text govuk-inset-text--s tariff-inset-information">
+    <% if search.country.present? %>
+      <p class= "govuk-body">
+        <strong>Check how to import or export goods</strong>
+      </p>
+
+      <p class= "govuk-body">
+        Now you have identified your commodity code, you can <%= declarable_stw_link(declarable, search, anchor) %>
+      </p>
+    <% else %>
+      To <strong>check how to import commodity <%= declarable.code %></strong>, select the <%= link_to("country from which you are importing", trading_partners_path) %>.
+  <% end %>
+  </p>
+</div>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -46,6 +46,7 @@ $govuk-images-path: '~govuk-frontend/govuk/assets/images/';
 @import '../src/stylesheets/panel';
 @import '../src/stylesheets/pagination';
 @import '../src/stylesheets/tariff-custom';
+@import '../src/stylesheets/tariff-inset';
 @import '../src/stylesheets/copy_code';
 @import '../src/stylesheets/rules_of_origin';
 @import '../src/stylesheets/news_items' ;

--- a/app/webpacker/src/stylesheets/_colors.scss
+++ b/app/webpacker/src/stylesheets/_colors.scss
@@ -10,5 +10,11 @@ $commodity-code-bg: #abeae5;
 $table-header-bg: #e1e8e8;
 $table-sub-border: tint($govuk-border-colour);
 
+ // TODO: Remove these - exchange rates are no longer something we manage/view via the frontend
 $current-rate-accent-color: govuk-colour("green");
 $current-rate-secondary-color: $govuk-secondary-text-colour;
+
+$tariff-inset-background-color-meursing: #e9f4f9;
+$tariff-inset-border-left-color-meursing: #098dc1;
+
+$tariff-inset-background-color-information: #f0f4f5;

--- a/app/webpacker/src/stylesheets/_measures.scss
+++ b/app/webpacker/src/stylesheets/_measures.scss
@@ -62,14 +62,6 @@ dt.has_children + dd[aria-hidden="true"] {
   padding-top: 3px;
 }
 
-$tariff-inset-background-color:  #e9f4f9;
-$tariff-inset-border-left-color: #098dc1;
-
-.tariff-inset {
-  background-color: $tariff-inset-background-color;
-  border-left: 10px solid $tariff-inset-border-left-color;
-}
-
 .meursing-form-textual-button {
   margin-left: 15px;
   margin-right: 15px;

--- a/app/webpacker/src/stylesheets/_tariff-inset.scss
+++ b/app/webpacker/src/stylesheets/_tariff-inset.scss
@@ -1,8 +1,3 @@
-$tariff-inset-background-color-meursing:  #e9f4f9;
-$tariff-inset-border-left-color-meursing: #098dc1;
-
-$tariff-inset-background-color-information:  #f0f4f5;
-
 .tariff-inset-meursing {
   background-color: $tariff-inset-background-color-meursing;
   border-left: 10px solid $tariff-inset-border-left-color-meursing;

--- a/app/webpacker/src/stylesheets/_tariff-inset.scss
+++ b/app/webpacker/src/stylesheets/_tariff-inset.scss
@@ -1,0 +1,14 @@
+$tariff-inset-background-color-meursing:  #e9f4f9;
+$tariff-inset-border-left-color-meursing: #098dc1;
+
+$tariff-inset-background-color-information:  #f0f4f5;
+
+.tariff-inset-meursing {
+  background-color: $tariff-inset-background-color-meursing;
+  border-left: 10px solid $tariff-inset-border-left-color-meursing;
+}
+
+.tariff-inset-information {
+  background-color: $tariff-inset-background-color-information;
+}
+

--- a/spec/helpers/declarable_helper_spec.rb
+++ b/spec/helpers/declarable_helper_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe DeclarableHelper, type: :helper do
       let(:declarable) { build(:heading) }
 
       it 'returns the expected text' do
-        expected_text = "Check how to import heading #{declarable.code} from France."
+        expected_text = "check how to import heading #{declarable.code} from France."
 
         expect(declarable_stw_link).to include(expected_text)
       end
@@ -50,7 +50,7 @@ RSpec.describe DeclarableHelper, type: :helper do
       let(:declarable) { build(:commodity) }
 
       it 'returns the expected text' do
-        expected_text = "Check how to import commodity #{declarable.code} from France."
+        expected_text = "check how to import commodity #{declarable.code} from France."
 
         expect(declarable_stw_link).to include(expected_text)
       end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1166

### What?

**Picked a country and see the stw link**

![Screenshot from 2021-12-08 16-45-06](https://user-images.githubusercontent.com/8156884/145249109-bea4e95e-0dab-42ff-9a53-f53a339b0472.png)

**No country picked see the trading partners link**

![Screenshot from 2021-12-08 16-51-03](https://user-images.githubusercontent.com/8156884/145249301-5794b601-76f5-4e3f-a962-df3ef25f3dbd.png)

I have added/removed/altered:

- [x] Updated copy of the current stw links and moved it to a partial for easier reading
- [x] Added tariff-inset.scss to reflect common colors/styles for govuk-inset-texts
- [x] Altered meursing form to use the new differentiating inset-text style
- [x] Added a new inset text style for informational insets

### Why?

I am doing this because:

- This is a feature request
- The way we manage insets as part of the measures.scss was a bit confused since insets are a global thing
