### PR TITLE
Update Gem Faraday to V.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,7 @@ end
 gem 'rails', '~> 7.0'
 
 gem 'addressable'
-gem 'faraday', '= 1.3.0' # TODO: Debug issue with newer versions of Faraday client under high loads
-gem 'faraday_middleware'
+gem 'faraday', '~> 2.2'
 gem 'faraday-net_http_persistent'
 gem 'multi_json'
 gem 'net-http-persistent'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,16 +153,13 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.3.0)
-      faraday-net_http (~> 1.0)
-      multipart-post (>= 1.2, < 3)
-      ruby2_keywords
-    faraday-net_http (1.0.1)
+    faraday (2.2.0)
+      faraday-net_http (~> 2.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (2.0.2)
     faraday-net_http_persistent (2.0.1)
       faraday-net_http
       net-http-persistent (~> 4.0)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
     forgery (0.8.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -243,7 +240,6 @@ GEM
     minitest (5.15.0)
     msgpack (1.4.5)
     multi_json (1.15.0)
-    multipart-post (2.1.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     net-imap (0.2.3)
@@ -466,9 +462,8 @@ DEPENDENCIES
   connection_pool
   dotenv-rails
   factory_bot_rails
-  faraday (= 1.3.0)
+  faraday (~> 2.2)
   faraday-net_http_persistent
-  faraday_middleware
   forgery
   govspeak
   govuk_design_system_formbuilder

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -1,4 +1,3 @@
-require 'faraday_middleware'
 require 'multi_json'
 require 'active_model'
 require 'tariff_jsonapi_parser'


### PR DESCRIPTION
### What?
Update Gem Faraday to V.2.2

### Jira link
https://transformuk.atlassian.net/browse/HOTT-1355

### Why?
We are using a very outdated Gem version.

Note:
The new gem has been already tested in Staging, 
and the response times and failures percentages are basically the same:
about 1% differences, that seems not related to Faraday - Even testing the same env multiple times I got slightly different results.

In production the behaviour could be different, that's why we'll monitor it constantly after the release.
