### PR TITLE
Tidy up spec factories

### DIFF
--- a/spec/controllers/chapters/changes_controller_spec.rb
+++ b/spec/controllers/chapters/changes_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Chapters::ChangesController, 'GET to #index', type: :controller do
-  let!(:chapter) { Chapter.new(attributes_for(:chapter, goods_nomenclature_item_id: '0100000000').stringify_keys) }
+  let!(:chapter) { Chapter.new(attributes_for(:chapter, goods_nomenclature_item_id: '0100000000')) }
 
   describe 'chapter is valid at given date', vcr: { cassette_name: 'chapters_changes#index' } do
     before do

--- a/spec/controllers/chapters_controller_spec.rb
+++ b/spec/controllers/chapters_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe ChaptersController, type: :controller, vcr: { cassette_name: 'chapters#show' } do
   describe 'GET #show' do
-    let!(:chapter) { build :chapter, section: attributes_for(:section).stringify_keys }
+    let!(:chapter) { build :chapter, section: attributes_for(:section) }
 
     before do
       get :show, params: { id: chapter.to_param }

--- a/spec/controllers/commodities/changes_controller_spec.rb
+++ b/spec/controllers/commodities/changes_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Commodities::ChangesController, 'GET to #index', type: :controller do
   describe 'commodity is valid at given date', vcr: { cassette_name: 'commodities_changes#index' } do
-    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '0101210000').stringify_keys) }
+    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '0101210000')) }
 
     before do
       get :index, params: { commodity_id: commodity.short_code }, format: :atom
@@ -14,7 +14,7 @@ RSpec.describe Commodities::ChangesController, 'GET to #index', type: :controlle
   end
 
   describe 'commodity has no changes at given date', vcr: { cassette_name: 'commodities_changes#index_4302130000_1998-01-01' }, type: :controller do
-    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '4302130000').stringify_keys) }
+    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '4302130000')) }
 
     before do
       get :index, params: { commodity_id: commodity.short_code, as_of: Date.new(1998, 1, 1) }, format: :atom
@@ -30,7 +30,7 @@ RSpec.describe Commodities::ChangesController, 'GET to #index', type: :controlle
   end
 
   describe 'commodity is not valid at given date', vcr: { cassette_name: 'commodities_changes#index_4302130000_2013-11-11' } do
-    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '4302130000').stringify_keys) }
+    let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '4302130000')) }
 
     before do
       get :index, params: { commodity_id: commodity.short_code, as_of: Date.new(2013, 11, 11) }, format: :atom

--- a/spec/controllers/headings/changes_controller_spec.rb
+++ b/spec/controllers/headings/changes_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Headings::ChangesController, 'GET to #index', type: :controller do
-  let!(:heading) { Heading.new(attributes_for(:heading, goods_nomenclature_item_id: '0101000000').stringify_keys) }
+  let!(:heading) { Heading.new(attributes_for(:heading, goods_nomenclature_item_id: '0101000000')) }
 
   describe 'heading is valid at given date', vcr: { cassette_name: 'headings_changes#index' } do
     before do

--- a/spec/controllers/headings_controller_spec.rb
+++ b/spec/controllers/headings_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe HeadingsController, type: :controller do
     end
 
     context 'with existing heading id provided', vcr: { cassette_name: 'headings#show' } do
-      let!(:heading) { Heading.new(attributes_for(:heading).stringify_keys) }
+      let!(:heading) { Heading.new(attributes_for(:heading)) }
 
       before do
         get :show, params: { id: heading.to_param }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
     export_measures { [] }
 
     initialize_with do
-      new(attributes.stringify_keys)
+      new(attributes)
     end
   end
 
@@ -59,7 +59,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      new(attributes.stringify_keys)
+      new(attributes)
     end
   end
 
@@ -95,7 +95,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      new(attributes.stringify_keys)
+      new(attributes)
     end
   end
 
@@ -134,11 +134,11 @@ FactoryBot.define do
     effective_end_date { nil }
 
     measure_type do
-      attributes_for(:measure_type, id: measure_type_id, description: measure_type_description).stringify_keys
+      attributes_for(:measure_type, id: measure_type_id, description: measure_type_description)
     end
 
     geographical_area do
