### PR TITLE
HOTT-1208: Adds coverage for measures.html template rendering

### DIFF
--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
     assign :search, search
   end
 
+  let(:render_page) do
+    render 'measures/measures',
+           declarable: presented_commodity,
+           uk_declarable: presented_commodity,
+           xi_declarable: nil,
+           rules_of_origin_schemes: []
+  end
+
   let(:search) { Search.new(q: '0101300000') }
   let(:all_countries) { GeographicalArea.all }
   let(:presented_commodity) { CommodityPresenter.new(commodity) }
@@ -34,6 +42,25 @@ RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
     it { is_expected.to have_css '.govuk-tabs__panel#rules-of-origin', count: 1 }
     it { is_expected.to have_css '.govuk-tabs__panel#footnotes', count: 1 }
   end
+
+  it { is_expected.to render_template('declarables/_consigned') }
+  it { is_expected.to render_template('footnotes/_footnote') }
+  it { is_expected.to render_template('measure_conditions/_measure_condition_code_document') }
+  it { is_expected.to render_template('measures/_export_tab_check_duties') }
+  it { is_expected.to render_template('measures/_measure') }
+  it { is_expected.to render_template('measures/_measure_condition_modal') }
+  it { is_expected.to render_template('measures/_measure_condition_modal_default') }
+  it { is_expected.to render_template('measures/_measure_references') }
+  it { is_expected.to render_template('measures/_measures') }
+  it { is_expected.to render_template('measures/grouped/_navigation') }
+  it { is_expected.to render_template('measures/grouped/_table') }
+  it { is_expected.to render_template('measures/grouped/_tariff_duty_calculator_link') }
+  it { is_expected.to render_template('measures/grouped/_uk') }
+  it { is_expected.to render_template('measures/grouped/_uk_navigation') }
+  it { is_expected.to render_template('rules_of_origin/_non_preferential') }
+  it { is_expected.to render_template('rules_of_origin/_without_country') }
+  it { is_expected.to render_template('shared/_notes') }
+  it { is_expected.to render_template('shared/_stw_link') }
 
   context 'with uk service' do
     let :render_page do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1208

### What?

I have added/removed/altered:

- [x] Added coverage for template rendering (especially measure/_references)

### Why?

I am doing this because:

- We missed the removal of this in a recent PR and want to avoid regressions
