### PR TITLE
Enable setting resource type in factories

### DIFF
--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -36,6 +36,7 @@ module ApiEntity
     include MultiJson
 
     attr_reader :attributes
+    attr_writer :resource_type
 
     attr_accessor :casted_by
 
@@ -55,6 +56,10 @@ module ApiEntity
 
     def to_param
       id
+    end
+
+    def resource_type
+      @attributes['resource_type'] || self.class.name.underscore.singularize
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
   end
 
   factory :goods_nomenclature do
+    resource_type { 'goods_nomenclature' }
     description { Forgery(:basic).text }
     goods_nomenclature_item_id { '0100000000' }
     validity_start_date { Time.zone.today.ago(3.years) }

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe ApiEntity do
     end
   end
 
+  describe '#resource_type' do
+    subject(:resource_type) { mock_entity.new(attributes).resource_type }
+
+    context 'when initialized with the resource type' do
+      let(:attributes) { { resource_type: 'foo' } }
+
+      it { is_expected.to eq('foo') }
+    end
+
+    context 'when initialized without the resource type' do
+      let(:attributes) { {} }
+
+      it { is_expected.to eq('mock_entity') }
+    end
+  end
+
   describe '#find' do
     subject(:request) { mock_entity.find(123) }
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Enable setting the resource type in factories
- [x] Set the resource type in the goods nomenclature model

### Why?

I am doing this because:

- We need this to simulate polymorphic measure goods nomenclature relationships in factories
