### PR TITLE
HOTT-1470 Text fixes for Certificate search page

### DIFF
--- a/app/views/search/certificate/_form.html.erb
+++ b/app/views/search/certificate/_form.html.erb
@@ -1,17 +1,28 @@
 <%= form_tag certificate_search_path, method: :get, class: "tariff-search quota-search #{@section_css}", id: 'new_search' do |f| %>
-  <%= page_header 'Search by Certificate' %>
+  <%= page_header 'Search for a certificate, licence or document' %>
+
+  <div class="govuk-inset-text">
+    Search for certificates, licences and other document codes and the commodities which reference them.
+    Document codes may be needed to complete your import or export declaration.
+  </div>
 
   <div class="govuk-form-group">
-    <%= label_tag :type, 'Type', class: 'govuk-label' %>
+    <%= label_tag :type, 'Certificate type', class: 'govuk-label' %>
     <%= select_tag :type, options_for_select(search_form.certificate_types, search_form.type), include_blank: true, class: "custom-select" %>
   </div>
   <div class="govuk-form-group">
-    <%= label_tag :code, 'Code', class: 'govuk-label' %>
-    <%= text_field_tag :code, search_form.code, class: "govuk-input govuk-input--width-10" %>
+    <%= label_tag :code, 'Certificate code', class: 'govuk-label' %>
+    <div class="govuk-hint" id="code-hint">
+      Enter the 3 digit certificate code
+    </div>
+    <%= text_field_tag :code, search_form.code, class: "govuk-input govuk-input--width-10", 'aria-describedby': 'code-hint' %>
   </div>
   <div class="govuk-form-group">
     <%= label_tag :description, 'Description', class: 'govuk-label' %>
-    <%= text_field_tag :description, search_form.description, class: "govuk-input govuk-input--width-20" %>
+    <div class="govuk-hint" id="description-hint">
+      Enter key terms from the certificate description
+    </div>
+    <%= text_field_tag :description, search_form.description, class: "govuk-input govuk-input--width-20", 'aria-describedby': 'description-hint' %>
   </div>
-  <input class="button govuk-button" type="submit" name="new_search" value="Search">
+  <input class="button govuk-button" type="submit" name="new_search" value="Search for a certificate">
 <% end %>


### PR DESCRIPTION
### Jira link

[HOTT-1470](https://transformuk.atlassian.net/browse/HOTT-1470)

### What?

I have added/removed/altered:

- [x] Text changes to the certificate search page

### Why?

I am doing this because:

- It clarifies the form
- It improves accessibility

### Screenshot

![Screenshot from 2022-03-31 17-24-21](https://user-images.githubusercontent.com/10818/161103872-fd045a0f-c43d-407c-bc0d-322bc9f4f5c8.png)

