### PR TITLE
HOTT-1194: Handle broken date type implementation 

### DIFF
--- a/app/controllers/import_export_dates_controller.rb
+++ b/app/controllers/import_export_dates_controller.rb
@@ -12,14 +12,14 @@ class ImportExportDatesController < ApplicationController
   def update
     @import_export_date = ImportExportDate.new(update_import_export_date_params)
 
-    if @import_export_date.errors.messages.any?
-      render 'show'
-    else
+    if @import_export_date.valid?
       redirect_to goods_nomenclature_path(
         day: @import_export_date.day,
         month: @import_export_date.month,
         year: @import_export_date.year,
       )
+    else
+      render 'show'
     end
   end
 

--- a/app/models/import_export_date.rb
+++ b/app/models/import_export_date.rb
@@ -3,37 +3,15 @@ class ImportExportDate
   include ActiveModel::Attributes
   include ActiveRecord::AttributeAssignment
 
-  attribute :import_date, :date
+  attribute :import_date, :tariff_date
 
   delegate :day, :month, :year, to: :import_date, allow_nil: true
 
-  def initialize(attributes = {})
-    # We need to do validations before attribute coersion for multiparameter assignment
-    # otherwise we get a MultiparameterAssignmentErrors error propagated when we fail to cast and do not attach the correct error messages for the form.
-    valid_attributes?(attributes)
-
-    super(attributes)
-  end
+  validate :import_date_valid
 
   private
 
-  def valid_attributes?(attributes)
-    return if attributes.empty? || valid_date?(attributes)
-
-    errors.add(:import_date, :invalid_date)
-
-    attributes.delete 'import_date(1i)'
-    attributes.delete 'import_date(2i)'
-    attributes.delete 'import_date(3i)'
-  end
-
-  def valid_date?(attributes)
-    Date.civil(
-      Integer(attributes['import_date(1i)']),
-      Integer(attributes['import_date(2i)']),
-      Integer(attributes['import_date(3i)']),
-    )
-  rescue ArgumentError
-    false
+  def import_date_valid
+    errors.add(:import_date, :invalid_date) unless attributes.empty? || import_date.is_a?(Date)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ module TradeTariffFrontend
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.time_zone = 'London'
 
     require 'trade_tariff_frontend'
 

--- a/config/initializers/attribute_types.rb
+++ b/config/initializers/attribute_types.rb
@@ -1,0 +1,3 @@
+require 'active_model_types/tariff_date'
+
+ActiveModel::Type.register(:tariff_date, ActiveModelTypes::TariffDate)

--- a/lib/active_model_types/tariff_date.rb
+++ b/lib/active_model_types/tariff_date.rb
@@ -13,7 +13,8 @@ module ActiveModelTypes
     def value_from_multiparameter_assignment(vargs)
       super
     rescue ArgumentError
-      :unparseable
+      # This needs to be nil to put an empty value in the form
+      nil
     end
   end
 end

--- a/lib/active_model_types/tariff_date.rb
+++ b/lib/active_model_types/tariff_date.rb
@@ -1,0 +1,19 @@
+module ActiveModelTypes
+  # There is currently no good way to handle the fact that
+  # the ActiveModel::Attributes module (through Time.utc)
+  # propagates an error on unparseable multi parameter date
+  # types currently. This is not something that happens within
+  # ActiveRecord where the broken date fails validation rather than
+  # when being casted.
+  #
+  # This is the most generic way we can think of to avoid propagating
+  # these errors and leave them to be appended to the messages hash as
+  # part of the validation callbacks.
+  class TariffDate < ActiveModel::Type::Date
+    def value_from_multiparameter_assignment(vargs)
+      super
+    rescue ArgumentError
+      :unparseable
+    end
+  end
+end

--- a/lib/active_model_types/tariff_date.rb
+++ b/lib/active_model_types/tariff_date.rb
@@ -10,8 +10,12 @@ module ActiveModelTypes
   # these errors and leave them to be appended to the messages hash as
   # part of the validation callbacks.
   class TariffDate < ActiveModel::Type::Date
-    def value_from_multiparameter_assignment(vargs)
-      super
+    def value_from_multiparameter_assignment(values_hash)
+      return unless values_hash[1] && values_hash[2] && values_hash[3]
+
+      values = values_hash.sort.map!(&:last)
+
+      ::Date.civil(*values)
     rescue ArgumentError
       # This needs to be nil to put an empty value in the form
       nil

--- a/spec/controllers/import_export_dates_controller_spec.rb
+++ b/spec/controllers/import_export_dates_controller_spec.rb
@@ -94,6 +94,12 @@ RSpec.describe ImportExportDatesController, type: :controller do
         expect(assigns(:import_export_date).errors.messages[:import_date]).to eq(['Enter a valid date'])
       end
 
