### PR TITLE
HOTT-1414: Refactor how we handle goods nomenclature and api entity nil relationships

### DIFF
--- a/app/models/additional_code.rb
+++ b/app/models/additional_code.rb
@@ -18,6 +18,7 @@ class AdditionalCode
   def all_goods_nomenclatures
     @all_goods_nomenclatures ||= measures
       .map(&:goods_nomenclature)
+      .compact
       .uniq(&:goods_nomenclature_item_id)
       .sort_by(&:goods_nomenclature_item_id)
   end

--- a/app/models/additional_code.rb
+++ b/app/models/additional_code.rb
@@ -2,6 +2,7 @@ require 'api_entity'
 
 class AdditionalCode
   include ApiEntity
+  include HasGoodsNomenclature
 
   collection_path '/additional_codes'
 
@@ -13,13 +14,5 @@ class AdditionalCode
 
   def id
     @id ||= "#{casted_by.destination}-#{casted_by.id}-additional-code-#{code}"
-  end
-
-  def all_goods_nomenclatures
-    @all_goods_nomenclatures ||= measures
-      .map(&:goods_nomenclature)
-      .compact
-      .uniq(&:goods_nomenclature_item_id)
-      .sort_by(&:goods_nomenclature_item_id)
   end
 end

--- a/app/models/additional_code.rb
+++ b/app/models/additional_code.rb
@@ -5,19 +5,20 @@ class AdditionalCode
 
   collection_path '/additional_codes'
 
+  has_many :measures
+
   attr_accessor :additional_code_type_id, :additional_code, :code, :description, :formatted_description
 
-  has_many :measures
+  delegate :present?, to: :code, allow_nil: true
 
   def id
     @id ||= "#{casted_by.destination}-#{casted_by.id}-additional-code-#{code}"
   end
 
-  def present?
-    code.present?
-  end
-
-  def to_s
-    code
+  def all_goods_nomenclatures
+    @all_goods_nomenclatures ||= measures
+      .map(&:goods_nomenclature)
+      .uniq(&:goods_nomenclature_item_id)
+      .sort_by(&:goods_nomenclature_item_id)
   end
 end

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -20,6 +20,7 @@ class Certificate
   def all_goods_nomenclatures
     @all_goods_nomenclatures ||= measures
       .map(&:goods_nomenclature)
+      .compact
       .uniq(&:goods_nomenclature_item_id)
       .sort_by(&:goods_nomenclature_item_id)
   end

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -2,6 +2,7 @@ require 'api_entity'
 
 class Certificate
   include ApiEntity
+  include HasGoodsNomenclature
 
   collection_path '/certificates'
 
@@ -15,13 +16,5 @@ class Certificate
 
   def to_s
     code
-  end
-
-  def all_goods_nomenclatures
-    @all_goods_nomenclatures ||= measures
-      .map(&:goods_nomenclature)
-      .compact
-      .uniq(&:goods_nomenclature_item_id)
-      .sort_by(&:goods_nomenclature_item_id)
   end
 end

--- a/app/models/concerns/has_goods_nomenclature.rb
+++ b/app/models/concerns/has_goods_nomenclature.rb
@@ -1,0 +1,14 @@
+module HasGoodsNomenclature
+  extend ActiveSupport::Concern
+
+  def base_goods_nomenclatures
+    measures.map(&:goods_nomenclature)
+  end
+
+  def all_goods_nomenclatures
+    @all_goods_nomenclatures ||= base_goods_nomenclatures
+      .compact
+      .uniq(&:goods_nomenclature_item_id)
+      .sort_by(&:goods_nomenclature_item_id)
+  end
+end

--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -14,6 +14,7 @@ class Footnote
     @all_goods_nomenclatures ||= measures
       .map(&:goods_nomenclature)
       .concat(goods_nomenclatures)
+      .compact
       .uniq(&:goods_nomenclature_item_id)
       .sort_by(&:goods_nomenclature_item_id)
   end

--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -2,6 +2,7 @@ require 'api_entity'
 
 class Footnote
   include ApiEntity
+  include HasGoodsNomenclature
 
   collection_path '/footnotes'
 
@@ -10,12 +11,9 @@ class Footnote
   has_many :measures
   has_many :goods_nomenclatures
 
-  def all_goods_nomenclatures
-    @all_goods_nomenclatures ||= measures
+  def base_goods_nomenclatures
+    measures
       .map(&:goods_nomenclature)
       .concat(goods_nomenclatures)
