### PR TITLE
HOTT-1381 Show banner news items

### DIFF
--- a/app/helpers/news_item_helper.rb
+++ b/app/helpers/news_item_helper.rb
@@ -1,0 +1,5 @@
+module NewsItemHelper
+  def format_news_item_content(content)
+    govspeak replace_service_tags content
+  end
+end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -64,7 +64,7 @@ class NewsItem
       end
     end
 
-    def cached_banner
+    def cached_latest_banner
       Rails.cache.fetch(banner_cache_key, expires_in: BANNER_CACHE_LIFETIME) do
         latest_banner
       end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -14,7 +14,7 @@ class NewsItem
   collection_path '/news_items'
 
   attr_accessor :id, :title, :content, :display_style, :show_on_xi, :show_on_uk,
-                :show_on_updates_page, :show_on_home_page
+                :show_on_updates_page, :show_on_home_page, :show_on_banner
 
   attr_reader :start_date, :end_date
 
@@ -26,6 +26,15 @@ class NewsItem
         collection_path,
         service: service_name,
         target: 'home',
+        per_page: 1,
+      ).first
+    end
+
+    def latest_for_banner
+      collection(
+        collection_path,
+        service: service_name,
+        target: 'banner',
         per_page: 1,
       ).first
     end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -6,8 +6,10 @@ class NewsItem
   include ApiEntity
 
   CACHE_KEY = 'news-item-any-updates'
+  BANNER_CACHE_KEY = 'news-item-latest-banner'
   CACHE_VERSION = 1
   CACHE_LIFETIME = 15.minutes
+  BANNER_CACHE_LIFETIME = 5.minutes
 
   DISPLAY_STYLE_REGULAR = 0
 
@@ -30,7 +32,7 @@ class NewsItem
       ).first
     end
 
