### PR TITLE
HOTT-1483 Show ancestors tree on Subheading page

### DIFF
--- a/app/controllers/subheadings_controller.rb
+++ b/app/controllers/subheadings_controller.rb
@@ -3,6 +3,7 @@ class SubheadingsController < GoodsNomenclaturesController
 
   def show
     @commodities = HeadingCommodityPresenter.new(subheading.commodities)
+    @subheading_commodities = Array.wrap(@subheading.find_self_in_commodities_list)
     @section = subheading.section
     @chapter = subheading.chapter
     @heading = subheading.heading

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -69,6 +69,12 @@ class Commodity < GoodsNomenclature
     end
   end
 
+  def parent
+    return if casted_by.blank?
+
+    casted_by.commodities.find { |c| c.goods_nomenclature_sid == parent_sid }
+  end
+
   def last_child?
     if casted_by.present?
       goods_nomenclature_sid == casted_by.commodities.select { |c| c.parent_sid == parent_sid }.last.goods_nomenclature_sid

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -69,12 +69,6 @@ class Commodity < GoodsNomenclature
     end
   end
 
-  def parent
-    return if casted_by.blank?
-
-    casted_by.commodities.find { |c| c.goods_nomenclature_sid == parent_sid }
-  end
-
   def last_child?
     if casted_by.present?
       goods_nomenclature_sid == casted_by.commodities.select { |c| c.parent_sid == parent_sid }.last.goods_nomenclature_sid

--- a/app/models/subheading.rb
+++ b/app/models/subheading.rb
@@ -42,7 +42,19 @@ class Subheading < GoodsNomenclature
   end
 
   def ancestors
-    []
+    @ancestors ||= [].tap { |ancestors|
+      commodity = find_self_in_commodities_list
+
+      while (commodity = commodity&.parent)
+        ancestors << commodity
+      end
+    }.reverse
+  end
+
+  def find_self_in_commodities_list
+    @find_self_in_commodities_list ||= commodities.find do |c|
+      c.goods_nomenclature_sid == goods_nomenclature_sid
+    end
   end
 
   private

--- a/app/models/subheading.rb
+++ b/app/models/subheading.rb
@@ -10,6 +10,7 @@ class Subheading < GoodsNomenclature
 
   has_many :footnotes
   has_many :commodities
+  has_many :ancestors, class_name: 'Commodity'
 
   collection_path '/subheadings'
 
@@ -39,16 +40,6 @@ class Subheading < GoodsNomenclature
 
   def to_s
     formatted_description || description
-  end
-
-  def ancestors
-    @ancestors ||= [].tap { |ancestors|
-      commodity = find_self_in_commodities_list
-
-      while (commodity = commodity&.parent)
-        ancestors << commodity
-      end
-    }.reverse
   end
 
   def find_self_in_commodities_list

--- a/app/models/subheading.rb
+++ b/app/models/subheading.rb
@@ -41,6 +41,10 @@ class Subheading < GoodsNomenclature
     formatted_description || description
   end
 
+  def ancestors
+    []
+  end
+
   private
 
   def harmonised_system_subheading_code

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -9,7 +9,7 @@
 
 <%= render 'shared/context_tables/commodity' %>
 
-<%= render 'commodities/ancestors', declarable: declarable %>
+<%= render 'goods_nomenclatures/ancestors', goods_nomenclature: declarable %>
 
 <%= render 'declarables/declarable',
            declarable: declarable,

--- a/app/views/goods_nomenclatures/_ancestors.html.erb
+++ b/app/views/goods_nomenclatures/_ancestors.html.erb
@@ -1,20 +1,20 @@
 <nav class="commodity-ancestors"
-     aria-label="A list of commodity code <%= declarable.code %>'s section, chapter and other parent commodity codes">
+     aria-label="A list of commodity code <%= goods_nomenclature.code %>'s section, chapter and other parent commodity codes">
   <a href="#import" class="govuk-skip-link">
-    Skip to information about importing commodity <%= declarable.code %>
+    Skip to information about importing commodity <%= goods_nomenclature.code %>
   </a>
 
   <ol class="govuk-list">
     <%# list commodities section %>
     <li id="commodity-ancestors__section"
         aria-owns="commodity-ancestors__chapter">
