### PR TITLE
HOTT-1403 Dropped queue from production deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,9 +479,6 @@ jobs:
     environment:
       SENTRY_ENVIRONMENT: "production"
     steps:
-      - queue/until_front_of_line:
-          time: '10'
-          dont-quit: true
       - cf_deploy_docker:
           docker_image_tag: $CIRCLE_TAG
           space: "production"


### PR DESCRIPTION
### Jira link

HOTT-1403

### What?

I have added/removed/altered:

- [x] Dropped the queuing from the deployment to production

### Why?

I am doing this because:

* Its not compatible with deploying from a tag. 
* The risk of us launching concurrent production releases is very low with the 2 stage confirmation for production deployment
