### PR TITLE
Removes unused geographical area functionality

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -144,9 +144,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_path_info
-    @path_info = {
-      geographical_areas_path: geographical_areas_path(format: :json),
-      search_suggestions_path: search_suggestions_path(format: :json),
-    }
+    @path_info = { search_suggestions_path: search_suggestions_path(format: :json) }
   end
 end

--- a/app/controllers/geographical_areas_controller.rb
+++ b/app/controllers/geographical_areas_controller.rb
@@ -4,16 +4,4 @@ class GeographicalAreasController < ApplicationController
     @tariff_last_updated = nil
     @geographical_area = GeographicalArea.find(params[:id], query_params)
   end
-
-  def index
-    respond_to { |format| format.json { respond_with results: geographical_areas } }
-  end
-
-  private
-
-  def geographical_areas
-    search_term = Regexp.escape(params[:term].to_s)
-
-    GeographicalArea.by_long_description(search_term)
-  end
 end

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -14,31 +14,6 @@ class GeographicalArea
   ERGA_OMNES = '1011'.freeze # Entire world
 
   class << self
-    def by_long_description(term)
-      lookup_regexp = /#{term}/i
-
-      areas = all.select do |geographical_area|
-        geographical_area.long_description =~ lookup_regexp
-      end
-
-      areas = areas.sort_by do |geographical_area|
-        match_id = geographical_area.id =~ lookup_regexp
-        match_desc = geographical_area.description =~ lookup_regexp
-        key = ''
-        key << (match_id ? '0' : '1')
-        key << (match_desc || '')
-        key << geographical_area.id
-        key
-      end
-
-      areas.map do |geographical_area|
-        {
-          id: geographical_area.id,
-          text: geographical_area.long_description,
-        }
-      end
-    end
-
     def european_union
       @european_union ||= find(EUROPEAN_UNION_ID)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,6 @@ Rails.application.routes.draw do
   get 'terms', to: 'pages#terms'
   get 'privacy', to: 'pages#privacy', as: 'privacy'
   get 'help', to: 'pages#help', as: 'help'
-  get 'geographical_areas', to: 'geographical_areas#index', as: :geographical_areas
   get 'geographical_areas/:id', to: 'geographical_areas#show', as: :geographical_area
   get 'feedback', to: 'feedback#new'
   post 'feedback', to: 'feedback#create'

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -22,20 +22,6 @@ RSpec.describe GeographicalArea do
     end
   end
 
-  describe '.by_long_description', vcr: { cassette_name: 'geographical_areas#countries' } do
-    subject(:by_long_desc) { described_class.by_long_description('Ind') }
-
-    it 'returns the correct presented geographical areas' do
-      expected_geographical_areas = [
-        { id: 'ID', text: 'Indonesia (ID)' },
-        { id: 'IN', text: 'India (IN)' },
-        { id: 'IO', text: 'British Indian Ocean Territory (IO)' },
-      ]
-
-      expect(by_long_desc).to eq(expected_geographical_areas)
-    end
-  end
-
   describe '#erga_omnes?' do
     context 'when the geographical area is the world' do
       subject(:geographical_area) { build(:geographical_area, :erga_omnes) }


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removed ability to index geographical areas in json
- [x] Removed associated downstream methods

### Why?

I am doing this because:

- This was used to get geographical areas as part of a javascript request for geographical areas. This functionality has been removed
