### PR TITLE
HOTT-1482 Link subheadings on the commodities page tree

### DIFF
--- a/app/views/commodities/_ancestors.html.erb
+++ b/app/views/commodities/_ancestors.html.erb
@@ -70,7 +70,7 @@
       <% declarable.ancestors.each.with_index do |ancestor, index| %>
       <li id="<%= commodity_ancestor_id(index + 1) %>"
           aria-owns="<%= commodity_ancestor_id(index + 2) %>">
-        <span>
+        <%= link_to subheading_path("#{ancestor.code}-#{ancestor.producline_suffix}") do %>
           <span class="commodity-ancestors__identifier">
             <%= segmented_commodity_code abbreviate_commodity_code(ancestor), coloured: true %>
           </span>
@@ -78,7 +78,7 @@
           <span class="commodity-ancestors__descriptor">
             <%= sanitize ancestor.description %>
           </span>
-        </span>
+        <% end %>
       </li>
       <% end %>
 

--- a/spec/views/commodities/_ancestors.html.erb_spec.rb
+++ b/spec/views/commodities/_ancestors.html.erb_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe 'commodities/_ancestors', type: :view do
           count: 3
     end
 
+    it 'links the subheadings' do
+      expect(rendered_page).to have_css %(li#commodity-ancestors__ancestor-1 a[href^="/subheadings/"])
+    end
+
     it 'checks the ancestors all chain ownership correctly' do
       declarable.ancestors.each_index do |index|
         expect(rendered_page).to have_css \


### PR DESCRIPTION
### Jira link

[HOTT-1482](https://transformuk.atlassian.net/browse/HOTT-1482)

### What?

I have added/removed/altered:

- [x] Link the subheadings items shown in the commodities tree

### Why?

I am doing this because:

- We now have a subheadings page and it will help our users to find related commodity codes - particularly if the code they are looking at is similar to what they require but not quite right

### Have you? (optional)

- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None
