### PR TITLE
HOTT 1549: Fix formatting for the Subheading code.

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -131,8 +131,10 @@ module CommoditiesHelper
   def abbreviate_commodity_code(commodity)
     code = commodity.code.to_s
 
-    return code if commodity.declarable?
+    commodity.declarable? ? code : abbreviate_code(code)
+  end
 
+  def abbreviate_code(code)
     case code.gsub(/0*\z/, '').length
     when 7..8
       code.slice(0, 8)

--- a/app/views/search_references/show.html.erb
+++ b/app/views/search_references/show.html.erb
@@ -30,7 +30,8 @@
             <span class="govuk-visually-hidden">Class: </span><%= search_reference.referenced_class %>
           </td>
           <td class="govuk-table__cell govuk-table__cell--numeric">
-           <span class="govuk-visually-hidden">Code: </span><%= search_reference.referenced_id %>
+           <span class="govuk-visually-hidden">Code: </span>
+            <%= segmented_commodity_code abbreviate_code(search_reference.referenced_id) %>
           </td>
         </tr>
       <% end %>

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -116,29 +116,40 @@ RSpec.describe CommoditiesHelper, type: :helper do
   describe '#abbreviate_commodity_code' do
     subject { abbreviate_commodity_code commodity }
 
+    let(:commodity_code_long_format) { '0123456700' }
+
+    let(:commodity) do
+      build(:commodity, goods_nomenclature_item_id: commodity_code_long_format, declarable:)
+    end
+
     context('when commodity is declarable') do
-      let(:commodity_code_long_format) { '0123456700' }
-      let(:commodity) do
-        build(:commodity, goods_nomenclature_item_id: commodity_code_long_format, declarable: true)
-      end
+      let(:declarable) { true }
 
       it { is_expected.to eql commodity_code_long_format }
     end
 
     context('when commodity is NOT declarable') do
-      shared_examples 'an abbreviated code' do |original, abbreviated|
-        let(:commodity) { build(:commodity, goods_nomenclature_item_id: original, declarable: false) }
+      let(:declarable) { false }
 
-        it { is_expected.to eql abbreviated }
-      end
-
-      it_behaves_like 'an abbreviated code', '0123400000', '012340'
-      it_behaves_like 'an abbreviated code', '0123450000', '012345'
-      it_behaves_like 'an abbreviated code', '0123456000', '01234560'
-      it_behaves_like 'an abbreviated code', '0123456700', '01234567'
-      it_behaves_like 'an abbreviated code', '0123456780', '0123456780'
-      it_behaves_like 'an abbreviated code', '0123456789', '0123456789'
+      it { is_expected.not_to eql commodity_code_long_format }
     end
+  end
+
+  describe '#abbreviate_code' do
+    subject { abbreviate_code(code) }
+
+    shared_examples 'an abbreviated code' do |original, abbreviated|
+      let(:code) { original }
+
+      it { is_expected.to eql abbreviated }
+    end
+
+    it_behaves_like 'an abbreviated code', '0123400000', '012340'
+    it_behaves_like 'an abbreviated code', '0123450000', '012345'
+    it_behaves_like 'an abbreviated code', '0123456000', '01234560'
+    it_behaves_like 'an abbreviated code', '0123456700', '01234567'
+    it_behaves_like 'an abbreviated code', '0123456780', '0123456780'
+    it_behaves_like 'an abbreviated code', '0123456789', '0123456789'
   end
 
   describe '#commodity_ancestor_id' do


### PR DESCRIPTION
### Jira link
[HOTT-1549](https://transformuk.atlassian.net/browse/HOTT-1549) 

### What?
This is the "Change 2" present in the ticket (link above)
It improves the formatting for the Subheading code on the a-z page.

### Why?
To make code more readable and with the same style as the commodities codes.

### Before:
<img width="1007" alt="Screenshot 2022-05-05 at 14 24 09" src="https://user-images.githubusercontent.com/58971/166932613-7355d029-e502-4f7a-b2b9-cbe535f9351f.png">

### After
<img width="1102" alt="Screenshot 2022-05-05 at 14 23 43" src="https://user-images.githubusercontent.com/58971/166932617-52bf5548-eacc-465a-be8d-224d300befc5.png">

