### PR TITLE
HOTT-1550 Added specs for the search result serializers

### DIFF
--- a/spec/serializers/search_result/chapter_serializer_spec.rb
+++ b/spec/serializers/search_result/chapter_serializer_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe SearchResult::ChapterSerializer do
+  subject(:serializer) { described_class.new(chapter) }
+
+  let(:chapter) { build(:chapter) }
+
+  describe '#as_json' do
+    subject { serializer.as_json }
+
+    it { is_expected.to include 'type' => 'chapter' }
+    it { is_expected.to include 'goods_nomenclature_item_id' => chapter.goods_nomenclature_item_id }
+    it { is_expected.to include 'description' => chapter.description }
+  end
+end

--- a/spec/serializers/search_result/commodity_serializer_spec.rb
+++ b/spec/serializers/search_result/commodity_serializer_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe SearchResult::CommoditySerializer do
+  subject(:serializer) { described_class.new(commodity) }
+
+  let(:commodity) { build(:commodity) }
+
+  describe '#as_json' do
+    subject { serializer.as_json }
+
+    it { is_expected.to include 'type' => 'commodity' }
+    it { is_expected.to include 'goods_nomenclature_item_id' => commodity.goods_nomenclature_item_id }
+    it { is_expected.to include 'declarable' => commodity.declarable }
+    it { is_expected.to include 'description' => commodity.description }
+    it { is_expected.to include 'number_indents' => commodity.number_indents }
+    it { is_expected.to include 'producline_suffix' => commodity.producline_suffix }
+    it { is_expected.to include 'validity_start_date' => commodity.validity_start_date.to_s }
+    it { is_expected.to include 'validity_end_date' => commodity.validity_end_date.to_s }
+  end
+end

--- a/spec/serializers/search_result/heading_serializer_spec.rb
+++ b/spec/serializers/search_result/heading_serializer_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe SearchResult::HeadingSerializer do
+  subject(:serializer) { described_class.new(heading) }
+
+  let(:heading) { build(:heading) }
+
+  describe '#as_json' do
+    subject { serializer.as_json }
+
+    it { is_expected.to include 'type' => 'heading' }
+    it { is_expected.to include 'goods_nomenclature_item_id' => heading.goods_nomenclature_item_id }
+    it { is_expected.to include 'description' => heading.description }
+    it { is_expected.to include 'number_indents' => heading.number_indents }
+    it { is_expected.to include 'producline_suffix' => heading.producline_suffix }
+    it { is_expected.to include 'validity_start_date' => heading.validity_start_date.to_s }
+    it { is_expected.to include 'validity_end_date' => heading.validity_end_date.to_s }
+  end
+end

--- a/spec/serializers/search_result/section_serializer_spec.rb
+++ b/spec/serializers/search_result/section_serializer_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe SearchResult::SectionSerializer do
+  subject(:serializer) { described_class.new(section) }
+
+  let(:section) { build(:section) }
+
+  describe '#as_json' do
+    subject { serializer.as_json }
+
+    it { is_expected.to include 'type' => 'section' }
+    it { is_expected.to include 'numeral' => section.numeral }
+    it { is_expected.to include 'position' => section.position }
+    it { is_expected.to include 'title' => section.title }
+    it { is_expected.to include 'chapter_from' }
+    it { is_expected.to include 'chapter_to' }
+    it { is_expected.to include 'section_note' }
+  end
+end

--- a/spec/serializers/search_result/subheading_serializer_spec.rb
+++ b/spec/serializers/search_result/subheading_serializer_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe SearchResult::SubheadingSerializer do
+  subject(:serializer) { described_class.new(subheading) }
+
+  let(:subheading) { build(:subheading) }
+
+  describe '#as_json' do
+    subject { serializer.as_json }
+
+    it { is_expected.to include 'type' => 'subheading' }
+    it { is_expected.to include 'goods_nomenclature_item_id' => subheading.goods_nomenclature_item_id }
+    it { is_expected.to include 'declarable' => false }
+    it { is_expected.to include 'description' => subheading.description }
+    it { is_expected.to include 'number_indents' => subheading.number_indents }
+    it { is_expected.to include 'producline_suffix' => subheading.producline_suffix }
+    it { is_expected.to include 'validity_start_date' => subheading.validity_start_date.to_s }
+    it { is_expected.to include 'validity_end_date' => subheading.validity_end_date.to_s }
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-1550](https://transformuk.atlassian.net/browse/HOTT-1550)

### What?

I have added/removed/altered:

- [x] Added missing specs for search result serializers

### Why?

I am doing this because:

- there wasn't anything testing the serializers worked

