### PR TITLE
Removes timecop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,6 @@ group :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
-  gem 'timecop'
   gem 'vcr'
   gem 'webdrivers'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,7 +421,6 @@ GEM
     statsd-ruby (1.5.0)
     strscan (3.0.1)
     thor (1.2.1)
-    timecop (0.9.4)
     timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -501,7 +500,6 @@ DEPENDENCIES
   sentry-rails
   shoulda-matchers
   simplecov
-  timecop
   vcr
   web-console
   webdrivers

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -111,12 +111,6 @@ RSpec.describe CommoditiesController, type: :controller do
               vcr: { cassette_name: 'commodities#show_010121000' } do
         let(:commodity_id) { '0101210000' } # commodity 0101210000 does not exist at 1st of Jan, 2000
 
-        around do |example|
-          Timecop.freeze(Time.zone.parse('2013-11-11 12:00:00')) do
-            example.run
-          end
-        end
-
         before do
           stub_api_request("/commodities/#{commodity_id}/validity_periods")
             .to_return jsonapi_response(:validity_periods, validity_periods)
@@ -137,12 +131,6 @@ RSpec.describe CommoditiesController, type: :controller do
       context 'with commodity id that does not exist in provided date and no validity_periods api',
               vcr: { cassette_name: 'commodities#show_010121000' } do
         let(:commodity_id) { '0101210000' } # commodity 0101210000 does not exist at 1st of Jan, 2000
-
-        around do |example|
-          Timecop.freeze(Time.zone.parse('2013-11-11 12:00:00')) do
-            example.run
-          end
-        end
 
         before do
           stub_api_request("/commodities/#{commodity_id}/validity_periods")


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removed timecop

### Why?

I am doing this because:

- Its not actually used and should never be necessary in the frontend (or anywhere?)
