### PR TITLE
HOTT-1361 Allow jsonapi objects without attributes

### DIFF
--- a/lib/tariff_jsonapi_parser.rb
+++ b/lib/tariff_jsonapi_parser.rb
@@ -31,7 +31,7 @@ class TariffJsonapiParser
   def parse_resource(resource)
     result = {}
 
-    parse_top_level_attributes!(resource, result)
+    parse_top_level_attributes!(resource, result) if resource.key?('attributes')
     parse_relationships!(resource['relationships'], result) if resource.key?('relationships')
     parse_meta!(resource, result) if resource.key?('meta')
 

--- a/spec/fixtures/jsonapi/singular_no_attributes.json
+++ b/spec/fixtures/jsonapi/singular_no_attributes.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "meta": { "foo": "bar" },
+    "id": "123",
+    "type": "mock_entity"
+  },
+  "included": []
+}

--- a/spec/lib/tariff_jsonapi_parser_spec.rb
+++ b/spec/lib/tariff_jsonapi_parser_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe TariffJsonapiParser do
         it { is_expected.to include 'age' => 21 }
       end
 
+      context 'without attributes field' do
+        let(:json_file) { 'singular_no_attributes' }
+
+        it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
+        it { is_expected.not_to include 'name' }
+      end
+
       context 'with relationships' do
         let(:json_file) { 'singular_with_relationship' }
 


### PR DESCRIPTION
### Jira link

[HOTT-1361](https://transformuk.atlassian.net/browse/HOTT-1361)

### What?

I have added/removed/altered:

- [x] Changed the JSON-API parser to not require an attributes key on a resource

### Why?

I am doing this because:

- `attributes` is not a required key according to the spec (see https://jsonapi.org/format/#document-resource-objects)
- a resource which only exists to define relationships (ie the new Permutations resource) will not have any attributes

### Deployment risks (optional)

- Makes changes to our api parser, which is used by pretty much every screen
