### PR TITLE
HOTT-1250: Expose subheadings

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -13,6 +13,7 @@ module TradeTariffFrontend
       sections
       chapters
       headings
+      subheadings
       commodities
       updates
       monetary_exchange_rates
@@ -29,6 +30,7 @@ module TradeTariffFrontend
       sections
       chapters
       headings
+      subheadings
       commodities
       monetary_exchange_rates
       quotas


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1250

### What?

I have added/removed/altered:

- [x] Added subheadings to list of allowed backend apis

### Why?

I am doing this because:

- This is required so we can expose subheadings (see https://github.com/trade-tariff/trade-tariff-backend/pull/377)
