### PR TITLE
Removes unused specs

### DIFF
--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -93,27 +93,6 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
           it { is_expected.to redirect_to(chapter_path('01', year: year, month: month, day: day)) }
         end
 
-        xcontext 'valid pre-EU Exit date params provided' do
-          let(:future_date) { Date.new(2020, 12, 31) }
-          let(:year)    { future_date.year }
-          let(:month)   { future_date.month }
-          let(:day)     { future_date.day }
-
-          before do
-            @request.env['HTTP_REFERER'] = '/chapters/01'
-
-            post :search, params: {
-              year: year,
-              month: month,
-              day: day,
-            }
-          end
-
-          it { is_expected.to respond_with(:redirect) }
-          it { expect(assigns(:search)).to be_a(Search) }
-          it { is_expected.to redirect_to(chapter_path('01', year: year, month: month, day: day)) }
-        end
-
         context 'when valid date params provided for today' do
           let(:year)    { now.year }
           let(:month)   { now.month }


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removes unused Brexit-related specs

### Why?

I am doing this because:

- Because they're not needed anymore
