### PR TITLE
HOTT-1295: Rails upgrade cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'responders'
 gem 'webpacker'
 
 # gov UK
-gem 'govspeak', github: 'willfish/govspeak', branch: 'rails7-compatibility'
+gem 'govspeak'
 gem 'nokogiri', '~> 1.13.2' # https://github.com/sparklemotion/nokogiri/issues/2205
 gem 'plek'
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'rails', '~> 7'
+gem 'rails', '~> 7.0'
 
 gem 'addressable'
 gem 'faraday', '= 1.3.0' # TODO: Debug issue with newer versions of Faraday client under high loads

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,22 +16,6 @@ GIT
       actionpack (>= 6.1)
       activesupport (>= 6.1)
 
-GIT
-  remote: https://github.com/willfish/govspeak.git
-  revision: 0a7ad9f54dcd5a2679eccaeaf905b687add8cf98
-  branch: rails7-compatibility
-  specs:
-    govspeak (6.7.8)
-      actionview (>= 5.0, < 8)
-      addressable (>= 2.3.8, < 3)
-      govuk_publishing_components (>= 23)
-      htmlentities (~> 4)
-      i18n (>= 0.7)
-      kramdown (>= 2.3.0)
-      nokogiri (~> 1.12)
-      rinku (~> 2.0)
-      sanitize (~> 6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -182,6 +166,16 @@ GEM
     forgery (0.8.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    govspeak (6.8.0)
+      actionview (>= 6)
+      addressable (>= 2.3.8, < 3)
+      govuk_publishing_components (>= 23)
+      htmlentities (~> 4)
+      i18n (>= 0.7)
+      kramdown (>= 2.3.0)
+      nokogiri (~> 1.12)
+      rinku (~> 2.0)
+      sanitize (~> 6)
     govuk_app_config (3.3.0)
       logstasher (>= 1.2.2, < 2.2.0)
       sentry-raven (~> 3.1.1)
@@ -479,7 +473,7 @@ DEPENDENCIES
   faraday-net_http_persistent
   faraday_middleware
   forgery
-  govspeak!
+  govspeak
   govuk_design_system_formbuilder
   kaminari
   letter_opener

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -495,7 +495,7 @@ DEPENDENCIES
   puma
   rack-cors
   rack-test
-  rails (~> 7)
+  rails (~> 7.0)
   rails-controller-testing!
   redis-rails
   responders


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1295

### What?

I have added/removed/altered:

- [x] Pin rails to 7.0
- [x] Move away from forked govspeak

### Why?

I am doing this because:

- We should control more closely breaking versions of rails
- Rails do not use semver and minor versions are breaking