-      .compact
-      .uniq(&:goods_nomenclature_item_id)
-      .sort_by(&:goods_nomenclature_item_id)
   end
 end

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -41,7 +41,7 @@ class OrderNumber
     end
 
     def all_goods_nomenclatures
-      measures.map(&:goods_nomenclature).uniq(&:goods_nomenclature_item_id).sort_by(&:goods_nomenclature_item_id)
+      measures.map(&:goods_nomenclature).compact.uniq(&:goods_nomenclature_item_id).sort_by(&:goods_nomenclature_item_id)
     end
 
     def geographical_areas

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -41,7 +41,11 @@ class OrderNumber
     end
 
     def all_goods_nomenclatures
-      measures.map(&:goods_nomenclature).compact.uniq(&:goods_nomenclature_item_id).sort_by(&:goods_nomenclature_item_id)
+      measures
+        .map(&:goods_nomenclature)
+        .compact
+        .uniq(&:goods_nomenclature_item_id)
+        .sort_by(&:goods_nomenclature_item_id)
     end
 
     def geographical_areas

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -40,6 +40,10 @@ class OrderNumber
       @id ||= quota_definition_sid
     end
 
+    def all_goods_nomenclatures
+      measures.map(&:goods_nomenclature).uniq(&:goods_nomenclature_item_id).sort_by(&:goods_nomenclature_item_id)
+    end
+
     def geographical_areas
       order_number&.geographical_areas.presence || measures&.map(&:geographical_area) || []
     end

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -4,6 +4,7 @@ require 'null_object'
 class OrderNumber
   class Definition
     include ApiEntity
+    include HasGoodsNomenclature
 
     collection_path '/quotas'
 
@@ -38,14 +39,6 @@ class OrderNumber
 
     def id
       @id ||= quota_definition_sid
-    end
-
-    def all_goods_nomenclatures
-      measures
-        .map(&:goods_nomenclature)
-        .compact
-        .uniq(&:goods_nomenclature_item_id)
-        .sort_by(&:goods_nomenclature_item_id)
     end
 
     def geographical_areas

--- a/app/views/additional_codes/_additional_code.html.erb
+++ b/app/views/additional_codes/_additional_code.html.erb
@@ -18,6 +18,5 @@
         </tr>
       </tbody>
     </table>
-    <!-- <p><a href="#" class="help-link">What does this mean?</a></p> -->
   </article>
 </div>

--- a/app/views/search/additional_code_search.html.erb
+++ b/app/views/search/additional_code_search.html.erb
@@ -37,8 +37,8 @@
         </thead>
         <tbody class="govuk-table__body">
           <% if additional_code.measures.any? %>
-            <% additional_code.measures&.uniq(&:goods_nomenclature_item_id)&.sort_by(&:goods_nomenclature_item_id)&.each do |measure| %>
-              <%= render partial: 'search/common/goods_nomenclature', object: measure.goods_nomenclature %>
+            <% additional_code.measures.uniq(&:goods_nomenclature).compact.sort_by(&:goods_nomenclature_item_id).each do |goods_nomenclature| %>
+              <%= render partial: 'search/common/goods_nomenclature', object: goods_nomenclature %>
             <% end %>
           <% else %>
             <tr class="govuk-table__row">

--- a/app/views/search/additional_code_search.html.erb
+++ b/app/views/search/additional_code_search.html.erb
@@ -37,7 +37,7 @@
         </thead>
         <tbody class="govuk-table__body">
           <% if additional_code.measures.any? %>
-            <% additional_code.measures.uniq(&:goods_nomenclature).compact.sort_by(&:goods_nomenclature_item_id).each do |goods_nomenclature| %>
+            <% additional_code.all_goods_nomenclatures.each do |goods_nomenclature| %>
               <%= render partial: 'search/common/goods_nomenclature', object: goods_nomenclature %>
             <% end %>
           <% else %>

--- a/app/views/search/quotas/_definition.html.erb
+++ b/app/views/search/quotas/_definition.html.erb
@@ -3,7 +3,7 @@
     <%= render partial: 'shared/quota_definition', locals: { order_number: definition.order_number, quota_definition: definition } %>
   </td>
   <td class="govuk-table__cell">
