### PR TITLE
HOTT-1137: Sanitize more descriptions

### DIFF
--- a/app/views/commodities/_ancestors.html.erb
+++ b/app/views/commodities/_ancestors.html.erb
@@ -44,7 +44,7 @@
           </span>
 
           <span class="commodity-ancestors__descriptor">
-            <%= declarable.description %>
+            <%= sanitize declarable.description %>
           </span>
         </span>
       </li>
@@ -61,7 +61,7 @@
           </span>
 
           <span class="commodity-ancestors__descriptor">
-            <%= declarable.heading.description %>
+            <%= sanitize declarable.heading.description %>
           </span>
         <% end %>
       </li>
@@ -77,7 +77,7 @@
           </span>
 
           <span class="commodity-ancestors__descriptor">
-            <%= ancestor.description %>
+            <%= sanitize ancestor.description %>
           </span>
         </span>
       </li>

--- a/app/views/declarables/_declarable.html.erb
+++ b/app/views/declarables/_declarable.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, commodity_title(declarable) %>
+<% content_for :title, strip_tags(commodity_title(declarable)) %>
 
 <article class="tariff commodity">
   <%= render partial: 'shared/country_picker', locals: { controller: @search, url: perform_search_path } %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1137

### What?

I have added/removed/altered:

- [x] Sanitize and strip more descriptions

### Why?

I am doing this because:

- These strings currently display with unescaped tags
