### PR TITLE
HOTT-1467 Text fixes to tools page

### DIFF
--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -24,9 +24,9 @@
       <% end %>
       <li>
         <p>
-          <%= link_to "Certificate, licenses and documents", certificate_search_path %>
+          <%= link_to "Certificates, licences and documents", certificate_search_path %>
           <br>
-          Search for certificates, licenses and other document codes.
+          Search for certificates, licences and other document codes.
         </p>
       </li>
       <li>
@@ -38,14 +38,14 @@
       </li>
       <li>
         <p>
-          <%= link_to t('breadcrumb.footnote_search'), footnote_search_path %>
-          <br>Search the tariff for footnotes
+          <%= link_to 'Footnotes', footnote_search_path %>
+          <br>Search the tariff for footnotes.
         </p>
       </li>
       <li>
         <p>
           <%= link_to t('breadcrumb.chemicals'), chemical_search_path %>
-          <br>Search the tariff for chemicals by <abbr title="Chemical Abstracts Service">CAS</abbr> Registry Number (RN)
+          <br>Search the tariff for chemicals by <abbr title="Chemical Abstracts Service">CAS</abbr> Registry Number (RN).
         </p>
       </li>
       <% if TradeTariffFrontend::ServiceChooser.xi? %>


### PR DESCRIPTION
### Jira link

[HOTT-1467](https://transformuk.atlassian.net/browse/HOTT-1467)

### What?

I have added/removed/altered:

- [x] Text changes to tools page

### Why?

I am doing this because:

- because we have US spelling on an english page

### Screenshot

![Screenshot from 2022-03-31 17-25-14](https://user-images.githubusercontent.com/10818/161104038-9c71b2d0-8890-48cf-ac38-eda895f1060a.png)
