### PR TITLE
Move to zeitwerk

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,8 +26,6 @@ module TradeTariffFrontend
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
-    config.autoloader = :classic
-
     require 'trade_tariff_frontend'
 
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1193

### What?

I have added/removed/altered:

- [x] Migrate us to zeitwerk

### Why?

I am doing this because:

- This enables an upgrade to rails 7
- And makes loading constants simpler
