### PR TITLE
Fix failing commodity history page specs

### DIFF
--- a/spec/views/commodities/show_404.html.erb_spec.rb
+++ b/spec/views/commodities/show_404.html.erb_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe 'commodities/show_404.html.erb', type: :view do
     it { is_expected.to have_css 'p', text: /for the dates shown below/ }
     it { is_expected.to have_css 'ul.govuk-list.govuk-list--bullet li', count: 2 }
 
-    it { is_expected.to have_css 'li', text: /From \d+ [a-z]{4}[a-z]+ \d{4}/i, count: 2 }
-    it { is_expected.to have_css 'li', text: /to \d+ [a-z]{4}[a-z]+ \d{4}/i, count: 1 }
+    it { is_expected.to have_css 'li', text: /From \d+ [a-z]{2}[a-z]+ \d{4}/i, count: 2 }
+    it { is_expected.to have_css 'li', text: /to \d+ [a-z]{2}[a-z]+ \d{4}/i, count: 1 }
 
     it { is_expected.to have_css 'li > a', count: 3 }
 

--- a/spec/views/headings/show_404.html.erb_spec.rb
+++ b/spec/views/headings/show_404.html.erb_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe 'headings/show_404.html.erb', type: :view do
     it { is_expected.to have_css 'p', text: /for the dates shown below/ }
     it { is_expected.to have_css 'ul.govuk-list.govuk-list--bullet li', count: 2 }
 
-    it { is_expected.to have_css 'li', text: /From \d+ [a-z]{4}[a-z]+ \d{4}/i, count: 2 }
-    it { is_expected.to have_css 'li', text: /to \d+ [a-z]{4}[a-z]+ \d{4}/i, count: 1 }
+    it { is_expected.to have_css 'li', text: /From \d+ [a-z]{2}[a-z]+ \d{4}/i, count: 2 }
+    it { is_expected.to have_css 'li', text: /to \d+ [a-z]{2}[a-z]+ \d{4}/i, count: 1 }
 
     it { is_expected.to have_css 'li > a', count: 3 }
 


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Fixed the commodity and heading history page specs

### Why?

I am doing this because:

The specs were checking that not only were the correct dates shown but
also that full month names were used, not 3 letter abbreviations.

May is a full month name though and is only 3 letters in length, so
differentiating is not possible hence just removing the checking for 'full'
month names and instead checking for at least 3 chars