### PR TITLE
Remove unused meursing tool link method

### DIFF
--- a/app/presenters/declarable_presenter.rb
+++ b/app/presenters/declarable_presenter.rb
@@ -1,12 +1,6 @@
 class DeclarablePresenter < TradeTariffFrontend::Presenter
-  MEURSING_TOOL_LINK = 'http://ec.europa.eu/taxation_customs/dds2/taric/measures.jsp?Lang=en&SimDate=%{date}&Taric=%{commodity_code}&LangDescr=en'.freeze
-
   def to_s
     formatted_description.html_safe
-  end
-
-  def meursing_tool_link_for(date)
-    sprintf(MEURSING_TOOL_LINK, date: date, commodity_code: code)
   end
 
   def self.model_name


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removed unused external meursing tool link method

### Why?

I am doing this because:

- This tool is now ported over to this service
