### PR TITLE
HOTT-1155: Fix Cache-Control header continued

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -111,7 +111,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_cache
-    response.headers['Cache-Control'] = 'no-store'
+    response.headers['Cache-Control'] = 'public, must-revalidate, proxy-revalidate, max-age=0'
     response.headers['Pragma'] = 'no-cache'
     response.headers['Expires'] = '-1'
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -10,7 +10,16 @@ RSpec.describe ApplicationController, type: :controller do
   describe 'GET #index' do
     subject(:response) { get :index }
 
-    it { expect(response.headers['Cache-Control']).to eq('no-store') }
+    let(:expected_cache_control) do
+      %w[
+        max-age=0
+        public
+        must-revalidate
+        proxy-revalidate
+      ].join(', ')
+    end
+
+    it { expect(response.headers['Cache-Control']).to eq(expected_cache_control) }
     it { expect(response.headers['Pragma']).to eq('no-cache') }
     it { expect(response.headers['Expires']).to eq('-1') }
   end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1155

### What?

See: https://stackoverflow.com/questions/18774069/amazon-cloudfront-cache-control-no-cache-header-has-no-effect-after-24-hours

I have added/removed/altered:

- [x] Added max-age=0 to the cache control header as per stackoverflow suggestions

### Why?

I am doing this because:

- This is required to make cloudfront pay attention to the cache control header
