### PR TITLE
HOTT-1449 Permutations modal

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -14,3 +14,4 @@ TARIFF_API_VERSION=2
 TARIFF_FROM_EMAIL=no-reply@example.com
 TARIFF_TO_EMAIL=support@example.com
 UPDATED_NAVIGATION=true
+PERMUTATIONS=true

--- a/.env.test
+++ b/.env.test
@@ -13,3 +13,4 @@ TARIFF_FROM_EMAIL=no-reply@example.com
 TARIFF_TO_EMAIL=support@example.com
 UPDATED_NAVIGATION=true
 NEWS_ITEMS_ENABLED=true
+PERMUTATIONS=true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -128,4 +128,8 @@ module ApplicationHelper
       from
     end
   end
+
+  def paragraph_if_content(content)
+    tag.p(content) if content.present?
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,9 +43,9 @@ module ApplicationHelper
     extra_content = block_given? ? capture(&block) : nil
 
     render 'shared/page_header',
-           heading_text: heading_text,
+           heading_text:,
            show_switch_service: is_switch_service_banner_enabled?,
-           extra_content: extra_content
+           extra_content:
   end
 
   def govuk_header_navigation_item(active_class: '', &block)

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -82,8 +82,7 @@ module MeasuresHelper
   end
 
   def format_measure_condition_document_code(condition)
-    case condition.measure_condition_class
-    when 'threshold'
+    if condition.measure_condition_class.threshold?
       'Threshold condition'
     else
       condition.document_code

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -73,7 +73,9 @@ module MeasuresHelper
         condition.requirement.presence || 'Condition not fulfilled'
       end
     else
-      (condition.certificate_description.presence || condition.requirement)
+      (condition.certificate_description.presence ||
+        condition.requirement.presence ||
+        'No document provided')
         .to_s
         .html_safe
     end

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -61,4 +61,24 @@ module MeasuresHelper
       safe_join components.flatten.compact, ' '
     end
   end
+
+  def format_measure_condition_requirement(condition)
+    case condition.measure_condition_class
+    when 'threshold'
+      'FIXME: need unit type'
+    else
+      (condition.certificate_description.presence || condition.requirement)
+        .to_s
+        .html_safe
+    end
+  end
+
+  def format_measure_condition_document_code(condition)
+    case condition.measure_condition_class
+    when 'threshold'
+      'Threshold condition'
+    else
+      condition.document_code
+    end
+  end
 end

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -81,4 +81,20 @@ module MeasuresHelper
       condition.document_code
     end
   end
+
+  def format_combined_conditions_requirement(conditions)
+    if conditions.length == 2
+      if conditions.map(&:measure_condition_class).all?(&:document?)
+        'Provide both documents'
+      else
+        'Meet both conditions'
+      end
+    elsif conditions.many?
+      if conditions.map(&:measure_condition_class).all?(&:document?)
+        'Provide all documents'
+      else
+        'Meet all conditions'
+      end
+    end
+  end
 end

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -65,7 +65,13 @@ module MeasuresHelper
   def format_measure_condition_requirement(condition)
     case condition.measure_condition_class
     when 'threshold'
-      'FIXME: need unit type'
+      if condition.is_weight_condition?
+        safe_join ['The weight of your goods must not exceed', condition.requirement], ' '
+      elsif condition.is_volume_condition?
+        safe_join ['The volume of your goods must not exceed', condition.requirement], ' '
+      else
+        condition.requirement.presence || 'Condition not fulfilled'
+      end
     else
       (condition.certificate_description.presence || condition.requirement)
         .to_s

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -65,7 +65,9 @@ module MeasuresHelper
   def format_measure_condition_requirement(condition)
     case condition.measure_condition_class
     when 'threshold'
-      if condition.is_weight_condition?
+      if condition.is_price_condition?
+        safe_join ['The price of your goods must not exceed', condition.requirement], ' '
+      elsif condition.is_weight_condition?
         safe_join ['The weight of your goods must not exceed', condition.requirement], ' '
       elsif condition.is_volume_condition?
         safe_join ['The volume of your goods must not exceed', condition.requirement], ' '

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -26,6 +26,7 @@ class Measure
   has_many :excluded_countries, class_name: 'GeographicalArea'
   has_many :measure_components
   has_many :measure_conditions
+  has_many :measure_condition_permutation_groups
   has_many :footnotes
   has_one :goods_nomenclature, polymorphic: true
 

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -10,7 +10,8 @@ class MeasureCondition
                 :duty_expression,
                 :certificate_description,
                 :guidance_cds,
-                :guidance_chief
+                :guidance_chief,
+                :measure_condition_class
 
   attr_writer :requirement
 

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -10,10 +10,10 @@ class MeasureCondition
                 :duty_expression,
                 :certificate_description,
                 :guidance_cds,
-                :guidance_chief,
-                :measure_condition_class
+                :guidance_chief
 
   attr_writer :requirement
+  attr_reader :measure_condition_class
 
   def requirement
     @requirement&.html_safe
@@ -21,5 +21,10 @@ class MeasureCondition
 
   def has_guidance?
     guidance_cds.present? || guidance_chief.present?
