### PR TITLE
HOTT-1570 Allow creation of sentry release to fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,10 +298,11 @@ commands:
                       https://github.com/getsentry/sentry-cli/releases/download/1.74.3/sentry-cli-Linux-x86_64
             sudo chmod 0755 /usr/local/bin/sentry-cli
             export SENTRY_RELEASE=$(sentry-cli releases propose-version)
-            sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
-            sentry-cli releases set-commits $SENTRY_RELEASE --auto
-            sentry-cli releases finalize $SENTRY_RELEASE
-            sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
+            sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE &&
+              sentry-cli releases set-commits $SENTRY_RELEASE --auto &&
+              sentry-cli releases finalize $SENTRY_RELEASE &&
+              sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT ||
+              /usr/bin/true # prevent sentry outage from blocking deploys - see HOTT-1570
 
 jobs:
   checks:


### PR DESCRIPTION
### Jira link

[HOTT-1570](https://transformuk.atlassian.net/browse/HOTT-1570)

### What?

I have added/removed/altered:

- [x] Allow Sentry release to fail

### Why?

I am doing this because:

- We've had problems with not being able to submit release info to sentry a couple of times now, once with the CLI changing and being automatically upgraded and once with an outage on their hosted service.
- Forcing the step to always return true will prevent it from blocking releasing
