### PR TITLE
More as_of search cleanup

### DIFF
--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -10,9 +10,9 @@ class GoodsNomenclaturesController < ApplicationController
   def find_relevant_goods_code_or_fallback
     @search = Search.new(
       q: goods_code_id,
-      'day' => @tariff_last_updated.try(:day),
-      'month' => @tariff_last_updated.try(:month),
-      'year' => @tariff_last_updated.try(:year),
+      day: @tariff_last_updated.try(:day),
+      month: @tariff_last_updated.try(:month),
+      year: @tariff_last_updated.try(:year),
     )
     results = @search.perform
 

--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -8,7 +8,12 @@ class GoodsNomenclaturesController < ApplicationController
   end
 
   def find_relevant_goods_code_or_fallback
-    @search = Search.new(q: goods_code_id, as_of: @tariff_last_updated)
+    @search = Search.new(
+      q: goods_code_id,
+      'day' => @tariff_last_updated.try(:day),
+      'month' => @tariff_last_updated.try(:month),
+      'year' => @tariff_last_updated.try(:year),
+    )
     results = @search.perform
 
     if results.exact_match?

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -7,8 +7,7 @@ class Search
   attr_accessor :country, # search country
                 :day,
                 :month,
-                :year,
-                :as_of    # legacy format for specifying date
+                :year
 
   delegate :today?, to: :date
 

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -56,6 +56,8 @@ module ApiEntity
   def initialize(attributes = {})
     class_name = self.class.name.downcase
 
+    attributes = HashWithIndifferentAccess.new(attributes)
+
     if attributes.present? && attributes.key?(class_name)
       @attributes = attributes[class_name]
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -512,4 +512,28 @@ FactoryBot.define do
       show_on_home_page { true }
     end
   end
+
+  factory :search do
+    transient do
+      search_date {}
+    end
+
+    q { 'foo' }
+
+    trait :with_search_date do
+      search_date { Time.zone.today }
+
+      day { search_date.day.to_s.rjust(2, '0') }
+      month { search_date.month.to_s.rjust(2, '0') }
+      year { search_date.year.to_s.rjust(2, '0') }
+    end
+
+    trait :with_country do
+      country { 'IT' }
+    end
+
+    initialize_with do
+      new(attributes.stringify_keys)
+    end
+  end
 end

--- a/spec/helpers/declarable_helper_spec.rb
+++ b/spec/helpers/declarable_helper_spec.rb
@@ -1,14 +1,15 @@
-require 'spec_helper'
-
 RSpec.describe DeclarableHelper, type: :helper, vcr: { cassette_name: 'geographical_areas#it' } do
   describe '#declarable_stw_link' do
     subject(:declarable_stw_link) { helper.declarable_stw_link(declarable, search) }
 
     let(:declarable) { build(:commodity) }
-    let(:search) { Search.new(country: 'IT', day: '01', month: '01', year: '2021') }
+
+    let(:search) { build(:search, :with_search_date, :with_country, search_date: search_date) }
+
+    let(:search_date) { Date.parse('2021-01-01') }
 
     context 'when no date is passed' do
-      let(:search) { Search.new(country: 'IT') }
+      let(:search) { build(:search, :with_country) }
 
       it { is_expected.to include("importDateDay=#{Time.zone.today.day}") }
       it { is_expected.to include("importDateMonth=#{Time.zone.today.month}") }
