### PR TITLE
HOTT-1449 expose resource id on api entities

### DIFF
--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -35,7 +35,7 @@ module ApiEntity
     include Faraday
     include MultiJson
 
-    attr_reader :attributes
+    attr_reader :resource_id, :attributes
     attr_writer :resource_type
 
     attr_accessor :casted_by
@@ -76,6 +76,10 @@ module ApiEntity
     attributes = HashWithIndifferentAccess.new(attributes)
 
     self.attributes = attributes
+  end
+
+  def resource_id=(resource_id)
+    @resource_id ||= resource_id # rubocop:disable Naming/MemoizedInstanceVariableName
   end
 
   def attributes=(attributes = {})

--- a/lib/tariff_jsonapi_parser.rb
+++ b/lib/tariff_jsonapi_parser.rb
@@ -32,6 +32,7 @@ class TariffJsonapiParser
     result = {}
 
     parse_type!(resource, result)
+    parse_id!(resource, result)
     parse_attributes!(resource, result) if resource.key?('attributes')
     parse_relationships!(resource['relationships'], result) if resource.key?('relationships')
     parse_meta!(resource, result) if resource.key?('meta')
@@ -47,6 +48,10 @@ class TariffJsonapiParser
 
   def parse_type!(resource, parent)
     parent.merge!('resource_type' => resource['type'])
+  end
+
+  def parse_id!(resource, parent)
+    parent.merge!('resource_id' => resource['id'])
   end
 
   def parse_attributes!(resource, parent)

