### PR TITLE
HOTT-1411: Tweak path formation for quota search results

### DIFF
--- a/app/views/search/quotas/_definition.html.erb
+++ b/app/views/search/quotas/_definition.html.erb
@@ -4,7 +4,7 @@
   </td>
   <td class="govuk-table__cell">
     <% definition.measures&.map(&:goods_nomenclature).uniq.each do |goods_nomenclature| %>
-      <%= link_to goods_nomenclature.to_param, polymorphic_url(goods_nomenclature) %>
+      <%= link_to goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature) %>
       <br>
     <% end %>
   </td>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe 'Search', js: true do
           using_wait_time 5 do
             expect(page).to have_content('Quota search results')
             expect(page).to have_content('050088')
-            expect(page).to have_content('2106909800-80')
+            expect(page).to have_link('2106909800', href: '/subheadings/2106909800-80?day=16&month=3&year=2022')
             expect(page).to have_content('All countries (1011)')
           end
         end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1411

### What?

I have added/removed/altered:

- [x] Altered links to quota goods nomenclature so that they now show the full goods nomenclature item id
- [x] Updated specs to reflect change

### Why?

I am doing this because:

- This is a presentation change requested by Matt