@@ -72,13 +73,13 @@ RSpec.describe DeclarableHelper, type: :helper, vcr: { cassette_name: 'geographi
     subject(:supplementary_geographical_area_id) { helper.supplementary_geographical_area_id(search) }
 
     context 'when the country is present on the search' do
-      let(:search) { Search.new(country: 'IT') }
+      let(:search) { build(:search, :with_country) }
 
       it { is_expected.to eq('IT') }
     end
 
     context 'when the country is not present on the search' do
-      let(:search) { Search.new(country: nil) }
+      let(:search) { build(:search) }
 
       it { is_expected.to eq('1011') }
     end

--- a/spec/views/context_tables/chapter.html.erb_spec.rb
+++ b/spec/views/context_tables/chapter.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'shared/context_tables/_chapter', type: :view, vcr: { cassette_na
   end
 
   let(:chapter) { build(:chapter) }
-  let(:search) { Search.new(as_of: Time.zone.today.iso8601, country: 'IT') }
+  let(:search) { build(:search, :with_search_date, :with_country) }
 
   describe 'goods nomenclature row' do
     it { is_expected.to have_css 'dl div dt', text: 'Chapter' }

--- a/spec/views/context_tables/commodity.html.erb_spec.rb
+++ b/spec/views/context_tables/commodity.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'shared/context_tables/_commodity', type: :view, vcr: { cassette_
   end
 
   let(:commodity) { build(:commodity) }
-  let(:search) { Search.new(as_of: Time.zone.today.iso8601, country: 'IT') }
+  let(:search) { build(:search, :with_search_date, :with_country) }
 
   describe 'commodity row' do
     it { is_expected.to have_css 'dl div dt', text: 'Commodity' }

--- a/spec/views/context_tables/heading.html.erb_spec.rb
+++ b/spec/views/context_tables/heading.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'shared/context_tables/_heading', type: :view, vcr: { cassette_na
   end
 
   let(:heading) { build(:heading, declarable: declarable) }
-  let(:search) { Search.new(as_of: Time.zone.today.iso8601, country: 'IT') }
+  let(:search) { build(:search, :with_search_date, :with_country) }
 
   let(:declarable) { true }
 

--- a/spec/views/find_commodities/show.html.erb_spec.rb
+++ b/spec/views/find_commodities/show.html.erb_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe 'find_commodities/show', type: :view do
 
   before { assign :search, search }
 
-  let(:now) { Time.zone.today }
+  let(:search_date) { Time.zone.today }
   let(:q) { nil }
-  let(:search) { Search.new q: q, 'day' => now.day, 'month' => now.month, 'year' => now.year }
+
+  let(:search) { build(:search, :with_search_date, q: '0101300000', search_date: search_date) }
 
   describe 'header' do
     it { is_expected.to have_css 'header h1', text: /commodity codes, import duties/ }
@@ -18,9 +19,9 @@ RSpec.describe 'find_commodities/show', type: :view do
     it { is_expected.to have_css 'form details .govuk-details__text' }
 
     shared_examples 'a populated date input' do
-      it { is_expected.to have_css %(.govuk-details__text input[name="day"][value="#{now.day}"]) }
-      it { is_expected.to have_css %(.govuk-details__text input[name="month"][value="#{now.month}"]) }
-      it { is_expected.to have_css %(.govuk-details__text input[name="year"][value="#{now.year}"]) }
+      it { is_expected.to have_css %(.govuk-details__text input[name="day"][value="#{search_date.day}"]) }
+      it { is_expected.to have_css %(.govuk-details__text input[name="month"][value="#{search_date.month}"]) }
+      it { is_expected.to have_css %(.govuk-details__text input[name="year"][value="#{search_date.year}"]) }
     end
 
     context 'with default date' do
@@ -28,7 +29,7 @@ RSpec.describe 'find_commodities/show', type: :view do
     end
 
     context 'with selected date' do
-      let(:now) { 3.days.ago }
+      let(:search_date) { 3.days.ago }
 
       it_behaves_like 'a populated date input'
     end

--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'measures/_measures', type: :view, vcr: {
            rules_of_origin_schemes: []
   end
 
-  let(:search) { Search.new(q: '0101300000') }
+  let(:search) { build(:search, q: '0101300000') }
   let(:all_countries) { GeographicalArea.all }
   let(:presented_commodity) { CommodityPresenter.new(commodity) }
 
@@ -76,7 +76,7 @@ RSpec.describe 'measures/_measures', type: :view, vcr: {
     end
 
     context 'with country selected' do
-      let(:search) { Search.new(q: '0101300000', 'country' => 'FR') }
+      let(:search) { build(:search, q: '0101300000', country: 'FR') }
 
       it_behaves_like 'measures with rules of origin tab'
       it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
@@ -98,7 +98,7 @@ RSpec.describe 'measures/_measures', type: :view, vcr: {
     end
 
     context 'with country selected' do
-      let(:search) { Search.new(q: '0101300000', 'country' => 'FR') }
+      let(:search) { build(:search, q: '0101300000', country: 'FR') }
 
       it_behaves_like 'measures with rules of origin tab'
       it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1333

### What?

I have added/removed/altered:

- [x] Updated specs to use a search factory
- [x] Removed unused as_of attribute from the Search model
- [x] Removed old references to as_of

### Why?

I am doing this because:

- This is part of the TariffDate cleanup
