### PR TITLE
Make rubocop config match brakeman requirements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,5 +63,8 @@ Style/FrozenStringLiteralComment:
 Style/GuardClause:
   MinBodyLength: 2
 
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -33,7 +33,7 @@ class SearchController < ApplicationController
     start_with = SearchSuggestion.start_with(search_term).sort_by(&:value)
     results = start_with.map { |s| { id: s.value, text: s.value } }
 
-    render json: { results: }
+    render json: { results: results }
   end
 
   def quota_search
@@ -105,7 +105,7 @@ class SearchController < ApplicationController
   end
 
   def missing_search_query_fallback_url
-    return sections_url(anchor:) if request.referer.blank?
+    return sections_url(anchor: anchor) if request.referer.blank?
 
     back_url = Addressable::URI.parse(request.referer)
     back_url.query_values ||= {}

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -82,15 +82,15 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
             @request.env['HTTP_REFERER'] = '/chapters/01'
 
             post :search, params: {
-              year:,
-              month:,
-              day:,
+              year: year,
+              month: month,
+              day: day,
             }
           end
 
           it { is_expected.to respond_with(:redirect) }
           it { expect(assigns(:search)).to be_a(Search) }
-          it { is_expected.to redirect_to(chapter_path('01', year:, month:, day:)) }
+          it { is_expected.to redirect_to(chapter_path('01', day: day, month: month, year: year)) }
         end
 
         context 'when valid date params provided for today' do
@@ -102,9 +102,9 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
             @request.env['HTTP_REFERER'] = '/chapters/01'
 
             post :search, params: {
-              year:,
-              month:,
-              day:,
+              year: year,
+              month: month,
+              day: day,
             }
           end
 
@@ -130,8 +130,8 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
 
             before do
               post :search, params: { date: {
-                year:,
-                month:,
+                year: year,
+                month: month,
               } }
             end
 
@@ -147,9 +147,9 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
 
             before do
               post :search, params: { date: {
-                year:,
-                month:,
-                day:,
+                year: year,
+                month: month,
+                day: day,
               } }
             end
 
@@ -171,7 +171,7 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
       let(:query) { 'car parts' }
 
       before do
-        get :search, params: { q: query, day:, month:, year: }, format: :json
+        get :search, params: { q: query, day: day, month: month, year: year }, format: :json
       end
 
       specify 'should return query and date within response body' do
@@ -187,7 +187,7 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
       let(:query) { '2204' }
 
       before do
-        get :search, params: { q: query, day:, month:, year: }, format: :json
+        get :search, params: { q: query, day: day, month: month, year: year }, format: :json
       end
 
       specify 'should return single goods nomenclature' do
@@ -203,7 +203,7 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
       let(:query) { 'account books' }
 
       before do
-        get :search, params: { q: query, day:, month:, year: }, format: :json
+        get :search, params: { q: query, day: day, month: month, year: year }, format: :json
       end
 
       specify 'should return single goods nomenclature' do
@@ -219,7 +219,7 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
       let(:query) { 'minerals' }
 
       before do
-        get :search, params: { q: query, day:, month:, year: }, format: :json
+        get :search, params: { q: query, day: day, month: month, year: year }, format: :json
       end
 
       specify 'should return single goods nomenclature' do
@@ -233,7 +233,7 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
       let(:query) { 'designed velocycles' }
 
       before do
-        get :search, params: { q: query, day:, month:, year: }, format: :json
+        get :search, params: { q: query, day: day, month: month, year: year }, format: :json
       end
 
       specify 'should return single goods nomenclature' do

--- a/spec/models/additional_code_spec.rb
+++ b/spec/models/additional_code_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe AdditionalCode do
   end
 
   it_behaves_like 'an entity that has goods nomenclatures' do
-    let(:entity) { build(:additional_code, measures:) }
+    let(:entity) { build(:additional_code, measures: measures) }
   end
 end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe Certificate do
   end
 
   it_behaves_like 'an entity that has goods nomenclatures' do
-    let(:entity) { build(:certificate, measures:) }
+    let(:entity) { build(:certificate, measures: measures) }
   end
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Feedback do
-  subject(:feedback) { build(:feedback, message:) }
+  subject(:feedback) { build(:feedback, message: message) }
 
   describe 'validations' do
     before { feedback.valid? }

--- a/spec/models/footnote_spec.rb
+++ b/spec/models/footnote_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Footnote do
   end
 
   it_behaves_like 'an entity that has goods nomenclatures' do
