### PR TITLE
HOTT-1265 Fix review apps bouncing back to DEV site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,22 +116,29 @@ commands:
           command: |
             cf create-app-manifest "$CF_APP-dev" -p deploy_manifest.yml
       - run:
-          name: Update app manifest
-          command: |
-            sed -i  "s/instances: [0-9]\+/instances\: 1/" deploy_manifest.yml
-      - run:
           name: Find PR number
           command: |
             PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | sed 's|https://github.com/||' | cut -d '/' -f 4)
             echo "export PR_NUMBER=${PR_NUMBER}" >> $BASH_ENV
+            echo "export REVIEW_URL_ID='pr${PR_NUMBER}'" >> $BASH_ENV
+      - run:
+          name: Update app manifest
+          command: |
+            sed -i "s/instances: [0-9]\+/instances\: 1/" deploy_manifest.yml
+            sed -i "s|CORS_HOST: dev\.trade-tariff\.service\.gov\.uk|CORS_HOST: ${CF_APP}-${REVIEW_URL_ID}.london.cloudapps.digital|" deploy_manifest.yml
+            sed -i "s|HOST: dev\.trade-tariff\.service\.gov\.uk|HOST: ${CF_APP}-${REVIEW_URL_ID}.london.cloudapps.digital|" deploy_manifest.yml
       - run:
           name: Push review app
           command: |
             export DOCKER_IMAGE=tariff-frontend
             export DOCKER_TAG=dev-${CIRCLE_SHA1}
-            export REVIEW_URL_ID="pr${PR_NUMBER}"
 
-            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "$CF_APP-${REVIEW_URL_ID}" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
+            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "$CF_APP-${REVIEW_URL_ID}" \
+              -f deploy_manifest.yml \
+              --no-route \
+              --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" \
+              --docker-username "$AWS_ACCESS_KEY_ID"
+
             cf map-route "$CF_APP-$REVIEW_URL_ID" london.cloudapps.digital -n "$CF_APP-$REVIEW_URL_ID"
 
             # Enable routing from this service to the backend applications which are private


### PR DESCRIPTION
### Jira link

[HOTT-1285](https://transformuk.atlassian.net/browse/HOTT-1285)

### What?

I have added/removed/altered:

- [x] Override the 'dev' versions of the HOST and CORS_HOST environment variables

### Why?

I am doing this because:

- We are generating incorrect absolute URLs in the search - they point back at the dev site