--- a/spec/fixtures/jsonapi/multiple_with_relationship.json
+++ b/spec/fixtures/jsonapi/multiple_with_relationship.json
@@ -12,7 +12,7 @@
         "parts": {
           "data": [
             {
-              "id": 456,
+              "id": "456",
               "type": "part"
             }
           ]
@@ -23,7 +23,7 @@
   "included": [
     {
       "meta": { "foo": "bar" },
-      "id": 456,
+      "id": "456",
       "type": "part",
       "attributes": {
         "part_name": "A part name"

--- a/spec/fixtures/jsonapi/singular_with_relationship.json
+++ b/spec/fixtures/jsonapi/singular_with_relationship.json
@@ -11,7 +11,7 @@
       "parts": {
         "data": [
           {
-            "id": 456,
+            "id": "456",
             "type": "part"
           }
         ]
@@ -21,7 +21,7 @@
   "included": [
     {
       "meta": { "foo": "bar" },
-      "id": 456,
+      "id": "456",
       "type": "part",
       "attributes": {
         "part_name": "A part name"

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -53,6 +53,24 @@ RSpec.describe ApiEntity do
     end
   end
 
+  describe '#resource_id' do
+    subject(:resource_id) { instance.resource_id }
+
+    let(:instance) { mock_entity.new(resource_id: '123') }
+
+    it { is_expected.to eq '123' }
+
+    context 'when reassigning id' do
+      let(:instance) do
+        mock_entity.new(resource_id: '123').tap do |instance|
+          instance.resource_id = '456'
+        end
+      end
+
+      it { is_expected.to eq '123' }
+    end
+  end
+
   describe '#find' do
     subject(:request) { mock_entity.find(123) }
 
@@ -70,13 +88,13 @@ RSpec.describe ApiEntity do
     context 'with valid response' do
       let(:body) { file_fixture('jsonapi/singular_no_relationship.json').read }
 
-      it { is_expected.to have_attributes name: 'Joe', age: 21 }
+      it { is_expected.to have_attributes resource_id: '123', name: 'Joe', age: 21 }
     end
 
     context 'with valid response and nil relationship' do
       let(:body) { file_fixture('jsonapi/singular_valid_null_singular_relationship.json').read }
 
-      it { is_expected.to have_attributes name: 'Joe', age: 21, part: nil }
+      it { is_expected.to have_attributes resource_id: '123', name: 'Joe', age: 21, part: nil }
     end
 
     context 'with 400 response' do
@@ -138,7 +156,7 @@ RSpec.describe ApiEntity do
       let(:body) { file_fixture('jsonapi/multiple_no_relationship.json').read }
 
       it { is_expected.to have_attributes length: 1 }
-      it { expect(request.first).to have_attributes name: 'Joe', age: 21 }
+      it { expect(request.first).to have_attributes resource_id: '123', name: 'Joe', age: 21 }
     end
 
     context 'with 400 response' do

--- a/spec/lib/tariff_jsonapi_parser_spec.rb
+++ b/spec/lib/tariff_jsonapi_parser_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe TariffJsonapiParser do
     let(:json) { JSON.parse file_fixture("jsonapi/#{json_file}.json").read }
 
     context 'with singular resource' do
-      subject(:parse) { described_class.new(json).parse }
+      subject(:parsed) { described_class.new(json).parse }
 
       context 'with valid' do
         let(:json_file) { 'singular_no_relationship' }
 
         it { is_expected.to include 'resource_type' => 'mock_entity' }
+        it { is_expected.to include 'resource_id' => '123' }
         it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
@@ -20,6 +21,7 @@ RSpec.describe TariffJsonapiParser do
         let(:json_file) { 'singular_no_attributes' }
 
         it { is_expected.to include 'resource_type' => 'mock_entity' }
+        it { is_expected.to include 'resource_id' => '123' }
         it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.not_to include 'name' }
       end
@@ -28,16 +30,26 @@ RSpec.describe TariffJsonapiParser do
         let(:json_file) { 'singular_with_relationship' }
 
         it { is_expected.to include 'resource_type' => 'mock_entity' }
+        it { is_expected.to include 'resource_id' => '123' }
         it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
-        it { is_expected.to include 'parts' => [{ 'resource_type' => 'part', 'meta' => { 'foo' => 'bar' }, 'part_name' => 'A part name' }] }
+
+        it 'maps relationship data' do
+          expect(parsed).to include 'parts' => [{
+            'resource_type' => 'part',
+            'resource_id' => '456',
+            'meta' => { 'foo' => 'bar' },
+            'part_name' => 'A part name',
+          }]
+        end
       end
 
       context 'with valid missing relationship' do
         let(:json_file) { 'singular_valid_null_singular_relationship' }
 
         it { is_expected.to include 'resource_type' => 'mock_entity' }
+        it { is_expected.to include 'resource_id' => '123' }
         it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
@@ -48,6 +60,7 @@ RSpec.describe TariffJsonapiParser do
         let(:json_file) { 'singular_missing_relationship' }
 
         it { is_expected.to include 'resource_type' => 'mock_entity' }
+        it { is_expected.to include 'resource_id' => '123' }
         it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
@@ -58,7 +71,7 @@ RSpec.describe TariffJsonapiParser do
         let(:json_file) { 'singular_invalid_relationship' }
 
         it 'raises a description exception' do
-          expect { parse }.to raise_exception \
+          expect { parsed }.to raise_exception \
             described_class::ParsingError,
             "Error finding relationship 'parts': nil"
         end
@@ -66,12 +79,13 @@ RSpec.describe TariffJsonapiParser do
     end
 
     context 'with array resource' do
-      subject(:parse) { described_class.new(json).parse.first }
+      subject(:parsed) { described_class.new(json).parse.first }
 
       context 'with valid' do
         let(:json_file) { 'multiple_no_relationship' }
 
         it { is_expected.to include 'resource_type' => 'mock_entity' }
+        it { is_expected.to include 'resource_id' => '123' }
         it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
@@ -81,16 +95,26 @@ RSpec.describe TariffJsonapiParser do
         let(:json_file) { 'multiple_with_relationship' }
 
         it { is_expected.to include 'resource_type' => 'mock_entity' }
+        it { is_expected.to include 'resource_id' => '123' }
         it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
-        it { is_expected.to include 'parts' => [{ 'resource_type' => 'part', 'meta' => { 'foo' => 'bar' }, 'part_name' => 'A part name' }] }
+
+        it 'maps relationship data' do
+          expect(parsed).to include 'parts' => [{
+            'resource_type' => 'part',
+            'resource_id' => '456',
+            'meta' => { 'foo' => 'bar' },
+            'part_name' => 'A part name',
+          }]
+        end
       end
 
       context 'with missing relationships' do
         let(:json_file) { 'multiple_missing_relationship' }
 
         it { is_expected.to include 'resource_type' => 'mock_entity' }
+        it { is_expected.to include 'resource_id' => '123' }
         it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
@@ -101,7 +125,7 @@ RSpec.describe TariffJsonapiParser do
         let(:json_file) { 'multiple_invalid_relationship' }
 
         it 'raises a description exception' do
-          expect { parse }.to raise_exception \
+          expect { parsed }.to raise_exception \
             described_class::ParsingError,
             "Error finding relationship 'parts': nil"
         end


### PR DESCRIPTION
### Jira link

HOTT-1449

### What?

I have added/removed/altered:

- [x] Added parsing the resource id to the Jsonapi Parser
- [x] Added a generic resource_id to ApiEntity
- [x] Added equality checking to ApiEntity

### Why?

I am doing this because:

- So that I can de-duplicate measure conditions in permutations dialog

### Deployment risks (optional)

- Makes changes to the ApiEntity class which is the foundation of our data layer