-    def latest_for_banner
+    def latest_banner
       collection(
         collection_path,
         service: service_name,
@@ -62,6 +64,12 @@ class NewsItem
       end
     end
 
+    def cached_banner
+      Rails.cache.fetch(banner_cache_key, expires_in: BANNER_CACHE_LIFETIME) do
+        latest_banner
+      end
+    end
+
   private
 
     def api
@@ -71,6 +79,10 @@ class NewsItem
 
     def updates_cache_key
       "#{CACHE_KEY}-#{service_name}-v#{CACHE_VERSION}"
+    end
+
+    def banner_cache_key
+      "#{BANNER_CACHE_KEY}-#{service_name}-v#{CACHE_VERSION}"
     end
   end
 

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -7,7 +7,7 @@ class NewsItem
 
   CACHE_KEY = 'news-item-any-updates'
   BANNER_CACHE_KEY = 'news-item-latest-banner'
-  CACHE_VERSION = 1
+  CACHE_VERSION = 2
   CACHE_LIFETIME = 15.minutes
   BANNER_CACHE_LIFETIME = 5.minutes
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,7 +64,7 @@
       <%= yield :proposition_header %>
     </div>
     <%= render 'shared/search_banner' if TradeTariffFrontend.search_banner? %>
-    <%= render 'shared/header_banner' %>
+    <%= render 'news_items/header_banner', news_item: NewsItem.cached_banner %>
   </header>
 
   <div class="tariff service govuk-width-container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,7 +64,7 @@
       <%= yield :proposition_header %>
     </div>
     <%= render 'shared/search_banner' if TradeTariffFrontend.search_banner? %>
-    <%= render 'news_items/header_banner', news_item: NewsItem.cached_banner %>
+    <%= render 'news_items/header_banner', news_item: NewsItem.cached_latest_banner %>
   </header>
 
   <div class="tariff service govuk-width-container">

--- a/app/views/news_items/_header_banner.html.erb
+++ b/app/views/news_items/_header_banner.html.erb
@@ -1,7 +1,7 @@
 <% if news_item.present? %>
 <div class="hott-header-banner">
   <div class="govuk-width-container">
-    <%= govspeak replace_service_tags news_item.content %>
+    <%= format_news_item_content news_item.content %>
   </div>
 </div>
 <% end %>

--- a/app/views/news_items/_header_banner.html.erb
+++ b/app/views/news_items/_header_banner.html.erb
@@ -1,0 +1,7 @@
+<% if news_item.present? %>
+<div class="hott-header-banner">
+  <div class="govuk-width-container">
+    <%= govspeak replace_service_tags news_item.content %>
+  </div>
+</div>
+<% end %>

--- a/app/views/news_items/_latest_news.html.erb
+++ b/app/views/news_items/_latest_news.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="govuk-notification-banner__content">
     <div class="tariff-markdown">
-      <%= govspeak replace_service_tags news_item.paragraphs.first %>
+      <%= format_news_item_content news_item.paragraphs.first %>
 
       <%- if news_item.paragraphs.many? -%>
         <%= link_to 'Show more ...', news_item,

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -19,7 +19,7 @@
         </h2>
 
         <div class="tariff-markdown">
-          <%= govspeak replace_service_tags(news_item.paragraphs.first) %>
+          <%= format_news_item_content news_item.paragraphs.first %>
         </div>
 
         <%= link_to 'Show more ...', news_item if news_item.paragraphs.many? %>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -16,7 +16,7 @@
   </h3>
 
   <div class="tariff-markdown">
-    <%= govspeak replace_service_tags(@news_item.content) %>
+    <%= format_news_item_content @news_item.content %>
   </div>
 </article>
 

--- a/app/views/shared/_header_banner.html.erb
+++ b/app/views/shared/_header_banner.html.erb
@@ -1,7 +1,0 @@
-<div class="hott-header-banner">
-  <div class="govuk-width-container">
-    <p>
-      New guidance has been published in regard to <a href="https://www.gov.uk/guidance/additional-duties-on-goods-originating-in-russia-and-belarus" target="_blank"> additional duties on goods originating in Russia and Belarus</a>.
-    </p>
-  </div>
-</div>

--- a/config/initializers/govspeak_sanitizer.rb
+++ b/config/initializers/govspeak_sanitizer.rb
@@ -1,0 +1,16 @@
+# Govspeak sanitizer appears completely unconfigurable so resorting to monkey patching
+
+module TariffGovspeakSanitizer
+  def sanitize_config(...)
+    orig_config = super
+
+    Sanitize::Config.merge(
+      orig_config,
+      attributes: {
+        'a' => orig_config[:attributes]['a'] + %w[target],
+      },
+    )
+  end
+end
+
+Govspeak::HtmlSanitizer.prepend TariffGovspeakSanitizer

--- a/spec/factories/news_item_factory.rb
+++ b/spec/factories/news_item_factory.rb
@@ -7,7 +7,8 @@ FactoryBot.define do
     show_on_xi { true }
     show_on_uk { true }
     show_on_updates_page { false }
-    show_on_home_page { true }
+    show_on_home_page { false }
+    show_on_banner { false }
 
     content do
       <<~CONTENT
@@ -27,13 +28,16 @@ FactoryBot.define do
       show_on_uk { false }
     end
 
-    trait :homepage do
-      show_on_updates_page { false }
+    trait :home_page do
       show_on_home_page { true }
     end
 
-    trait :updates_and_homepage do
-      show_on_home_page { true }
+    trait :banner do
+      show_on_banner { true }
+    end
+
+    trait :updates_page do
+      show_on_updates_page { true }
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe ApplicationHelper, type: :helper do
         ).to eq ''
       end
     end
+
+    context 'with link with target attribute' do
+      subject { govspeak source }
+
+      let(:source) { %(<a href="/" target="_blank">/</a>) }
+
+      it { is_expected.to eql "<p>#{source}</p>\n" }
+    end
   end
 
   describe '.generate_breadcrumbs' do

--- a/spec/helpers/news_item_helper_spec.rb
+++ b/spec/helpers/news_item_helper_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe NewsItemHelper, type: :helper do
+  include ServiceHelper
+  include ApplicationHelper
+
+  describe '#format_news_item_content' do
+    subject(:formatted) { format_news_item_content source }
+
+    let :source do
+      <<~EOCONTENT
+        # Heading for [[SERVICE_NAME]]
+
+        This is a para <a href="/" target="_blank">test</a>
+      EOCONTENT
+    end
+
+    it 'converts markdown' do
+      expect(formatted).to have_css 'h1'
+    end
+
+    it 'replaces service tags' do
+      expect(formatted).to have_content 'Heading for UK'
+    end
+  end
+end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -42,6 +42,32 @@ RSpec.describe NewsItem do
     end
   end
 
