### PR TITLE
HOTT-1504 Fix for redirecting to url instead of path

### DIFF
--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -17,7 +17,7 @@ class GoodsNomenclaturesController < ApplicationController
     results = @search.perform
 
     if results.exact_match?
-      redirect_to url_for(results.to_param.merge(url_options))
+      redirect_to url_for(results.to_param.merge(url_options).merge(only_path: true))
     else
       redirect_to sections_url
     end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -12,7 +12,7 @@ class SearchController < ApplicationController
         if @search.missing_search_term?
           redirect_to missing_search_query_fallback_url
         elsif @results.exact_match?
-          redirect_to url_for @results.to_param.merge(url_options)
+          redirect_to url_for @results.to_param.merge(url_options).merge(only_path: true)
         end
       end
 


### PR DESCRIPTION
### Jira link

[HOTT-1504](https://transformuk.atlassian.net/browse/HOTT-1504)

### What?

I have added/removed/altered:

- [x] Replace generation of URLs for redirects, with absolute paths

### Why?

I am doing this because:

- If the site is being accessed on a different url to the one configured as the canonical url, then the redirect will trigger `ActionController::Redirecting::UnsafeRedirectError`
- This can be observed when accessing the sites via the GovUK PaaS URLs and doing a search

