### PR TITLE
This PR reduces the noise (10k of lines) in the Ruby console

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -69,4 +69,15 @@ class GoodsNomenclature
   def self.is_heading_id?(goods_nomenclature_item_id)
     goods_nomenclature_item_id.ends_with?('000000') && goods_nomenclature_item_id.slice(2, 2) != '00'
   end
+
+  def inspect
+    {
+      object_id: object_id,
+      id:,
+      type:,
+      goods_nomenclature_item_id:,
+      formatted_description:,
+      description:,
+    }
+  end
 end


### PR DESCRIPTION
### What?
This PR reduces the noise (10k of lines) in the Ruby console, that occurred when method missing for any type of GoodsNomenclature.

### Why?
To make the world less digitally noisy, and improve Alessandro's mental health.

### Jira link
HOTT-1362

Screenshot:
<img width="1399" alt="Screenshot 2022-02-23 at 11 43 52" src="https://user-images.githubusercontent.com/58971/155313152-a47fe570-6b54-45ec-957e-75e4a2501b75.png">