-      <%= link_to section_path(declarable.section) do %>
+      <%= link_to section_path(goods_nomenclature.section) do %>
         <span class="commodity-ancestors__identifier">
-          Section <%= declarable.section.numeral %>
+          Section <%= goods_nomenclature.section.numeral %>
         </span>
 
         <span class="commodity-ancestors__descriptor">
-          <%= declarable.section.title %>
+          <%= goods_nomenclature.section.title %>
         </span>
       <% end %>
     </li>
@@ -22,29 +22,29 @@
     <%# list commodities chapter %>
     <li id="commodity-ancestors__chapter"
         aria-owns="commodity-ancestors__heading">
-      <%= link_to chapter_path(declarable.chapter) do %>
+      <%= link_to chapter_path(goods_nomenclature.chapter) do %>
         <span class="commodity-ancestors__identifier">
-          Chapter <%= declarable.chapter.short_code %>
+          Chapter <%= goods_nomenclature.chapter.short_code %>
         </span>
 
         <span class="commodity-ancestors__descriptor">
-          <%= declarable.chapter %>
+          <%= goods_nomenclature.chapter %>
         </span>
       <% end %>
     </li>
 
-    <% if declarable.heading? %>
+    <% if goods_nomenclature.heading? %>
 
       <%# list commodities heading %>
       <li id="commodity-ancestors__heading">
         <span>
           <span class="commodity-ancestors__identifier">
-            <%= segmented_commodity_code declarable.code,
+            <%= segmented_commodity_code goods_nomenclature.code,
                                          coloured: true %>
           </span>
 
           <span class="commodity-ancestors__descriptor">
-            <%= sanitize declarable.description %>
+            <%= sanitize goods_nomenclature.description %>
           </span>
         </span>
       </li>
@@ -54,20 +54,20 @@
       <%# list commodities heading %>
       <li id="commodity-ancestors__heading"
           aria-owns="<%= commodity_ancestor_id 1 %>">
-        <%= link_to heading_path(declarable.heading) do %>
+        <%= link_to heading_path(goods_nomenclature.heading) do %>
           <span class="commodity-ancestors__identifier">
-            <%= segmented_commodity_code declarable.heading.short_code,
+            <%= segmented_commodity_code goods_nomenclature.heading.short_code,
                                          coloured: true %>
           </span>
 
           <span class="commodity-ancestors__descriptor">
-            <%= sanitize declarable.heading.description %>
+            <%= sanitize goods_nomenclature.heading.description %>
           </span>
         <% end %>
       </li>
 
       <%# list each of commodities ancestors %>
-      <% declarable.ancestors.each.with_index do |ancestor, index| %>
+      <% goods_nomenclature.ancestors.each.with_index do |ancestor, index| %>
       <li id="<%= commodity_ancestor_id(index + 1) %>"
           aria-owns="<%= commodity_ancestor_id(index + 2) %>">
         <%= link_to subheading_path("#{ancestor.code}-#{ancestor.producline_suffix}") do %>
@@ -83,15 +83,15 @@
       <% end %>
 
       <%# list current commodity %>
-      <li id="<%= commodity_ancestor_id(declarable.ancestors.length + 1) %>">
+      <li id="<%= commodity_ancestor_id(goods_nomenclature.ancestors.length + 1) %>">
         <span>
           <span class="commodity-ancestors__identifier">
-            <%= segmented_commodity_code declarable.code,
+            <%= segmented_commodity_code goods_nomenclature.code,
                                          coloured: true %>
           </span>
 
           <span class="commodity-ancestors__descriptor">
-            <%= sanitize declarable.formatted_description %>
+            <%= sanitize goods_nomenclature.formatted_description %>
           </span>
         </span>
       </li>

--- a/app/views/goods_nomenclatures/_ancestors.html.erb
+++ b/app/views/goods_nomenclatures/_ancestors.html.erb
@@ -76,7 +76,7 @@
           </span>
 
           <span class="commodity-ancestors__descriptor">
