### PR TITLE
HOTT-1507 Fix view specs not being run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@2.0.3
-  ruby: circleci/ruby@1.4.0
+  ruby: circleci/ruby@1
   node: circleci/node@4.7.0
   browser-tools: circleci/browser-tools@1.1
   cloudfoundry: circleci/cloudfoundry@1.0

--- a/spec/support/factoy_bot.rb
+++ b/spec/support/factoy_bot.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  initialize_with { new attributes }
+end

--- a/spec/views/commodities/_commodity.html.erb_spec.rb
+++ b/spec/views/commodities/_commodity.html.erb_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe 'commodities/_commodity', type: :view do
 
         it 'will show the commodity code' do
           expect(rendered_page).to have_css \
-            'li.has_children > .sub_heading_commodity_code_block .commodity-code'
+            'li.has_children > .sub_heading_commodity_code_block .segmented-commodity-code'
         end
 
         it 'shows the children with their codes' do
           expect(rendered_page).to have_css \
-            'li.has_children ul.govuk-list > li .commodity__info .commodity-code',
+            'li.has_children ul.govuk-list > li .commodity__info .segmented-commodity-code',
             count: 1
         end
       end
@@ -45,12 +45,12 @@ RSpec.describe 'commodities/_commodity', type: :view do
 
         it 'will not show the commodity code' do
           expect(rendered_page).not_to have_css \
-            'li.has_children > .sub_heading_commodity_code_block .commodity-code'
+            'li.has_children > .sub_heading_commodity_code_block .segmented-commodity-code'
         end
 
         it 'shows the children with their codes' do
           expect(rendered_page).to have_css \
-            'li.has_children ul.govuk-list > li .commodity__info .commodity-code',
+            'li.has_children ul.govuk-list > li .commodity__info .segmented-commodity-code',
             count: 1
         end
       end
@@ -59,7 +59,7 @@ RSpec.describe 'commodities/_commodity', type: :view do
     context 'without children' do
       let(:commodity) { build :commodity }
 
-      it { is_expected.to have_css 'li .commodity__info .commodity-code' }
+      it { is_expected.to have_css 'li .commodity__info .segmented-commodity-code' }
       it { is_expected.not_to have_css 'li.has_children' }
     end
   end


### PR DESCRIPTION
### Jira link

[HOTT-1507](https://transformuk.atlassian.net/browse/HOTT-1507)

### What?

I have added/removed/altered:

- [x] Switch to using the latest v1 ruby Orb
- [x] Fixed failing specs in _commodity.html.erb_spec.rb 
- [x] Globally set `initialize_with` on all factories.

### Why?

I am doing this because:

We have failing view specs on `main` - these were missed because CI isn't running all specs. The number of specs being run jumps from **295** to **390**

This appears to be a bug in the CircleCI Ruby orb. It's already been fixed upstream but we're not benefiting because we're locked to a specific (old) version.

The Orb uses semver so switching `@1` allows us to benefit from bugfixes whilst avoid any switches to incompatible versions.

Spec fixes:
* `_commodity.html.erb_spec.rb` - caused by css selector not being updated in specs to match code change
* factory fixes - `initialize_with` lines had been dropped from factories but some models (notably Search) require these for correct instantiation. The `initialize_with { new attributes }` actually better matches our ApiEntity usage, and expectations of any PORO classes so setting that as the default makes sense.