### PR TITLE
HOTT-1205: Replace EU members with EU in measure exclusions

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -41,7 +41,18 @@ class Measure
   end
 
   def excluded_country_list
-    excluded_countries.map(&:description).join(', ').html_safe
+    countries = if exclusions_include_european_union?
+                  # Replace EU members with the EU geographical_area
+                  [GeographicalArea.european_union] + excluded_countries.delete_if(&:eu_member?)
+                else
+                  excluded_countries
+                end
+
+    countries.map(&:description).join(', ').html_safe
+  end
+
+  def exclusions_include_european_union?
+    GeographicalArea.eu_members_ids.all? { |eu_member| eu_member.in?(excluded_country_ids) }
   end
 
   def national?
@@ -134,6 +145,10 @@ class Measure
   end
 
   private
+
+  def excluded_country_ids
+    @excluded_country_ids ||= excluded_countries.map(&:id)
+  end
 
   def declarable_types
     @declarable_types ||= Rails.configuration.declarable_types

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -187,6 +187,55 @@ FactoryBot.define do
       end
     end
 
+    trait :with_eu_member_exclusions do
+      excluded_countries do
+        [
+          { 'id' => 'AT', 'description' => 'Austria', 'geographical_area_id' => 'AT' },
+          { 'id' => 'BE', 'description' => 'Belgium', 'geographical_area_id' => 'BE' },
+          { 'id' => 'BG', 'description' => 'Bulgaria', 'geographical_area_id' => 'BG' },
+          { 'id' => 'CH', 'description' => 'Switzerland', 'geographical_area_id' => 'CH' },
+          { 'id' => 'CY', 'description' => 'Cyprus', 'geographical_area_id' => 'CY' },
+          { 'id' => 'CZ', 'description' => 'Czechia', 'geographical_area_id' => 'CZ' },
+          { 'id' => 'DE', 'description' => 'Germany', 'geographical_area_id' => 'DE' },
+          { 'id' => 'DK', 'description' => 'Denmark', 'geographical_area_id' => 'DK' },
+          { 'id' => 'EE', 'description' => 'Estonia', 'geographical_area_id' => 'EE' },
+          { 'id' => 'ES', 'description' => 'Spain', 'geographical_area_id' => 'ES' },
+          { 'id' => 'EU', 'description' => 'European Union', 'geographical_area_id' => 'EU' },
+          { 'id' => 'FI', 'description' => 'Finland', 'geographical_area_id' => 'FI' },
+          { 'id' => 'FR', 'description' => 'France', 'geographical_area_id' => 'FR' },
+          { 'id' => 'GR', 'description' => 'Greece', 'geographical_area_id' => 'GR' },
+          { 'id' => 'HR', 'description' => 'Croatia', 'geographical_area_id' => 'HR' },
+          { 'id' => 'HU', 'description' => 'Hungary', 'geographical_area_id' => 'HU' },
+          { 'id' => 'IE', 'description' => 'Ireland', 'geographical_area_id' => 'IE' },
+          { 'id' => 'IS', 'description' => 'Iceland', 'geographical_area_id' => 'IS' },
+          { 'id' => 'IT', 'description' => 'Italy', 'geographical_area_id' => 'IT' },
+          { 'id' => 'LI', 'description' => 'Liechtenstein', 'geographical_area_id' => 'LI' },
+          { 'id' => 'LT', 'description' => 'Lithuania', 'geographical_area_id' => 'LT' },
+          { 'id' => 'LU', 'description' => 'Luxembourg', 'geographical_area_id' => 'LU' },
+          { 'id' => 'LV', 'description' => 'Latvia', 'geographical_area_id' => 'LV' },
+          { 'id' => 'MT', 'description' => 'Malta', 'geographical_area_id' => 'MT' },
+          { 'id' => 'NL', 'description' => 'Netherlands', 'geographical_area_id' => 'NL' },
+          { 'id' => 'NO', 'description' => 'Norway', 'geographical_area_id' => 'NO' },
+          { 'id' => 'PL', 'description' => 'Poland', 'geographical_area_id' => 'PL' },
+          { 'id' => 'PT', 'description' => 'Portugal', 'geographical_area_id' => 'PT' },
+          { 'id' => 'RO', 'description' => 'Romania', 'geographical_area_id' => 'RO' },
+          { 'id' => 'SE', 'description' => 'Sweden', 'geographical_area_id' => 'SE' },
+          { 'id' => 'SI', 'description' => 'Slovenia', 'geographical_area_id' => 'SI' },
+          { 'id' => 'SK', 'description' => 'Slovakia', 'geographical_area_id' => 'SK' },
+        ]
+      end
+    end
+
+    trait :with_exclusions do
+      excluded_countries do
+        [
+          { 'id' => 'CH', 'description' => 'Switzerland', 'geographical_area_id' => 'CH' },
+          { 'id' => 'CY', 'description' => 'Cyprus', 'geographical_area_id' => 'CY' },
+          { 'id' => 'CZ', 'description' => 'Czechia', 'geographical_area_id' => 'CZ' },
+        ]
+      end
+    end
+
     trait :specific_country do
       geographical_area { attributes_for(:geographical_area, :specific_country).stringify_keys }
     end