-      attributes_for(:geographical_area, id: geographical_area_id).stringify_keys
+      attributes_for(:geographical_area, id: geographical_area_id)
     end
 
     trait :vat do
@@ -146,49 +146,49 @@ FactoryBot.define do
     end
 
     trait :erga_omnes do
-      geographical_area { attributes_for(:geographical_area, :erga_omnes).stringify_keys }
+      geographical_area { attributes_for(:geographical_area, :erga_omnes) }
     end
 
     trait :vat_excise do
       measure_type do
-        attributes_for(:measure_type, :vat_excise, description: measure_type_description).stringify_keys
+        attributes_for(:measure_type, :vat_excise, description: measure_type_description)
       end
     end
 
     trait :trade_remedies do
       measure_type do
-        attributes_for(:measure_type, :trade_remedies, description: measure_type_description).stringify_keys
+        attributes_for(:measure_type, :trade_remedies, description: measure_type_description)
       end
     end
 
     trait :import_controls do
       measure_type do
-        attributes_for(:measure_type, :import_controls, description: measure_type_description).stringify_keys
+        attributes_for(:measure_type, :import_controls, description: measure_type_description)
       end
     end
 
     trait :customs_duties do
       measure_type do
-        attributes_for(:measure_type, :customs_duties, description: measure_type_description).stringify_keys
+        attributes_for(:measure_type, :customs_duties, description: measure_type_description)
       end
     end
 
     trait :quotas do
       measure_type do
-        attributes_for(:measure_type, :quotas, description: measure_type_description).stringify_keys
+        attributes_for(:measure_type, :quotas, description: measure_type_description)
       end
     end
 
     trait :third_country do
       measure_type do
-        attributes_for(:measure_type, :third_country, description: measure_type_description).stringify_keys
+        attributes_for(:measure_type, :third_country, description: measure_type_description)
       end
-      geographical_area { attributes_for(:geographical_area, :erga_omnes).stringify_keys }
+      geographical_area { attributes_for(:geographical_area, :erga_omnes) }
     end
 
     trait :import_export_supplementary do
       measure_type do
-        attributes_for(:measure_type, :import_export_supplementary, description: measure_type_description).stringify_keys
+        attributes_for(:measure_type, :import_export_supplementary, description: measure_type_description)
       end
 
       duty_expression do
@@ -198,7 +198,7 @@ FactoryBot.define do
 
     trait :import_only_supplementary do
       measure_type do
-        attributes_for(:measure_type, :import_only_supplementary, description: measure_type_description).stringify_keys
+        attributes_for(:measure_type, :import_only_supplementary, description: measure_type_description)
       end
 
       duty_expression do
@@ -262,19 +262,19 @@ FactoryBot.define do
     end
 
     trait :specific_country do
-      geographical_area { attributes_for(:geographical_area, :specific_country).stringify_keys }
+      geographical_area { attributes_for(:geographical_area, :specific_country) }
     end
 
     trait :with_conditions do
-      measure_conditions { [attributes_for(:measure_condition).stringify_keys] }
+      measure_conditions { [attributes_for(:measure_condition)] }
     end
 
     trait :with_additional_code do
-      additional_code { attributes_for(:additional_code).stringify_keys }
+      additional_code { attributes_for(:additional_code) }
     end
 
     trait :with_footnotes do
-      footnotes { [attributes_for(:footnote).stringify_keys] }
+      footnotes { [attributes_for(:footnote)] }
     end
 
     trait :national do
@@ -294,7 +294,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      new(attributes.stringify_keys)
+      new(attributes)
     end
   end
 
@@ -371,7 +371,7 @@ FactoryBot.define do
       end
 
       measurement_unit do
-        attributes_for(:measurement_unit, :supplementary).stringify_keys
+        attributes_for(:measurement_unit, :supplementary)
       end
     end
   end
@@ -399,7 +399,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      new(attributes.stringify_keys)
+      new(attributes)
     end
   end
 
@@ -432,7 +432,7 @@ FactoryBot.define do
     filename { 'filename.txt' }
 
     initialize_with do