+  end
+
+  def measure_condition_class=(condition_class)
+    @measure_condition_class =
+      ActiveSupport::StringInquirer.new(condition_class.to_s)
   end
 end

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -3,7 +3,11 @@ require 'api_entity'
 class MeasureCondition
   include ApiEntity
 
+  WEIGHT_UNITS = %w[DTN DAP DHS GFI GRM GRT KGM KMA RET TNE].freeze
+  VOLUME_UNITS = %w[HLT KLT LPA LTR MIL MTQ].freeze
+
   attr_accessor :condition_code,
+                :condition_measurement_unit_code,
                 :condition,
                 :document_code,
                 :action,
@@ -26,5 +30,13 @@ class MeasureCondition
   def measure_condition_class=(condition_class)
     @measure_condition_class =
       ActiveSupport::StringInquirer.new(condition_class.to_s)
+  end
+
+  def is_weight_condition?
+    WEIGHT_UNITS.include? condition_measurement_unit_code
+  end
+
+  def is_volume_condition?
+    VOLUME_UNITS.include? condition_measurement_unit_code
   end
 end

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -8,6 +8,7 @@ class MeasureCondition
 
   attr_accessor :condition_code,
                 :condition_measurement_unit_code,
+                :condition_monetary_unit_code,
                 :condition,
                 :document_code,
                 :action,
@@ -30,6 +31,10 @@ class MeasureCondition
   def measure_condition_class=(condition_class)
     @measure_condition_class =
       ActiveSupport::StringInquirer.new(condition_class.to_s)
+  end
+
+  def is_price_condition?
+    condition_monetary_unit_code.present?
   end
 
   def is_weight_condition?

--- a/app/models/measure_condition_permutation.rb
+++ b/app/models/measure_condition_permutation.rb
@@ -1,0 +1,7 @@
+require 'api_entity'
+
+class MeasureConditionPermutation
+  include ApiEntity
+
+  has_many :measure_conditions
+end

--- a/app/models/measure_condition_permutation_group.rb
+++ b/app/models/measure_condition_permutation_group.rb
@@ -1,0 +1,9 @@
+require 'api_entity'
+
+class MeasureConditionPermutationGroup
+  include ApiEntity
+
+  attr_accessor :condition_code
+
+  has_many :permutations, class_name: 'MeasureConditionPermutation'
+end

--- a/app/presenters/measure_presenter.rb
+++ b/app/presenters/measure_presenter.rb
@@ -46,4 +46,8 @@ class MeasurePresenter < SimpleDelegator
       }
     end
   end
+
+  def permutations_enabled?
+    TradeTariffFrontend.permutations? && measure_condition_permutation_groups.any?
+  end
 end

--- a/app/views/measure_conditions/_permutation.html.erb
+++ b/app/views/measure_conditions/_permutation.html.erb
@@ -8,11 +8,7 @@
   </td>
 
   <td class="govuk-table__cell">
-    <% if permutation.measure_conditions.length == 2 %>
-      <p>Meet both conditions</p>
-    <% elsif permutation.measure_conditions.many? %>
-      <p>Meet all conditions</p>
-    <% end %>
+    <%= paragraph_if_content format_combined_conditions_requirement(permutation.measure_conditions) %>
 
     <% permutation.measure_conditions.each.with_index do |condition, index| %>
       <%= tag.p('and') unless index.zero? %>

--- a/app/views/measure_conditions/_permutation.html.erb
+++ b/app/views/measure_conditions/_permutation.html.erb
@@ -1,0 +1,13 @@
+<tr class="govuk-table__row">
+  <td class="govuk-table__cell numerical">
+    <%= safe_join permutation.measure_conditions.map(&:document_code), ' + ' %>
+  </td>
+
+  <td class="govuk-table__cell">
+    TBD
+  </td>
+
+  <td class="govuk-table__cell">
+    TBD
+  </td>
+</tr>

--- a/app/views/measure_conditions/_permutation.html.erb
+++ b/app/views/measure_conditions/_permutation.html.erb
@@ -1,13 +1,34 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell numerical">
-    <%= safe_join permutation.measure_conditions.map(&:document_code), ' + ' %>
+    <% permutation.measure_conditions.each.with_index do |condition, index| %>
+      <%= ' + ' unless index.zero? %>
+
+      <%= format_measure_condition_document_code condition %>
+    <% end %>
   </td>
 
   <td class="govuk-table__cell">
-    TBD
+    <% if permutation.measure_conditions.length == 2 %>
+      <p>Meet both conditions</p>
+    <% elsif permutation.measure_conditions.many? %>
+      <p>Meet all conditions</p>
+    <% end %>
+
+    <% permutation.measure_conditions.each.with_index do |condition, index| %>
+      <%= tag.p('and') unless index.zero? %>
+
+      <p>
+        <%= format_measure_condition_requirement condition %>
+      </p>
+    <% end %>
   </td>
 
   <td class="govuk-table__cell">
-    TBD
+    <% if permutation.measure_conditions.first.action.present? %>
+      <%= permutation.measure_conditions.first.action %>
+      <br />
+    <% end %>
+
+    <%= permutation.measure_conditions.first.duty_expression.to_s.html_safe %>
   </td>
 </tr>