--- a/spec/features/commodities_spec.rb
+++ b/spec/features/commodities_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'Commodity show page', js: true do
+RSpec.describe 'Commodity show page', vcr: { cassette_name: 'geographical_areas#1013' }, js: true do
   before do
     stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
 

--- a/spec/helpers/declarable_helper_spec.rb
+++ b/spec/helpers/declarable_helper_spec.rb
@@ -1,19 +1,14 @@
 require 'spec_helper'
 
-RSpec.describe DeclarableHelper, type: :helper do
+RSpec.describe DeclarableHelper, type: :helper, vcr: { cassette_name: 'geographical_areas#it' } do
   describe '#declarable_stw_link' do
     subject(:declarable_stw_link) { helper.declarable_stw_link(declarable, search) }
 
     let(:declarable) { build(:commodity) }
-    let(:geographical_area) { build(:geographical_area, id: 'FR', description: 'France') }
-    let(:search) { Search.new(country: 'FR', day: '01', month: '01', year: '2021') }
-
-    before do
-      allow(GeographicalArea).to receive(:find).and_return(geographical_area)
-    end
+    let(:search) { Search.new(country: 'IT', day: '01', month: '01', year: '2021') }
 
     context 'when no date is passed' do
-      let(:search) { Search.new(country: 'FR') }
+      let(:search) { Search.new(country: 'IT') }
 
       it { is_expected.to include("importDateDay=#{Time.zone.today.day}") }
       it { is_expected.to include("importDateMonth=#{Time.zone.today.month}") }
@@ -24,14 +19,14 @@ RSpec.describe DeclarableHelper, type: :helper do
       let(:declarable) { build(:heading) }
 
       it 'returns the expected text' do
-        expected_text = "check how to import heading #{declarable.code} from France."
+        expected_text = "check how to import heading #{declarable.code} from Italy."
 
         expect(declarable_stw_link).to include(expected_text)
       end
 
       it { is_expected.to include('https://test.com/stw-testing?') }
       it { is_expected.to include("commodity=#{declarable.code}") }
-      it { is_expected.to include('originCountry=FR') }
+      it { is_expected.to include('originCountry=IT') }
       it { is_expected.to include('goodsIntent=bringGoodsToSell') }
       it { is_expected.to include('userTypeTrader=true') }
       it { is_expected.to include('tradeType=import') }
@@ -50,14 +45,14 @@ RSpec.describe DeclarableHelper, type: :helper do
       let(:declarable) { build(:commodity) }
 
       it 'returns the expected text' do
-        expected_text = "check how to import commodity #{declarable.code} from France."
+        expected_text = "check how to import commodity #{declarable.code} from Italy."
 
         expect(declarable_stw_link).to include(expected_text)
       end
 
       it { is_expected.to include('https://test.com/stw-testing?') }
       it { is_expected.to include("commodity=#{declarable.code}") }
-      it { is_expected.to include('originCountry=FR') }
+      it { is_expected.to include('originCountry=IT') }
       it { is_expected.to include('goodsIntent=bringGoodsToSell') }
       it { is_expected.to include('userTypeTrader=true') }
       it { is_expected.to include('tradeType=import') }
@@ -89,7 +84,7 @@ RSpec.describe DeclarableHelper, type: :helper do
     end
   end
 
-  describe '#trading_partner_country_description', vcr: { cassette_name: 'geographical_areas#it' } do
+  describe '#trading_partner_country_description' do
     context 'when the country is a valid country' do
       subject(:trading_partner_country_description) { helper.trading_partner_country_description('IT') }
 

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -50,6 +50,28 @@ RSpec.describe GeographicalArea do
     end
   end
 
