### PR TITLE
HOTT-1278: Use UTC as time zone

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module TradeTariffFrontend
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-    config.time_zone = 'London'
+    config.time_zone = 'UTC'
 
     require 'trade_tariff_frontend'
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1278

### What?

```ruby
[2] pry(main)> Time.zone.now
=> Mon, 17 Jan 2022 13:20:45.147375744 UTC +00:00
```

I have added/removed/altered:

- [x] Altered timezone globally to be UTC

### Why?

I am doing this because:

- We store validity start/end dates with times in UTC (which is technically wrong - these dates are just meant to be dates without a zone and shouldn't be coerced).
- We want these dates to be presented without coersion in their original form otherwise we end up changing by 1 day when BST hits.

### Deployment risks (optional)

- This is presentational, only, and does not affect anything in the data in the backend/change functionality around time machine (which takes dates not times anyway).
