### PR TITLE
HOTT-1504 Check referer host before redirect

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -104,6 +104,10 @@ class SearchController < ApplicationController
     return sections_url(anchor:) if request.referer.blank?
 
     back_url = Addressable::URI.parse(request.referer)
+    if back_url.host.present? && back_url.host != request.host
+      return sections_url(anchor:)
+    end
+
     back_url.query_values ||= {}
     back_url.query_values = back_url.query_values.merge(@search.query_attributes)
     if @search.date.today?


### PR DESCRIPTION
### Jira link

[HOTT-1504](https://transformuk.atlassian.net/browse/HOTT-1504)

### What?

I have added/removed/altered:

- [x] Redirect to homepage if the referer's host is set and is not the requests host

### Why?

I am doing this because:

- Previously we would try to redirect back to the referer, even if it was from another website - this would trigger the Rails 7 UnsafeRedirectException