+  describe '#european_union', vcr: { cassette_name: 'geographical_areas#1013' } do
+    subject(:european_union) { described_class.european_union }
+
+    it { is_expected.to have_attributes(id: '1013', geographical_area_id: '1013', description: 'European Union') }
+  end
+
+  describe '#european_union_members', vcr: { cassette_name: 'geographical_areas#1013' } do
+    subject(:european_union_members) { described_class.european_union_members }
+
+    it { expect(european_union_members.count).to eq(28) }
+  end
+
+  describe '#eu_member_ids', vcr: { cassette_name: 'geographical_areas#1013' } do
+    subject(:eu_member_ids) { described_class.eu_members_ids }
+
+    let(:expected_countries) do
+      %w[AT BE BG CY CZ DE DK EE ES EU FI FR GR HR HU IE IT LT LU LV MT NL PL PT RO SE SI SK]
+    end
+
+    it { is_expected.to eq(expected_countries) }
+  end
+
   describe '#eu_member?', vcr: { cassette_name: 'geographical_areas#1013' } do
     subject(:geographical_area) { build(:geographical_area, id: geographical_area_id) }
 

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -164,4 +164,30 @@ RSpec.describe Measure do
       it { is_expected.not_to be_export }
     end
   end
+
+  describe '#excluded_country_list', vcr: { cassette_name: 'geographical_areas#1013' } do
+    context 'when the excluded_countries include all eu members' do
+      subject(:measure) { build(:measure, :with_eu_member_exclusions) }
+
+      let(:expected_list) { 'European Union, Switzerland, Iceland, Liechtenstein, Norway' }
+
+      it { expect(measure.excluded_country_list).to eq(expected_list) }
+    end
+
+    context 'when the excluded_countries do not include all eu members' do
+      subject(:measure) { build(:measure, :with_exclusions) }
+
+      let(:expected_list) { 'Switzerland, Cyprus, Czechia' }
+
+      it { expect(measure.excluded_country_list).to eq(expected_list) }
+    end
+
+    context 'when there are no excluded countries' do
+      subject(:measure) { build(:measure) }
+
+      let(:expected_list) { '' }
+
+      it { expect(measure.excluded_country_list).to eq(expected_list) }
+    end
+  end
 end

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'Commodity page', type: :request do
   before do
     stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
 
-    allow(GeographicalArea).to receive(:find).with('1013').and_return(build(:geographical_area, id: '1013', description: 'European Union'))
     allow(GeographicalArea).to receive(:find).with('AD').and_return(build(:geographical_area, id: 'AD', description: 'Andorra'))
     allow(RulesOfOrigin::Scheme).to receive(:all).and_return([])
     TradeTariffFrontend::ServiceChooser.service_choice = nil

--- a/spec/requests/heading_spec.rb
+++ b/spec/requests/heading_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'Heading page', type: :request do
   before do
     stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
 
-    allow(GeographicalArea).to receive(:find).with('1013').and_return(build(:geographical_area, id: '1013', description: 'European Union'))
     allow(GeographicalArea).to receive(:find).with('ZW').and_return(build(:geographical_area, id: 'ZW', description: 'Zimbabwe'))
 
     allow(RulesOfOrigin::Scheme).to receive(:all).and_return([])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,10 @@ Capybara.register_driver(:selenium_chrome_headless) do |app|
   )
 end
 
+VCR.use_cassette('geographical_areas#1013') do
+  GeographicalArea.european_union
+end
+
 Capybara.javascript_driver = :selenium_chrome_headless
 
 Capybara.ignore_hidden_elements = false

--- a/spec/views/measures/_measure.html.erb_spec.rb
+++ b/spec/views/measures/_measure.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'measures/_measure.html.erb', type: :view do
+RSpec.describe 'measures/_measure.html.erb', type: :view, vcr: { cassette_name: 'geographical_areas#1013' } do
   let(:measure) do
     Measure.new(
       attributes_for(:measure, :third_country,

--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -1,14 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
-  cassette_name: 'geographical_areas_countries',
+  cassette_name: 'geographical_areas#countries',
 } do
   subject { render_page && rendered }
 
   before do
     stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
 
-    allow(GeographicalArea).to receive(:find).with('1013').and_return(build(:geographical_area, id: '1013', description: 'European Union'))
     allow(GeographicalArea).to receive(:find).with('FR').and_return(build(:geographical_area, id: 'FR', description: 'France'))
     allow(search).to receive(:countries).and_return all_countries
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1205

**Before**

![Screenshot from 2021-12-22 15-53-57](https://user-images.githubusercontent.com/8156884/147119788-eb923e87-dba8-463c-a8f5-60b8b66ea04d.png)

**After**

![Screenshot from 2021-12-22 15-54-46](https://user-images.githubusercontent.com/8156884/147119853-6ca65b22-9eba-47dd-a75a-9ef4b38226d7.png)



### What?

I have added/removed/altered:

- [x] Altered excluded_countries_list method to return the EU when all EU members are present
- [x] Added specs to cover changes
- [x] Added memoization of EU members for better performance
- [x] Moved all GeographicalArea class methods together for easier reading 

### Why?

I am doing this because:

- This is required for a better user experience
