### PR TITLE
HOTT-1485 Fix for rendering bullets in guidance tables

### DIFF
--- a/app/views/measures/_guidance_table.html.erb
+++ b/app/views/measures/_guidance_table.html.erb
@@ -18,10 +18,10 @@
             <td class="govuk-table__cell">
               <%= mc.document_code %>
             </td>
-            <td class="govuk-table__cell">
+            <td class="govuk-table__cell tariff-markdown">
               <%= govspeak mc.guidance_cds %>
             </td>
-            <td class="govuk-table__cell">
+            <td class="govuk-table__cell tariff-markdown">
               <%= govspeak mc.guidance_chief %>
             </td>
           </tr>


### PR DESCRIPTION
### Jira link

[HOTT-1485](https://transformuk.atlassian.net/browse/HOTT-1485)

### What?

I have added/removed/altered:

- [x] Added missing `tariff-markdown` classes to rendered markdown

### Why?

I am doing this because:

- The alignment of bullets is off on the guidance table
- The govuk design system did have fixes for these elements but these were not being applied because govspeak renders 'unclassed' HTML nodes
- We have a css class to automatically apply appropriate `govuk-*` css classes to unclassed HTML elements

### Before

![Screenshot from 2022-04-19 14-56-18](https://user-images.githubusercontent.com/10818/164020767-cb84c0d0-e6d0-4e82-ac7c-3138f3800f41.png)

### After

![Screenshot from 2022-04-19 14-51-12](https://user-images.githubusercontent.com/10818/164020012-504ca6c7-81a6-46ba-a074-f585c0d66e3a.png)