-    <% definition.measures&.map(&:goods_nomenclature).uniq.each do |goods_nomenclature| %>
+    <% definition.all_goods_nomenclatures.each do |goods_nomenclature| %>
       <%= link_to goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature) %>
       <br>
     <% end %>

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -140,13 +140,16 @@ module ApiEntity
       attr_reader association.to_sym
 
       define_method("#{association}=") do |attributes|
-        class_name = if options[:polymorphic]
-                       attributes['resource_type'].classify
-                     else
-                       options[:class_name]
-                     end
-
-        entity = class_name.constantize.new((attributes.presence || {}).merge(casted_by: self))
+        entity = if attributes.nil?
+                   nil
+                 else
+                   class_name = if options[:polymorphic]
+                                  attributes['resource_type'].classify
+                                else
+                                  options[:class_name]
+                                end
+                   class_name.constantize.new((attributes.presence || {}).merge(casted_by: self))
+                 end
 
         instance_variable_set("@#{association}", entity)
       end

--- a/lib/tariff_jsonapi_parser.rb
+++ b/lib/tariff_jsonapi_parser.rb
@@ -59,7 +59,7 @@ class TariffJsonapiParser
                      when Array
                        find_and_parse_multiple_included(name, values['data'])
                      when Hash
-                       find_and_parse_included(name, values['data']['id'], values['data']['type'])
+                       find_and_parse_included(name, values.dig('data', 'id'), values.dig('data', 'type'))
                      else
                        values['data']
                      end
@@ -78,6 +78,8 @@ class TariffJsonapiParser
   end
 
   def find_and_parse_included(name, id, type)
+    return nil if id.blank? || type.blank?
+
     found_resource = find_included(id, type)
 
     return {} if found_resource.blank?

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -464,9 +464,14 @@ FactoryBot.define do
   end
 
   factory :additional_code do
-    code { Forgery(:basic).text }
+    additional_code_type_id { Forgery(:basic).text(exactly: 1).upcase }
+    additional_code { Forgery(:basic).text(exactly: 3).upcase }
+    code { Forgery(:basic).text(exactly: 4).upcase }
     description { Forgery(:basic).text }
+    formatted_description { Forgery(:basic).text }
+    measures { [attributes_for(:measure)] }
   end
+  j
 
   factory :footnote do
     code { Forgery(:basic).text }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -471,7 +471,6 @@ FactoryBot.define do
     formatted_description { Forgery(:basic).text }
     measures { [attributes_for(:measure)] }
   end
-  j
 
   factory :footnote do
     code { Forgery(:basic).text }

--- a/spec/fixtures/jsonapi/singular_valid_null_singular_relationship.json
+++ b/spec/fixtures/jsonapi/singular_valid_null_singular_relationship.json
@@ -1,0 +1,17 @@
+{
+  "data" : {
+    "meta": { "foo": "bar" },
+    "id": "123",
+    "type": "mock_entity",
+    "attributes": {
+      "name": "Joe",
+      "age": 21
+    },
+    "relationships": {
+      "part": {
+        "data": null
+      }
+    }
+  },
+  "included": []
+}

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ApiEntity do
       attr_accessor :name, :age
 
       has_many :parts, class_name: 'Part'
+      has_one :part, class_name: 'Part'
 
       def self.name
         'MockEntity'
@@ -51,6 +52,12 @@ RSpec.describe ApiEntity do
       let(:body) { file_fixture('jsonapi/singular_no_relationship.json').read }
 
       it { is_expected.to have_attributes name: 'Joe', age: 21 }
+    end
+
+    context 'with valid response and nil relationship' do
+      let(:body) { file_fixture('jsonapi/singular_valid_null_singular_relationship.json').read }
+
+      it { is_expected.to have_attributes name: 'Joe', age: 21, part: nil }
     end
 
     context 'with 400 response' do

--- a/spec/lib/tariff_jsonapi_parser_spec.rb
+++ b/spec/lib/tariff_jsonapi_parser_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe TariffJsonapiParser do
         it { is_expected.to include 'parts' => [{ 'resource_type' => 'part', 'meta' => { 'foo' => 'bar' }, 'part_name' => 'A part name' }] }
       end
 
+      context 'with valid missing relationship' do
+        let(:json_file) { 'singular_valid_null_singular_relationship' }
+
+        it { is_expected.to include 'resource_type' => 'mock_entity' }
+        it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
+        it { is_expected.to include 'name' => 'Joe' }
+        it { is_expected.to include 'age' => 21 }
+        it { is_expected.to include 'part' => nil }
+      end
+
       context 'with missing relationships' do
         let(:json_file) { 'singular_missing_relationship' }
 

