### PR TITLE
HOTT-1262: Dont show comm code unless declarable

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -87,4 +87,8 @@ class Commodity < GoodsNomenclature
   def page_heading
     "Commodity #{code}"
   end
+
+  def umbrella_code?
+    has_children? && producline_suffix != '80'
+  end
 end

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -89,6 +89,6 @@ class Commodity < GoodsNomenclature
   end
 
   def umbrella_code?
-    has_children? && producline_suffix != '80'
+    producline_suffix != '80' && has_children?
   end
 end

--- a/app/presenters/heading_commodity_presenter.rb
+++ b/app/presenters/heading_commodity_presenter.rb
@@ -6,4 +6,8 @@ class HeadingCommodityPresenter
   def root_commodities
     @commodities.select(&:root)
   end
+
+  def leaf_commodities_count
+    @commodities.select(&:leaf?).length
+  end
 end

--- a/app/views/commodities/_commodity.html.erb
+++ b/app/views/commodities/_commodity.html.erb
@@ -3,7 +3,7 @@
     <span class="description open without_right_margin" aria-expanded="false" role="button" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></span>
 
     <div class='sub_heading_commodity_code_block pull-right'>
-      <%= format_commodity_code_based_on_level(commodity) %>
+      <%= format_commodity_code_based_on_level(commodity) unless commodity.umbrella_code? %>
     </div>
 
     <ul class="govuk-list"><%= render commodity.children %></ul>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -13,7 +13,8 @@
   <% end %>
 
   <%= render 'shared/context_tables/heading' %>
-  <%= render 'shared/callouts/heading'%>
+  <%= render 'shared/callouts/heading',
+             leaf_commodity_count: @commodities.leaf_commodities_count %>
 
 <% if @heading.declarable? %>
   <%= render 'declarables/declarable',

--- a/app/views/shared/callouts/_heading.html.erb
+++ b/app/views/shared/callouts/_heading.html.erb
@@ -1,6 +1,7 @@
 <div class="panel panel-border-wide govuk-panel">
   <p>
-    Choose the commodity code below that best matches your goods to see more information. If your item is not listed by name, it may be shown under what it's used for, what it's made from or 'Other'.
+    There are <strong><%= pluralize leaf_commodity_count, 'commodity' %></strong> in this category.
+    Choose the commodity code that best matches your goods to see more information. If your item is not listed by name, it may be shown under what it's used for, what it's made from or 'Other'.
   </p>
   <p>
     There are <%= link_to 'important notes for classifying your goods', "#notes" %> shown further down this page

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -24,6 +24,7 @@ FactoryBot.define do
     formatted_description { Forgery(:basic).text }
     goods_nomenclature_item_id { '0101000000' }
 
+    commodities { [] }
     import_measures { [] }
     export_measures { [] }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -38,9 +38,10 @@ FactoryBot.define do
     section { attributes_for(:section) }
     description { Forgery(:basic).text }
     formatted_description { Forgery(:basic).text }
-    goods_nomenclature_item_id { '0101300000' }
-    goods_nomenclature_sid { Forgery(:basic).number }
-    parent_sid { Forgery(:basic).number }
+    sequence(:goods_nomenclature_sid) { |id| id }
+    goods_nomenclature_item_id { sprintf '010130%04d', goods_nomenclature_sid }
+    parent_sid { nil }
+    number_indents { 2 }
     meursing_code { false }
 
     import_measures { [] }

--- a/spec/features/headings_spec.rb
+++ b/spec/features/headings_spec.rb
@@ -4,12 +4,11 @@ RSpec.describe 'JS behaviour', js: true, vcr: { cassette_name: 'headings#8501' }
   it 'render table tools on the top and bottom' do
     visit heading_path('8501')
 
-    expect(page).to have_content('Choose the commodity code below that best matches your goods to see more information')
+    expect(page).to have_content('Choose the commodity code that best matches your goods to see more information')
     expect(page.find_all('.tree-controls').length).to eq(2)
 
-    page.find_all('.has_children').each do |parent|
-      expect(parent).to have_xpath("//ul[@class='govuk-list' and @aria-hidden='true']")
-    end
+    expect(page.find_all('.has_children')).to \
+      all(have_xpath("//ul[@class='govuk-list' and @aria-hidden='true']"))
 
     page.find_all('.tree-controls')[0].first('a').click
 

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CommoditiesHelper, type: :helper do
 
       it 'returns the correct footnote heading' do
         expect(helper.footnote_heading(declarable)).to eq(
-          'Notes for commodity 0101300000',
+          "Notes for commodity #{declarable.goods_nomenclature_item_id}",
         )
       end
     end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe Commodity do
     let(:commodity) { described_class.new(attributes_for(:commodity).stringify_keys) }
 
     it 'formats the aria label correctly' do
-      expect(commodity.aria_label).to eq("Commodity code 0101300000, #{commodity.description}")
+      expect(commodity.aria_label).to \
+        eq("Commodity code #{commodity.goods_nomenclature_item_id}, #{commodity.description}")
     end
 
     context 'when the description is nil' do

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -150,4 +150,47 @@ RSpec.describe Commodity do
       end
     end
   end
