### PR TITLE
HOTT-1280: Support overrides on measure type descriptions

### DIFF
--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -6,13 +6,28 @@ class MeasureType
   SUPPLEMENTARY_MEASURE_TYPES = %w[109 110 111].freeze
   SUPPLEMENTARY_IMPORT_ONLY_MEASURE_TYPES = %w[110].freeze
 
-  attr_accessor :id, :description
+  attr_accessor :id
+  attr_writer :description
 
   def supplementary?
     id.in?(SUPPLEMENTARY_MEASURE_TYPES)
   end
 
+  def description
+    translated_description || attributes['description']
+  end
+
   def supplementary_unit_import_only?
     id.in?(SUPPLEMENTARY_IMPORT_ONLY_MEASURE_TYPES)
+  end
+
+  private
+
+  def translated_description
+    I18n.t("measure_type_descriptions.#{geographical_area_id}.#{id}", default: nil)
+  end
+
+  def geographical_area_id
+    casted_by.geographical_area.id
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,10 @@ en:
     date: Enter date of trade
     trading_partner: Select a country
 
+  measure_type_descriptions:
+    1400:
+      103: 'Channel Islands duty'
+      105: 'Channel Islands duty'
   service_banner:
     service_name:
       uk: "UK Integrated Online Tariff"

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -38,4 +38,23 @@ RSpec.describe MeasureType do
       it { is_expected.not_to be_a_supplementary_unit_import_only }
     end
   end
+
+  describe '#description' do
+    subject(:description) { measure.measure_type.description }
+
+    shared_examples_for 'a Channel Island measure type description' do |measure_type_id, geographical_area_id|
+      let(:measure) { build(:measure, measure_type_id: measure_type_id, geographical_area_id: geographical_area_id) }
+
+      it { is_expected.to eq('Channel Islands duty') }
+    end
+
+    it_behaves_like 'a Channel Island measure type description', '103', '1400'
+    it_behaves_like 'a Channel Island measure type description', '105', '1400'
+
+    context 'when there are no matching locales' do
+      let(:measure) { build(:measure, measure_type_description: 'Bar') }
+
+      it { is_expected.to eq('Bar') }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1280

### What?

I have added/removed/altered:

- [x] Added mechanism for translating measure type descriptions
- [x] Added translations for Jersey and Guernsey MFN measure types
- [x] Added specs to validate this new mechanism

### Why?

I am doing this because:

- This is required so we can tweak anticipated measures for Jersey and Guernsey
