### PR TITLE
HOTT-1066 Purge Review Apps over a certain age

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,8 +254,9 @@ commands:
       - run:
           name: Find PRs
           command: |
+            DAYS=3
             REPO_API_URL=$(echo "${CIRCLE_REPOSITORY_URL}/" | sed 's|.git/$||' | sed 's|git@github.com:|https://api.github.com/repos/|')
-            curl --fail --show-error "${REPO_API_URL}/pulls?state=open" | jq '.[].number' > open_prs.txt
+            curl --fail --show-error "${REPO_API_URL}/pulls?state=open" |  jq ".[] | select((.updated_at | fromdate) > (now - $DAYS*24*60*60)) | .number" > open_prs.txt
             cat open_prs.txt | sed "s/^/${CF_APP}-pr/" | sort > expected_apps.txt
             cat expected_apps.txt
       - run:


### PR DESCRIPTION
### Jira link

HOTT-1066

### What?

I have added/removed/altered:

- [x] Changed the find open prs step to filter out PRs which haven't been updated in 3 days

### Why?

I am doing this because:

- We don't want to keep review apps around indefinitely - any review apps not having been updated within the timescale will be removed