-            <%= sanitize ancestor.description %>
+            <%= sanitize (ancestor.description_plain.presence || ancestor.description) %>
           </span>
         <% end %>
       </li>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -14,7 +14,7 @@
 <%= render 'shared/context_tables/heading' %>
 <%= render 'shared/callouts/heading', leaf_commodity_count: @commodities.leaf_commodities_count,
                                       section_note: @heading.section.section_note, chapter_note: @heading.chapter.chapter_note %>
-<%= render 'shared/commodity_tree' %>
+<%= render 'shared/commodity_tree', commodities: @commodities.root_commodities %>
 <%= render 'shared/footnote', footnotes: @heading.footnotes %>
 
 <% if @heading.declarable? %>

--- a/app/views/shared/_commodity_tree.html.erb
+++ b/app/views/shared/_commodity_tree.html.erb
@@ -12,7 +12,7 @@
       </div>
     </div>
     <ul class="commodities js-commodities">
-      <%= render @commodities.root_commodities %>
+      <%= render commodities %>
     </ul>
   </div>
 </article>

--- a/app/views/subheadings/show.html.erb
+++ b/app/views/subheadings/show.html.erb
@@ -4,6 +4,7 @@
 
 <%= render 'shared/context_tables/subheading' %>
 <%= render 'shared/callouts/subheading', leaf_commodity_count: @commodities.leaf_commodities_count %>
+<%= render 'goods_nomenclatures/ancestors', goods_nomenclature: @subheading %>
 <%= render 'shared/commodity_tree' %>
 <%= render 'shared/footnote', footnotes: @subheading.footnotes %>
 <%= render 'shared/notes', section_note: @subheading.section.section_note, chapter_note: @subheading.chapter.chapter_note %>

--- a/app/views/subheadings/show.html.erb
+++ b/app/views/subheadings/show.html.erb
@@ -5,6 +5,6 @@
 <%= render 'shared/context_tables/subheading' %>
 <%= render 'shared/callouts/subheading', leaf_commodity_count: @commodities.leaf_commodities_count %>
 <%= render 'goods_nomenclatures/ancestors', goods_nomenclature: @subheading %>
-<%= render 'shared/commodity_tree', commodities: @commodities.root_commodities %>
+<%= render 'shared/commodity_tree', commodities: @subheading_commodities %>
 <%= render 'shared/footnote', footnotes: @subheading.footnotes %>
 <%= render 'shared/notes', section_note: @subheading.section.section_note, chapter_note: @subheading.chapter.chapter_note %>

--- a/app/views/subheadings/show.html.erb
+++ b/app/views/subheadings/show.html.erb
@@ -5,6 +5,6 @@
 <%= render 'shared/context_tables/subheading' %>
 <%= render 'shared/callouts/subheading', leaf_commodity_count: @commodities.leaf_commodities_count %>
 <%= render 'goods_nomenclatures/ancestors', goods_nomenclature: @subheading %>
-<%= render 'shared/commodity_tree' %>
+<%= render 'shared/commodity_tree', commodities: @commodities.root_commodities %>
 <%= render 'shared/footnote', footnotes: @subheading.footnotes %>
 <%= render 'shared/notes', section_note: @subheading.section.section_note, chapter_note: @subheading.chapter.chapter_note %>

--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -197,10 +197,10 @@
                   };
 
                   // Open/close tree nodes on load based on cookie
