### PR TITLE
HOTT-1279 Hide search boxes on 404 pages

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -18,6 +18,8 @@ class CommoditiesController < GoodsNomenclaturesController
     @heading_code = params[:id].first(4)
     @chapter_code = params[:id].first(2)
 
+    disable_search_form
+
     render :show_404, status: :not_found
   end
 

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -20,6 +20,8 @@ class HeadingsController < GoodsNomenclaturesController
     @heading_code = params[:id]
     @chapter_code = params[:id].first(2)
 
+    disable_search_form
+
     render :show_404, status: :not_found
   end
 


### PR DESCRIPTION
### Jira link

[HOTT-1279](https://transformuk.atlassian.net/browse/HOTT-1279)

### What?

I have added/removed/altered:

- [x] Removed the search box from the commodities 404 page
- [x] Removed the search box from the headings 404 page

### Why?

I am doing this because:

- These pages shouldn't have the search box on them

