### PR TITLE
HOTT-1183 Fix section table col width containing the section ID

### DIFF
--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -1,5 +1,5 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell">
+  <td class="govuk-table__cell section-id-col">
     <div class="chapter-code">
       <span class="code-text"><%= chapter.short_code %></span>
     </div>

--- a/app/webpacker/src/stylesheets/_tables.scss
+++ b/app/webpacker/src/stylesheets/_tables.scss
@@ -252,3 +252,6 @@ table.section-browser {
   font-size: 12px;
 }
 
+.section-id-col {
+  width: 40px;
+}


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1183

### What?
Fix spacing between chapter number and description (see screenshot)

![image](https://user-images.githubusercontent.com/58971/146051173-4f5a0aba-bbce-4230-8557-88d4768ca6ad.png)

Fixed version:
Now the col with is fixed, non-dependant on the length of the description.

<img width="781" alt="Screenshot 2021-12-14 at 17 42 26" src="https://user-images.githubusercontent.com/58971/146052018-f55bfb20-e09f-4548-8e22-cd958a6b5140.png">

