### PR TITLE
Add General Rules for the interpretation of good summary.

### DIFF
--- a/app/views/shared/_general_rules_for_interpretation.html.erb
+++ b/app/views/shared/_general_rules_for_interpretation.html.erb
@@ -1,0 +1,39 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">General Rules for the Interpretation of goods</span>
+  </summary>
+  <div class="govuk-details__text">
+    <p>Classification of goods in the Tariff shall be governed by the following principles: </p>
+
+    <h3 class="govuk-heading-s" id="rule-1">Rule 1</h3>
+    <p>The titles of sections, chapters and sub-chapters are provided for ease of reference only. For legal purposes, classification shall be determined according to the terms of the headings and any relative section or chapter notes and, provided such headings or notes do not otherwise require, according to the following provisions. </p>
+
+    <h3 class="govuk-heading-s" id="rule-2">Rule 2</h3>
+    <ol class="govuk-list govuk-list govuk-list--number" style="list-style-type: lower-alpha;">
+      <li>Any reference in a heading to an article shall be taken to include a reference to that article incomplete or unfinished, provided that, as presented, the incomplete or unfinished article has the essential character of the complete or finished article. It shall also be taken to include a reference to that article complete or finished (or falling to be classified as complete or finished by virtue of this rule), presented unassembled or disassembled.</li>
+      <li>Any reference in a heading to a material or substance shall be taken to include a reference to mixtures or combinations of that material or substance with other materials or substances. Any reference to goods of a given material or substance shall be taken to include a reference to goods consisting wholly or partly of such material or substance. The classification of goods consisting of more than one material or substance shall be according to the principles of rule 3. </li>
+    </ol>
+
+    <h3 class="govuk-heading-s" id="rule-3">Rule 3</h3>
+    <p>When, by application of rule 2(b) or for any other reason, goods are prima facie classifiable under two or more headings, classification shall be effected as follows: </p>
+    <ol class="govuk-list govuk-list govuk-list--number" style="list-style-type: lower-alpha;">
+      <li>the heading which provides the most specific description shall be preferred to headings providing a more general description. However, when two or more headings each refer to part only of the materials or substances contained in mixed or composite goods or to part only of the items in a set put up for retail sale, those headings are to be regarded as equally specific in relation to those goods, even if one of them gives a more complete or precise description of the goods; </li>
+      <li>mixtures, composite goods consisting of different materials or made up of different components, and goods put up in sets for retail sale, which cannot be classified by reference to 3(a), shall be classified as if they consisted of the material or component which gives them their essential character, insofar as this criterion is applicable;</li>
+      <li>when goods cannot be classified by reference to 3(a) or (b), they shall be classified under the heading which occurs last in numerical order among those which equally merit consideration.</li>
+    </ol>
+
+    <h class="govuk-heading-s"3 id="rule-4">Rule 4</h3>
+    <p>Goods which cannot be classified in accordance with the above rules shall be classified under the heading appropriate to the goods to which they are most akin.</p>
+
+    <h3 class="govuk-heading-s" id="rule-5">Rule 5</h3>
+    <p>In addition to the foregoing provisions, the following rules shall apply in respect of the goods referred to therein:</p>
+
+    <ol class="govuk-list govuk-list govuk-list--number" style="list-style-type: lower-alpha;">
+      <li>camera cases, musical instrument cases, gun cases, drawing-instrument cases, necklace cases and similar containers, specially shaped or fitted to contain a specific article or set of articles, suitable for long-term use and presented with the articles for which they are intended, shall be classified with such articles when of a kind normally sold therewith. This rule does not, however, apply to containers which give the whole its essential character;</li>
+      <li>subject to the provisions of rule 5(a), packing materials and packing containers ( 1 ) presented with the goods therein shall be classified with the goods if they are of a kind normally used for packing such goods. However, this provision is not binding when such packing materials or packing containers are clearly suitable for repetitive use. </li>
+    </ol>
+
+    <h3 class="govuk-heading-s" class="govuk-heading-s" id="rule-6">Rule 6</h3>
+    <p>For legal purposes, the classification of goods in the subheadings of a heading shall be determined according to the terms of those subheadings and any related subheading notes and, mutatis mutandis, to the above rules, on the understanding that only subheadings at the same level are comparable. For the purposes of this rule, the relative section and chapter notes also apply, unless the context requires otherwise.</p>
+  </div>
+</details>

--- a/app/views/shared/_notes.html.erb
+++ b/app/views/shared/_notes.html.erb
@@ -19,4 +19,6 @@ chapter_note ||= false %>
     <h2 class="govuk-heading-s">There are important section notes for this part of the tariff:</h2>
     <%= govspeak(section_note) %>
   <% end %>
+
+  <%= render 'shared/general_rules_for_interpretation' %>
 </article>


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1405

### What?
Add General Rules for the interpretation of goods summary.

### Why?

> Query has come in from members of the trading public and been echoed by the HMRC team that we should be showing the general rules of interpretation, which are the way in which the UK tariff classification should be understood.