+
+  describe 'umbrella_code?' do
+    subject { commodity.umbrella_code? }
+
+    let(:heading) { build :heading, commodities: [parent, child] }
+    let(:parent) { attributes_for :commodity, producline_suffix: producline_suffix }
+    let(:child) do
+      attributes_for :commodity, producline_suffix: producline_suffix,
+                                 parent_sid: parent[:goods_nomenclature_sid]
+    end
+
+    context 'with a commodity without children' do
+      let(:commodity) { heading.commodities.last }
+
+      context 'with producline_suffix of 10' do
+        let(:producline_suffix) { '10' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'with producline_suffix of 80' do
+        let(:producline_suffix) { '80' }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'with a commodity with children' do
+      let(:commodity) { heading.commodities.first }
+
+      context 'with producline_suffix of 10' do
+        let(:producline_suffix) { '10' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'with producline_suffix of 80' do
+        let(:producline_suffix) { '80' }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
 end

--- a/spec/presenters/heading_commodity_presenter_spec.rb
+++ b/spec/presenters/heading_commodity_presenter_spec.rb
@@ -2,20 +2,32 @@ require 'spec_helper'
 
 RSpec.describe HeadingCommodityPresenter do
   describe '#root_commodities' do
+    subject(:root_commodities) { described_class.new(commodities).root_commodities }
+
     let(:root_commodity) { OpenStruct.new(root: true) }
     let(:non_root_commodity) { OpenStruct.new(root: false) }
     let(:commodities) { [root_commodity, non_root_commodity] }
 
     it 'returns commodities that have root identication' do
-      expect(
-        HeadingCommodityPresenter.new(commodities).root_commodities,
-      ).to include root_commodity
+      expect(root_commodities).to include root_commodity
     end
 
     it 'does not return commodity not marked as root' do
-      expect(
-        HeadingCommodityPresenter.new(commodities).root_commodities,
-      ).not_to include non_root_commodity
+      expect(root_commodities).not_to include non_root_commodity
     end
+  end
+
+  describe '#leaf_commodities_count' do
+    subject { described_class.new(heading.commodities).leaf_commodities_count }
+
+    let(:heading) { build :heading, commodities: [standalone, parent, child, grandchild] }
+    let(:standalone) { attributes_for :commodity }
+    let(:parent) { attributes_for :commodity }
+    let(:child) { attributes_for :commodity, parent_sid: parent[:goods_nomenclature_sid] }
+    let(:grandchild) do
+      attributes_for :commodity, parent_sid: child[:goods_nomenclature_sid]
+    end
+
+    it { is_expected.to be 2 }
   end
 end

--- a/spec/views/commodities/_ancestors.html.erb_spec.rb
+++ b/spec/views/commodities/_ancestors.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'rules_of_origin/_ancestors.html.erb', type: :view do
+RSpec.describe 'commodities/_ancestors.html.erb', type: :view do
   subject(:rendered_page) { render_page && rendered }
 
   let(:render_page) { render 'commodities/ancestors', declarable: declarable }

--- a/spec/views/commodities/_commodity.html.erb_spec.rb
+++ b/spec/views/commodities/_commodity.html.erb_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe 'commodities/_commodity.html.erb', type: :view do
+  subject(:rendered_page) do
+    render 'commodities/commodity', commodity: commodity
+    rendered
+  end
+
+  describe 'for commodity' do
+    context 'with children' do
+      let(:heading) { build :heading, commodities: [parent, child] }
+
+      let(:parent) do
+        attributes_for :commodity, producline_suffix: producline_suffix,
+                                   number_indents: 2
+      end
+
+      let(:child) do
+        attributes_for :commodity, producline_suffix: producline_suffix,
+                                   parent_sid: parent[:goods_nomenclature_sid],
+                                   number_indents: 3
+      end
+
+      let(:commodity) { heading.commodities.first }
+
+      context 'with producline_suffix of 80' do
+        let(:producline_suffix) { '80' }
+
+        it 'will show the commodity code' do
+          expect(rendered_page).to have_css \
+            'li.has_children > .sub_heading_commodity_code_block .commodity-code'
+        end
+
+        it 'shows the children with their codes' do
+          expect(rendered_page).to have_css \
+            'li.has_children ul.govuk-list > li .commodity__info .commodity-code',
+            count: 1
+        end
+      end
+
+      context 'with producline_suffix of 10' do
+        let(:producline_suffix) { '10' }
+
+        it { is_expected.to have_css 'li.has_children > .sub_heading_commodity_code_block' }
+
+        it 'will not show the commodity code' do
+          expect(rendered_page).not_to have_css \
+            'li.has_children > .sub_heading_commodity_code_block .commodity-code'
+        end
+
+        it 'shows the children with their codes' do
+          expect(rendered_page).to have_css \
+            'li.has_children ul.govuk-list > li .commodity__info .commodity-code',
+            count: 1
+        end
+      end
+    end
+
+    context 'without children' do
+      let(:commodity) { build :commodity }
+
+      it { is_expected.to have_css 'li .commodity__info .commodity-code' }
+      it { is_expected.not_to have_css 'li.has_children' }
+    end
+  end
+end

--- a/spec/views/context_tables/commodity.html.erb_spec.rb
+++ b/spec/views/context_tables/commodity.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'shared/context_tables/_commodity.html.erb', type: :view, vcr: { 
 
   describe 'commodity row' do
     it { is_expected.to have_css 'dl div dt', text: 'Commodity' }
-    it { is_expected.to have_css 'dl div dd', text: '0101300000' }
+    it { is_expected.to have_css 'dl div dd', text: commodity.goods_nomenclature_item_id }
   end
 
   describe 'classification row' do


### PR DESCRIPTION
### Jira link

[HOTT-1262](https://transformuk.atlassian.net/browse/HOTT-1262)

### What?

I have added/removed/altered:

- [x] Removed display of commodity codes for umbrella codes 

### Why?

I am doing this because:

- These are not declarable and showing the code incorrectly implies that they are

