### PR TITLE
HOTT-1362 separate out 999L

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -10,7 +10,8 @@ class Measure
                 :excise,
                 :goods_nomenclature_item_id,
                 :meursing,
-                :resolved_duty_expression
+                :resolved_duty_expression,
+                :universal_waiver_applies
 
   attr_reader :effective_start_date,
               :effective_end_date
@@ -29,6 +30,18 @@ class Measure
   has_one :goods_nomenclature, polymorphic: true
 
   delegate :erga_omnes?, to: :geographical_area
+
+  class << self
+    def grouped_measure_types
+      @grouped_measure_types ||= Rails.configuration.grouped_measure_types
+    end
+
+    def all_grouped_types
+      @all_grouped_types ||= grouped_measure_types.values.flatten.sort
+    end
+  end
+
+  delegate :grouped_measure_types, :all_grouped_types, to: :class
 
   def relevant_for_country?(country_code)
     return true if country_code.blank?
@@ -159,18 +172,6 @@ class Measure
       additional_code.code.to_s
     end
   end
-
-  class << self
-    def grouped_measure_types
-      @grouped_measure_types ||= Rails.configuration.grouped_measure_types
-    end
-
-    def all_grouped_types
-      @all_grouped_types ||= grouped_measure_types.values.flatten.sort
-    end
-  end
-
-  delegate :grouped_measure_types, :all_grouped_types, to: :class
 
   private
 

--- a/app/presenters/measure_presenter.rb
+++ b/app/presenters/measure_presenter.rb
@@ -1,4 +1,6 @@
 class MeasurePresenter < SimpleDelegator
+  DOCUMENT_CODE_EXCLUSIONS = %w[999L].freeze
+
   def has_children_geographical_areas?
     geographical_area.children_geographical_areas.any?
   end
@@ -19,8 +21,14 @@ class MeasurePresenter < SimpleDelegator
     geographical_area.children_geographical_areas.sort_by(&:id)
   end
 
+  def measure_conditions_without_exclusions
+    measure_conditions.reject do |condition|
+      DOCUMENT_CODE_EXCLUSIONS.include?(condition.document_code)
+    end
+  end
+
   def grouped_measure_conditions
-    measure_conditions.group_by do |condition|
+    measure_conditions_without_exclusions.group_by do |condition|
       {
         condition: condition.condition,
         partial_type: case condition.condition_code[0]

--- a/app/views/measures/_measure_condition_modal_default.html.erb
+++ b/app/views/measures/_measure_condition_modal_default.html.erb
@@ -2,3 +2,18 @@
 <% measure.grouped_measure_conditions.each do |condition_group, conditions| %>
   <%= render partial: "measure_conditions/measure_condition_code_#{condition_group[:partial_type]}", locals: { condition_group: condition_group, conditions: conditions } %>
 <% end %>
+
+<% if TradeTariffFrontend::ServiceChooser.uk? && measure.universal_waiver_applies %>
+<div class="universal-waiver-applies-panel">
+  <h3 class="govuk-heading-m govuk-!-margin-top-6">
+    Customs Declaration Service (CDS) universal waiver
+  </h3>
+
+  <p>
+    Requirement for a licence is waived by entering the 999L document code and the
+    document identifier CDS WAIVER in the additional documentation field for this
+    commodity item. 999L can be used for CDS in a similar way to LIC99 on the
+    CHIEF system, when a waiver may be applied.
+  </p>
+</div>
+<% end %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -466,6 +466,10 @@ FactoryBot.define do
     requirement { Forgery(:basic).text }
     action { Forgery(:basic).text }
     duty_expression { Forgery(:basic).text }
+
+    trait :universal_waiver do
+      document_code { '999L' }
+    end
   end
 
   factory :additional_code do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -133,6 +133,7 @@ FactoryBot.define do
     origin { %w[eu uk].sample }
     effective_start_date { Time.zone.today.ago(3.years).to_s }
     effective_end_date { nil }
+    universal_waiver_applies { false }
 
     measure_type do
       attributes_for(:measure_type, id: measure_type_id, description: measure_type_description)
@@ -322,6 +323,10 @@ FactoryBot.define do
 
     trait :export do
       import { false }
+    end
+
+    trait :universal_waiver do
+      universal_waiver_applies { true }
     end
 
     initialize_with do

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Measure do
     it { expect(described_class.relationships).to eq(expected_relationships) }
   end
 
+  it { is_expected.to respond_to :universal_waiver_applies }
+
   describe '#relevant_for_country?' do
     context 'when the area is not present' do
       subject(:measure) { build(:measure, :eu, geographical_area: { id: 'br', description: 'Brazil' }) }

--- a/spec/presenters/measure_presenter_spec.rb
+++ b/spec/presenters/measure_presenter_spec.rb
@@ -80,6 +80,26 @@ RSpec.describe MeasurePresenter do
     end
   end
 
+  describe '#measure_conditions_without_exclusions' do
+    subject { presented_measure.measure_conditions_without_exclusions }
+
+    context 'with normal measure' do
+      let(:measure) { build :measure, :with_conditions }
+
+      it { is_expected.to include measure.measure_conditions.first }
+    end
+
+    context 'with universal waiver measure' do
+      let :measure do
+        build :measure, measure_conditions: [
+          attributes_for(:measure_condition, :universal_waiver),
+        ]
+      end
+
+      it { is_expected.not_to include measure.measure_conditions.first }
+    end
+  end
+
   describe '#grouped_measure_conditions' do
     subject(:grouped_conditions) { presented_measure.grouped_measure_conditions }
 

--- a/spec/views/measures/_measure_condition_modal_default.html.erb_spec.rb
+++ b/spec/views/measures/_measure_condition_modal_default.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe 'measures/_measure_condition_modal_default', type: :view do
+  subject { render_page && rendered }
+
+  let :render_page do
+    render 'measures/measure_condition_modal_default',
+           measure: MeasurePresenter.new(measure)
+  end
+
+  context 'with measure which universal waiver does not apply to' do
+    let(:measure) { build :measure, :with_conditions }
+
+    it { is_expected.not_to have_css '.universal-waiver-applies-panel' }
+  end
+
+  context 'with measure which universal waiver applies to' do
+    let(:measure) { build :measure, :with_conditions, :universal_waiver }
+
+    context 'with UK service' do
+      include_context 'with UK service'
+
+      it { is_expected.to have_css '.universal-waiver-applies-panel' }
+    end
+
+    context 'with XI service' do
+      include_context 'with XI service'
+
+      it { is_expected.not_to have_css '.universal-waiver-applies-panel' }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-1362](https://transformuk.atlassian.net/browse/HOTT-1362)

### What?

I have added/removed/altered:

- [x] Changed the MeasurePresenter to exclude universal waiver conditions from the list of grouped conditions
- [x] Show an additional 'universal waiver' panel on the measure conditions modal if the measure has the 'universal_waiver_applies' attribute

### Why?

I am doing this because:

- We want to more clearly display the 999L requirements

### Screenshots

For measure with universal waiver

![Screenshot from 2022-04-01 13-45-00](https://user-images.githubusercontent.com/10818/161266354-54299744-095f-4c1e-a6a5-b164ffb4bd15.png)

For measure without universal waiver

![Screenshot from 2022-04-01 13-45-23](https://user-images.githubusercontent.com/10818/161266406-dbae2093-64c5-4754-aa9d-ced2bfe18f25.png)

