### PR TITLE
Exposes backend healthcheck api

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -45,6 +45,7 @@ module TradeTariffFrontend
       footnote_types
       changes
       rules_of_origin_schemes
+      healthcheck
     ]
   end
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Expose backend healthcheck api

### Why?

I am doing this because:

- I want to be able to validate the current sha that is deployed on the backend without looking in the circle ci dashboard
