### PR TITLE
Remove $, @, and other special symbols from description.

### DIFF
--- a/app/views/commodities/_ancestors.html.erb
+++ b/app/views/commodities/_ancestors.html.erb
@@ -92,7 +92,7 @@
           </span>
 
           <span class="commodity-ancestors__descriptor">
-            <%= sanitize declarable.description %>
+            <%= sanitize declarable.formatted_description %>
           </span>
         </span>
       </li>

--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -9,7 +9,7 @@
 
   <% if heading_text.present? %>
     <h1 class="<%= css_heading_size(heading_text) %>">
-      <%= heading_text %>
+      <%= sanitize heading_text %>
     </h1>
   <% end %>
 

--- a/app/views/shared/context_tables/_commodity.html.erb
+++ b/app/views/shared/context_tables/_commodity.html.erb
@@ -13,7 +13,7 @@
       Classification
     </dt>
     <dd class="govuk-summary-list__value">
-      <%= sanitize @commodity.description %>
+      <%= sanitize @commodity.formatted_description %>
     </dd>
     <dd class="govuk-summary-list__actions"></dd>
   </div>

--- a/spec/views/context_tables/commodity.html.erb_spec.rb
+++ b/spec/views/context_tables/commodity.html.erb_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'shared/context_tables/_commodity.html.erb', type: :view, vcr: { 
 
   describe 'classification row' do
     it { is_expected.to have_css 'dl div dt', text: 'Classification' }
-    it { is_expected.to have_css 'dl div dd', text: commodity.description }
+    it { is_expected.to have_css 'dl div dd', text: commodity.formatted_description }
   end
 
   describe 'supplementary unit row' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1211

### What?
In many entries like $, @ and other special chars are used in place of HTML tag `<sup>` or `<sub>` in the good nomenclatures description entries.

### Why?
To make the description clearly readable.

Issue:
![image](https://user-images.githubusercontent.com/58971/146740219-7715d491-42f4-4781-a713-c862938b5ad8.png)

Fix 1:
<img width="910" alt="Screenshot 2021-12-20 at 11 22 04" src="https://user-images.githubusercontent.com/58971/146752886-ca039410-00df-47c3-9636-8f9fef348f07.png">

Fix 2:
<img width="913" alt="Screenshot 2021-12-20 at 11 21 54" src="https://user-images.githubusercontent.com/58971/146752891-98b17abe-4b62-42ff-9298-228242f5973e.png">

