### PR TITLE
HOTT-1630 Hide guidance when no conditions

### DIFF
--- a/app/views/measures/_guidance_table.html.erb
+++ b/app/views/measures/_guidance_table.html.erb
@@ -1,3 +1,4 @@
+<% if measure_conditions_with_guidance.any? %>
 <details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">Guidance for completing Box 44 or Data Element 2/3</span>
@@ -31,3 +32,4 @@
     </table>
   </div>
 </details>
+<% end %>

--- a/spec/views/measures/_guidance_table.html.erb_spec.rb
+++ b/spec/views/measures/_guidance_table.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe 'measures/guidance_table', type: :view do
+  subject { render_page && rendered }
+
+  let :render_page do
+    render 'measures/guidance_table', measure_conditions_with_guidance: conditions
+  end
+
+  let(:conditions) { build_list :measure_condition, 2, :with_guidance }
+
+  it { is_expected.to have_css 'details summary', text: /Guidance for completing/ }
+  it { is_expected.to have_css 'table tbody tr', count: 2 }
+  it { is_expected.to have_css 'table tbody td', text: conditions.first.document_code }
+  it { is_expected.to have_css 'table tbody td', text: /Guidance CDS/ }
+  it { is_expected.to have_css 'table tbody td', text: /Guidance CHIEF/ }
+
+  context 'with no conditions' do
+    let(:conditions) { [] }
+
+    it { is_expected.not_to have_css 'details' }
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-1630](https://transformuk.atlassian.net/browse/HOTT-1630)

### What?

I have added/removed/altered:

- [x] Hide guidance notes section when there are no measure conditoins with guidance

### Why?

I am doing this because:

- Currently we are showing an empty table under certain circumstances