### PR TITLE
HOTT-1264 show commodity count on headings page

### DIFF
--- a/app/presenters/heading_commodity_presenter.rb
+++ b/app/presenters/heading_commodity_presenter.rb
@@ -6,4 +6,8 @@ class HeadingCommodityPresenter
   def root_commodities
     @commodities.select(&:root)
   end
+
+  def leaf_commodities_count
+    @commodities.select(&:leaf?).length
+  end
 end

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -13,7 +13,8 @@
   <% end %>
 
   <%= render 'shared/context_tables/heading' %>
-  <%= render 'shared/callouts/heading'%>
+  <%= render 'shared/callouts/heading',
+             leaf_commodity_count: @commodities.leaf_commodities_count %>
 
 <% if @heading.declarable? %>
   <%= render 'declarables/declarable',

--- a/app/views/shared/callouts/_heading.html.erb
+++ b/app/views/shared/callouts/_heading.html.erb
@@ -1,6 +1,7 @@
 <div class="panel panel-border-wide govuk-panel">
   <p>
-    Choose the commodity code below that best matches your goods to see more information. If your item is not listed by name, it may be shown under what it's used for, what it's made from or 'Other'.
+    There are <strong><%= pluralize leaf_commodity_count, 'commodity' %></strong> in this category.
+    Choose the commodity code that best matches your goods to see more information. If your item is not listed by name, it may be shown under what it's used for, what it's made from or 'Other'.
   </p>
   <p>
     There are <%= link_to 'important notes for classifying your goods', "#notes" %> shown further down this page

--- a/spec/features/headings_spec.rb
+++ b/spec/features/headings_spec.rb
@@ -4,12 +4,11 @@ RSpec.describe 'JS behaviour', js: true, vcr: { cassette_name: 'headings#8501' }
   it 'render table tools on the top and bottom' do
     visit heading_path('8501')
 
-    expect(page).to have_content('Choose the commodity code below that best matches your goods to see more information')
+    expect(page).to have_content('Choose the commodity code that best matches your goods to see more information')
     expect(page.find_all('.tree-controls').length).to eq(2)
 
-    page.find_all('.has_children').each do |parent|
-      expect(parent).to have_xpath("//ul[@class='govuk-list' and @aria-hidden='true']")
-    end
+    expect(page.find_all('.has_children')).to \
+      all(have_xpath("//ul[@class='govuk-list' and @aria-hidden='true']"))
 
     page.find_all('.tree-controls')[0].first('a').click
 

--- a/spec/presenters/heading_commodity_presenter_spec.rb
+++ b/spec/presenters/heading_commodity_presenter_spec.rb
@@ -2,20 +2,32 @@ require 'spec_helper'
 
 RSpec.describe HeadingCommodityPresenter do
   describe '#root_commodities' do
+    subject(:root_commodities) { described_class.new(commodities).root_commodities }
+
     let(:root_commodity) { OpenStruct.new(root: true) }
     let(:non_root_commodity) { OpenStruct.new(root: false) }
     let(:commodities) { [root_commodity, non_root_commodity] }
 
     it 'returns commodities that have root identication' do
-      expect(
-        HeadingCommodityPresenter.new(commodities).root_commodities,
-      ).to include root_commodity
+      expect(root_commodities).to include root_commodity
     end
 
     it 'does not return commodity not marked as root' do
-      expect(
-        HeadingCommodityPresenter.new(commodities).root_commodities,
-      ).not_to include non_root_commodity
+      expect(root_commodities).not_to include non_root_commodity
     end
+  end
+
+  describe '#leaf_commodities_count' do
+    subject { described_class.new(heading.commodities).leaf_commodities_count }
+
+    let(:heading) { build :heading, commodities: [standalone, parent, child, grandchild] }
+    let(:standalone) { attributes_for :commodity }
+    let(:parent) { attributes_for :commodity }
+    let(:child) { attributes_for :commodity, parent_sid: parent[:goods_nomenclature_sid] }
+    let(:grandchild) do
+      attributes_for :commodity, parent_sid: child[:goods_nomenclature_sid]
+    end
+
+    it { is_expected.to be 2 }
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1264](https://transformuk.atlassian.net/browse/HOTT-1264)

### What?

I have added/removed/altered:

- [x] Display the commodity count above the commodity tree

### Why?

I am doing this because:

- HMRC have requested that we display the count of end line commodities