--- a/spec/models/additional_code_spec.rb
+++ b/spec/models/additional_code_spec.rb
@@ -5,18 +5,7 @@ RSpec.describe AdditionalCode do
     it { expect(described_class.relationships).to eq(%i[measures]) }
   end
 
-  describe '#all_goods_nomenclatures' do
-    subject(:all_goods_nomenclatures) { build(:additional_code, measures:).all_goods_nomenclatures.map(&:goods_nomenclature_item_id) }
-
-    let(:measures) do
-      [
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')), # Unsorted
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Unsorted
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Duplicate
-        attributes_for(:measure, goods_nomenclature: nil), # Compacted
-      ]
-    end
-
-    it { is_expected.to eq(%w[ABC DEF]) }
+  it_behaves_like 'an entity that has goods nomenclatures' do
+    let(:entity) { build(:additional_code, measures:) }
   end
 end

--- a/spec/models/additional_code_spec.rb
+++ b/spec/models/additional_code_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe AdditionalCode do
 
     let(:measures) do
       [
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')),
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')),
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')), # Unsorted
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Unsorted
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Duplicate
+        attributes_for(:measure, goods_nomenclature: nil), # Compacted
       ]
     end
 

--- a/spec/models/additional_code_spec.rb
+++ b/spec/models/additional_code_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe AdditionalCode do
+  describe '.relationships' do
+    it { expect(described_class.relationships).to eq(%i[measures]) }
+  end
+
+  describe '#all_goods_nomenclatures' do
+    subject(:all_goods_nomenclatures) { build(:additional_code, measures:).all_goods_nomenclatures.map(&:goods_nomenclature_item_id) }
+
+    let(:measures) do
+      [
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')),
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')),
+      ]
+    end
+
+    it { is_expected.to eq(%w[ABC DEF]) }
+  end
+end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -5,18 +5,7 @@ RSpec.describe Certificate do
     it { expect(described_class.relationships).to eq(%i[measures]) }
   end
 
-  describe '#all_goods_nomenclatures' do
-    subject(:all_goods_nomenclatures) { build(:certificate, measures:).all_goods_nomenclatures.map(&:goods_nomenclature_item_id) }
-
-    let(:measures) do
-      [
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')), # Unsorted
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Unsorted
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Duplicate
-        attributes_for(:measure, goods_nomenclature: nil), # Compacted
-      ]
-    end
-
-    it { is_expected.to eq(%w[ABC DEF]) }
+  it_behaves_like 'an entity that has goods nomenclatures' do
+    let(:entity) { build(:certificate, measures:) }
   end
 end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe Certificate do
 
     let(:measures) do
       [
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')),
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')),
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')), # Unsorted
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Unsorted
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Duplicate
+        attributes_for(:measure, goods_nomenclature: nil), # Compacted
       ]
     end
 

--- a/spec/models/footnote_spec.rb
+++ b/spec/models/footnote_spec.rb
@@ -10,14 +10,16 @@ RSpec.describe Footnote do
 
     let(:measures) do
       [
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')),
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')),
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')), # Unsorted
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Unsorted
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Duplicate
+        attributes_for(:measure, goods_nomenclature: nil), # Compacted
       ]
     end
 
     let(:goods_nomenclatures) do
       [
-        attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC'),
+        attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC'), # Duplicate
         attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'GHI'),
       ]
     end

--- a/spec/models/footnote_spec.rb
+++ b/spec/models/footnote_spec.rb
@@ -5,25 +5,13 @@ RSpec.describe Footnote do
     it { expect(described_class.relationships).to eq(%i[measures goods_nomenclatures]) }
   end
 
-  describe '#all_goods_nomenclatures' do
-    subject(:all_goods_nomenclatures) { build(:footnote, measures:, goods_nomenclatures:).all_goods_nomenclatures.map(&:goods_nomenclature_item_id) }
-
-    let(:measures) do
-      [
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')), # Unsorted
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Unsorted
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Duplicate
-        attributes_for(:measure, goods_nomenclature: nil), # Compacted
-      ]
-    end
+  it_behaves_like 'an entity that has goods nomenclatures' do
+    let(:entity) { build(:footnote, measures:, goods_nomenclatures:) }
 
     let(:goods_nomenclatures) do
       [
         attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC'), # Duplicate
-        attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'GHI'),
       ]
     end
