### PR TITLE
HOTT-1374 Fixed spelling of news feed

### DIFF
--- a/app/views/news_items/_feed.html.erb
+++ b/app/views/news_items/_feed.html.erb
@@ -6,7 +6,7 @@
   <details class="govuk-details govuk-!-margin-top-2" data-module="govuk-details">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
-        Using the new feed
+        Using the news feed
       </span>
     </summary>
 


### PR DESCRIPTION
### Jira link

[HOTT-1374](https://transformuk.atlassian.net/browse/HOTT-1374)

### What?

I have added/removed/altered:

- [x] Spelling fix for news feed

### Why?

I am doing this because:

- Because 'new feed' has a different semantic meaning
