### PR TITLE
HOTT-1226: Removes obfuscating fetching of the page heading

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -3,12 +3,6 @@ module ServiceHelper
     t('title.default', service_name: service_name, service_description: service_description)
   end
 
-  def heading_for(section:, chapter: nil, heading: nil, commodity: nil)
-    item = commodity || heading || chapter || section
-
-    item ? item.page_heading : t('h1.service_description')
-  end
-
   def goods_nomenclature_title(goods_nomenclature)
     t(
       'title.goods_nomenclature',

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -6,7 +6,7 @@
 
 <% content_for :bodyClasses, "page--wide" %>
 
-<%= page_header heading_for(section: @section,chapter: @chapter,heading: @heading, commodity: @commodity) %>
+<%= page_header @chapter.page_heading %>
 
 <%= render 'shared/context_tables/chapter' %>
 <%= render 'shared/callouts/chapter', chapter: @chapter %>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -9,7 +9,7 @@
   <% if @heading.declarable? %>
     <%= render 'commodities/header', commodity_code: (@heading.page_heading + '000000') %>
   <% else %>
-    <%= page_header heading_for(section: @section, chapter: @chapter, heading: @heading, commodity: @commodity) %>
+    <%= page_header @heading.page_heading %>
   <% end %>
 
   <%= render 'shared/context_tables/heading' %>

--- a/app/views/sections/show.html.erb
+++ b/app/views/sections/show.html.erb
@@ -5,7 +5,7 @@
   <link rel='alternate' type='application/json' href='<%= section_url(@section, format: :json) %>' title='Section information page in JSON format' />
 <% end %>
 
-<%= page_header heading_for(section: @section,chapter: @chapter,heading: @heading, commodity: @commodity) %>
+<%= page_header @section.page_heading %>
 
 <% content_for :bodyClasses, "page--wide" %>
 

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -43,40 +43,6 @@ RSpec.describe ServiceHelper, type: :helper do
     end
   end
 
-  describe '#heading_for' do
-    subject { helper.heading_for(section: section, chapter: chapter, heading: heading, commodity: commodity) }
-
-    let(:section) { instance_double('Section', page_heading: 'Section AAA') }
-    let(:chapter) { instance_double('Chapter', page_heading: 'Chapter BBB') }
-    let(:heading) { instance_double('Heading', page_heading: 'Heading CCC') }
-    let(:commodity) { instance_double('Commodity', page_heading: 'Commodity EEE') }
-
-    context 'when in Commodity page' do
-      it { is_expected.to eq('Commodity EEE') }
-    end
-
-    context 'when in Heading page' do
-      let(:commodity) { nil }
-
-      it { is_expected.to eq('Heading CCC') }
-    end
-
-    context 'when in Chapter page' do
-      let(:heading) { nil }
-      let(:commodity) { nil }
-
-      it { is_expected.to eq('Chapter BBB') }
-    end
-
-    context 'when in Section page' do
-      let(:heading) { nil }
-      let(:commodity) { nil }
-      let(:chapter) { nil }
-
-      it { is_expected.to eq('Section AAA') }
-    end
-  end
-
   describe '#goods_nomenclature_title' do
     let(:commodity) { build(:commodity, formatted_description: 'Live horses, asses, mules and hinnies') }
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1226

### What?

I have added/removed/altered:

- [x] Removed obfuscating code around fetching a page header for goods nomenclature

### Why?

I am doing this because:

- We know from where we're called (e.g. show me a section/chapter/heading/subheading/commodity) what the page header should be
- All of these entities implement a page_heading method (rightly or wrongly)
- This is obfuscating and defensive when we know what the resource is