+      it 'sets the import date to nil' do
+        response
+
+        expect(assigns(:import_export_date).import_date).to be_nil
+      end
+
       it { is_expected.to render_template('import_export_dates/show') }
       it { is_expected.to have_http_status(:ok) }
     end

--- a/spec/lib/active_model_types/tariff_date_spec.rb
+++ b/spec/lib/active_model_types/tariff_date_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe ActiveModelTypes::TariffDate do
+  subject(:type) { described_class.new }
+
+  let(:now) { Time.zone.today }
+
+  describe '#cast' do
+    context 'when passed a values hash' do
+      let(:value) { { 1 => now.year, 2 => now.mon, 3 => now.mday } }
+
+      it { expect(type.cast(value)).to eq(now) }
+    end
+
+    context 'when passed a valid iso8601 date string' do
+      let(:value) { now.iso8601 }
+
+      it { expect(type.cast(value)).to eq(now) }
+    end
+
+    context 'when passed an invalid iso8601 date string' do
+      let(:value) { { 1 => now.year, 2 => now.mon, 3 => 32 } }
+
+      it { expect(type.cast(value)).to be_nil }
+    end
+
+    context 'when passed a nil value' do
+      let(:value) { nil }
+
+      it { expect(type.cast(value)).to be_nil }
+    end
+
+    context 'when passed an empty string value' do
+      let(:value) { '' }
+
+      it { expect(type.cast(value)).to be_nil }
+    end
+
+    context 'when passed a string with just a space value' do
+      let(:value) { ' ' }
+
+      it { expect(type.cast(value)).to be_nil }
+    end
+
+    context 'when passed a string with invalid characters value' do
+      let(:value) { 'ABC' }
+
+      it { expect(type.cast(value)).to be_nil }
+    end
+  end
+end

--- a/spec/models/import_export_date_spec.rb
+++ b/spec/models/import_export_date_spec.rb
@@ -27,11 +27,24 @@ RSpec.describe ImportExportDate do
       it { is_expected.to be_valid }
     end
 
-    context 'when an invalid date is passed' do
+    context 'when a non-date is passed' do
       let(:attributes) do
         {
           'import_date(3i)' => 'foo',  # invalid
           'import_date(2i)' => '1',    # month
+          'import_date(1i)' => '2021', # year
+        }
+      end
+
+      it { expect(import_export_date.errors.messages[:import_date]).to include('Enter a valid date') }
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when an invalid date is passed' do
+      let(:attributes) do
+        {
+          'import_date(3i)' => '30',   # invalid
+          'import_date(2i)' => '2',    # month
           'import_date(1i)' => '2021', # year
         }
       end

--- a/spec/models/import_export_date_spec.rb
+++ b/spec/models/import_export_date_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe ImportExportDate do
     }
   end
 
-  describe 'errors' do
+  describe 'valid?' do
+    before { import_export_date.valid? }
+
     context 'when a valid date is passed' do
       let(:attributes) do
         {
@@ -22,18 +24,33 @@ RSpec.describe ImportExportDate do
       end
 
       it { expect(import_export_date.errors.messages).to be_empty }
+      it { is_expected.to be_valid }
     end
 
     context 'when an invalid date is passed' do
       let(:attributes) do
         {
-          'import_date(3i)' => 'foo',  # day
+          'import_date(3i)' => 'foo',  # invalid
           'import_date(2i)' => '1',    # month
           'import_date(1i)' => '2021', # year
         }
       end
 
       it { expect(import_export_date.errors.messages[:import_date]).to include('Enter a valid date') }
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when an empty date is passed' do
+      let(:attributes) do
+        {
+          'import_date(3i)' => '', # invalid
+          'import_date(2i)' => '', # invalid
+          'import_date(1i)' => '', # invalid
+        }
+      end
+
+      it { expect(import_export_date.errors.messages[:import_date]).to include('Enter a valid date') }
+      it { is_expected.not_to be_valid }
     end
   end
 


### PR DESCRIPTION

### Jira link

https://transformuk.atlassian.net/browse/HOTT-1194

### What?

I have added/removed/altered:

- [x] Handle invalid dates during Date type casting more gracefully

### Why?

I am doing this because:

- This was meant to resolve our need for the sentry-rails monkey patch by
  removing `include ActiveRecord::AttributeAssignment` (having ActiveRecord
  loaded in the AST triggers preloading connections before sending telemetry
  as part of an optimisation for serializing ActiveRecord model instances) but
  unfortunately was not able to achieve this
- It does achieve a significant tidy up in the api of the ImportExportDate model
  however
