### PR TITLE
HOTT-1265 Show comm code in duty calculator link

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -111,9 +111,8 @@ module CommoditiesHelper
   end
 
   def segmented_commodity_code(code, coloured: false)
-    return if code.blank?
-
-    parts = code.to_s.gsub(/[^\d]/, '').split('').each_slice(4).map(&:join)
+    parts = divide_commodity_code(code)
+    return unless parts
 
     css_classes = %w[segmented-commodity-code]
     css_classes << 'segmented-commodity-code--coloured' if coloured
@@ -121,6 +120,12 @@ module CommoditiesHelper
     tag.span class: css_classes.join(' ') do
       safe_join parts.map(&tag.method(:span))
     end
+  end
+
+  def divide_commodity_code(code)
+    return if code.blank?
+
+    code.to_s.gsub(/[^\d]/, '').split('').each_slice(4).map(&:join)
   end
 
   def abbreviate_commodity_code(code)

--- a/app/views/measures/grouped/_tariff_duty_calculator_link.html.erb
+++ b/app/views/measures/grouped/_tariff_duty_calculator_link.html.erb
@@ -1,8 +1,16 @@
 <div class="calculator-panel">
   <%= image_tag('calculator.png') %>
-  <p>The table below lists the customs duties that apply to the import of commodity <%= declarable_code %>.</p>
 
-  <p>Use our <strong>tariff duty calculator</strong> to
-    <%= link_to("work out the duties and taxes applicable to the import of commodity.", "/duty-calculator/#{service_choice}/#{declarable_code}/import-date") %>
+  <p>
+    The table below lists the customs duties that apply to the import of
+    commodity <%= segmented_commodity_code declarable_code %>.
+  </p>
+
+  <p>
+    Use our <strong>tariff duty calculator</strong> to
+    <%= link_to "/duty-calculator/#{service_choice}/#{declarable_code}/import-date" do %>
+      work out the duties and taxes applicable to the import of commodity
+      <%= divide_commodity_code(declarable_code).join ' ' %>.
+    <% end %>
   </p>
 </div>

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -23,6 +23,38 @@ RSpec.describe CommoditiesHelper, type: :helper do
     end
   end
 
+  describe '#divide_commodity_code' do
+    subject { divide_commodity_code comm_code }
+
+    let(:comm_code) { '0123456789' }
+
+    it { is_expected.to eql %w[0123 4567 89] }
+
+    context 'with blank comm code' do
+      let(:comm_code) { '' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with already divided comm code' do
+      let(:comm_code) { '0123 4567 89' }
+
+      it { is_expected.to eql %w[0123 4567 89] }
+    end
+
+    context 'with a heading' do
+      let(:comm_code) { '0123' }
+
+      it { is_expected.to eql %w[0123] }
+    end
+
+    context 'with an 8 digit code' do
+      let(:comm_code) { '01234567' }
+
+      it { is_expected.to eql %w[0123 4567] }
+    end
+  end
+
   describe '#segmented_commodity_code' do
     subject { segmented_commodity_code comm_code }
 


### PR DESCRIPTION
### Jira link

[HOTT-1265](https://transformuk.atlassian.net/browse/HOTT-1265)

### What?

I have added/removed/altered:

- [x] Segment the commodity code on the duty calculator link
- [x] Include the commodity code in the link itself

### Why?

I am doing this because:

- it improves the UX