--- a/app/views/measure_conditions/_permutation.html.erb
+++ b/app/views/measure_conditions/_permutation.html.erb
@@ -25,6 +25,6 @@
       <br />
     <% end %>
 
-    <%= permutation.measure_conditions.first.duty_expression.to_s.html_safe %>
+    <%= sanitize permutation.measure_conditions.first.duty_expression.to_s %>
   </td>
 </tr>

--- a/app/views/measure_conditions/_permutation_group.html.erb
+++ b/app/views/measure_conditions/_permutation_group.html.erb
@@ -6,7 +6,7 @@
     Meet the following condition
     <% end %>
 
-    and supply the relevant document code(s) on your declation.
+    and supply the relevant document code(s) on your declaration.
   </p>
 
   <table class="govuk-table govuk-!-margin-bottom-2">

--- a/app/views/measure_conditions/_permutation_group.html.erb
+++ b/app/views/measure_conditions/_permutation_group.html.erb
@@ -1,26 +1,26 @@
-<p>
-  Meet
+<div class="permutation-group">
+  <p>
+    <% if permutation_group.permutations.many? %>
+    Meet one of the following conditions
+    <% else %>
+    Meet the following condition
+    <% end %>
 
-  <% if permutation_group.permutations.many? %>
-  one of the following conditions
-  <% else %>
-  the following condition
-  <% end %>
+    and supply the relevant document code(s) on your declation.
+  </p>
 
-  and supply the relevant document code(s) on your declation.
-</p>
+  <table class="govuk-table govuk-!-margin-bottom-2">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Document code</th>
+        <th scope="col" class="govuk-table__header">Requirement</th>
+        <th scope="col" class="govuk-table__header">Action</th>
+      </tr>
+    </thead>
 
-<table class="govuk-table govuk-!-margin-bottom-2">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Document code</th>
-      <th scope="col" class="govuk-table__header">Requirement</th>
-      <th scope="col" class="govuk-table__header">Action</th>
-    </tr>
-  </thead>
-
-  <tbody class="govuk-table__body">
-    <%= render partial: 'measure_conditions/permutation',
-               collection: permutation_group.permutations %>
-  </tbody>
-</table>
+    <tbody class="govuk-table__body">
+      <%= render partial: 'measure_conditions/permutation',
+                 collection: permutation_group.permutations %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/measure_conditions/_permutation_group.html.erb
+++ b/app/views/measure_conditions/_permutation_group.html.erb
@@ -23,4 +23,11 @@
                  collection: permutation_group.permutations %>
     </tbody>
   </table>
+
+  <%= render 'measures/guidance_table',
+             measure_conditions_with_guidance: permutation_group
+                                                 .permutations
+                                                 .flat_map(&:measure_conditions)
+                                                 .select(&:has_guidance?)
+                                                 .uniq(&:resource_id) %>
 </div>

--- a/app/views/measure_conditions/_permutation_group.html.erb
+++ b/app/views/measure_conditions/_permutation_group.html.erb
@@ -1,9 +1,9 @@
 <div class="permutation-group">
   <p>
     <% if permutation_group.permutations.many? %>
-    Meet one of the following conditions
+      Meet one of the following conditions
     <% else %>
-    Meet the following condition
+      Meet the following condition
     <% end %>
 
     and supply the relevant document code(s) on your declaration.

--- a/app/views/measure_conditions/_permutation_group.html.erb
+++ b/app/views/measure_conditions/_permutation_group.html.erb
@@ -1,0 +1,26 @@
+<p>
+  Meet
+
+  <% if permutation_group.permutations.many? %>
+  one of the following conditions
+  <% else %>
+  the following condition
+  <% end %>
+
+  and supply the relevant document code(s) on your declation.
+</p>
+
+<table class="govuk-table govuk-!-margin-bottom-2">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Document code</th>
+      <th scope="col" class="govuk-table__header">Requirement</th>
+      <th scope="col" class="govuk-table__header">Action</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <%= render partial: 'measure_conditions/permutation',
+               collection: permutation_group.permutations %>
+  </tbody>
+</table>

--- a/app/views/measures/_guidance_table.html.erb
+++ b/app/views/measures/_guidance_table.html.erb
@@ -2,6 +2,7 @@
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">Guidance for completing Box 44 or Data Element 2/3</span>
   </summary>
+
   <div class="govuk-details__text  govuk-!-font-size-16">
     <table class="govuk-table govuk-!-margin-bottom-2">
       <thead class="govuk-table__head">

--- a/app/views/measures/_measure_condition_modal_default.html.erb
+++ b/app/views/measures/_measure_condition_modal_default.html.erb
@@ -5,7 +5,8 @@
 <%= render 'measures/measure_from_to', measure: measure %>
 
 <% if measure.permutations_enabled? %>
-  FIXME: Use new permutations layout
+  <%= render partial: 'measure_conditions/permutation_group',
+             collection: measure.measure_condition_permutation_groups %>
 <% else %>
   <% measure.grouped_measure_conditions.each do |condition_group, conditions| %>
     <%= render partial: "measure_conditions/measure_condition_code_#{condition_group[:partial_type]}",

