### PR TITLE
HOTT-1242 Fix duty rendering

### DIFF
--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -33,4 +33,26 @@ module MeasuresHelper
       link_to('Check how to export commodity goods (link opens in new tab)', TradeTariffFrontend.check_duties_service_url, target: '_blank', rel: 'noopener')
     end
   end
+
+  def reformat_duty_expression(expression)
+    sanitized = sanitize(expression, tags: %w[abbr], attributes: %w[title])
+    components = []
+
+    while sanitized.length.positive?
+      matched = sanitized.match(%r{ (\+|-|MIN|MAX) })
+
+      if matched
+        components << tag.span(sanitized.slice(0, matched.begin(0)).html_safe)
+        components << matched[1]
+        sanitized = sanitized.slice(matched.end(0), sanitized.length)
+      else
+        components << tag.span(sanitized.html_safe)
+        sanitized = ''
+      end
+    end
+
+    tag.span(class: 'duty-expression') do
+      safe_join components.flatten.compact, ' '
+    end
+  end
 end

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -2,7 +2,7 @@ module MeasuresHelper
   def filter_duty_expression(measure)
     return '' if measure.duty_expression.to_s == 'NIHIL'
 
-    reformat_duty_expression(measure.duty_expression.to_s)
+    control_line_wrapping_in_duty_expression(measure.duty_expression.to_s)
   end
 
   def legal_act_regulation_url_link_for(measure)
@@ -34,8 +34,11 @@ module MeasuresHelper
     end
   end
 
-  def reformat_duty_expression(expression)
-    # meursing measures are wrapped with strong tags it seems
+  # This rewrites the duty expression, removing existing span tags and applying
+  # them in a manner which allows preventing line breaks at confusing points
+  # in the expression
+  def control_line_wrapping_in_duty_expression(expression)
+    # meursing measures are wrapped with strong tags
     wrapping_tag = expression.start_with?('<strong>') ? :strong : :span
     sanitized = sanitize(expression, tags: %w[abbr], attributes: %w[title])
     components = []

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -43,9 +43,10 @@ module MeasuresHelper
     sanitized = sanitize(expression, tags: %w[abbr], attributes: %w[title])
     components = []
 
-    while sanitized.length.positive?
-      matched = sanitized.match(%r{ (\+|-|MIN|MAX) })
+    1.upto(20) do
+      break unless sanitized.length.positive?
 
+      matched = sanitized.match(%r{ (\+|-|MIN|MAX) })
       if matched
         components << tag.span(sanitized.slice(0, matched.begin(0)).html_safe)
         components << matched[1]

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -14,7 +14,7 @@ module MeasuresHelper
       legal_act.regulation_code,
       legal_act.regulation_url,
       target: '_blank',
-      rel: 'noopener norefferer',
+      rel: 'noopener noreferrer',
       class: 'govuk-link',
       title: legal_act.description,
     )

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -1,8 +1,8 @@
 module MeasuresHelper
   def filter_duty_expression(measure)
-    duty_expression = measure.duty_expression.to_s.html_safe
-    duty_expression = '' if duty_expression == 'NIHIL'
-    duty_expression
+    return '' if measure.duty_expression.to_s == 'NIHIL'
+
+    reformat_duty_expression(measure.duty_expression.to_s)
   end
 
   def legal_act_regulation_url_link_for(measure)

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -35,6 +35,8 @@ module MeasuresHelper
   end
 
   def reformat_duty_expression(expression)
+    # meursing measures are wrapped with strong tags it seems
+    wrapping_tag = expression.start_with?('<strong>') ? :strong : :span
     sanitized = sanitize(expression, tags: %w[abbr], attributes: %w[title])
     components = []
 
@@ -51,7 +53,7 @@ module MeasuresHelper
       end
     end
 
-    tag.span(class: 'duty-expression') do
+    content_tag(wrapping_tag, class: 'duty-expression') do
       safe_join components.flatten.compact, ' '
     end
   end

--- a/app/webpacker/src/stylesheets/_measures.scss
+++ b/app/webpacker/src/stylesheets/_measures.scss
@@ -68,3 +68,7 @@ dt.has_children + dd[aria-hidden="true"] {
   top: 9px !important;
   position: relative;
 }
+
+.duty-expression > span {
+  white-space: nowrap;
+}

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe MeasuresHelper, type: :helper do
     context 'when the legal act has a regulation url' do
       let(:legal_acts) { [attributes_for(:legal_act)] }
       let(:expected_link) do
-        '<a target="_blank" rel="noopener norefferer" class="govuk-link" title="The Customs Tariff (Preferential Trade Arrangements) (EU Exit) (Amendment) Regulations 2021" href="https://www.legislation.gov.uk/uksi/2020/1432">S.I. 2020/1432</a>'
+        '<a target="_blank" rel="noopener noreferrer" class="govuk-link" title="The Customs Tariff (Preferential Trade Arrangements) (EU Exit) (Amendment) Regulations 2021" href="https://www.legislation.gov.uk/uksi/2020/1432">S.I. 2020/1432</a>'
       end
 
       it { expect(helper.legal_act_regulation_url_link_for(measure)).to eq(expected_link) }

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -68,4 +68,40 @@ RSpec.describe MeasuresHelper, type: :helper do
       end
     end
   end
