### PR TITLE
HOTT-1401: Handle commodity mismatch on XI commodities

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -29,7 +29,13 @@ class CommoditiesController < GoodsNomenclaturesController
   end
 
   def uk_declarable
-    @uk_declarable ||= heading? ? uk_heading : uk_commodity
+    @uk_declarable ||= begin
+      heading? ? uk_heading : uk_commodity
+    rescue Faraday::ResourceNotFound
+      # When loading EU commodities we pull some measures from the UK commodity. If the UK commodity is not present
+      # in the UK database, then we should show only the applicable EU measures and not render the 404 page.
+      raise if TradeTariffFrontend::ServiceChooser.uk?
+    end
   end
 
   def xi_declarable

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe 'Commodity page', type: :request do
     end
   end
 
+  context 'when on the XI service and the UK commodity returns a 404' do
+    before do
+      allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).with(:uk).and_raise(Faraday::ResourceNotFound, 'foo')
+    end
+
+    it 'still loads the XI commodity' do
+      VCR.use_cassette('commodities#0501000000#xi') do
+        get '/xi/commodities/0501000000'
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
   context 'when mime type is HTML' do
     it 'displays declarable related information' do
       VCR.use_cassette('commodities#0101300000.html') do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1401

### What?

I have added/removed/altered:

- [x] Added handling for commodities on XI that have no UK commodity

### Why?

I am doing this because:

- We updated the behaviour around 404s so that we show only the EU measures when there is no corresponding UK commodity and missed this on a recent refactor
- See: https://github.com/trade-tariff/trade-tariff-frontend/pull/675