--- a/app/views/measures/_measure_condition_modal_default.html.erb
+++ b/app/views/measures/_measure_condition_modal_default.html.erb
@@ -1,14 +1,21 @@
-<h3 class="govuk-heading-l govuk-!-margin-bottom-0"><%= measure.measure_type.description %> for <%= measure.geographical_area.description %></h3>
+<h3 class="govuk-heading-l govuk-!-margin-bottom-0">
+  <%= measure.measure_type.description %> for <%= measure.geographical_area.description %>
+</h3>
 
 <%= render 'measures/measure_from_to', measure: measure %>
 
-<% measure.grouped_measure_conditions.each do |condition_group, conditions| %>
-  <%= render partial: "measure_conditions/measure_condition_code_#{condition_group[:partial_type]}", locals: { condition_group: condition_group, conditions: conditions } %>
-<% end %>
+<% if measure.permutations_enabled? %>
+  FIXME: Use new permutations layout
+<% else %>
+  <% measure.grouped_measure_conditions.each do |condition_group, conditions| %>
+    <%= render partial: "measure_conditions/measure_condition_code_#{condition_group[:partial_type]}",
+               locals: { condition_group: condition_group, conditions: conditions } %>
+  <% end %>
 
-<%= render 'measures/guidance_table',
+  <%= render 'measures/guidance_table',
       measure_conditions_with_guidance: measure.measure_conditions_with_guidance
-%>
+  %>
+<% end %>
 
 <% if TradeTariffFrontend::ServiceChooser.uk? && measure.universal_waiver_applies %>
 <div class="universal-waiver-applies-panel">

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -108,6 +108,10 @@ module TradeTariffFrontend
     ENV['NEWS_ITEMS_ENABLED'].to_s == 'true'
   end
 
+  def permutations?
+    ENV['PERMUTATIONS'].to_s == 'true'
+  end
+
   class FilterBadURLEncoding
     def initialize(app)
       @app = app

--- a/spec/factories/measure_condition_factory.rb
+++ b/spec/factories/measure_condition_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :measure_condition do
+    sequence(:resource_id)
     condition_code { Forgery(:basic).text(exactly: 1) }
     condition { Forgery(:basic).text }
     document_code { Forgery(:basic).text(exactly: 4) }

--- a/spec/factories/measure_condition_factory.rb
+++ b/spec/factories/measure_condition_factory.rb
@@ -21,5 +21,15 @@ FactoryBot.define do
     trait :threshold do
       measure_condition_class { 'threshold' }
     end
+
+    trait :weight do
+      threshold
+      condition_measurement_unit_code { 'KGM' }
+    end
+
+    trait :volume do
+      threshold
+      condition_measurement_unit_code { 'LTR' }
+    end
   end
 end

--- a/spec/factories/measure_condition_factory.rb
+++ b/spec/factories/measure_condition_factory.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     requirement { Forgery(:basic).text }
     action { Forgery(:basic).text }
     duty_expression { Forgery(:basic).text }
+    measure_condition_class { document_code.presence && 'document' }
 
     trait :universal_waiver do
       document_code { '999L' }
@@ -14,6 +15,10 @@ FactoryBot.define do
     trait :with_guidance do
       guidance_cds { 'Guidance CDS' }
       guidance_chief { 'Guidance CHIEF' }
+    end
+
+    trait :threshold do
+      measure_condition_class { 'threshold' }
     end
   end
 end

--- a/spec/factories/measure_condition_factory.rb
+++ b/spec/factories/measure_condition_factory.rb
@@ -31,5 +31,15 @@ FactoryBot.define do
       threshold
       condition_measurement_unit_code { 'LTR' }
     end
+
+    trait :price do
+      threshold
+      condition_monetary_unit_code { 'EUR' }
+    end
+
+    trait :eps do
+      weight
+      price
+    end
   end
 end

--- a/spec/factories/measure_condition_permutation_factory.rb
+++ b/spec/factories/measure_condition_permutation_factory.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :measure_condition_permutation do
-    measure_conditions { attributes_for_list :measure_condition, 1 }
+    transient do
+      condition_count { 1 }
+    end
+
+    measure_conditions do
+      attributes_for_list :measure_condition, condition_count, :with_guidance
+    end
   end
 end

--- a/spec/factories/measure_condition_permutation_factory.rb
+++ b/spec/factories/measure_condition_permutation_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :measure_condition_permutation do
+    measure_conditions { attributes_for_list :measure_condition, 1 }
+  end
+end

--- a/spec/factories/measure_condition_permutation_group_factory.rb
+++ b/spec/factories/measure_condition_permutation_group_factory.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :measure_condition_permutation_group do
+    transient do
+      measure_conditions { nil }
+    end
+
+    permutations do
+      if measure_conditions
+        attributes_for_list :measure_condition_permutation, 1,
+                            measure_conditions: measure_conditions
+      else
+        attributes_for_list :measure_condition_permutation, 1
+      end
+    end
+  end
+end

--- a/spec/factories/measure_condition_permutation_group_factory.rb
+++ b/spec/factories/measure_condition_permutation_group_factory.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :measure_condition_permutation_group do
     transient do
       measure_conditions { nil }
