### PR TITLE
HOTT-1564 Fix for changing date on subheadings page

### DIFF
--- a/app/helpers/goods_nomenclature_helper.rb
+++ b/app/helpers/goods_nomenclature_helper.rb
@@ -13,6 +13,8 @@ module GoodsNomenclatureHelper
       chapter_path(path_opts)
     when Heading::SHORT_CODE_LENGTH
       heading_path(path_opts)
+    when Subheading::FULL_CODE_LENGTH
+      subheading_path(path_opts)
     else
       commodity_path(path_opts)
     end

--- a/app/models/subheading.rb
+++ b/app/models/subheading.rb
@@ -1,4 +1,7 @@
 class Subheading < GoodsNomenclature
+  # Commodity code: 10 chars  + separator: 1 char +  Product Line Suffix: 2 chars
+  FULL_CODE_LENGTH = 13
+
   include ApiEntity
 
   has_one :section

--- a/spec/helpers/goods_nomenclature_helper_spec.rb
+++ b/spec/helpers/goods_nomenclature_helper_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe GoodsNomenclatureHelper, type: :helper do
       it { expect(helper.goods_nomenclature_path).to eq(expected_path) }
     end
 
+    it_behaves_like 'a goods_nomenclature_path', '1901200000-10', '/subheadings/1901200000-10?country=AR&day=01&month=01&year=2021#export'
     it_behaves_like 'a goods_nomenclature_path', '1901200000', '/commodities/1901200000?country=AR&day=01&month=01&year=2021#export'
     it_behaves_like 'a goods_nomenclature_path', '1901', '/headings/1901?country=AR&day=01&month=01&year=2021#export'
     it_behaves_like 'a goods_nomenclature_path', '19', '/chapters/19?country=AR&day=01&month=01&year=2021#export'


### PR DESCRIPTION
### Jira link

[HOTT-1564](https://transformuk.atlassian.net/browse/HOTT-1564)

### What?

I have added/removed/altered:

- [x] Added support for generating subheading paths from goods_nomenclature_path

### Why?

I am doing this because:

- we currently generate a 500 when the user clicks the 'change date' link on a subheadings page

### Deployment risks (optional)

- Changes a generic path helper which is used in multiple places
