### PR TITLE
HOTT-1192: Removes maxlength from import export dates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'aws-sdk-rails'
 gem 'newrelic_rpm'
 
 # For MeursingLookup functionality
-gem 'govuk_design_system_formbuilder', github: 'DFE-Digital/govuk-formbuilder'
+gem 'govuk_design_system_formbuilder'
 gem 'wizard_steps'
 
 # Sentry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/DFE-Digital/govuk-formbuilder.git
-  revision: 48ec42c5d144b34b0c21dcc0b0df25128e6b291f
-  specs:
-    govuk_design_system_formbuilder (2.8.0)
-      actionview (>= 6.0)
-      activemodel (>= 6.0)
-      activesupport (>= 6.0)
-      deep_merge (~> 1.2.1)
-
-GIT
   remote: https://github.com/rails/rails-controller-testing.git
   revision: bc6f3356803d7c5d373f89a44625d59953dc0cef
   branch: master
@@ -184,7 +174,12 @@ GEM
       sentry-ruby (~> 4.5.0)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
-    govuk_personalisation (0.11.0)
+    govuk_design_system_formbuilder (2.8.0)
+      actionview (>= 6.0)
+      activemodel (>= 6.0)
+      activesupport (>= 6.0)
+      deep_merge (~> 1.2.1)
+    govuk_personalisation (0.10.0)
       plek (>= 1.9.0)
       rails (~> 6)
     govuk_publishing_components (27.17.0)
@@ -461,7 +456,7 @@ DEPENDENCIES
   faraday_middleware
   forgery
   govspeak
-  govuk_design_system_formbuilder!
+  govuk_design_system_formbuilder
   kaminari
   letter_opener
   lograge

--- a/app/views/import_export_dates/show.html.erb
+++ b/app/views/import_export_dates/show.html.erb
@@ -12,8 +12,7 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_date_field :import_date,
         legend: { text: t('import_export_date.form.legend_text'), size: 'xl', tag: 'h1' },
-        hint: { text: t('import_export_date.form.hint_text_html') },
-        maxlength_enabled: true %>
+        hint: { text: t('import_export_date.form.hint_text_html') } %>
 
       <div class="govuk-button-group">
         <%= f.govuk_submit('Update date') %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1192

### What?

I have added/removed/altered:

- [x] Removed maxlength option from formbuilder for import export date form

### Why?

I am doing this because:

- See for a rationale https://github.com/DFE-Digital/govuk-formbuilder/pull/329#issuecomment-986008839
