### PR TITLE
HOTT-1550 Added search serializer for subheadings

### DIFF
--- a/app/serializers/search_result/subheading_serializer.rb
+++ b/app/serializers/search_result/subheading_serializer.rb
@@ -1,0 +1,8 @@
+module SearchResult
+  class SubheadingSerializer < CommoditySerializer
+    include ActiveModel::Serializers::JSON
+    def serializable_hash(_opts = {})
+      super.merge(type: 'subheading')
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-1550](https://transformuk.atlassian.net/browse/HOTT-1550)

### What?

I have added/removed/altered:

- [x] Added a search serializer for subheadings

### Why?

I am doing this because:

- Any search results for `/search.json` which included subheadings would result in an error
