### PR TITLE
Disable RSpec dsl in main

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,7 @@ RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
   config.file_fixture_path = 'spec/fixtures'
+  config.expose_dsl_globally = false
 
   config.include FactoryBot::Syntax::Methods
   config.include Rails.application.routes.url_helpers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ Capybara.register_driver(:selenium_chrome_headless) do |app|
   options.add_argument('--headless')
 
   Capybara::Selenium::Driver.new(
-    app, browser: :chrome, options: options
+    app, browser: :chrome, options:
   )
 end
 


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Avoid monkey patched rspec dsl

### Why?

I am doing this because:

- This is consistent with the rails generators and it is generally more desirable to do things in one way, only: https://github.com/rspec/rspec-rails/commit/ca0d249858903949052e06884e8e7f9d596cdc79
