### PR TITLE
HOTT-1255 Show certificate description instead of requirement

### DIFF
--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -3,7 +3,7 @@ require 'api_entity'
 class MeasureCondition
   include ApiEntity
 
-  attr_accessor :condition_code, :condition, :document_code, :action, :duty_expression
+  attr_accessor :condition_code, :condition, :document_code, :action, :duty_expression, :certificate_description
   attr_writer :requirement
 
   def requirement

--- a/app/views/measure_conditions/_measure_condition_code_default.html.erb
+++ b/app/views/measure_conditions/_measure_condition_code_default.html.erb
@@ -13,7 +13,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell numerical"><%= condition.document_code %></td>
       <td class="govuk-table__cell">
-        <%= condition.requirement.to_s.html_safe %>
+        <%= condition.certificate_description.presence || condition.requirement.to_s.html_safe %>
       </td>
       <td class="govuk-table__cell"><%= condition.action %></td>
       <td class="govuk-table__cell numerical">

--- a/app/views/measure_conditions/_measure_condition_code_document.html.erb
+++ b/app/views/measure_conditions/_measure_condition_code_document.html.erb
@@ -13,7 +13,7 @@
       <% if condition.document_code.present? %>
         <td class="govuk-table__cell numerical"><%= condition.document_code %></td>
         <td class="govuk-table__cell">
-          <%= condition.requirement %>
+          <%= condition.certificate_description.presence || condition.requirement %>
         </td>
       <% else %>
         <td class="govuk-table__cell">&nbsp;</td>

--- a/app/views/measure_conditions/_measure_condition_code_quantity.html.erb
+++ b/app/views/measure_conditions/_measure_condition_code_quantity.html.erb
@@ -21,7 +21,7 @@
       <% else %>
         <td class="govuk-table__cell numerical"><%= condition.document_code %></td>
         <td class="govuk-table__cell">
-          <%= condition.requirement.to_s.html_safe %>
+          <%= condition.certificate_description.presence || condition.requirement.to_s.html_safe %>
         </td>
       <% end %>
       <td class="govuk-table__cell numerical">


### PR DESCRIPTION
### Jira link

[HOTT-1255](https://transformuk.atlassian.net/browse/HOTT-1255)

### What?

I have added/removed/altered:

- [x] Changed to show the `certiicate_description` field if set in place of the requirement field - for Default, Document and Quantity Measure condition codes

### Why?

I am doing this because:

- It avoids showing the duplication in the requirements field

