### PR TITLE
HOTT-1324 Allow HTML in `certificate_descriptions`

### DIFF
--- a/app/views/measure_conditions/_measure_condition_code_default.html.erb
+++ b/app/views/measure_conditions/_measure_condition_code_default.html.erb
@@ -13,7 +13,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell numerical"><%= condition.document_code %></td>
       <td class="govuk-table__cell">
-        <%= condition.certificate_description.presence || condition.requirement.to_s.html_safe %>
+        <%= (condition.certificate_description.presence || condition.requirement).to_s.html_safe %>
       </td>
       <td class="govuk-table__cell"><%= condition.action %></td>
       <td class="govuk-table__cell numerical">

--- a/app/views/measure_conditions/_measure_condition_code_document.html.erb
+++ b/app/views/measure_conditions/_measure_condition_code_document.html.erb
@@ -13,7 +13,7 @@
       <% if condition.document_code.present? %>
         <td class="govuk-table__cell numerical"><%= condition.document_code %></td>
         <td class="govuk-table__cell">
-          <%= condition.certificate_description.presence || condition.requirement %>
+          <%= (condition.certificate_description.presence || condition.requirement).to_s.html_safe %>
         </td>
       <% else %>
         <td class="govuk-table__cell">&nbsp;</td>

--- a/app/views/measure_conditions/_measure_condition_code_quantity.html.erb
+++ b/app/views/measure_conditions/_measure_condition_code_quantity.html.erb
@@ -21,7 +21,7 @@
       <% else %>
         <td class="govuk-table__cell numerical"><%= condition.document_code %></td>
         <td class="govuk-table__cell">
-          <%= condition.certificate_description.presence || condition.requirement.to_s.html_safe %>
+          <%= (condition.certificate_description.presence || condition.requirement).to_s.html_safe %>
         </td>
       <% end %>
       <td class="govuk-table__cell numerical">


### PR DESCRIPTION
### Jira link

[HOTT-1324](https://transformuk.atlassian.net/browse/HOTT-1324)

### What?

I have added/removed/altered:

- [x] Mark certificate description content as html safe in models

### Why?

I am doing this because:

- Currently its getting escaped but is coming from a source we trust