-
-    it { is_expected.to eq(%w[ABC DEF GHI]) }
   end
 end

--- a/spec/models/order_number/definition_spec.rb
+++ b/spec/models/order_number/definition_spec.rb
@@ -35,18 +35,7 @@ RSpec.describe OrderNumber::Definition do
     end
   end
 
-  describe '#all_goods_nomenclatures' do
-    subject(:definition) { build(:definition, measures:).all_goods_nomenclatures.map(&:goods_nomenclature_item_id) }
-
-    let(:measures) do
-      [
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')),
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')),
-        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')),
-        attributes_for(:measure, goods_nomenclature: nil),
-      ]
-    end
-
-    it { is_expected.to eq(%w[ABC DEF]) }
+  it_behaves_like 'an entity that has goods nomenclatures' do
+    let(:entity) { build(:definition, measures:) }
   end
 end

--- a/spec/models/order_number/definition_spec.rb
+++ b/spec/models/order_number/definition_spec.rb
@@ -34,4 +34,20 @@ RSpec.describe OrderNumber::Definition do
       end
     end
   end
+
+  describe '#all_goods_nomenclatures' do
+    subject(:definition) do
+      build(:definition, measures:).all_goods_nomenclatures.map(&:goods_nomenclature_item_id)
+    end
+
+    let(:measures) do
+      [
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')),
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')),
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')),
+      ]
+    end
+
+    it { is_expected.to eq(%w[ABC DEF]) }
+  end
 end

--- a/spec/models/order_number/definition_spec.rb
+++ b/spec/models/order_number/definition_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe OrderNumber::Definition do
     end
 
     context 'when the order number defines geographical areas' do
-      subject(:definition) { build(:definition, order_number: order_number) }
+      subject(:definition) { build(:definition, order_number:) }
 
       let(:order_number) { attributes_for(:order_number, geographical_areas: [geographical_area]) }
       let(:geographical_area) { attributes_for(:geographical_area) }
@@ -26,7 +26,7 @@ RSpec.describe OrderNumber::Definition do
     context 'when the definition measures define geographical areas' do
       subject(:definition) { build(:definition, measures: [measure]) }
 
-      let(:measure) { attributes_for(:measure, geographical_area: geographical_area) }
+      let(:measure) { attributes_for(:measure, geographical_area:) }
       let(:geographical_area) { attributes_for(:geographical_area) }
 
       it 'returns the measure geographical areas' do
@@ -36,9 +36,7 @@ RSpec.describe OrderNumber::Definition do
   end
 
   describe '#all_goods_nomenclatures' do
-    subject(:definition) do
-      build(:definition, measures:).all_goods_nomenclatures.map(&:goods_nomenclature_item_id)
-    end
+    subject(:definition) { build(:definition, measures:).all_goods_nomenclatures.map(&:goods_nomenclature_item_id) }
 
     let(:measures) do
       [

--- a/spec/models/order_number/definition_spec.rb
+++ b/spec/models/order_number/definition_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe OrderNumber::Definition do
         attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')),
         attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')),
         attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')),
+        attributes_for(:measure, goods_nomenclature: nil),
       ]
     end
 

--- a/spec/support/shared_examples/an_entity_that_has_goods_nomenclature.rb
+++ b/spec/support/shared_examples/an_entity_that_has_goods_nomenclature.rb
@@ -1,0 +1,16 @@
+RSpec.shared_examples 'an entity that has goods nomenclatures' do
+  describe '#all_goods_nomenclatures' do
+    subject(:all_goods_nomenclatures) { entity.all_goods_nomenclatures.map(&:goods_nomenclature_item_id) }
+
+    let(:measures) do
+      [
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'DEF')), # Unsorted
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Unsorted
+        attributes_for(:measure, goods_nomenclature: attributes_for(:goods_nomenclature, goods_nomenclature_item_id: 'ABC')), # Duplicate
+        attributes_for(:measure, goods_nomenclature: nil), # Compacted
+      ]
+    end
+
+    it { is_expected.to eq(%w[ABC DEF]) }
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1414

### What?

I have added/removed/altered:

- [x] Added support for duplicate goods nomenclature in all search results (additional code, certificates, footnotes and quotas)
- [x] Added coverage for all_goods_nomenclatures method
- [x] Added support for nil relationships in has_one (has_many already works) - updating the api entity and jsonapi parser modules
- [x] Compact nil goods_nomenclature

### Why?

I am doing this because:

- We are seeing duplicates in production
