### PR TITLE
Retry GitHub Pull Requests API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ commands:
             DAYS=7
             REPO_API_URL=$(echo "${CIRCLE_REPOSITORY_URL}/" | sed 's|.git/$||' | sed 's|git@github.com:|https://api.github.com/repos/|')
 
-            curl --fail --show-error "${REPO_API_URL}/pulls?state=open" | \
+            curl --fail --retry 3 --show-error "${REPO_API_URL}/pulls?state=open" | \
               jq ".[] | select((.updated_at | fromdate) > (now - $DAYS*24*60*60)) | .number" > open_prs.txt
 
             cat open_prs.txt | sed "s/^/${CF_APP}-pr/" | sort > expected_apps.txt


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Retry CI GitHub PR API requests

### Why?

I am doing this because:

- Occassionally the Purge Reviews step will fail, I think this is caused by network flakiness in CircleCI and retrying that endpoint should be safe