+
+  describe '#reformat_duty_expression' do
+    subject { reformat_duty_expression expression }
+
+    context 'with simple percentage' do
+      let(:expression) { '<span>20.00</span> % ' }
+
+      it { is_expected.to have_css 'span.duty-expression > span', text: '20.00 %' }
+    end
+
+    context 'with abbreviation' do
+      let :expression do
+        '<span>16.50</span> % / <abbr title="Retail Price">Retail Price</abbr> '
+      end
+
+      it { is_expected.to have_css 'span.duty-expression > span > abbr', text: 'Retail Price' }
+    end
+
+    context 'with multi segment expression' do
+      let :expression do
+        '<span>16.50</span> % / <abbr title="Retail Price">Retail Price</abbr> ' \
+        '+ <span>244.78</span> GBP / <abbr title="1000 items">1000 p/st</abbr> ' \
+        'MIN <span>320.90</span> GBP / <abbr title="1000 items">1000 p/st</abbr>'
+      end
+
+      let :expected do
+        '<span class="duty-expression">' \
+        '<span>16.50 % / <abbr title="Retail Price">Retail Price</abbr></span> ' \
+        '+ <span>244.78 GBP / <abbr title="1000 items">1000 p/st</abbr></span> ' \
+        'MIN <span>320.90 GBP / <abbr title="1000 items">1000 p/st</abbr></span>' \
+        '</span>'
+      end
+
+      it { is_expected.to match expected }
+    end
+  end
 end

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe MeasuresHelper, type: :helper do
     end
   end
 
-  describe '#reformat_duty_expression' do
-    subject { reformat_duty_expression expression }
+  describe '#control_line_wrapping_in_duty_expression' do
+    subject { control_line_wrapping_in_duty_expression expression }
 
     context 'with simple percentage' do
       let(:expression) { '<span>20.00</span> % ' }

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe MeasuresHelper, type: :helper do
       it { is_expected.to have_css 'span.duty-expression > span > abbr', text: 'Retail Price' }
     end
 
+    context 'with strong tag' do
+      let :expression do
+        '<strong><span>16.50</span> % / <abbr title="Retail Price">Retail Price</abbr> </strong>'
+      end
+
+      it { is_expected.to have_css 'strong.duty-expression > span > abbr', text: 'Retail Price' }
+    end
+
     context 'with multi segment expression' do
       let :expression do
         '<span>16.50</span> % / <abbr title="Retail Price">Retail Price</abbr> ' \

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe MeasuresHelper, type: :helper do
     context 'when the duty expression is present' do
       let(:duty_expression) { attributes_for(:duty_expression) }
 
-      it { expect(filtered_expression).to eq("80.50 EUR / <abbr title='Hectokilogram'>Hectokilogram</abbr>") }
+      it { expect(filtered_expression).to match('80.50 EUR / <abbr title="Hectokilogram">Hectokilogram</abbr>') }
     end
 
     context 'when the duty expression is `NIHIL`' do

--- a/spec/views/measures/_measure.html.erb_spec.rb
+++ b/spec/views/measures/_measure.html.erb_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'measures/_measure.html.erb', type: :view, vcr: { cassette_name: 
 
     it { expect(rendered).to match(/EUR/) }
     it { expect(rendered).to match(/Hectokilogram/) }
-    it { expect(rendered).to match(/<abbr title='Hectokilogram'>/) }
+    it { expect(rendered).to match(/<abbr title="Hectokilogram">/) }
   end
 
   context 'without formatted_base' do


### PR DESCRIPTION
### Jira link

[HOTT-1242](https://transformuk.atlassian.net/browse/HOTT-1242)

### What?

I have added/removed/altered:

- [x] Drive by fix for misspelt noreferrer
- [x] Added a helper to reformat the duty expression

### Why?

I am doing this because:

- Currently the duty expressions are being inappropriately wrapped - improving the html allow using css to control the where the duty expression will be wrapped

### Before

![Screenshot from 2022-01-11 11-07-18](https://user-images.githubusercontent.com/10818/148931872-a2059494-45ef-4624-b0b8-e678ebbdb014.png)
![Screenshot from 2022-01-11 11-07-05](https://user-images.githubusercontent.com/10818/148931875-dc44f0e8-84c5-4650-889d-c267660423f1.png)

### After

![Screenshot from 2022-01-11 11-08-31](https://user-images.githubusercontent.com/10818/148932024-2fd65ee5-b0f0-4e49-8330-4139f87132de.png)
![Screenshot from 2022-01-11 11-08-13](https://user-images.githubusercontent.com/10818/148932030-d50ed14a-b132-45bc-bb6c-fe68672ee5b3.png)

