### PR TITLE
HOTT-1345 Show full comm code for declarable

### DIFF
--- a/app/views/commodities/_ancestors.html.erb
+++ b/app/views/commodities/_ancestors.html.erb
@@ -39,7 +39,7 @@
       <li id="commodity-ancestors__heading">
         <span>
           <span class="commodity-ancestors__identifier">
-            <%= segmented_commodity_code declarable.short_code,
+            <%= segmented_commodity_code declarable.code,
                                          coloured: true %>
           </span>
 
@@ -87,7 +87,7 @@
       <li id="<%= commodity_ancestor_id(declarable.ancestors.length + 1) %>">
         <span>
           <span class="commodity-ancestors__identifier">
-            <%= segmented_commodity_code abbreviate_commodity_code(declarable.code),
+            <%= segmented_commodity_code declarable.code,
                                          coloured: true %>
           </span>
 


### PR DESCRIPTION
in ancestors tree

### Jira link

[HOTT-1345](https://transformuk.atlassian.net/browse/HOTT-1345)

### What?

I have added/removed/altered:

- [x] Show full 10 digit code for declarable in ancestors tree

### Why?

I am doing this because:

- Currently we are abbreviating the code and this is incorrect

