### PR TITLE
HOTT-1206 Fix queueing in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
   browser-tools: circleci/browser-tools@1.1
   cloudfoundry: circleci/cloudfoundry@1.0
   slack: circleci/slack@4.3.0
-  queue: eddiewebb/queue@1.6.1
+  queue: eddiewebb/queue@1.6.4
 
 commands:
   cf_deploy_docker:


### PR DESCRIPTION
### Jira link

[HOTT-1206](https://transformuk.atlassian.net/browse/HOTT-1206)

### What?

I have added/removed/altered:

- [x] Upgraded the version of our queuing orb

### Why?

I am doing this because:

- Circle have changed their API responses breaking our queueing orb - using the newer versions fixes it.