-      new(attributes.stringify_keys)
+      new(attributes)
     end
   end
 
@@ -529,7 +529,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      new(attributes.stringify_keys)
+      new(attributes)
     end
   end
 
@@ -555,7 +555,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      new(attributes.stringify_keys)
+      new(attributes)
     end
   end
 end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -42,12 +42,12 @@ RSpec.describe Commodity do
     let(:associated_commodities) do
       {
         commodities: [attributes_for(:commodity, goods_nomenclature_sid: 1,
-                                                 parent_sid: nil).stringify_keys,
+                                                 parent_sid: nil),
                       attributes_for(:commodity, parent_sid: 1,
-                                                 goods_nomenclature_sid: 2).stringify_keys],
+                                                 goods_nomenclature_sid: 2)],
       }
     end
-    let(:heading_attributes) { attributes_for(:heading).merge(associated_commodities).stringify_keys }
+    let(:heading_attributes) { attributes_for(:heading).merge(associated_commodities) }
     let(:heading) { Heading.new(heading_attributes) }
 
     describe '#children' do
@@ -90,7 +90,7 @@ RSpec.describe Commodity do
   end
 
   describe '#to_param' do
-    let(:commodity) { described_class.new(attributes_for(:commodity).stringify_keys) }
+    let(:commodity) { described_class.new(attributes_for(:commodity)) }
 
     it 'returns commodity code as param' do
       expect(commodity.to_param).to eq commodity.code
@@ -98,7 +98,7 @@ RSpec.describe Commodity do
   end
 
   describe '#aria_label' do
-    let(:commodity) { described_class.new(attributes_for(:commodity).stringify_keys) }
+    let(:commodity) { described_class.new(attributes_for(:commodity)) }
 
     it 'formats the aria label correctly' do
       expect(commodity.aria_label).to \
@@ -121,7 +121,7 @@ RSpec.describe Commodity do
   end
 
   describe '#meursing_code?' do
-    subject(:commodity) { described_class.new(attributes_for(:commodity, meta: commodity_metadata).stringify_keys) }
+    subject(:commodity) { described_class.new(attributes_for(:commodity, meta: commodity_metadata)) }
 
     let(:commodity_metadata) do
       { 'duty_calculator' => { 'meursing_code' => meursing_code } }
@@ -145,7 +145,7 @@ RSpec.describe Commodity do
   end
 
   describe '#calculate_duties?' do
-    subject(:commodity) { described_class.new(attributes_for(:commodity, meta: commodity_metadata).stringify_keys) }
+    subject(:commodity) { described_class.new(attributes_for(:commodity, meta: commodity_metadata)) }
 
     let(:commodity_metadata) { { 'duty_calculator' => { 'entry_price_system' => entry_price_system } } }
     let(:entry_price_system) { false }

--- a/spec/models/footnote_spec.rb
+++ b/spec/models/footnote_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Footnote do
   end
 
   describe '#id' do
-    let(:measure) { Measure.new(attributes_for(:measure, id: '123').stringify_keys) }
-    let(:footnote) { described_class.new(attributes_for(:footnote, casted_by: measure, code: '456').stringify_keys) }
+    let(:measure) { Measure.new(attributes_for(:measure, id: '123')) }
+    let(:footnote) { described_class.new(attributes_for(:footnote, casted_by: measure, code: '456')) }
 
     it 'contains casted_by info' do
       expect(footnote.id).to include(footnote.casted_by.destination)
@@ -24,8 +24,8 @@ RSpec.describe Footnote do
   end
 
   describe '#eco?' do
-    let(:footnote) { described_class.new(attributes_for(:footnote, code: described_class::ECO_CODE).stringify_keys) }
-    let(:footnote1) { described_class.new(attributes_for(:footnote).stringify_keys) }
+    let(:footnote) { described_class.new(attributes_for(:footnote, code: described_class::ECO_CODE)) }
+    let(:footnote1) { described_class.new(attributes_for(:footnote)) }
 
     it 'returns true if ECO code' do
       expect(footnote.eco?).to be_truthy

