### PR TITLE
HOTT-1417 Show brakeman failures in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
       - run:
           name: Inspecting with Brakeman
           when: always
-          command: 'bundle exec brakeman -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models'
+          command: 'bundle exec brakeman -o /dev/stdout -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models'
       - store_test_results:
           path: test-results/brakeman/
       - store_artifacts:


### PR DESCRIPTION
### Jira link

HOTT-1417

### What?

I have added/removed/altered:

- [x] Changed brakeman CI config to show errors inline as welll as other formats

### Why?

I am doing this because:

Previously we were not reporting the brakeman output to stdout.
    
The output from Brakeman, when there are no errors to show, doesn't fully comply with the JUnit format because there are no `<testcase>` nodes. Normally this doesn't matter because if there are errors, its valid, if there aren't, we don't need the output.
    
There is an additional `<brakeman:properties>` node but this does not match the JUnit XSD and is ignored by CircleCI.
    
When there is a parsing failure (as opposed to a scanning error), this is documented in the `<brakeman:properties>` section but this is ignore by CircleCI.
    
This results in silent parsing failures providing no information as to the source of the problem.

