### PR TITLE
Refactor measure collection

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -9,10 +9,12 @@ module Declarable
     has_many :footnotes
     has_many :import_measures, class_name: 'Measure',
                                wrapper: MeasureCollection,
-                               filter: :without_excluded
+                               filter: :without_excluded,
+                               presenter: MeasurePresenter
     has_many :export_measures, class_name: 'Measure',
                                wrapper: MeasureCollection,
-                               filter: :without_excluded
+                               filter: :without_excluded,
+                               presenter: MeasurePresenter
 
     attr_accessor :description,
                   :goods_nomenclature_item_id,

--- a/app/models/measure_collection.rb
+++ b/app/models/measure_collection.rb
@@ -1,33 +1,32 @@
-class MeasureCollection
-  include Enumerable
-
-  attr_accessor :measures
-
-  delegate :+, :present?, :size, :length, :collect, :map, :each, :all?, :include?, to: :to_a
+class MeasureCollection < SimpleDelegator
   delegate :new, to: :class
+
+  attr_reader :measures
 
   def initialize(measures)
     @measures = measures.clone.presence || []
+
+    super @measures
   end
 
   def without_supplementary_unit
-    new(measures.reject(&:supplementary?))
+    new(reject(&:supplementary?))
   end
 
   def without_excluded
-    new(measures.reject(&:excluded?))
+    new(reject(&:excluded?))
   end
 
   def for_country(country)
-    new(measures.select { |m| m.relevant_for_country?(country) })
+    new(select { |m| m.relevant_for_country?(country) })
   end
 
   def vat_excise
-    new(measures.select(&:vat_excise?))
+    new(select(&:vat_excise?))
   end
 
   def import_controls
-    new(measures.select(&:import_controls?) + measures.select(&:unclassified_import_controls?))
+    new(select(&:import_controls?) + select(&:unclassified_import_controls?))
   end
 
   def customs_duties
@@ -35,44 +34,40 @@ class MeasureCollection
   end
 
   def trade_remedies
-    new(measures.select(&:trade_remedies?))
+    new(select(&:trade_remedies?))
   end
 
   def quotas
-    new(measures.select(&:quotas?))
+    new(select(&:quotas?))
   end
 
   def third_country_duties
-    new(measures.select(&:third_country_duties?))
+    new(select(&:third_country_duties?))
   end
 
   def vat
-    new(measures.select(&:vat?))
+    new(select(&:vat?))
   end
 
   def national
-    new(measures.select(&:national?))
+    new(select(&:national?))
   end
 
   def supplementary
-    new(measures.select(&:supplementary?))
-  end
-
-  def to_a
-    measures.map { |entry| MeasurePresenter.new(entry) }
+    new(select(&:supplementary?))
   end
 
   private
 
   def tariff_preferences
-    measures.select(&:tariff_preferences?)
+    select(&:tariff_preferences?)
   end
 
   def other_customs_duties
-    measures.select(&:other_customs_duties?)
+    select(&:other_customs_duties?)
   end
 
   def unclassified_customs_duties
-    measures.select(&:unclassified_customs_duties?)
+    select(&:unclassified_customs_duties?)
   end
 end

--- a/app/models/order_number.rb
+++ b/app/models/order_number.rb
@@ -8,7 +8,7 @@ class OrderNumber
 
   delegate :present?, to: :number
 
-  has_one :definition
+  has_one :definition, class_name: 'OrderNumber::Definition'
   has_one :geographical_area
   has_many :geographical_areas
 

--- a/spec/models/measure_collection_spec.rb
+++ b/spec/models/measure_collection_spec.rb
@@ -94,27 +94,4 @@ RSpec.describe MeasureCollection do
 
     it { expect(collection.customs_duties.measures).to eq([third_country_measure, tariff_preference_measure, other_customs_duties_measure, unclassified_customs_measure]) }
   end
-
-  describe '#to_a' do
-    subject(:collection) { described_class.new([measure]) }
-
-    let(:measure) { build(:measure) }
-
-    it { expect(collection.to_a).to be_kind_of Array }
-    it { expect(collection.to_a.first).to be_kind_of MeasurePresenter }
-  end
-
-  describe '#present?' do
-    context 'when there are measures' do
-      subject(:collection) { described_class.new([build(:measure)]) }
-
-      it { is_expected.to be_present }
-    end
-
-    context 'when there are no measures' do
-      subject(:collection) { described_class.new([]) }
-
-      it { is_expected.not_to be_present }
-    end
-  end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Remove unused Enumerable implementation from MeasureCollection wrapper
- [x] Use SimpleDelegator to simplify MeasureCollection wrapping Measures
- [x] Move away from class_eval in ApiEntity
- [x] Add support for presenter option in has_many method of ApiEntity to clean up measure collection implementation 
- [x] Removes testing of Array functionality

### Why?

I am doing this because:

- The ApiEntity module is a bit hard to understand and there's a mixture of responsibilities between the MeasureCollection wrapper and the ApiEntity module
- class_eval is confusing/less explicit and less obvious to debug at runtime
- Enumerable doesn't fit the use case of the MeasureCollection implementation which uses the measures array to drive the behaviour it needs. It also wasn't implemented properly.
- Adding a presenter option means we have a global way of setting collection presenters rather than not really knowing what you're getting
