### PR TITLE
HOTT-1155: Update cache policy for cookies

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -111,7 +111,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_cache
-    expires_now
+    response.headers['Cache-Control'] = 'no-store'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = '-1'
   end
 
   def cookies_policy

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,8 +7,11 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
-  it 'has the correct Cache-Control header' do
-    get :index
-    expect(response.headers['Cache-Control']).to eq('no-cache')
+  describe 'GET #index' do
+    subject(:response) { get :index }
+
+    it { expect(response.headers['Cache-Control']).to eq('no-store') }
+    it { expect(response.headers['Pragma']).to eq('no-cache') }
+    it { expect(response.headers['Expires']).to eq('-1') }
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1155

### What?

I have added/removed/altered:

- [x] Added explicit cache policy in application controller
- [x] Added specs to cover the new policy

### Why?

I am doing this because:

- This is part of working through the issues we've been seeing in production cookie sharing between multiple responses from different users

```
The no-store response directive indicates that any caches of any kind (private or shared) should not store this response.
```