+  describe '.latest_for_banner' do
+    subject { described_class.latest_for_banner }
+
+    context 'with UK service' do
+      include_context 'with UK service'
+
+      before do
+        stub_api_request('/news_items?service=uk&target=banner&per_page=1', backend: 'uk')
+          .to_return jsonapi_response :news_item, attributes_for_list(:news_item, 1, :banner)
+      end
+
+      it { is_expected.to have_attributes title: /News item \d+/ }
+    end
+
+    context 'with XI service' do
+      include_context 'with XI service'
+
+      before do
+        stub_api_request('/news_items?service=xi&target=banner&per_page=1', backend: 'uk')
+          .to_return jsonapi_response :news_item, attributes_for_list(:news_item, 1, :banner)
+      end
+
+      it { is_expected.to have_attributes title: /News item \d+/ }
+    end
+  end
+
   describe '.updates_page' do
     subject { described_class.updates_page }
 

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -167,8 +167,8 @@ RSpec.describe NewsItem do
     end
   end
 
-  describe '.cached_banner' do
-    subject(:cached_banner) { described_class.cached_banner }
+  describe '.cached_latest_banner' do
+    subject(:cached_banner) { described_class.cached_latest_banner }
 
     before { allow(Rails.cache).to receive(:fetch).and_call_original }
 

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-          .with('news-item-any-updates-uk-v1', expires_in: 15.minutes)
+          .with('news-item-any-updates-uk-v2', expires_in: 15.minutes)
       end
 
       context 'with no news items' do
@@ -156,7 +156,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-          .with('news-item-any-updates-xi-v1', expires_in: 15.minutes)
+          .with('news-item-any-updates-xi-v2', expires_in: 15.minutes)
       end
 
       context 'with no news items' do
@@ -185,7 +185,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-            .with('news-item-latest-banner-uk-v1', expires_in: 5.minutes)
+            .with('news-item-latest-banner-uk-v2', expires_in: 5.minutes)
       end
     end
 
@@ -202,7 +202,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-            .with('news-item-latest-banner-xi-v1', expires_in: 5.minutes)
+            .with('news-item-latest-banner-xi-v2', expires_in: 5.minutes)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,7 @@ RSpec.configure do |config|
   config.before do
     allow(TariffUpdate).to receive(:all).and_return([OpenStruct.new(applied_at: Time.zone.today)])
     allow(NewsItem).to receive(:any_updates?).and_return true
+    allow(NewsItem).to receive(:latest_banner).and_return build(:news_item, :banner)
     Thread.current[:service_choice] = nil
   end
 

--- a/spec/views/news_items/_header_banner.html.erb_spec.rb
+++ b/spec/views/news_items/_header_banner.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe 'news_items/_header_banner', type: :view do
+  subject { render 'news_items/header_banner', news_item: news_item }
+
+  let(:news_item) { build :news_item, content: 'Important news for [[SERVICE_NAME]]' }
+
+  it { is_expected.to have_css '.hott-header-banner .govuk-width-container p', count: 1 }
+  it { is_expected.to have_css 'p', text: 'Important news for UK' }
+
+  context 'without any news' do
+    let(:news_item) { nil }
+
+    it { is_expected.not_to have_css '.hott-header-banner' }
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-1381](https://transformuk.atlassian.net/browse/HOTT-1381)

### What?

I have added/removed/altered:

- [x] Added querying the latest banner from NewsItem
- [x] Added caching of that query
- [x] Show the banner news item in the header banner
- [x] Changed the govspeak sanitizer to allow `<a target="_blank"` links

### Why?

I am doing this because:

- We want to drive the header banner from the news items, controlled via the admin area.

### Deployment risks (optional)

- Affects every page, should not be merged before the backend changes are released