+      condition_count { 1 }
+      permutation_count { 1 }
     end
 
     permutations do
@@ -9,7 +11,9 @@ FactoryBot.define do
         attributes_for_list :measure_condition_permutation, 1,
                             measure_conditions: measure_conditions
       else
-        attributes_for_list :measure_condition_permutation, 1
+        attributes_for_list :measure_condition_permutation,
+                            permutation_count,
+                            condition_count: condition_count
       end
     end
   end

--- a/spec/factories/measure_condition_permutation_group_factory.rb
+++ b/spec/factories/measure_condition_permutation_group_factory.rb
@@ -9,11 +9,10 @@ FactoryBot.define do
     permutations do
       if measure_conditions
         attributes_for_list :measure_condition_permutation, 1,
-                            measure_conditions: measure_conditions
+                            measure_conditions:
       else
-        attributes_for_list :measure_condition_permutation,
-                            permutation_count,
-                            condition_count: condition_count
+        attributes_for_list :measure_condition_permutation, permutation_count,
+                            condition_count:
       end
     end
   end

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -186,6 +186,17 @@ FactoryBot.define do
       end
     end
 
+    trait :with_permutations do
+      measure_condition_permutation_groups do
+        if respond_to?(:measure_conditions) && measure_conditions
+          attributes_for_list :measure_condition_permutation_group, 1,
+                              measure_conditions: measure_conditions
+        else
+          attributes_for_list :measure_condition_permutation_group, 1
+        end
+      end
+    end
+
     trait :with_additional_code do
       additional_code { attributes_for(:additional_code) }
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -308,4 +308,27 @@ RSpec.describe ApplicationHelper, type: :helper do
     it_behaves_like 'a from to expression', nil, nil, '2023-02-01'
     it_behaves_like 'a from to expression', nil, nil, nil
   end
+
+  describe '#paragraph_if_content' do
+    subject { paragraph_if_content content }
+
+    context 'with content' do
+      let(:content) { 'this is some <em>content</em>'.html_safe }
+
+      it { is_expected.to have_css 'p', text: /this is some/ }
+      it { is_expected.to have_css 'p em', text: 'content' }
+    end
+
+    context 'with nil' do
+      let(:content) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with blank string' do
+      let(:content) { '' }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -117,9 +117,24 @@ RSpec.describe MeasuresHelper, type: :helper do
     subject { format_measure_condition_requirement condition }
 
     context 'with threshold condition' do
-      let(:condition) { build :measure_condition, :threshold }
+      context 'with weight condition' do
+        let(:condition) { build :measure_condition, :weight }
 
-      xit { is_expected.to match 'Your goods must' }
+        it { is_expected.to match 'The weight of your goods must not exceed' }
+      end
+
+      context 'with volume condition' do
+        let(:condition) { build :measure_condition, :volume }
+
+        it { is_expected.to match 'The volume of your goods must not exceed' }
+      end
+
+      context 'with other threshold' do
+        let(:condition) { build :measure_condition, :threshold }
+
+        it { is_expected.to be_present }
+        it { is_expected.not_to match 'of your goods' }
+      end
     end
 
     context 'with any other classification of condition' do

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -117,17 +117,14 @@ RSpec.describe MeasuresHelper, type: :helper do
     subject { format_measure_condition_requirement condition }
 
     context 'with threshold condition' do
-      let :condition do
-        build :measure_condition, measure_condition_class: 'threshold'
-      end
+      let(:condition) { build :measure_condition, :threshold }
 
       xit { is_expected.to match 'Your goods must' }
     end
 
     context 'with any other classification of condition' do
       let :condition do
-        build :measure_condition, measure_condition_class: nil,
-                                  certificate_description: 'test description'
+        build :measure_condition, certificate_description: 'test description'
       end
 
       it { is_expected.to match 'test description' }
@@ -138,20 +135,55 @@ RSpec.describe MeasuresHelper, type: :helper do
     subject { format_measure_condition_document_code condition }
 
     context 'with threshold condition' do
-      let :condition do
-        build :measure_condition, measure_condition_class: 'threshold'
-      end
+      let(:condition) { build :measure_condition, :threshold }
 
       it { is_expected.to eql 'Threshold condition' }
     end
 
     context 'with any other classification of condition' do
-      let :condition do
-        build :measure_condition, measure_condition_class: nil,
-                                  document_code: 'X123'
-      end
+      let(:condition) { build :measure_condition, document_code: 'X123' }
 
       it { is_expected.to eql 'X123' }
+    end
+  end
+
+  describe '#format_combined_conditions_requirement' do
+    subject { format_combined_conditions_requirement conditions }
+
+    context 'with one threshold condition' do
+      let(:conditions) { build_list :measure_condition, 1, :threshold }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with one document condition' do
+      let(:conditions) { build_list :measure_condition, 1 }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with two threshold conditions' do
+      let(:conditions) { build_pair :measure_condition, :threshold }
+
+      it { is_expected.to eql 'Meet both conditions' }
+    end
+
+    context 'with two document conditions' do
+      let(:conditions) { build_pair :measure_condition }
+
+      it { is_expected.to eql 'Provide both documents' }
+    end
+
+    context 'with three threshold conditions' do
+      let(:conditions) { build_list :measure_condition, 3, :threshold }
+
+      it { is_expected.to eql 'Meet all conditions' }
+    end
+
+    context 'with three document conditions' do
+      let(:conditions) { build_list :measure_condition, 3 }
+
+      it { is_expected.to eql 'Provide all documents' }
     end
   end
 end

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -112,4 +112,46 @@ RSpec.describe MeasuresHelper, type: :helper do
       it { is_expected.to match expected }
     end
   end