-    let(:entity) { build(:footnote, measures:, goods_nomenclatures:) }
+    let(:entity) { build(:footnote, measures: measures, goods_nomenclatures: goods_nomenclatures) }
 
     let(:goods_nomenclatures) do
       [

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Measure do
   end
 
   describe '#vat_excise?' do
-    subject(:measure) { build(:measure, measure_type:) }
+    subject(:measure) { build(:measure, measure_type: measure_type) }
 
     let(:measure_type) { attributes_for(:measure_type, id: measure_type_id) }
 
@@ -87,7 +87,7 @@ RSpec.describe Measure do
   end
 
   describe '#import_controls?' do
-    subject(:measure) { build(:measure, measure_type:) }
+    subject(:measure) { build(:measure, measure_type: measure_type) }
 
     let(:measure_type) { attributes_for(:measure_type, id: measure_type_id) }
 
@@ -175,7 +175,7 @@ RSpec.describe Measure do
   end
 
   describe '#quotas?' do
-    subject(:measure) { build(:measure, measure_type:) }
+    subject(:measure) { build(:measure, measure_type: measure_type) }
 
     let(:measure_type) { attributes_for(:measure_type, id: measure_type_id) }
 
@@ -193,7 +193,7 @@ RSpec.describe Measure do
   end
 
   describe '#trade_remedies?' do
-    subject(:measure) { build(:measure, measure_type:) }
+    subject(:measure) { build(:measure, measure_type: measure_type) }
 
     let(:measure_type) { attributes_for(:measure_type, id: measure_type_id) }
 

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 RSpec.describe MeasureType do
   describe '#duties_permitted?' do
-    subject(:measure_type) { build(:measure_type, measure_component_applicable_code:) }
+    subject(:measure_type) do
+      build(:measure_type,
+            measure_component_applicable_code: measure_component_applicable_code)
+    end
 
     context 'when the component applicable code is `0`' do
       let(:measure_component_applicable_code) { 0 }
@@ -18,7 +21,10 @@ RSpec.describe MeasureType do
   end
 
   describe '#duties_mandatory?' do
-    subject(:measure_type) { build(:measure_type, measure_component_applicable_code:) }
+    subject(:measure_type) do
+      build(:measure_type,
+            measure_component_applicable_code: measure_component_applicable_code)
+    end
 
     context 'when the component applicable code is `1`' do
       let(:measure_component_applicable_code) { 1 }
@@ -34,7 +40,10 @@ RSpec.describe MeasureType do
   end
 
   describe '#duties_not_permitted?' do
-    subject(:measure_type) { build(:measure_type, measure_component_applicable_code:) }
+    subject(:measure_type) do
+      build(:measure_type,
+            measure_component_applicable_code: measure_component_applicable_code)
+    end
 
     context 'when the component applicable code is `2`' do
       let(:measure_component_applicable_code) { 2 }
@@ -91,7 +100,10 @@ RSpec.describe MeasureType do
     subject(:description) { measure.measure_type.description }
 
     shared_examples_for 'a Channel Island measure type description' do |measure_type_id, geographical_area_id|
-      let(:measure) { build(:measure, measure_type_id:, geographical_area_id:) }
+      let(:measure) do
+        build(:measure, measure_type_id: measure_type_id,
+                        geographical_area_id: geographical_area_id)
+      end
 
       it { is_expected.to eq('Channel Islands duty') }
     end

--- a/spec/models/order_number/definition_spec.rb
+++ b/spec/models/order_number/definition_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe OrderNumber::Definition do
     end
 
     context 'when the order number defines geographical areas' do
-      subject(:definition) { build(:definition, order_number:) }
+      subject(:definition) { build(:definition, order_number: order_number) }
 
       let(:order_number) { attributes_for(:order_number, geographical_areas: [geographical_area]) }
       let(:geographical_area) { attributes_for(:geographical_area) }
@@ -26,7 +26,7 @@ RSpec.describe OrderNumber::Definition do
     context 'when the definition measures define geographical areas' do
       subject(:definition) { build(:definition, measures: [measure]) }
 
-      let(:measure) { attributes_for(:measure, geographical_area:) }
+      let(:measure) { attributes_for(:measure, geographical_area: geographical_area) }
       let(:geographical_area) { attributes_for(:geographical_area) }
 
       it 'returns the measure geographical areas' do
@@ -36,6 +36,6 @@ RSpec.describe OrderNumber::Definition do
   end
 
   it_behaves_like 'an entity that has goods nomenclatures' do
-    let(:entity) { build(:definition, measures:) }
+    let(:entity) { build(:definition, measures: measures) }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Changed rubocop to prevent rather then require Ruby 3.1 short hash literals
- [x] Removed usage of short hash literals from existing code

### Why?

I am doing this because:

- Brakeman is more important than utilising Ruby 3.1 hash syntax
- its trivial to convert back at a future point
- for now it reduces noise in PRs because rubocop isn't insisting on an syntax change to existing code

