### PR TITLE
HOTT-1379 redirect unknown comm codes

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -11,6 +11,10 @@ class SearchController < ApplicationController
       format.html do
         if @search.missing_search_term?
           redirect_to missing_search_query_fallback_url
+        elsif @search.search_term_is_commodity_code?
+          redirect_to commodity_path(@search.q)
+        elsif @search.search_term_is_heading_code?
+          redirect_to heading_path(@search.q)
         elsif @results.exact_match?
           redirect_to url_for @results.to_param.merge(url_options).merge(only_path: true)
         end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -11,12 +11,12 @@ class SearchController < ApplicationController
       format.html do
         if @search.missing_search_term?
           redirect_to missing_search_query_fallback_url
-        elsif @search.search_term_is_commodity_code?
-          redirect_to commodity_path(@search.q)
-        elsif @search.search_term_is_heading_code?
-          redirect_to heading_path(@search.q)
         elsif @results.exact_match?
           redirect_to url_for @results.to_param.merge(url_options).merge(only_path: true)
+        elsif @results.none? && @search.search_term_is_commodity_code?
+          redirect_to commodity_path(@search.q)
+        elsif @results.none? && @search.search_term_is_heading_code?
+          redirect_to heading_path(@search.q)
         end
       end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -3,6 +3,9 @@ require 'api_entity'
 class Search
   include ApiEntity
 
+  COMMODITY_CODE = /\A[0-9]{10}\z/
+  HEADING_CODE = /\A[0-9]{4}\z/
+
   attr_reader   :q        # search text query
   attr_accessor :country, # search country
                 :day,
@@ -72,6 +75,14 @@ class Search
 
   def missing_search_term?
     !contains_search_term?
+  end
+
+  def search_term_is_commodity_code?
+    COMMODITY_CODE.match? q
+  end
+
+  def search_term_is_heading_code?
+    HEADING_CODE.match? q
   end
 
   def query_attributes

--- a/app/models/search/outcome.rb
+++ b/app/models/search/outcome.rb
@@ -23,6 +23,10 @@ class Search
         (reference_match.present? && reference_match.any?)
     end
 
+    def none?
+      !any?
+    end
+
     def goods_nomenclature_match
       @goods_nomenclature_match || GoodsNomenclatureMatch::BLANK_RESULT
     end

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
         end
       end
 
-      context 'with commodity code', vcr: { cassette_name: 'search#search_exact' } do
+      context 'with unknown commodity code', vcr: { cassette_name: 'search#blank_match' } do
         let(:query) { '0123456789' }
 
         it { is_expected.to redirect_to commodity_path(query) }
       end
 
-      context 'with heading code', vcr: { cassette_name: 'search#search_exact' } do
+      context 'with heading code', vcr: { cassette_name: 'search#blank_match' } do
         let(:query) { '0123' }
 
         it { is_expected.to redirect_to heading_path(query) }

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
 
   context 'with HTML format' do
     context 'with search term' do
+      before do
+        get :search, params: { q: query }
+      end
+
       context 'with exact match query', vcr: { cassette_name: 'search#search_exact' } do
         let(:query) { '01' }
-
-        before do
-          get :search, params: { q: query }
-        end
 
         it { is_expected.to redirect_to commodity_path('0101210000') }
         it { expect(assigns(:search)).to be_a(Search) }
@@ -22,10 +22,6 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
 
       context 'with fuzzy match query', vcr: { cassette_name: 'search#search_fuzzy' } do
         let(:query) { 'horses' }
-
-        before do
-          get :search, params: { q: query }
-        end
 
         it { is_expected.to respond_with(:success) }
         it { expect(assigns(:search)).to be_a(Search) }
@@ -40,10 +36,6 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
 
         let(:query) { ' !such string should not exist in the database! ' }
 
-        before do
-          get :search, params: { q: query }
-        end
-
         it { is_expected.to respond_with(:success) }
         it { expect(assigns(:search)).to be_a(Search) }
 
@@ -54,6 +46,18 @@ RSpec.describe SearchController, 'GET to #search', type: :controller do
         it 'displays no results' do
           expect(response.body).to match(/no results/)
         end
+      end
+
+      context 'with commodity code', vcr: { cassette_name: 'search#search_exact' } do
+        let(:query) { '0123456789' }
+
+        it { is_expected.to redirect_to commodity_path(query) }
+      end
+
+      context 'with heading code', vcr: { cassette_name: 'search#search_exact' } do
+        let(:query) { '0123' }
+
+        it { is_expected.to redirect_to heading_path(query) }
       end
     end
 

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -90,4 +90,72 @@ RSpec.describe Search do
       it { is_expected.to be true }
     end
   end
+
+  describe '#search_term_is_commodity_code?' do
+    subject { described_class.new(q: search_term).search_term_is_commodity_code? }
+
+    context 'with commodity_code' do
+      let(:search_term) { '0101191919' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with commodity_code with whitespace' do
+      let(:search_term) { ' 0101191919' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with other code' do
+      let(:search_term) { '010119191' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with textual search term' do
+      let(:search_term) { 'testing123' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with no search term' do
+      let(:search_term) { ' ' }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#search_term_is_heading_code?' do
+    subject { described_class.new(q: search_term).search_term_is_heading_code? }
+
+    context 'with heading_code' do
+      let(:search_term) { '0101' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with heading_code with whitespace' do
+      let(:search_term) { ' 0101' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with other code' do
+      let(:search_term) { '010119191' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with textual search term' do
+      let(:search_term) { 'testing123' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with no search term' do
+      let(:search_term) { ' ' }
+
+      it { is_expected.to be false }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1379](https://transformuk.atlassian.net/browse/HOTT-1379)

### What?

I have added/removed/altered:

- [x] Reintroduce the automatic redirect _but_ only use it when there are no results

### Why?

I am doing this because:

- When the user supplies a comm code and we don't have a match we want to show the relevant histories pages

