### PR TITLE
HOTT-1145 Fix bad encoding error

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -128,7 +128,7 @@ module TradeTariffFrontend
             {
               status: @status.to_s,
               title: 'There was a problem with your query',
-              source: { parameter: @query_string },
+              source: { parameter: 'Invalid query string' },
             },
           ],
         }.to_json,


### PR DESCRIPTION
### Jira link

[HOTT-1145](https://transformuk.atlassian.net/browse/HOTT-1145)

### What?

I have added/removed/altered:

- [x] Changed the existing bad encoding middleware to not try to process the badly encoded query string into JSON

### Why?

I am doing this because:

- If the string is mis-encoded, and processing it causes an error - trying to process it again in the error handler is a bad idea.

### Notes

No test case because I haven't been able to replicate.

Review carefully because this is a rack middleware and this has no specs - though to my eyes this should be a safe fix.