+
+  describe '#format_measure_condition_requirement' do
+    subject { format_measure_condition_requirement condition }
+
+    context 'with threshold condition' do
+      let :condition do
+        build :measure_condition, measure_condition_class: 'threshold'
+      end
+
+      xit { is_expected.to match 'Your goods must' }
+    end
+
+    context 'with any other classification of condition' do
+      let :condition do
+        build :measure_condition, measure_condition_class: nil,
+                                  certificate_description: 'test description'
+      end
+
+      it { is_expected.to match 'test description' }
+    end
+  end
+
+  describe '#format_measure_condition_document_code' do
+    subject { format_measure_condition_document_code condition }
+
+    context 'with threshold condition' do
+      let :condition do
+        build :measure_condition, measure_condition_class: 'threshold'
+      end
+
+      it { is_expected.to eql 'Threshold condition' }
+    end
+
+    context 'with any other classification of condition' do
+      let :condition do
+        build :measure_condition, measure_condition_class: nil,
+                                  document_code: 'X123'
+      end
+
+      it { is_expected.to eql 'X123' }
+    end
+  end
 end

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -138,11 +138,32 @@ RSpec.describe MeasuresHelper, type: :helper do
     end
 
     context 'with any other classification of condition' do
-      let :condition do
-        build :measure_condition, certificate_description: 'test description'
+      context 'with certificate description' do
+        let :condition do
+          build :measure_condition, certificate_description: 'test description',
+                                    requirement: 'test requirement'
+        end
+
+        it { is_expected.to match 'test description' }
       end
 
-      it { is_expected.to match 'test description' }
+      context 'with requirement but no certificate description' do
+        let :condition do
+          build :measure_condition, certificate_description: nil,
+                                    requirement: 'test requirement'
+        end
+
+        it { is_expected.to match 'test requirement' }
+      end
+
+      context 'with neither' do
+        let :condition do
+          build :measure_condition, certificate_description: nil,
+                                    requirement: nil
+        end
+
+        it { is_expected.to match 'No document provided' }
+      end
     end
   end
 

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -129,6 +129,18 @@ RSpec.describe MeasuresHelper, type: :helper do
         it { is_expected.to match 'The volume of your goods must not exceed' }
       end
 
+      context 'with price condition' do
+        let(:condition) { build :measure_condition, :price }
+
+        it { is_expected.to match 'The price of your goods must not exceed' }
+      end
+
+      context 'with eps condition' do
+        let(:condition) { build :measure_condition, :eps }
+
+        it { is_expected.to match 'The price of your goods must not exceed' }
+      end
+
       context 'with other threshold' do
         let(:condition) { build :measure_condition, :threshold }
 

--- a/spec/models/measure_condition_permutation_group_spec.rb
+++ b/spec/models/measure_condition_permutation_group_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+RSpec.describe MeasureConditionPermutationGroup do
+  it { is_expected.to respond_to :condition_code }
+  it { is_expected.to respond_to :permutations }
+  it { is_expected.to have_attributes permutations: instance_of(Array) }
+  it { is_expected.to have_attributes relationships: include(:permutations) }
+end

--- a/spec/models/measure_condition_permutation_spec.rb
+++ b/spec/models/measure_condition_permutation_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe MeasureConditionPermutation do
+  it { is_expected.to respond_to :measure_conditions }
+  it { is_expected.to have_attributes measure_conditions: instance_of(Array) }
+  it { is_expected.to have_attributes relationships: include(:measure_conditions) }
+end

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -39,4 +39,32 @@ RSpec.describe MeasureCondition do
       it { is_expected.not_to have_guidance }
     end
   end
+
+  describe '#measure_condition_class' do
+    subject { condition.measure_condition_class }
+
+    let :condition do
+      build :measure_condition, measure_condition_class: condition_class
+    end
+
+    context 'with nil class' do
+      let(:condition_class) { nil }
+
+      it { is_expected.to eql '' }
+      it { is_expected.to respond_to :threshold? }
+      it { is_expected.to respond_to :document? }
+      it { is_expected.to have_attributes 'threshold?': false }
+      it { is_expected.to have_attributes 'document?': false }
+    end
+
+    context 'with document_class' do
+      let(:condition_class) { 'document' }
+
+      it { is_expected.to eql 'document' }
+      it { is_expected.to respond_to :threshold? }
+      it { is_expected.to respond_to :document? }
+      it { is_expected.to have_attributes 'threshold?': false }
+      it { is_expected.to have_attributes 'document?': true }
+    end
+  end
 end

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -3,6 +3,14 @@ require 'spec_helper'
 RSpec.describe MeasureCondition do
   subject(:condition) { build(:measure_condition) }
 
