### PR TITLE
Remove unused (and wrong) export method.

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -105,10 +105,6 @@ class Measure
     import
   end
 
-  def export?
-    !import
-  end
-
   def destination
     import? ? 'import' : 'export'
   end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -172,20 +172,6 @@ RSpec.describe Measure do
     end
   end
 
-  describe '#export?' do
-    context 'when the measure is an export measure' do
-      subject(:measure) { build(:measure, :export) }
-
-      it { is_expected.to be_export }
-    end
-
-    context 'when the measure is an import measure' do
-      subject(:measure) { build(:measure, :import) }
-
-      it { is_expected.not_to be_export }
-    end
-  end
-
   describe '#excluded_country_list', vcr: { cassette_name: 'geographical_areas#1013' } do
     context 'when the excluded_countries include all eu members' do
       subject(:measure) { build(:measure, :with_eu_member_exclusions) }


### PR DESCRIPTION
### What?
The method `export?` is semantically wrong, and it is not used. This PR removes it.

### Why?
To prevent developers to use a wrong method.

