### PR TITLE
HOTT-1228 Exclude certain additional codes from form

### DIFF
--- a/app/forms/additional_code_search_form.rb
+++ b/app/forms/additional_code_search_form.rb
@@ -1,7 +1,9 @@
 class AdditionalCodeSearchForm
-  OPTIONAL_PARAMS = [:@page]
+  OPTIONAL_PARAMS = [:@page].freeze
+  EXCLUDED_TYPES = %w[6 7 9 D F P].freeze
 
-  attr_accessor :code, :type, :description, :page
+  attr_accessor :code, :type, :description
+  attr_writer :page
 
   def initialize(params)
     params.each do |key, value|
@@ -10,10 +12,12 @@ class AdditionalCodeSearchForm
   end
 
   def additional_code_types
-    TradeTariffFrontend::ServiceChooser.cache_with_service_choice('cached_additional_code_types', expires_in: 24.hours) do
-      AdditionalCodeType.all&.sort_by(&:additional_code_type_id).map do |type|
-        [ "#{type&.additional_code_type_id} - #{type&.description}", type&.additional_code_type_id ]
-      end.to_h
+    TradeTariffFrontend::ServiceChooser.cache_with_service_choice('cached_additional_code_types-v2', expires_in: 24.hours) do
+      AdditionalCodeType.all
+                        &.sort_by(&:additional_code_type_id)
+                        &.reject(&method(:exclude_additional_code_type?))
+                        &.map(&method(:additional_code_type_option))
+                        &.to_h
     end
   end
 
@@ -32,5 +36,15 @@ class AdditionalCodeSearchForm
       description: description,
       page: page,
     }
+  end
+
+private
+
+  def additional_code_type_option(type)
+    ["#{type&.additional_code_type_id} - #{type&.description}", type&.additional_code_type_id]
+  end
+
+  def exclude_additional_code_type?(type)
+    EXCLUDED_TYPES.include? type.additional_code_type_id
   end
 end

--- a/spec/forms/additional_code_search_form_spec.rb
+++ b/spec/forms/additional_code_search_form_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe AdditionalCodeSearchForm, type: :model do
+  describe '#additional_code_types',
+           vcr: { cassette_name: 'search#additional_code_search' } do
+    subject { described_class.new({}).additional_code_types.values }
+
+    it { is_expected.to include('2') }
+    it { is_expected.not_to include('6') }
+    it { is_expected.not_to include('7') }
+    it { is_expected.not_to include('9') }
+    it { is_expected.not_to include('D') }
+    it { is_expected.not_to include('F') }
+    it { is_expected.not_to include('P') }
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-1228

### What?

I have added/removed/altered:

- [x] Excluded several additional code types from the additional code search

### Why?

I am doing this because:

- These types are either old or irrelevant