+  it { is_expected.to respond_to :condition_code }
+  it { is_expected.to respond_to :condition }
+  it { is_expected.to respond_to :document_code }
+  it { is_expected.to respond_to :action }
+  it { is_expected.to respond_to :duty_expression }
+  it { is_expected.to respond_to :certificate_description }
+  it { is_expected.to respond_to :measure_condition_class }
+
   describe '#requirement' do
     it { expect(condition.requirement).to be_html_safe }
   end

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -67,4 +67,58 @@ RSpec.describe MeasureCondition do
       it { is_expected.to have_attributes 'document?': true }
     end
   end
+
+  describe '#is_weight_condition?' do
+    subject { condition.is_weight_condition? }
+
+    context 'with weight unit' do
+      let(:condition) { build :measure_condition, :weight }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with other unit' do
+      let(:condition) { build :measure_condition, :volume }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#is_volume_condition?' do
+    subject { condition.is_volume_condition? }
+
+    context 'with volume unit' do
+      let(:condition) { build :measure_condition, :volume }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with other unit' do
+      let(:condition) { build :measure_condition, :weight }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#is_price_condition?' do
+    subject { condition.is_price_condition? }
+
+    context 'with price unit' do
+      let(:condition) { build :measure_condition, :price }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with other unit' do
+      let(:condition) { build :measure_condition, :weight }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with eps condition' do
+      let(:condition) { build :measure_condition, :eps }
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Measure do
         excluded_countries
         measure_components
         measure_conditions
+        measure_condition_permutation_groups
         footnotes
         goods_nomenclature
       ]

--- a/spec/views/measure_conditions/_permutation.html.erb_spec.rb
+++ b/spec/views/measure_conditions/_permutation.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe 'measure_conditions/permutation', type: :view do
+  subject { render_page && rendered }
+
+  let :render_page do
+    render 'measure_conditions/permutation', permutation: permutation
+  end
+
+  let :permutation do
+    build :measure_condition_permutation, measure_conditions: conditions
+  end
+
+  let(:conditions) { [condition] }
+  let(:condition) { attributes_for :measure_condition }
+
+  it { is_expected.to have_css 'tr td', count: 3 }
+  it { is_expected.to have_css 'tr td:nth-of-type(1)', text: Regexp.new(condition[:document_code]) }
+  it { is_expected.to have_css 'tr td:nth-of-type(2)', text: Regexp.new(condition[:requirement]) }
+  it { is_expected.to have_css 'tr td:nth-of-type(3)', text: Regexp.new(condition[:action]) }
+  it { is_expected.to have_css 'tr td:nth-of-type(3)', text: Regexp.new(condition[:duty_expression]) }
+  it { is_expected.to have_css 'tr td:nth-of-type(3) br', count: 1 }
+
+  context 'with multiple conditions in permutation' do
+    let(:conditions) { attributes_for_pair :measure_condition }
+
+    it { is_expected.to have_css 'tr td', count: 3 }
+    it { is_expected.to have_css 'tr td:nth-of-type(1)', text: ' + ' }
+    it { is_expected.to have_css 'tr td:nth-of-type(2) p', text: 'and' }
+    it { is_expected.to have_css 'tr td:nth-of-type(3) br', count: 1 }
+  end
+end

--- a/spec/views/measure_conditions/_permutation.html.erb_spec.rb
+++ b/spec/views/measure_conditions/_permutation.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'measure_conditions/permutation', type: :view do
   subject { render_page && rendered }
 
   let :render_page do
-    render 'measure_conditions/permutation', permutation: permutation
+    render 'measure_conditions/permutation', permutation:
   end
 
   let :permutation do

--- a/spec/views/measure_conditions/_permutation_group.html.erb_spec.rb
+++ b/spec/views/measure_conditions/_permutation_group.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe 'measure_conditions/permutation_group', type: :view do
+  subject { render_page && rendered }
+
+  let :render_page do
+    render 'measure_conditions/permutation_group',
+           permutation_group: permutation_group
+  end
+
+  let(:permutation_group) { build :measure_condition_permutation_group }
+
+  it { is_expected.to have_css '.permutation-group' }
+  it { is_expected.to have_css '.permutation-group table thead tr' }
+  it { is_expected.to have_css '.permutation-group table tbody tr', count: 1 }
+  it { is_expected.to have_css '.permutation-group > p', text: /Meet the following condition/ }
+
+  context 'with multiple permutations' do
+    let :permutation_group do
+      build :measure_condition_permutation_group,
+            permutations: attributes_for_pair(:measure_condition_permutation)
+    end
+
+    it { is_expected.to have_css '.permutation-group table tbody tr', count: 2 }
+    it { is_expected.to have_css '.permutation-group > p', text: /Meet one of the following/ }
+  end
+end

--- a/spec/views/measure_conditions/_permutation_group.html.erb_spec.rb
+++ b/spec/views/measure_conditions/_permutation_group.html.erb_spec.rb
@@ -5,23 +5,46 @@ RSpec.describe 'measure_conditions/permutation_group', type: :view do
 
   let :render_page do
     render 'measure_conditions/permutation_group',
-           permutation_group: permutation_group
+           permutation_group: group
   end
 
