### PR TITLE
HOTT-1642 Fixed URL generation on Search References

### DIFF
--- a/app/presenters/search_reference_presenter.rb
+++ b/app/presenters/search_reference_presenter.rb
@@ -1,16 +1,10 @@
-class SearchReferencePresenter
-  attr_reader :search_reference
-
-  def initialize(search_reference)
-    @search_reference = search_reference
-  end
-
+class SearchReferencePresenter < SimpleDelegator
   def to_s
-    search_reference.title.titleize
+    title.titleize
   end
 
   def link
-    "/#{APP_SLUG}/#{referenced_class.tableize}/#{composite_id}"
+    "/#{referenced_class.tableize}/#{composite_id}"
   end
 
   def composite_id
@@ -23,10 +17,6 @@ class SearchReferencePresenter
   end
 
   private
-
-  def method_missing(*args, &block)
-    @search_reference.send(*args, &block)
-  end
 
   def append_product_line_suffix(link)
     link + (referenced_class == 'Subheading' ? "-#{productline_suffix}" : '')

--- a/spec/presenters/search_reference_presenter_spec.rb
+++ b/spec/presenters/search_reference_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SearchReferencePresenter do
   let(:declarable) { build :search_reference, :with_subheading }
 
   describe '#link' do
-    it { expect(presenter.link).to eq('/trade-tariff/subheadings/1234567890-12') }
+    it { expect(presenter.link).to eq('/subheadings/1234567890-12') }
   end
 
   describe '#to_s' do


### PR DESCRIPTION
And dropped custom delegator pattern - use the stock SimpleDelegator
from Ruby instead

### Jira link

[HOTT-1642](https://transformuk.atlassian.net/browse/HOTT-1642)

### What?

I have added/removed/altered:

- [x] Changed the URL generated on the A-Z page
- [x] Removed custom delegation pattern from SearchReferencePresenter in favour of Ruby's built in `SimpleDelegator`

### Why?

I am doing this because:

- the URLs were incorrect
- the delegator was missing `respond_to` checks - better to leg Ruby do the leg work