-                  if (this.openCloseCookie() === 'open') {
-                    effectAll(0);
-                  } else {
+                  if (this.openCloseCookie() === 'closed') {
                     effectAll(1);
+                  } else {
+                    effectAll(0);
                   }
 
                   $('.tree-controls').prepend('<a href="#">Open all headings</a><a href="#">Close all headings</a>');

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     sequence(:goods_nomenclature_sid) { |id| id }
     goods_nomenclature_item_id { sprintf '010130%04d', goods_nomenclature_sid }
     parent_sid { nil }
+    producline_suffix { 80 }
     number_indents { 2 }
     meursing_code { false }
 

--- a/spec/factories/heading_factory.rb
+++ b/spec/factories/heading_factory.rb
@@ -15,8 +15,12 @@ FactoryBot.define do
 
     trait :with_commodity_tree do
       commodities do
-        attributes_for_list(:commodity, commodity_count || 2) do |c, i|
-          c[:parent_sid] = (i > 0 ? c[:goods_nomenclature_sid] - 1 : nil)
+        attributes_for_list(:commodity, commodity_count || 2) do |commodity, index|
+          commodity[:parent_sid] = if index.zero? # First commodity, so no parent
+                                     nil
+                                   else # point parent to the previous commodity
+                                     commodity[:goods_nomenclature_sid] - 1
+                                   end
         end
       end
     end

--- a/spec/factories/heading_factory.rb
+++ b/spec/factories/heading_factory.rb
@@ -1,12 +1,24 @@
 FactoryBot.define do
   factory :heading do
+    transient do
+      commodity_count { nil }
+    end
+
     chapter { attributes_for(:chapter) }
     description { Forgery(:basic).text }
     formatted_description { Forgery(:basic).text }
     goods_nomenclature_item_id { '0101000000' }
 
-    commodities { [] }
+    commodities { attributes_for_list :commodity, commodity_count || 0 }
     import_measures { [] }
     export_measures { [] }
+
+    trait :with_commodity_tree do
+      commodities do
+        attributes_for_list(:commodity, commodity_count || 2) do |c, i|
+          c[:parent_sid] = (i > 0 ? c[:goods_nomenclature_sid] - 1 : nil)
+        end
+      end
+    end
   end
 end

--- a/spec/factories/subheading_factory.rb
+++ b/spec/factories/subheading_factory.rb
@@ -21,7 +21,15 @@ FactoryBot.define do
     goods_nomenclature_sid { 131_312 }
     number_indents { 3 }
 
-    commodities { attributes_for_list :commodity, commodities_count }
+    commodities do
+      attributes_for_list :commodity, commodities_count do |c, i|
+        if i.zero?
+          c[:goods_nomenclature_sid] == goods_nomenclature_sid
+        else
+          c[:parent_sid] == goods_nomenclature_sid
+        end
+      end
+    end
 
     description { 'Horses' }
     formatted_description { '<strong>Horses</strong>' }

--- a/spec/factories/subheading_factory.rb
+++ b/spec/factories/subheading_factory.rb
@@ -1,13 +1,28 @@
 FactoryBot.define do
   factory :subheading do
+    transient do
+      commodities_count { 0 }
+    end
+
     section { attributes_for(:section) }
-    chapter { attributes_for(:chapter) }
-    commodities { [] }
+
+    chapter do
+      attributes_for :chapter,
+                     goods_nomenclature_item_id: "#{goods_nomenclature_item_id.first(2)}00000000"
+    end
+
+    heading do
+      attributes_for :heading,
+                     goods_nomenclature_item_id: "#{goods_nomenclature_item_id.first(4)}000000"
+    end
 
     goods_nomenclature_item_id { '0101100000' }
     producline_suffix { '10' }
     goods_nomenclature_sid { 131_312 }
     number_indents { 3 }
+
+    commodities { attributes_for_list :commodity, commodities_count }
+
     description { 'Horses' }
     formatted_description { '<strong>Horses</strong>' }
     declarable { false }

--- a/spec/features/headings_spec.rb
+++ b/spec/features/headings_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe 'JS behaviour', js: true, vcr: { cassette_name: 'headings#8501' }
     expect(page.find_all('.tree-controls').length).to eq(2)
 
     expect(page.find_all('.has_children')).to \
-      all(have_xpath("//ul[@class='govuk-list' and @aria-hidden='true']"))
+      all(have_xpath("//ul[@class='govuk-list' and @aria-hidden='false']"))
 
-    page.find_all('.tree-controls')[0].first('a').click
+    page.find_all('.tree-controls')[1].first('a').click # hide all
 
     expect(page.find_all(".has_children ul[aria-hidden='true']").length).to eq(0)
 
-    page.find_all('.tree-controls')[1].find('a:nth-child(2)').click
+    page.find_all('.tree-controls')[0].find('a:nth-child(2)').click # reshow all
 
     expect(page.find_all(".has_children ul[aria-hidden='false']").length).to eq(0)
   end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -25,16 +25,7 @@ RSpec.describe Commodity do
   end
 
   describe 'parent/children relationships' do
-    let(:associated_commodities) do
-      {
-        commodities: [attributes_for(:commodity, goods_nomenclature_sid: 1,
-                                                 parent_sid: nil),
-                      attributes_for(:commodity, parent_sid: 1,
-                                                 goods_nomenclature_sid: 2)],
-      }
-    end
-    let(:heading_attributes) { attributes_for(:heading).merge(associated_commodities) }
-    let(:heading) { Heading.new(heading_attributes) }
+    let(:heading) { build :heading, :with_commodity_tree }
 
     describe '#children' do
       it 'returns list of commodities children' do
@@ -47,6 +38,28 @@ RSpec.describe Commodity do
         heading
 
         expect(heading.commodities.last.children).to be_blank
+      end
+    end
+
+    describe '#parent' do
+      let(:heading) { build :heading, :with_commodity_tree, commodity_count: 3 }
+
+      context 'with parent' do
+        subject { heading.commodities.first.parent }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'with child' do
+        subject { heading.commodities.second.parent }
+
+        it { is_expected.to be heading.commodities.first }
+      end
+
+      context 'with grandchild' do
+        subject { heading.commodities.third.parent.parent }
+
+        it { is_expected.to be heading.commodities.first }
       end
     end
 

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -41,28 +41,6 @@ RSpec.describe Commodity do
       end
     end
 
-    describe '#parent' do
-      let(:heading) { build :heading, :with_commodity_tree, commodity_count: 3 }
-
-      context 'with parent' do
-        subject { heading.commodities.first.parent }
-
-        it { is_expected.to be_nil }
-      end
-
-      context 'with child' do
-        subject { heading.commodities.second.parent }
-
-        it { is_expected.to be heading.commodities.first }
-      end
-
-      context 'with grandchild' do
-        subject { heading.commodities.third.parent.parent }
-
-        it { is_expected.to be heading.commodities.first }
-      end
-    end
-
     describe '#root' do
       it 'returns children that have no parent_sid set' do
         heading

--- a/spec/models/subheading_spec.rb
+++ b/spec/models/subheading_spec.rb
@@ -76,8 +76,19 @@ RSpec.describe Subheading do
   end
 
   describe '#ancestors' do
-    subject { heading.ancestors }
+    subject { subheading.ancestors.map(&:goods_nomenclature_sid) }
 
-    it { is_expected.to be_empty }
+    let :subheading do
+      build :subheading, goods_nomenclature_sid: commodities[3][:goods_nomenclature_sid],
+                         commodities:
+    end
+
+    let :commodities do
+      attributes_for_list :commodity, 5 do |c, i|
+        c[:parent_sid] = (i > 0 ? c[:goods_nomenclature_sid] - 1 : nil)
+      end
+    end
+
+    it { is_expected.to eql commodities.first(3).pluck(:goods_nomenclature_sid) }
   end
 end

--- a/spec/models/subheading_spec.rb
+++ b/spec/models/subheading_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Subheading do
         heading
         footnotes
         commodities
+        ancestors
       ]
     end
 