-  let(:permutation_group) { build :measure_condition_permutation_group }
+  let(:group) { build :measure_condition_permutation_group, condition_count: 2 }
 
   it { is_expected.to have_css '.permutation-group' }
-  it { is_expected.to have_css '.permutation-group table thead tr' }
-  it { is_expected.to have_css '.permutation-group table tbody tr', count: 1 }
+  it { is_expected.to have_css '.permutation-group > table thead tr' }
+  it { is_expected.to have_css '.permutation-group > table tbody tr', count: 1 }
   it { is_expected.to have_css '.permutation-group > p', text: /Meet the following condition/ }
+  it { is_expected.to have_css '.permutation-group > details', count: 1 }
+  it { is_expected.to have_css '.permutation-group > details tbody tr', count: 2 }
 
   context 'with multiple permutations' do
-    let :permutation_group do
-      build :measure_condition_permutation_group,
-            permutations: attributes_for_pair(:measure_condition_permutation)
+    let :group do
+      build :measure_condition_permutation_group, permutation_count: 2,
+                                                  condition_count: 2
     end
 
-    it { is_expected.to have_css '.permutation-group table tbody tr', count: 2 }
+    it { is_expected.to have_css '.permutation-group > table tbody tr', count: 2 }
     it { is_expected.to have_css '.permutation-group > p', text: /Meet one of the following/ }
+    it { is_expected.to have_css '.permutation-group > details', count: 1 }
+    it { is_expected.to have_css '.permutation-group > details tbody tr', count: 4 }
+  end
+
+  context 'with permutations with repeated conditions' do
+    let :group do
+      build :measure_condition_permutation_group,
+            permutations: [
+              attributes_for(:measure_condition_permutation,
+                             measure_conditions: [shared, first]),
+              attributes_for(:measure_condition_permutation,
+                             measure_conditions: [shared, second]),
+            ]
+    end
+
+    let(:shared) { attributes_for :measure_condition, :with_guidance }
+    let(:first)  { attributes_for :measure_condition, :with_guidance }
+    let(:second) { attributes_for :measure_condition, :with_guidance }
+
+    it { is_expected.to have_css '.permutation-group > details', count: 1 }
+    it { is_expected.to have_css '.permutation-group > details tbody tr', count: 3 }
   end
 end

--- a/spec/views/measures/_measure_condition_modal_default.html.erb_spec.rb
+++ b/spec/views/measures/_measure_condition_modal_default.html.erb_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'measures/_measure_condition_modal_default', type: :view do
 
     it { is_expected.to render_template('measures/_measure_from_to') }
     it { is_expected.not_to have_css '.universal-waiver-applies-panel' }
+    it { is_expected.not_to have_css '.permutation-group' }
   end
 
   context 'with measure which universal waiver applies to' do
@@ -31,5 +32,29 @@ RSpec.describe 'measures/_measure_condition_modal_default', type: :view do
       it { is_expected.to render_template('measures/_measure_from_to') }
       it { is_expected.not_to have_css '.universal-waiver-applies-panel' }
     end
+  end
+
+  context 'with permutations enabled' do
+    let(:measure) { build :measure, :with_conditions, :with_permutations }
+
+    it { is_expected.to have_css '.permutation-group', count: 1 }
+  end
+
+  context 'with multiple permutation groups' do
+    let :measure do
+      build :measure, measure_conditions: conditions,
+                      measure_condition_permutation_groups: groups
+    end
+
+    let(:conditions) { attributes_for_pair :measure_condition }
+
+    let :groups do
+      conditions.map do |measure_condition|
+        attributes_for :measure_condition_permutation_group,
+                       measure_conditions: [measure_condition]
+      end
+    end
+
+    it { is_expected.to have_css '.permutation-group', count: 2 }
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1449](https://transformuk.atlassian.net/browse/HOTT-1449)

### What?

I have added/removed/altered:

- [x] Added ApiEntity models for the Permutation and Permutation Groups
- [x] Feature flagged showing the permutations dialog
- [x] Added a new 'permutations' dialog replacing the existing 'non overridden' measure conditions modals
- [x] Show the appropriate guidance for each permutation group

### Why?

I am doing this because:

- We wish to more clearly show which combinations of conditions are available to our users

### Screenshots

![Screenshot from 2022-05-13 12-31-12](https://user-images.githubusercontent.com/10818/168274731-0f044b3d-4aa1-4336-b006-5e5aee4885a5.png)
![Screenshot from 2022-05-13 12-30-41](https://user-images.githubusercontent.com/10818/168274734-d5b4f905-671f-4361-85f3-76b32efe26b5.png)
![Screenshot from 2022-05-13 12-29-47](https://user-images.githubusercontent.com/10818/168274738-484b742a-2fe5-4b01-828b-7f369fc0d63d.png)
![Screenshot from 2022-05-13 12-28-42](https://user-images.githubusercontent.com/10818/168274740-ba6e7f0b-db7c-4495-b8ba-bbbd2eed749c.png)
![Screenshot from 2022-05-13 12-27-54](https://user-images.githubusercontent.com/10818/168274742-43e86118-aea2-49af-8ae8-9e07ebf24a3b.png)