--- a/spec/presenters/measure_presenter_spec.rb
+++ b/spec/presenters/measure_presenter_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe MeasurePresenter do
       let(:geographical_area) do
         attributes_for(
           :geographical_area,
-          children_geographical_areas: [attributes_for(:geographical_area).stringify_keys],
-        ).stringify_keys
+          children_geographical_areas: [attributes_for(:geographical_area)],
+        )
       end
 
       it { is_expected.to be_has_children_geographical_areas }
     end
 
     context 'when the measure has a GeographicalArea with no children' do
-      let(:geographical_area) { attributes_for(:geographical_area).stringify_keys }
+      let(:geographical_area) { attributes_for(:geographical_area) }
 
       it { is_expected.not_to be_has_children_geographical_areas }
     end
@@ -26,12 +26,12 @@ RSpec.describe MeasurePresenter do
 
   describe '#children_geographical_areas' do
     let(:measure) { build(:measure, geographical_area: geographical_area) }
-    let(:geographical_area) { attributes_for(:geographical_area, geographical_area_id: nil, children_geographical_areas: children_geographical_areas).stringify_keys }
+    let(:geographical_area) { attributes_for(:geographical_area, geographical_area_id: nil, children_geographical_areas: children_geographical_areas) }
 
     let(:children_geographical_areas) do
       [
-        attributes_for(:geographical_area, id: 'CD').stringify_keys,
-        attributes_for(:geographical_area, id: 'AB').stringify_keys,
+        attributes_for(:geographical_area, id: 'CD'),
+        attributes_for(:geographical_area, id: 'AB'),
       ]
     end
 

--- a/spec/requests/chapters/changes_spec.rb
+++ b/spec/requests/chapters/changes_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'GET to #index - getting chapter change feed', type: :request do
-  let!(:chapter) { Chapter.new(attributes_for(:chapter, goods_nomenclature_item_id: '0101000000').stringify_keys) }
+  let!(:chapter) { Chapter.new(attributes_for(:chapter, goods_nomenclature_item_id: '0101000000')) }
 
   describe 'no request format supplied' do
     before do

--- a/spec/requests/commodities/changes_spec.rb
+++ b/spec/requests/commodities/changes_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'GET to #index - getting commodity change feed', type: :request do
-  let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '0101000000').stringify_keys) }
+  let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '0101000000')) }
 
   describe 'no request format supplied' do
     before do

--- a/spec/requests/headings/changes_spec.rb
+++ b/spec/requests/headings/changes_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'GET to #index - getting heading change feed', type: :request do
-  let!(:heading) { Heading.new(attributes_for(:heading, goods_nomenclature_item_id: '0101000000').stringify_keys) }
+  let!(:heading) { Heading.new(attributes_for(:heading, goods_nomenclature_item_id: '0101000000')) }
 
   describe 'no request format supplied' do
     before do

--- a/spec/views/measures/_measure.html.erb_spec.rb
+++ b/spec/views/measures/_measure.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'measures/_measure', type: :view, vcr: { cassette_name: 'geograph
   let(:measure) do
     Measure.new(
       attributes_for(:measure, :third_country,
-                     duty_expression: duty_expression).stringify_keys,
+                     duty_expression: duty_expression),
     )
   end
 
@@ -15,7 +15,7 @@ RSpec.describe 'measures/_measure', type: :view, vcr: { cassette_name: 'geograph
   end
 
   context 'with formatted_base' do
-    let(:duty_expression) { attributes_for(:duty_expression).stringify_keys }
+    let(:duty_expression) { attributes_for(:duty_expression) }
 
     it { expect(rendered).to match(/EUR/) }
     it { expect(rendered).to match(/Hectokilogram/) }
@@ -24,7 +24,7 @@ RSpec.describe 'measures/_measure', type: :view, vcr: { cassette_name: 'geograph
 
   context 'without formatted_base' do
     let(:duty_expression) do
-      attributes_for(:duty_expression, formatted_base: nil).stringify_keys
+      attributes_for(:duty_expression, formatted_base: nil)
     end
 
     it { expect(rendered).to match(/EUR/) }


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removes stringify keys from the project

### Why?

I am doing this because:

- Api attributes use HashWithIndifferentAccess so no longer require factories to use strings