@@ -73,22 +74,5 @@ RSpec.describe Subheading do
     subject { heading.declarable? }
 
     it { is_expected.to be false }
-  end
-
-  describe '#ancestors' do
-    subject { subheading.ancestors.map(&:goods_nomenclature_sid) }
-
-    let :subheading do
-      build :subheading, goods_nomenclature_sid: commodities[3][:goods_nomenclature_sid],
-                         commodities:
-    end
-
-    let :commodities do
-      attributes_for_list :commodity, 5 do |c, i|
-        c[:parent_sid] = (i > 0 ? c[:goods_nomenclature_sid] - 1 : nil)
-      end
-    end
-
-    it { is_expected.to eql commodities.first(3).pluck(:goods_nomenclature_sid) }
   end
 end

--- a/spec/models/subheading_spec.rb
+++ b/spec/models/subheading_spec.rb
@@ -69,9 +69,15 @@ RSpec.describe Subheading do
     end
   end
 
-  describe 'declarable?' do
+  describe '#declarable?' do
     subject { heading.declarable? }
 
     it { is_expected.to be false }
+  end
+
+  describe '#ancestors' do
+    subject { heading.ancestors }
+
+    it { is_expected.to be_empty }
   end
 end

--- a/spec/views/goods_nomenclatures/_ancestors.html.erb_spec.rb
+++ b/spec/views/goods_nomenclatures/_ancestors.html.erb_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-RSpec.describe 'commodities/_ancestors', type: :view do
+RSpec.describe 'goods_nomenclatures/_ancestors', type: :view do
   subject(:rendered_page) { render_page && rendered }
 
