### PR TITLE
HOTT-1448: Only show guidance on UK data

### DIFF
--- a/app/views/search/certificate_search.html.erb
+++ b/app/views/search/certificate_search.html.erb
@@ -35,34 +35,36 @@
         </div>
       </dl>
 
-      <details class="govuk-details govuk-!-margin-top-2" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            Using this certificate on CDS or CHIEF
-          </span>
-        </summary>
+      <% if TradeTariffFrontend::ServiceChooser.uk? %>
+        <details class="govuk-details govuk-!-margin-top-2" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Using this certificate on CDS or CHIEF
+            </span>
+          </summary>
 
-        <div class="govuk-details__text">
-          <dl class="govuk-summary-list govuk-summary-list--no-border">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-              <strong>CDS guidance:</strong>
-              </dt>
-              <dd class="govuk-summary-list__value">
-              <%= govspeak(certificate.guidance_cds) %>
-              </ddk>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-              <strong>CHIEF guidance:</strong>
-              </dt>
-              <dd class="govuk-summary-list__value">
-              <%= govspeak(certificate.guidance_chief) %>
-              </dd>
-            </div>
-          </dl>
-        </div>
-      </details>
+          <div class="govuk-details__text">
+            <dl class="govuk-summary-list govuk-summary-list--no-border">
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                <strong>CDS guidance:</strong>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                <%= govspeak(certificate.guidance_cds) %>
+                </ddk>
+              </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                <strong>CHIEF guidance:</strong>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                <%= govspeak(certificate.guidance_chief) %>
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </details>
+      <% end %>
 
       <details class="govuk-details govuk-!-margin-top-2" data-module="govuk-details">
         <summary class="govuk-details__summary">

--- a/app/views/search/certificate_search.html.erb
+++ b/app/views/search/certificate_search.html.erb
@@ -47,18 +47,18 @@
             <dl class="govuk-summary-list govuk-summary-list--no-border">
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
-                <strong>CDS guidance:</strong>
+                  <strong>CDS guidance:</strong>
                 </dt>
                 <dd class="govuk-summary-list__value">
-                <%= govspeak(certificate.guidance_cds) %>
-                </ddk>
+                  <%= govspeak(certificate.guidance_cds) %>
+                </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
-                <strong>CHIEF guidance:</strong>
+                  <strong>CHIEF guidance:</strong>
                 </dt>
                 <dd class="govuk-summary-list__value">
-                <%= govspeak(certificate.guidance_chief) %>
+                  <%= govspeak(certificate.guidance_chief) %>
                 </dd>
               </div>
             </dl>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -632,4 +632,33 @@ FactoryBot.define do
   end
 
   factory :feedback
+
+  factory :certificate_search_form do
+    type { 'N' }
+    code { '002' }
+    description { 'Certificate of conformity with the GB marketing standards for fresh fruit and vegetables' }
+    page { 1 }
+
+    initialize_with do
+      params = ActionController::Parameters.new(
+        type: type,
+        code: code,
+        description: description,
+        page: page,
+      )
+
+      new(params)
+    end
+  end
+
+  factory :kaminari do
+    collection { [] }
+
+    initialize_with do
+      Kaminari
+        .paginate_array(collection, total_count: collection.size)
+        .page(1)
+        .per(5)
+    end
+  end
 end

--- a/spec/views/search/certificate_search_spec.rb
+++ b/spec/views/search/certificate_search_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+RSpec.describe 'search/certificate_search', type: :view, vcr: { cassette_name: 'search#certificate_search_form' } do
+  subject { render }
+
+  before { assign :result, result }
+
+  let(:result) do
+    instance_double(
+      'CertificateSearchPresenter',
+      search_form: search_form,
+      search_result: certificates,
+      with_errors: with_errors,
+    )
+  end
+
+  let(:search_form) { build(:certificate_search_form) }
+
+  context 'when there are results and no errors' do
+    let(:certificates) { build(:kaminari, collection: build_list(:certificate, 2)) }
+    let(:with_errors) { false }
+
+    it { is_expected.to have_css('article.search-results h1.govuk-heading-l', text: 'Certificate search results') }
+
+    describe 'guidance' do
+      context 'when on the uk service' do
+        include_context 'with UK service'
+
+        it { is_expected.to have_css('details summary span', text: 'Using this certificate on CDS or CHIEF') }
+      end
+
+      context 'when on the xi service' do
+        include_context 'with XI service'
+
+        it { is_expected.not_to have_css('details summary span', text: 'Using this certificate on CDS or CHIEF') }
+      end
+    end
+  end
+
+  context 'when there are no results and the search includes errors' do
+    let(:certificates) { [] }
+    let(:with_errors) { true }
+
+    it { is_expected.to have_css('article.search-results h1.govuk-heading-l', text: /Sorry, there is a problem with the search query./) }
+  end
+
+  context 'when there are no results and no errors' do
+    let(:certificates) { [] }
+    let(:with_errors) { false }
+
+    it { is_expected.to have_css('article.search-results h1.govuk-heading-l', text: 'There are no matching results') }
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1468

### What?

I have added/removed/altered:

- [x] Only show guidance on UK service data

### Why?

I am doing this because:

- CDS and CHIEF guidance is never relevant on European data
