### PR TITLE
Adds news item feed for users

### DIFF
--- a/app/controllers/feed/news_items_controller.rb
+++ b/app/controllers/feed/news_items_controller.rb
@@ -1,0 +1,7 @@
+module Feed
+  class NewsItemsController < ApplicationController
+    def index
+      @news_items = NewsItem.for_feed
+    end
+  end
+end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -38,6 +38,13 @@ class NewsItem
       )
     end
 
+    def for_feed
+      collection(
+        collection_path,
+        target: 'updates',
+      )
+    end
+
     def any_updates?
       return false unless TradeTariffFrontend.news_items_enabled?
 

--- a/app/views/feed/news_items/index.atom.builder
+++ b/app/views/feed/news_items/index.atom.builder
@@ -1,0 +1,19 @@
+atom_feed do |feed|
+  feed.title t('feed.news_item_title')
+
+  @news_items.each do |news_item|
+    feed.entry(
+      news_item,
+      url: news_item_url(news_item.id),
+    ) do |entry|
+      entry.title        news_item.title
+      entry.content      news_item.content
+      entry.start_date   news_item.start_date.try(:to_s, :rfc822) || ''
+      entry.end_date     news_item.end_date.try(:to_s, :rfc822) || ''
+      entry.uk           news_item.show_on_uk
+      entry.xi           news_item.show_on_xi
+      entry.home_page    home_url
+      entry.updates_page news_items_url
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,9 @@
 en:
   meta_description: "Search for import and export commodity codes and for tax, duty and licences that apply to your goods"
 
+  feed:
+    news_item_title: "Online Trade Tariff News Items"
+
   import_destination:
     uk: United Kingdom
     xi: Northern Ireland

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -68,6 +68,19 @@ RSpec.describe NewsItem do
     end
   end
 
+  describe '.for_feed' do
+    subject { described_class.for_feed }
+
+    include_context 'with UK service'
+
+    before do
+      stub_api_request('/news_items?target=updates', backend: 'uk')
+        .to_return jsonapi_response :news_item, attributes_for_list(:news_item, 2)
+    end
+
+    it { is_expected.to have_attributes length: 2 }
+  end
+
   describe '.any_updates?' do
     subject(:any_updates) { described_class.any_updates? }
 

--- a/spec/requests/feed/news_items_controller_spec.rb
+++ b/spec/requests/feed/news_items_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe Feed::NewsItemsController, type: :request, vcr: { cassette_name: 'news_items#updates' } do
+  describe 'GET #index' do
+    subject(:do_request) { get(feed_news_items_path) && response }
+
+    it { is_expected.to have_http_status :ok }
+    it { is_expected.to have_attributes content_type: 'application/atom+xml; charset=utf-8' }
+  end
+end