-  let(:render_page) { render 'commodities/ancestors', declarable: declarable }
+  let(:render_page) { render 'goods_nomenclatures/ancestors', goods_nomenclature: declarable }
 
   context 'with commodity', vcr: { cassette_name: 'commodities_2208909110' } do
     let(:commodity) { Commodity.find('2208909110', as_of: '2018-11-15') }

--- a/spec/views/subheading/show.html.erb_spec.rb
+++ b/spec/views/subheading/show.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe 'subheadings/show', type: :view do
+  subject(:rendered_page) { render }
+
+  before do
+    assign :subheading, subheading
+    assign :commodities, HeadingCommodityPresenter.new(subheading.commodities)
+    assign :search, Search.new
+  end
+
+  let(:subheading) { build :subheading, commodities_count: 3 }
+
+  it { is_expected.to have_css 'h1', text: "Subheading #{subheading.code} - #{subheading.description}" }
+  it { is_expected.to have_css 'dl.govuk-summary-list' }
+  it { is_expected.to have_css 'strong', text: '3 commodities' }
+  it { is_expected.to have_css 'nav.commodity-ancestors ol li', count: 4 }
+  it { is_expected.to have_css '.commodity-tree ul li', count: 3 }
+end

--- a/spec/views/subheading/show.html.erb_spec.rb
+++ b/spec/views/subheading/show.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'subheadings/show', type: :view do
 
   let :subheading do
     build :subheading, goods_nomenclature_sid: commodities[3][:goods_nomenclature_sid],
+                       ancestors: commodities.first(3),
                        commodities:
   end
 

--- a/spec/views/subheading/show.html.erb_spec.rb
+++ b/spec/views/subheading/show.html.erb_spec.rb
@@ -6,14 +6,26 @@ RSpec.describe 'subheadings/show', type: :view do
   before do
     assign :subheading, subheading
     assign :commodities, HeadingCommodityPresenter.new(subheading.commodities)
+    assign :subheading_commodities, [subheading.find_self_in_commodities_list]
     assign :search, Search.new
   end
 
-  let(:subheading) { build :subheading, commodities_count: 3 }
+  let :subheading do
+    build :subheading, goods_nomenclature_sid: commodities[3][:goods_nomenclature_sid],
+                       commodities:
+  end
+
+  let :commodities do
+    attributes_for_list :commodity, 7 do |commodity, index|
+      next if index.zero?
+
+      commodity[:parent_sid] = commodity[:goods_nomenclature_sid] - 1
+    end
+  end
 
   it { is_expected.to have_css 'h1', text: "Subheading #{subheading.code} - #{subheading.description}" }
   it { is_expected.to have_css 'dl.govuk-summary-list' }
-  it { is_expected.to have_css 'strong', text: '3 commodities' }
-  it { is_expected.to have_css 'nav.commodity-ancestors ol li', count: 4 }
-  it { is_expected.to have_css '.commodity-tree ul li', count: 3 }
+  it { is_expected.to have_css 'strong', text: '1 commodity' }
+  it { is_expected.to have_css 'nav.commodity-ancestors ol li', count: 7 }
+  it { is_expected.to have_css '.commodity-tree ul li', count: 4 }
 end


### PR DESCRIPTION
### Jira link

[HOTT-1483](https://transformuk.atlassian.net/browse/HOTT-1483)

### What?

I have added/removed/altered:

- [x] Moved ancestors partial into common goods_nomenclatures folder to show it applies to more then declarables/commodities
- [x] Show the ancestors tree on the Subheading page
- [x] Changed the Subheading tree to only show commodities below the Subheading being viewed
- [x] Default Commodity Tree on Heading and Subheading pages to show open instead of closed

### Why?

I am doing this because:

- It will aid users with navigating the site

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

