### PR TITLE
HOTT-1549: Fix links for Subheadings in a-z-index page

### DIFF
--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -5,7 +5,7 @@ class SearchReference
 
   collection_path '/search_references'
 
-  attr_accessor :id, :title, :referenced_id, :referenced_class
+  attr_accessor :id, :title, :referenced_id, :referenced_class, :productline_suffix
 
   def referenced_entity
     reference_class.new(attributes['referenced'])

--- a/app/presenters/search_reference_presenter.rb
+++ b/app/presenters/search_reference_presenter.rb
@@ -10,9 +10,16 @@ class SearchReferencePresenter
   end
 
   def link
-    reference_link = "/#{APP_SLUG}/#{referenced_class.tableize}/#{referenced_id}"
+    "/#{APP_SLUG}/#{referenced_class.tableize}/#{composite_id}"
+  end
 
-    append_product_line_suffix(reference_link)
+  def composite_id
+    case referenced_class
+    when 'Subheading'
+      "#{referenced_id}-#{productline_suffix}"
+    else
+      referenced_id
+    end
   end
 
   private

--- a/app/presenters/search_reference_presenter.rb
+++ b/app/presenters/search_reference_presenter.rb
@@ -10,12 +10,18 @@ class SearchReferencePresenter
   end
 
   def link
-    "/#{APP_SLUG}/#{referenced_class.tableize}/#{referenced_id}"
+    reference_link = "/#{APP_SLUG}/#{referenced_class.tableize}/#{referenced_id}"
+
+    append_product_line_suffix(reference_link)
   end
 
   private
 
   def method_missing(*args, &block)
     @search_reference.send(*args, &block)
+  end
+
+  def append_product_line_suffix(link)
+    link + (referenced_class == 'Subheading' ? "-#{productline_suffix}" : '')
   end
 end

--- a/spec/factories/search_reference_factory.rb
+++ b/spec/factories/search_reference_factory.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :search_reference do
+    id { '1' }
+
+    title { 'tomatoes' }
+
+    referenced_id { '1234567890' }
+
+    trait :with_subheading do
+      referenced_class { 'Subheading' }
+      productline_suffix { '12' }
+    end
+  end
+end

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe SearchReference do
-  subject { build :search_reference, :with_subheading }
+  subject(:search_reference) { build :search_reference, :with_subheading }
 
-    it 'has correct attributes' do
-      is_expected.to have_attributes(id: '1',
-        title: 'tomatoes',
-        referenced_id: '1234567890',
-        referenced_class: 'Subheading',
-        productline_suffix: '12')
-    end
+  it 'has correct attributes' do
+    expect(search_reference).to have_attributes(id: '1',
+                                                title: 'tomatoes',
+                                                referenced_id: '1234567890',
+                                                referenced_class: 'Subheading',
+                                                productline_suffix: '12')
+  end
 end

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe SearchReference do
+  subject { build :search_reference, :with_subheading }
+
+    it 'has correct attributes' do
+      is_expected.to have_attributes(id: '1',
+        title: 'tomatoes',
+        referenced_id: '1234567890',
+        referenced_class: 'Subheading',
+        productline_suffix: '12')
+    end
+end

--- a/spec/presenters/search_reference_presenter_spec.rb
+++ b/spec/presenters/search_reference_presenter_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe SearchReferencePresenter do
+  subject(:presenter) { described_class.new(declarable) }
+
+  let(:declarable) { build :search_reference, :with_subheading }
+
+  describe '#link' do
+    it { expect(presenter.link).to eq('/trade-tariff/subheadings/1234567890-12') }
+  end
+
+  describe '#to_s' do
+    it { expect(presenter.to_s).to eq('Tomatoes') }
+  end
+end


### PR DESCRIPTION
### Jira link
[HOTT-1549](https://transformuk.atlassian.net/browse/HOTT-1549)

### What?

Fix links for Subheadings in a-z-index page.

### Why?
The links are broken, they point to a 404 Not found page.

## Note: this fix requires the relevant BE fix: https://github.com/trade-tariff/trade-tariff-backend/pull/565
