### PR TITLE
HOTT-1493 Show full 10 digit commodity code on heading page.

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -128,8 +128,11 @@ module CommoditiesHelper
     code.to_s.gsub(/[^\d]/, '').split('').each_slice(4).map(&:join)
   end
 
-  def abbreviate_commodity_code(code)
-    code = code.to_s
+  def abbreviate_commodity_code(commodity)
+    code = commodity.code.to_s
+
+    return code if commodity.declarable?
+
     case code.gsub(/0*\z/, '').length
     when 7..8
       code.slice(0, 8)

--- a/app/views/commodities/_ancestors.html.erb
+++ b/app/views/commodities/_ancestors.html.erb
@@ -72,8 +72,7 @@
           aria-owns="<%= commodity_ancestor_id(index + 2) %>">
         <span>
           <span class="commodity-ancestors__identifier">
-            <%= segmented_commodity_code abbreviate_commodity_code(ancestor.code),
-                                         coloured: true %>
+            <%= segmented_commodity_code abbreviate_commodity_code(ancestor), coloured: true %>
           </span>
 
           <span class="commodity-ancestors__descriptor">

--- a/app/views/commodities/_commodity.html.erb
+++ b/app/views/commodities/_commodity.html.erb
@@ -4,7 +4,7 @@
 
     <div class='sub_heading_commodity_code_block pull-right'>
       <% unless commodity.umbrella_code? %>
-        <%= segmented_commodity_code abbreviate_commodity_code(commodity.code), coloured: true %>
+        <%= segmented_commodity_code abbreviate_commodity_code(commodity), coloured: true %>
       <% end %>
     </div>
 
@@ -41,7 +41,7 @@
           <% end %>
         </div>
         <div class="identifier" aria-describedby="commodity-<%= commodity.short_code %>">
-          <%= segmented_commodity_code abbreviate_commodity_code(commodity.code), coloured: true %>
+          <%= segmented_commodity_code abbreviate_commodity_code(commodity), coloured: true %>
         </div>
       </div>
     <% end %>

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -114,20 +114,31 @@ RSpec.describe CommoditiesHelper, type: :helper do
   end
 
   describe '#abbreviate_commodity_code' do
-    subject { abbreviate_commodity_code comm_code }
+    subject { abbreviate_commodity_code commodity }
 
-    shared_examples 'an abbreviated code' do |original, abbreviated|
-      let(:comm_code) { original }
+    context('when commodity is declarable') do
+      let(:commodity_code_long_format) { '0123456700' }
+      let(:commodity) do
+        build(:commodity, goods_nomenclature_item_id: commodity_code_long_format, declarable: true)
+      end
 
-      it { is_expected.to eql abbreviated }
+      it { is_expected.to eql commodity_code_long_format }
     end
 
-    it_behaves_like 'an abbreviated code', '0123400000', '012340'
-    it_behaves_like 'an abbreviated code', '0123450000', '012345'
-    it_behaves_like 'an abbreviated code', '0123456000', '01234560'
-    it_behaves_like 'an abbreviated code', '0123456700', '01234567'
-    it_behaves_like 'an abbreviated code', '0123456780', '0123456780'
-    it_behaves_like 'an abbreviated code', '0123456789', '0123456789'
+    context('when commodity is NOT declarable') do
+      shared_examples 'an abbreviated code' do |original, abbreviated|
+        let(:commodity) { build(:commodity, goods_nomenclature_item_id: original, declarable: false) }
+
+        it { is_expected.to eql abbreviated }
+      end
+
+      it_behaves_like 'an abbreviated code', '0123400000', '012340'
+      it_behaves_like 'an abbreviated code', '0123450000', '012345'
+      it_behaves_like 'an abbreviated code', '0123456000', '01234560'
+      it_behaves_like 'an abbreviated code', '0123456700', '01234567'
+      it_behaves_like 'an abbreviated code', '0123456780', '0123456780'
+      it_behaves_like 'an abbreviated code', '0123456789', '0123456789'
+    end
   end
 
   describe '#commodity_ancestor_id' do


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1493

### What?
The end line comm codes should be still showing all of the 10 digits in all cases, not the cut down 8 digits etc


![image](https://user-images.githubusercontent.com/58971/162968829-a8d600ff-eb1d-43dd-9144-bcbd80711b25.png)
