### PR TITLE
HOTT-1163 Show help text on quotas section

### DIFF
--- a/app/views/measures/grouped/_table.html.erb
+++ b/app/views/measures/grouped/_table.html.erb
@@ -2,6 +2,12 @@
   <%= local_assigns[:caption] %>
 </h3>
 
+<% if local_assigns[:information] %>
+  <div class="govuk-inset-text tariff-inset-information">
+    <%= local_assigns[:information] %>
+  </div>
+<% end %>
+
 <%= render 'shared/stw_link', declarable: declarable, search: search, anchor: anchor if local_assigns[:show_stw_text]  %>
 
 <%= render 'measures/grouped/tariff_duty_calculator_link', declarable_code: declarable.code if local_assigns[:show_duty_calculator] %>

--- a/app/views/measures/grouped/_uk.html.erb
+++ b/app/views/measures/grouped/_uk.html.erb
@@ -29,6 +29,7 @@
 <% if uk_import_measures.quotas.present? %>
   <%= render partial: 'measures/grouped/table', locals: {
     caption: 'Quotas',
+    information: t('tabs.measures.quotas_information_html'),
     collection: uk_import_measures.quotas.sort_by(&:key),
     css_id: 'quotas'
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,18 @@ en:
   tabs:
     footnote:
       heading: Notes for %{declarable_type} %{goods_nomenclature_item_id}
+    measures:
+      quotas_information_html: |
+        <p>
+          Quotas allow a limited amount of goods to be imported at a lower duty
+          rate. Once the quota has been used up, you will revert to the out-of-quota
+          rate, which may be the third-country duty or a preferential rate.
+        </p>
+
+        <p>
+          Quotas can be non-preferential (open to many countries) or preferential
+          (restricted to a particular trading partner).
+        </p>
   breadcrumb:
     home: Home
     privacy: Privacy Notice


### PR DESCRIPTION
of import/export tabs

### Jira link

[HOTT-1163](https://transformuk.atlassian.net/browse/HOTT-1163)

### What?

I have added/removed/altered:

- [x] Added a generic information panel on measure tables
- [x] Added the quotas help information to the locales file
- [x] Used the information panel to show the help info for quotas

### Why?

I am doing this because:

- We want to show help information to our users regarding quotas

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

