### PR TITLE
HOTT-1279 Search refactor

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
 
   layout :set_layout
 
-  rescue_from ApiEntity::Error, Faraday::ServerError, Errno::ECONNREFUSED do
+  rescue_from Faraday::ServerError, Errno::ECONNREFUSED do
     request.format = :html
     render_500
   end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,7 +1,7 @@
 require 'api_entity'
 
 class HealthcheckController < ActionController::Base
-  rescue_from ApiEntity::Error, Faraday::ServerError do |_e|
+  rescue_from Faraday::ServerError do |_e|
     render plain: '', status: :internal_server_error
   end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -73,6 +73,10 @@ class Search
     q.present?
   end
 
+  def missing_search_term?
+    !contains_search_term?
+  end
+
   def query_attributes
     {
       'day' => date.day,

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -20,9 +20,6 @@ class Search
     retries = 0
     begin
       response = self.class.post('/search', q: q, as_of: date.to_fs(:db))
-
-      raise ApiEntity::Error if response.status == 500
-
       response = TariffJsonapiParser.new(response.body).parse
       Outcome.new(response)
     rescue StandardError

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -4,8 +4,6 @@ require 'active_model'
 require 'tariff_jsonapi_parser'
 
 module ApiEntity
-  class Error < StandardError; end
-
   class UnparseableResponseError < StandardError
     def initialize(response)
       @response = response

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -28,16 +28,14 @@ RSpec.describe Search do
   end
 
   describe 'raises on error if search responds with status 500' do
-    let(:api_mock) { double(:api_mock) }
-    let(:response_stub) { double(:response_stub, status: 500) }
+    subject(:perform_search) { described_class.new(q: 'abc').perform }
 
     before do
-      allow(api_mock).to receive(:post).and_return(response_stub)
-      allow(described_class).to receive(:api).and_return(api_mock)
+      stub_api_request('/search', :post).to_return jsonapi_error_response
     end
 
     it 'search' do
-      expect { described_class.new(q: 'abc').perform }.to raise_error ApiEntity::Error
+      expect { perform_search }.to raise_error Faraday::ServerError
     end
   end
 
@@ -58,6 +56,38 @@ RSpec.describe Search do
       it 'returns false' do
         expect(search.day_month_and_year_set?).to be false
       end
+    end
+  end
+
+  describe '#contains_search_term?' do
+    subject { described_class.new(q: search_term).contains_search_term? }
+
+    context 'with search query' do
+      let(:search_term) { 'testing123' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'without search query' do
+      let(:search_term) { ' ' }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#missing_search_term?' do
+    subject { described_class.new(q: search_term).missing_search_term? }
+
+    context 'with search query' do
+      let(:search_term) { 'testing123' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'without search query' do
+      let(:search_term) { ' ' }
+
+      it { is_expected.to be true }
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1279](https://transformuk.atlassian.net/browse/HOTT-1279)

### What?

I have added/removed/altered:

- [x] Reorganised the SearchController to improve readability
- [x] Dropped references to ApiEntity::Error
- [x] Fixed the '500' spec on Search model testing its own mocks rather then the real behaviour

### Why?

I am doing this because:

- The current code lacks readability
- The last usage of ApiEntity::Error wasn't actually using it anyway

### Deployment risks (optional)

- Makes minor cleanups to our core ApiEntity layer - tests pass and removed code appears unused
