### PR TITLE
HOTT-1567: Make use of redis_cache_store instead of outdated redis_st…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'puma'
 gem 'rack-cors'
 
 # Redis
-gem 'redis-rails'
+gem 'redis'
 
 # AWS
 gem 'aws-sdk-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,22 +318,6 @@ GEM
     raindrops (0.20.0)
     rake (13.0.6)
     redis (4.6.0)
-    redis-actionpack (5.3.0)
-      actionpack (>= 5, < 8)
-      redis-rack (>= 2.1.0, < 3)
-      redis-store (>= 1.1.0, < 2)
-    redis-activesupport (5.3.0)
-      activesupport (>= 3, < 8)
-      redis-store (>= 1.3, < 2)
-    redis-rack (2.1.4)
-      rack (>= 2.0.8, < 3)
-      redis-store (>= 1.2, < 2)
-    redis-rails (5.0.2)
-      redis-actionpack (>= 5.0, < 6)
-      redis-activesupport (>= 5.0, < 6)
-      redis-store (>= 1.2, < 2)
-    redis-store (1.9.1)
-      redis (>= 4, < 5)
     regexp_parser (2.4.0)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -488,7 +472,7 @@ DEPENDENCIES
   rack-test
   rails (~> 7.0)
   rails-controller-testing!
-  redis-rails
+  redis
   responders
   routing-filter!
   rspec-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_store,
+  config.cache_store = :redis_cache_store,
                        PaasConfig.redis.merge({
                          expires_in: 1.day,
                          namespace: ENV['GOVUK_APP_DOMAIN'],


### PR DESCRIPTION
### What?
Make use of redis_cache_store instead of outdated redis_store.

Why?

The reason of this PR is because Rails 5.2.0 (and following versions) includes a Redis cache store out of the box, so you don't need this gem anymore if you just need to store the cache in Redis.
For more: https://github.com/redis-store/redis-activesupport

### Jira link
https://transformuk.atlassian.net/browse/HOTT-1567
