### PR TITLE
HOTT-1563 Fixed links on history pages to go to selected date

### DIFF
--- a/app/views/commodities/show_404.html.erb
+++ b/app/views/commodities/show_404.html.erb
@@ -41,13 +41,13 @@
 
     <p>
       Alternatively, you can visit
-      <%= link_to "heading #{@heading_code}", heading_on_date_path(@heading_code, nil) %>
+      <%= link_to "heading #{@heading_code}", heading_path(@heading_code) %>
       or
       <% if @search.today? %>
-        <%= link_to "chapter #{@chapter_code}", chapter_on_date_path(@chapter_code, nil) %>.
+        <%= link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>.
       <% else %>
-        <%= link_to "chapter #{@chapter_code}", chapter_on_date_path(@chapter_code, nil) %>
-        for <%= Time.zone.today.to_formatted_s :long %>.
+        <%= link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>
+        for <%= @search.date.to_formatted_s :long %>.
       <% end %>
     </p>
   </div>

--- a/app/views/headings/show_404.html.erb
+++ b/app/views/headings/show_404.html.erb
@@ -38,10 +38,10 @@
     <p>
       Alternatively, you can visit
       <% if @search.today? %>
-        <%= link_to "chapter #{@chapter_code}", chapter_on_date_path(@chapter_code, nil) %>.
+        <%= link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>.
       <% else %>
-        <%= link_to "chapter #{@chapter_code}", chapter_on_date_path(@chapter_code, nil) %>
-        for <%= Time.zone.today.to_formatted_s :long %>.
+        <%= link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>
+        for <%= @search.date.to_formatted_s :long %>.
       <% end %>
     </p>
   </div>


### PR DESCRIPTION
### Jira link

[HOTT-1563](https://transformuk.atlassian.net/browse/HOTT-1563)

### What?

I have added/removed/altered:

- [x] Changed the heading and chapter links in the commodities history page to link to heading/chapter on the users currently selected date
- [x] Same change for Headings history page

### Why?

I am doing this because:

- I'd misunderstood the original intention of this feature