--- a/spec/vcr/news_items_updates.yml
+++ b/spec/vcr/news_items_updates.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3018/news_items?target=updates
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.uktt.v2
+      User-Agent:
+      - Faraday v1.3.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"4a4ac91101515d78450d60b156111103"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c0fbd950-5b1b-4cd3-97af-fcab6cf9efe1
+      X-Runtime:
+      - '0.535808'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"5","type":"news_item","attributes":{"id":5,"title":"
+        UK Goods classification 2022 - 10-digit code publication (update)","content":"10-digit
+        code changes have been published for chapters 08, 15, 25, 28, 29, 32, 36,
+        38, 39, 57, 62, 70, 73, 74, 76, 81, 84, 85, 87, 88, 94. [View 10-digit code
+        changes for these chapters](/help/cn2021_cn2022).\r\n","display_style":0,"show_on_xi":true,"show_on_uk":true,"show_on_updates_page":true,"show_on_home_page":false,"start_date":"2021-12-15","end_date":null,"created_at":"2021-12-15T10:50:45.862Z","updated_at":null}},{"id":"4","type":"news_item","attributes":{"id":4,"title":"UK
+        Goods classification 2022 - 10-digit code publication","content":"10-digit
+        code changes have been published for chapters 03, 04, 07, 08, 12, 24, 32,
+        33, 34, 40, 49, 55, 58, 68, 71, 74. [View 10-digit code changes for these
+        chapters](/help/cn2021_cn2022).\r\n","display_style":0,"show_on_xi":true,"show_on_uk":true,"show_on_updates_page":true,"show_on_home_page":false,"start_date":"2021-12-08","end_date":null,"created_at":"2021-12-09T15:47:54.821Z","updated_at":"2021-12-09T15:50:45.128Z"}},{"id":"6","type":"news_item","attributes":{"id":6,"title":"UK
+        Goods classification 2021 to 2022 correlation table","content":"From 1 January
+        2022, the UK will introduce its 2022 Integrated Tariff. This will incorporate
+        the WCO''s changes to the Harmonised System Nomenclature. This full nomenclature
+        will be published soon but you can now view the [correlation of commodity
+        codes, at 8-digit level, from the 2021 Tariff to that of 2022](/help/cn2021_cn2022).","display_style":0,"show_on_xi":true,"show_on_uk":true,"show_on_updates_page":true,"show_on_home_page":false,"start_date":"2021-11-24","end_date":null,"created_at":"2021-11-24T10:35:35.488Z","updated_at":"2021-12-02T10:27:02.216Z"}},{"id":"3","type":"news_item","attributes":{"id":3,"title":"UK
+        Goods classification 2021 to 2022 correlation table","content":"From 1 January
+        2022, the UK will introduce its 2022 Integrated Tariff. This will incorporate
+        the WCO''s changes to the Harmonised System Nomenclature. This full nomenclature
+        will be published soon but you can now view the [correlation of commodity
+        codes, at 8-digit level, from the 2021 Tariff to that of 2022](/help/cn2021_cn2022).","display_style":0,"show_on_xi":true,"show_on_uk":true,"show_on_updates_page":true,"show_on_home_page":false,"start_date":"2021-11-24","end_date":null,"created_at":"2021-11-24T11:09:52.116Z","updated_at":null}}]}'
+  recorded_at: Thu, 06 Jan 2022 10:23:00 GMT
+recorded_with: VCR 6.0.0

--- a/spec/views/feed/news_items/index.atom.builder_spec.rb
+++ b/spec/views/feed/news_items/index.atom.builder_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe 'feed/news_items/index.atom.builder', type: :view do
+  subject { render }
+
+  before { assign :news_items, news_items }
+
+  context 'with a single news item' do
+    let(:news_items) { [news_item] }
+
+    let(:news_item) do
+      build(
+        :news_item,
+        id: '1',
+        start_date: Date.parse('2022-01-05'),
+        end_date: Date.parse('2022-01-06'),
+        title: 'Are you importing goods into Northern Ireland?',
+        content: 'Tempus fugit',
+      )
+    end
+
+    it { is_expected.to have_css 'feed title', text: 'Online Trade Tariff News Items' }
+    it { is_expected.to have_css 'feed entry id', text: 'tag:test.host,2005:NewsItem/1' }
+    it { is_expected.to have_css 'feed entry title', text: 'Are you importing goods into Northern Ireland?' }
+    it { is_expected.to have_css 'feed entry start_date', text: '05 Jan 2022' }
+    it { is_expected.to have_css 'feed entry end_date', text: '06 Jan 2022' }
+    it { is_expected.to have_css 'feed entry content', text: 'Tempus fugit' }
+    it { is_expected.to have_css 'feed entry uk', text: 'true' }
+    it { is_expected.to have_css 'feed entry xi', text: 'true' }
+    it { is_expected.to have_css 'feed entry home_page', text: 'http://test.host/find_commodity' }
+    it { is_expected.to have_css 'feed entry updates_page', text: 'http://test.host/news' }
+  end
+
+  context 'with no news items' do
+    let(:news_items) { [] }
+
+    it { is_expected.to have_css 'feed title', text: 'Online Trade Tariff News Items' }
+    it { is_expected.not_to have_css 'feed entry' }
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1225

### What?

Surface news items for all services for the update target under /feed/news_items

I have added/removed/altered:

- [x] Added atom feed for news items

### Why?

I am doing this because:

- This is a feature request
