### PR TITLE
HOTT-1225: Expose feed

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -46,6 +46,7 @@ module TradeTariffFrontend
       changes
       rules_of_origin_schemes
       healthcheck
+      feed
     ]
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1225

### What?

I have added/removed/altered:

- [x] Exposes feed to the world

### Why?

I am doing this because:

- This is needed to get access to feeds in the backend
