### PR TITLE
HOTT-1256 Only show CHEG link to UK users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,8 @@ class ApplicationController < ActionController::Base
 
   helper_method :cookies_policy,
                 :meursing_lookup_result,
-                :is_switch_service_banner_enabled?
+                :is_switch_service_banner_enabled?,
+                :client_location
 
   def render_500
     disable_search_form
@@ -122,6 +123,10 @@ class ApplicationController < ActionController::Base
 
   def meursing_lookup_result
     @meursing_lookup_result ||= MeursingLookup::Result.new(meursing_additional_code_id: session[MeursingLookup::Result::CURRENT_MEURSING_ADDITIONAL_CODE_KEY])
+  end
+
+  def client_location
+    ClientLocation.new(request.headers)
   end
 
   protected

--- a/app/models/client_location.rb
+++ b/app/models/client_location.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ClientLocation
+  HEADER = 'CloudFront-Viewer-Country-Name'
+
+  attr_reader :location_header
+
+  def initialize(request_headers)
+    @location_header = request_headers[HEADER].presence
+  end
+
+  def unknown?
+    location_header.blank?
+  end
+
+  def united_kingdom?
+    location_header == 'United Kingdom'
+  end
+end

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -56,6 +56,10 @@
                 country_name: @search.geographical_area&.description,
                 eu_member: @search.geographical_area&.eu_member? \
                 if client_location.united_kingdom? %>
+
+    <p>
+      HEADER CloudFront-Viewer-Country-Name: '<%= client_location.location_header %>'
+    </p>
   </div>
 
   <!-- Rules of Origin tab -->

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -54,7 +54,8 @@
                 declarable: declarable,
                 country_code: @search.country,
                 country_name: @search.geographical_area&.description,
-                eu_member: @search.geographical_area&.eu_member? %>
+                eu_member: @search.geographical_area&.eu_member? \
+                if client_location.unknown? || client_location.united_kingdom? %>
   </div>
 
   <!-- Rules of Origin tab -->

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -55,7 +55,7 @@
                 country_code: @search.country,
                 country_name: @search.geographical_area&.description,
                 eu_member: @search.geographical_area&.eu_member? \
-                if client_location.unknown? || client_location.united_kingdom? %>
+                if client_location.united_kingdom? %>
   </div>
 
   <!-- Rules of Origin tab -->

--- a/spec/models/client_location_spec.rb
+++ b/spec/models/client_location_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe ClientLocation do
+  subject(:client_location) { described_class.new(headers) }
+
+  let(:headers) { { 'CloudFront-Viewer-Country-Name' => location } }
+
+  describe '#unknown?' do
+    subject { client_location.unknown? }
+
+    context 'without header' do
+      let(:headers) { {} }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with header' do
+      let(:location) { 'United Kingdom' }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#united_kingdom?' do
+    subject { client_location.united_kingdom? }
+
+    context 'without header' do
+      let(:headers) { {} }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with header for somewhere else' do
+      let(:location) { 'France' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with header for UK' do
+      let(:location) { 'United Kingdom' }
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'measures/_measures.html.erb', type: :view, vcr: {
   it { is_expected.to render_template('declarables/_consigned') }
   it { is_expected.to render_template('footnotes/_footnote') }
   it { is_expected.to render_template('measure_conditions/_measure_condition_code_document') }
-  it { is_expected.to render_template('measures/_export_tab_check_duties') }
+  # it { is_expected.to render_template('measures/_export_tab_check_duties') }
   it { is_expected.to render_template('measures/_measure') }
   it { is_expected.to render_template('measures/_measure_condition_modal') }
   it { is_expected.to render_template('measures/_measure_condition_modal_default') }


### PR DESCRIPTION
### Jira link

[HOTT-1256](https://transformuk.atlassian.net/browse/HOTT-1256)

### What?

I have added/removed/altered:

- [x] Conditionalised display of CHEG link - if the Cloudfront header is either missing or its present and set to the UK then we'll display the link box, otherwise we exclude it

### Why?

I am doing this because:

- We only want to present that link to UK users

