### PR TITLE
HOTT-1371 Allow rendering XI measures without UK commodity

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -67,6 +67,9 @@ class CommoditiesController < GoodsNomenclaturesController
       @commodities[:xi] = CommodityPresenter.new(Commodity.find(params[:id], query_params))
       @commodities[:uk] = TradeTariffFrontend::ServiceChooser.with_source(:uk) do
         CommodityPresenter.new(Commodity.find(params[:id], query_params))
+      rescue Faraday::ResourceNotFound
+        # Handle when no UK equivalent commodity available
+        nil
       end
     end
   end

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -93,7 +93,7 @@
 
   <div id="import-measure-references">
     <%= render partial: 'measures/measure_references', collection: declarable.import_measures.for_country(@search.country), as: 'measure', locals: { declarable: declarable } %>
-    <% if TradeTariffFrontend::ServiceChooser.xi? %>
+    <% if TradeTariffFrontend::ServiceChooser.xi? && uk_declarable.present? %>
       <%= render partial: 'measures/measure_references', collection: uk_declarable.import_measures.import_controls.for_country(@search.country), as: 'measure', locals: { declarable: declarable } %>
       <%= render partial: 'measures/measure_references', collection: uk_declarable.import_measures.vat_excise.for_country(@search.country), as: 'measure', locals: { declarable: declarable } %>
     <% end %>

--- a/app/views/measures/grouped/_xi.html.erb
+++ b/app/views/measures/grouped/_xi.html.erb
@@ -1,5 +1,5 @@
 <%- xi_import_measures = xi_declarable.import_measures.for_country(@search.country) %>
-<%- uk_import_measures = uk_declarable.import_measures.for_country(@search.country) %>
+<%- uk_import_measures = uk_declarable&.import_measures&.for_country(@search.country) %>
 
 <!-- IMPORT DUTIES -->
 <% if xi_import_measures.customs_duties.present? %>
@@ -22,7 +22,7 @@
 <% end %>
 
 <!-- VAT & EXCISE -->
-<% if uk_import_measures.vat_excise.present? %>
+<% if uk_import_measures&.vat_excise.present? %>
   <%= render partial: 'measures/grouped/table', locals: {
     caption: 'VAT and excise',
     collection: uk_import_measures.vat_excise.sort_by(&:key),
@@ -41,7 +41,7 @@
 <% end %>
 
 <!-- UK IMPORT CONTROLS -->
-<% if uk_import_measures.import_controls.present? %>
+<% if uk_import_measures&.import_controls.present? %>
   <%= render partial: 'measures/grouped/table', locals: {
     caption: TradeTariffFrontend::ServiceChooser.uk? ? 'Import controls' : 'UK import controls',
     collection: uk_import_measures.import_controls.sort_by(&:key),

--- a/app/views/measures/grouped/_xi_navigation.html.erb
+++ b/app/views/measures/grouped/_xi_navigation.html.erb
@@ -1,5 +1,5 @@
 <%- xi_import_measures = xi_declarable.import_measures.for_country(@search.country) %>
-<%- uk_import_measures = uk_declarable.import_measures.for_country(@search.country) %>
+<%- uk_import_measures = uk_declarable&.import_measures&.for_country(@search.country) %>
 
 <!-- CUSTOMS DUTIES -->
 <% if xi_import_measures.customs_duties.present? %>
@@ -16,7 +16,7 @@
 <% end %>
 
 <!-- VAT & EXCISE -->
-<% if uk_import_measures.vat_excise.present? %>
+<% if uk_import_measures&.vat_excise.present? %>
   <li class="govuk-!-margin-bottom-2">
     <%= link_to('VAT and excise', '#vat_excise', class: 'govuk-link') %>
   </li>
@@ -30,10 +30,8 @@
 <% end %>
 
 <!-- UK IMPORT CONTROLS -->
-<% if uk_import_measures.import_controls.present? %>
+<% if uk_import_measures&.import_controls.present? %>
   <li class="govuk-!-margin-bottom-2">
     <%= link_to('UK import controls', '#uk_import_controls', class: 'govuk-link') %>
   </li>
 <% end %>
-
- 

--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -104,4 +104,28 @@ RSpec.describe 'measures/_measures', type: :view, vcr: {
       it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
     end
   end
+
+  context 'with xi service with no equivalent uk commodity' do
+    include_context 'with XI service'
+
+    let :render_page do
+      render 'measures/measures',
+             declarable: presented_commodity,
+             uk_declarable: nil,
+             xi_declarable: presented_commodity,
+             rules_of_origin_schemes: []
+    end
+
+    context 'without country selected' do
+      it_behaves_like 'measures with rules of origin tab'
+      it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin' }
+    end
+
+    context 'with country selected' do
+      let(:search) { build(:search, q: '0101300000', country: 'FR') }
+
+      it_behaves_like 'measures with rules of origin tab'
+      it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1371](https://transformuk.atlassian.net/browse/HOTT-1371)

### What?

I have added/removed/altered:

- [x] Updated measures views to still render when no UK commodity present
- [x] Updated commodities controller to handle commodities present in the XI service but not the UK service

### Why?

I am doing this because:

- Currently we cannot render XI commodities if there is not a UK equivalent

### Have you? (optional)

- [x] Reviewed view changes with stake holders


