### PR TITLE
HOTT-1253 Fix incorrect rendering of section and chapter notes from the admin

### DIFF
--- a/app/views/shared/_notes.html.erb
+++ b/app/views/shared/_notes.html.erb
@@ -2,7 +2,7 @@
 chapter_note ||= false %>
 
 <% if section_note || chapter_note %>
-  <article id="notes" class="notes">
+  <article id="notes" class="tariff-markdown">
     <% if chapter_note %>
       <div>
         <% if section_note %>
@@ -23,6 +23,5 @@ chapter_note ||= false %>
         <%= govspeak(section_note) %>
       </div>
     <% end %>
-
   </article>
 <% end %>


### PR DESCRIPTION
### Jira link

[HOTT-1253](https://transformuk.atlassian.net/browse/HOTT-1253)

### What?

I have added/removed/altered:

- [x] Changed to render govuk markdown using the `tariff-markdown` css classes

### Why?

I am doing this because:

- Previously the notes was relying on some hacks in the markdown which are no longer present, and those hacks are now actually causing problems with valid markdown
