### PR TITLE
HOTT-1653 Added gsp import step

### DIFF
--- a/app/controllers/rules_of_origin/steps_controller.rb
+++ b/app/controllers/rules_of_origin/steps_controller.rb
@@ -1,7 +1,5 @@
 module RulesOfOrigin
   class StepsController < ApplicationController
-    default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
-
     include WizardSteps
     self.wizard_class = RulesOfOrigin::Wizard
 

--- a/app/helpers/rules_of_origin_helper.rb
+++ b/app/helpers/rules_of_origin_helper.rb
@@ -20,11 +20,11 @@ module RulesOfOriginHelper
              scheme: schemes.first
     elsif schemes.first.unilateral
       render 'rules_of_origin/intros/unilateral_trade_bloc',
-             country_name: country_name,
+             country_name:,
              scheme: schemes.first
     else
       render 'rules_of_origin/intros/trade_bloc',
-             country_name: country_name,
+             country_name:,
              scheme: schemes.first
     end
   end
@@ -51,5 +51,17 @@ module RulesOfOriginHelper
     safe_content.gsub(ROO_NON_BREAKING_HEADING) { |match|
       tag.span match, class: 'rules-of-origin__non-breaking-heading'
     }.html_safe
+  end
+
+  def rules_of_origin_form_for(current_step, *args, **kwargs, &block)
+    form_for(current_step, *args, builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+                                  url: step_path,
+                                  **kwargs) do |form|
+      safe_join [
+        form.govuk_error_summary,
+        capture(form, &block),
+        form.govuk_submit(t('rules_of_origin.steps.common.continue')),
+      ], "\n"
+    end
   end
 end

--- a/app/models/rules_of_origin/steps/base.rb
+++ b/app/models/rules_of_origin/steps/base.rb
@@ -17,8 +17,11 @@ module RulesOfOrigin
       end
 
       def chosen_scheme
-        # FIXME: multiple scheme support coming in a later ticket
-        rules_of_origin_schemes.first
+        if @store['scheme_code']
+          rules_of_origin_schemes.index_by(&:scheme_code)[@store['scheme_code']]
+        else
+          rules_of_origin_schemes.first
+        end
       end
     end
   end

--- a/app/models/rules_of_origin/steps/base.rb
+++ b/app/models/rules_of_origin/steps/base.rb
@@ -1,8 +1,14 @@
 module RulesOfOrigin
   module Steps
     class Base < ::WizardSteps::Step
+      delegate :rules_of_origin_schemes, to: :@wizard
+
+      def service
+        @store['service']
+      end
+
       def service_country_name
-        I18n.t "title.region_name.#{@store['service']}"
+        I18n.t "title.region_name.#{service}"
       end
 
       def trade_country_name
@@ -10,10 +16,8 @@ module RulesOfOrigin
                                                 .description
       end
 
-      def rules_of_origin_schemes
-        @rules_of_origin_schemes =
-          RulesOfOrigin::Scheme.all(@store['commodity_code'],
-                                    @store['country_code'])
+      def commodity_code
+        @store['commodity_code']
       end
 
       def chosen_scheme

--- a/app/models/rules_of_origin/steps/import_export.rb
+++ b/app/models/rules_of_origin/steps/import_export.rb
@@ -20,6 +20,10 @@ module RulesOfOrigin
       def options
         OPTIONS
       end
+
+      def unilateral_scheme?
+        @unilateral_scheme ||= !!chosen_scheme.unilateral
+      end
     end
   end
 end

--- a/app/models/rules_of_origin/steps/import_export.rb
+++ b/app/models/rules_of_origin/steps/import_export.rb
@@ -21,8 +21,8 @@ module RulesOfOrigin
         OPTIONS
       end
 
-      def unilateral_scheme?
-        @unilateral_scheme ||= !!chosen_scheme.unilateral
+      def skipped?
+        !!chosen_scheme.unilateral
       end
     end
   end

--- a/app/models/rules_of_origin/steps/import_only.rb
+++ b/app/models/rules_of_origin/steps/import_only.rb
@@ -1,0 +1,11 @@
+module RulesOfOrigin
+  module Steps
+    class ImportOnly < Base
+      attribute :import_only, :boolean
+
+      def skipped?
+        !chosen_scheme.unilateral
+      end
+    end
+  end
+end

--- a/app/models/rules_of_origin/steps/scheme.rb
+++ b/app/models/rules_of_origin/steps/scheme.rb
@@ -6,11 +6,11 @@ module RulesOfOrigin
       validates :scheme_code, inclusion: { in: :available_scheme_codes }
 
       def available_scheme_codes
-        @store['available_scheme_codes'] ||= rules_of_origin_schemes.map(&:scheme_code)
+        rules_of_origin_schemes.map(&:scheme_code)
       end
 
       def skipped?
-        available_scheme_codes.one?
+        rules_of_origin_schemes.one?
       end
     end
   end

--- a/app/models/rules_of_origin/steps/scheme.rb
+++ b/app/models/rules_of_origin/steps/scheme.rb
@@ -3,22 +3,14 @@ module RulesOfOrigin
     class Scheme < Base
       attribute :scheme_code
 
-      validates :scheme_code, inclusion: { in: :scheme_codes }
+      validates :scheme_code, inclusion: { in: :available_scheme_codes }
 
-      def scheme_codes
-        @store['scheme_codes'] || persist_scheme_codes
+      def available_scheme_codes
+        @store['available_scheme_codes'] ||= rules_of_origin_schemes.map(&:scheme_code)
       end
 
       def skipped?
-        scheme_codes.one?
-      end
-
-    private
-
-      def persist_scheme_codes
-        @store.persist(scheme_codes: rules_of_origin_schemes.map(&:scheme_code))
-
-        @store['scheme_codes']
+        available_scheme_codes.one?
       end
     end
   end

--- a/app/models/rules_of_origin/wizard.rb
+++ b/app/models/rules_of_origin/wizard.rb
@@ -4,8 +4,15 @@ module RulesOfOrigin
       Steps::Start,
       Steps::Scheme,
       Steps::ImportExport,
+      Steps::ImportOnly,
       Steps::Originating,
       Steps::End,
     ]
+
+    def rules_of_origin_schemes
+      @rules_of_origin_schemes ||=
+        RulesOfOrigin::Scheme.all(@store['commodity_code'],
+                                  @store['country_code'])
+    end
   end
 end

--- a/app/views/rules_of_origin/steps/_import_export.html.erb
+++ b/app/views/rules_of_origin/steps/_import_export.html.erb
@@ -1,14 +1,16 @@
-<%= form.govuk_collection_radio_buttons \
-      :import_or_export,
-      form.object.options,
-      :to_sym,
-      -> (option) {
-        t "helpers.label.rules_of_origin_steps_import_export.import_or_export_options.#{option}",
-          service_country: form.object.service_country_name,
-          trade_country: form.object.trade_country_name
-      },
-      legend: {
-        text: t('helpers.legend.rules_of_origin_steps_import_export.import_or_export',
-                service_country: form.object.service_country_name,
-                trade_country: form.object.trade_country_name)
-      } %>
+<%= rules_of_origin_form_for(current_step) do |form| %>
+  <%= form.govuk_collection_radio_buttons \
+        :import_or_export,
+        form.object.options,
+        :to_sym,
+        -> (option) {
+          t "helpers.label.rules_of_origin_steps_import_export.import_or_export_options.#{option}",
+            service_country: form.object.service_country_name,
+            trade_country: form.object.trade_country_name
+        },
+        legend: {
+          text: t('helpers.legend.rules_of_origin_steps_import_export.import_or_export',
+                  service_country: form.object.service_country_name,
+                  trade_country: form.object.trade_country_name)
+        } %>
+<% end %>

--- a/app/views/rules_of_origin/steps/_import_only.html.erb
+++ b/app/views/rules_of_origin/steps/_import_only.html.erb
@@ -1,0 +1,20 @@
+<span class="govuk-caption-xl">
+  <%= t '.caption', commodity_code: form.object.commodity_code,
+                    trade_country_name: form.object.trade_country_name %>
+</span>
+
+<h1 class="govuk-heading-l">
+  <%= t '.title', service_country_name: t("service.country_name.#{form.object.service}") %>
+</h1>
+
+<p class="govuk-body-l">
+  <%= t '.lead_para_html', trade_country_name: form.object.trade_country_name %>
+</p>
+
+<h3 class="govuk-heading-s">
+  <%= t '.importing_from', trade_country_name: form.object.trade_country_name %>
+</h3>
+
+<p>
+  <%= t '.import_instructions', trade_country_name: form.object.trade_country_name %>
+</p>

--- a/app/views/rules_of_origin/steps/_import_only.html.erb
+++ b/app/views/rules_of_origin/steps/_import_only.html.erb
@@ -1,20 +1,22 @@
-<span class="govuk-caption-xl">
-  <%= t '.caption', commodity_code: form.object.commodity_code,
-                    trade_country_name: form.object.trade_country_name %>
-</span>
+<%= rules_of_origin_form_for(current_step) do |form| %>
+  <span class="govuk-caption-xl">
+    <%= t '.caption', commodity_code: form.object.commodity_code,
+                      trade_country_name: form.object.trade_country_name %>
+  </span>
 
-<h1 class="govuk-heading-l">
-  <%= t '.title', service_country_name: t("service.country_name.#{form.object.service}") %>
-</h1>
+  <h1 class="govuk-heading-l">
+    <%= t '.title', service_country_name: t("service.country_name.#{form.object.service}") %>
+  </h1>
 
-<p class="govuk-body-l">
-  <%= t '.lead_para_html', trade_country_name: form.object.trade_country_name %>
-</p>
+  <p class="govuk-body-l">
+    <%= t '.lead_para_html', trade_country_name: form.object.trade_country_name %>
+  </p>
 
-<h3 class="govuk-heading-s">
-  <%= t '.importing_from', trade_country_name: form.object.trade_country_name %>
-</h3>
+  <h3 class="govuk-heading-s">
+    <%= t '.importing_from', trade_country_name: form.object.trade_country_name %>
+  </h3>
 
-<p>
-  <%= t '.import_instructions', trade_country_name: form.object.trade_country_name %>
-</p>
+  <p>
+    <%= t '.import_instructions', trade_country_name: form.object.trade_country_name %>
+  </p>
+<% end %>

--- a/app/views/rules_of_origin/steps/_import_only.html.erb
+++ b/app/views/rules_of_origin/steps/_import_only.html.erb
@@ -20,3 +20,16 @@
     <%= t '.import_instructions', trade_country_name: form.object.trade_country_name %>
   </p>
 <% end %>
+
+<h3 class="govuk-heading-s">
+  <%= t '.exporting_to', trade_country_name: current_step.trade_country_name %>
+</h3>
+
+<div class="tariff-markdown">
+  <%= simple_format t '.export_information', trade_country_name: current_step.trade_country_name %>
+</div>
+
+<p>
+  <%= link_to t('.export_info_link'),
+              "https://www.gov.uk/government/publications/reference-document-for-the-customs-origin-of-chargeable-goods-eu-exit-regulations-2020" %>
+</p>

--- a/app/views/rules_of_origin/steps/_originating.html.erb
+++ b/app/views/rules_of_origin/steps/_originating.html.erb
@@ -1,23 +1,25 @@
-<span class="govuk-caption-xl">
-  <%= t '.caption' %>
-</span>
+<%= rules_of_origin_form_for(current_step) do |form| %>
+  <span class="govuk-caption-xl">
+    <%= t '.caption' %>
+  </span>
 
-<h1 class="govuk-heading-l">
-  <%= t '.title', originating_country: form.object.originating_country %>
-</h1>
+  <h1 class="govuk-heading-l">
+    <%= t '.title', originating_country: form.object.originating_country %>
+  </h1>
 
-<p class="govuk-body-l">
-  <%= t '.lead_para', originating_country: form.object.originating_country,
-                      scheme_title: form.object.scheme_title %>
-</p>
+  <p class="govuk-body-l">
+    <%= t '.lead_para', originating_country: form.object.originating_country,
+                        scheme_title: form.object.scheme_title %>
+  </p>
 
-<div class="tariff-markdown">
-  <%= govspeak t '.conditions_md', originating_country: form.object.originating_country,
-                                   scheme_title: form.object.scheme_title %>
+  <div class="tariff-markdown">
+    <%= govspeak t '.conditions_md', originating_country: form.object.originating_country,
+                                     scheme_title: form.object.scheme_title %>
 
-  <h3 class="govuk-heading-s">
-    <%= t 'rules_of_origin.steps.common.next_step' %>
-  </h3>
+    <h3 class="govuk-heading-s">
+      <%= t 'rules_of_origin.steps.common.next_step' %>
+    </h3>
 
-  <%= govspeak t '.next_step_md', scheme_title: form.object.scheme_title %>
-</div>
+    <%= govspeak t '.next_step_md', scheme_title: form.object.scheme_title %>
+  </div>
+<% end %>

--- a/app/views/rules_of_origin/steps/_originating.html.erb
+++ b/app/views/rules_of_origin/steps/_originating.html.erb
@@ -15,9 +15,9 @@
   <%= govspeak t '.conditions_md', originating_country: form.object.originating_country,
                                    scheme_title: form.object.scheme_title %>
 
-  <p>
-    <strong><%= t 'rules_of_origin.steps.common.next_step' %></strong>
-  </p>
+  <h3 class="govuk-heading-s">
+    <%= t 'rules_of_origin.steps.common.next_step' %>
+  </h3>
 
   <%= govspeak t '.next_step_md', scheme_title: form.object.scheme_title %>
 </div>

--- a/app/views/rules_of_origin/steps/_scheme.html.erb
+++ b/app/views/rules_of_origin/steps/_scheme.html.erb
@@ -1,13 +1,15 @@
-<%= form.govuk_collection_radio_buttons \
-      :scheme_code,
-      form.object.rules_of_origin_schemes,
-      :scheme_code,
-      :title,
-      legend: {
-        text: t('helpers.legend.rules_of_origin_steps_scheme.scheme_code',
-                trade_country: form.object.trade_country_name)
-      },
-      hint: {
-        text: simple_format(t('helpers.hint.rules_of_origin_steps_scheme.scheme_code',
-                            trade_country: form.object.trade_country_name))
-      } %>
+<%= rules_of_origin_form_for(current_step) do |form| %>
+  <%= form.govuk_collection_radio_buttons \
+        :scheme_code,
+        form.object.rules_of_origin_schemes,
+        :scheme_code,
+        :title,
+        legend: {
+          text: t('helpers.legend.rules_of_origin_steps_scheme.scheme_code',
+                  trade_country: form.object.trade_country_name)
+        },
+        hint: {
+          text: simple_format(t('helpers.hint.rules_of_origin_steps_scheme.scheme_code',
+                              trade_country: form.object.trade_country_name))
+        } %>
+<% end %>

--- a/app/views/rules_of_origin/steps/show.html.erb
+++ b/app/views/rules_of_origin/steps/show.html.erb
@@ -5,13 +5,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= form_for current_step, url: step_path do |form| %>
-        <%= form.govuk_error_summary %>
-
-        <%= render current_step.key, form: form, wizard: wizard %>
-
-        <%= form.govuk_submit t('.continue') %>
-      <% end %>
+      <%= render current_step.key, current_step: current_step, wizard: wizard %>
     </div>
 
     <div class="govuk-grid-column-one-third">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,6 +105,11 @@ en:
       uk: You are viewing the UK Integrated Online Tariff.
       xi: You are viewing the Northern Ireland Online Tariff.
 
+  service:
+    country_name:
+      uk: the United Kingdom
+      xi: Northern Ireland
+
   meursing_lookup:
     steps:
       starch:
@@ -233,6 +238,22 @@ en:
       show:
         meta_title: "Rules of Origin: %{step}"
         continue: Continue
+      import_only:
+        caption: Trading commodity %{commodity_code} with %{trade_country_name}
+        title: |
+          Importing goods into %{service_country_name} from countries which belong to
+          the GSP scheme
+        lead_para_html: |
+          %{trade_country_name} is a member of the unilateral
+          <a href="https://www.gov.uk/government/publications/trading-with-developing-nations">
+            Generalised System of Preferences (GSP)
+          </a>
+          scheme. The rules of origin apply only to the import of goods from the
+          overseas country.
+        importing_from: Importing goods from %{trade_country_name}
+        import_instructions: |
+          Click on the 'Continue' button to determine if the rules of origin
+          apply to your import from %{trade_country_name}.
       originating:
         caption: Are your goods originating?
         title: How to work out if your goods are classed as 'originating' in %{originating_country}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,6 +254,16 @@ en:
         import_instructions: |
           Click on the 'Continue' button to determine if the rules of origin
           apply to your import from %{trade_country_name}.
+        exporting_to: Exporting goods to %{trade_country_name}
+        export_information: |
+          If you would like to export goods to %{trade_country_name}, then MFN duties will apply.
+
+          For Most-Favoured Nation (MFN) duties, anti-dumping, anti-subsidies or
+          safeguard measures, origin marking, non-preferential rules of origin
+          apply.
+        export_info_link:
+          Find out about the product-specific rules, to determine the origin of
+          imports outside of a preferential agreement.
       originating:
         caption: Are your goods originating?
         title: How to work out if your goods are classed as 'originating' in %{originating_country}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,9 +235,9 @@ en:
     steps:
       common:
         next_step: Next step
+        continue: Continue
       show:
         meta_title: "Rules of Origin: %{step}"
-        continue: Continue
       import_only:
         caption: Trading commodity %{commodity_code} with %{trade_country_name}
         title: |

--- a/spec/factories/rules_of_origin_wizard_store_factory.rb
+++ b/spec/factories/rules_of_origin_wizard_store_factory.rb
@@ -4,24 +4,25 @@ FactoryBot.define do
 
     transient do
       schemes { build_list :rules_of_origin_scheme, 2 }
+      chosen_scheme { 1 }
     end
 
     service { 'uk' }
     country_code { 'JP' }
     commodity_code { '6004100091' }
 
-    trait :first_scheme do
-      scheme_count { schemes.length }
-      scheme_code { schemes.first.scheme_code }
+    trait :with_chosen_scheme do
+      available_scheme_codes { schemes.map(&:scheme_code) }
+      scheme_code { schemes[chosen_scheme - 1].scheme_code }
     end
 
     trait :importing do
-      trait :first_scheme
+      with_chosen_scheme
       import_or_export { 'import' }
     end
 
     trait :exporting do
-      trait :first_scheme
+      with_chosen_scheme
       import_or_export { 'export' }
     end
   end

--- a/spec/factories/rules_of_origin_wizard_store_factory.rb
+++ b/spec/factories/rules_of_origin_wizard_store_factory.rb
@@ -12,7 +12,6 @@ FactoryBot.define do
     commodity_code { '6004100091' }
 
     trait :with_chosen_scheme do
-      available_scheme_codes { schemes.map(&:scheme_code) }
       scheme_code { schemes[chosen_scheme - 1].scheme_code }
     end
 

--- a/spec/helpers/rules_of_origin_helper_spec.rb
+++ b/spec/helpers/rules_of_origin_helper_spec.rb
@@ -128,4 +128,35 @@ RSpec.describe RulesOfOriginHelper, type: :helper do
       it { is_expected.to eql expected }
     end
   end
+
+  describe '#rules_of_origin_form_for' do
+    subject do
+      helper.rules_of_origin_form_for(model_instance) do |f|
+        f.govuk_text_field :name
+      end
+    end
+
+    before { allow(helper).to receive(:step_path).and_return '/' }
+
+    let :stub_model do
+      Class.new do
+        include ActiveModel::Model
+
+        attr_accessor :name
+
+        validates :name, presence: true
+
+        def self.name
+          'StubModel'
+        end
+      end
+    end
+
+    let(:model_instance) { stub_model.new.tap(&:validate) }
+
+    it { is_expected.to have_css 'form input[name="stub_model[name]"]' }
+    it { is_expected.to have_css '.govuk-error-summary' }
+    it { is_expected.to have_css '.govuk-error-message' }
+    it { is_expected.to have_css 'button[type="submit"]' }
+  end
 end

--- a/spec/models/rules_of_origin/steps/import_export_spec.rb
+++ b/spec/models/rules_of_origin/steps/import_export_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe RulesOfOrigin::Steps::ImportExport do
-  include_context 'with rules of origin store'
+  include_context 'with rules of origin store', :with_chosen_scheme
   include_context 'with wizard step', RulesOfOrigin::Wizard
 
   it { is_expected.to respond_to :import_or_export }
@@ -27,6 +27,18 @@ RSpec.describe RulesOfOrigin::Steps::ImportExport do
 
     context 'when blank' do
       it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe '#unilateral_scheme?' do
+    subject { instance.unilateral_scheme? }
+
+    it { is_expected.to be false }
+
+    context 'with GSP selected' do
+      let(:schemes) { build_list :rules_of_origin_scheme, 2, unilateral: true }
+
+      it { is_expected.to be true }
     end
   end
 end

--- a/spec/models/rules_of_origin/steps/import_export_spec.rb
+++ b/spec/models/rules_of_origin/steps/import_export_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe RulesOfOrigin::Steps::ImportExport do
     end
   end
 
-  describe '#unilateral_scheme?' do
-    subject { instance.unilateral_scheme? }
+  describe '#skipped?' do
+    subject { instance.skipped? }
 
     it { is_expected.to be false }
 

--- a/spec/models/rules_of_origin/steps/import_only_spec.rb
+++ b/spec/models/rules_of_origin/steps/import_only_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe RulesOfOrigin::Steps::ImportOnly do
+  include_context 'with rules of origin store', :with_chosen_scheme
+  include_context 'with wizard step', RulesOfOrigin::Wizard
+
+  let :schemes do
+    build_list :rules_of_origin_scheme, 2, countries: [country.id],
+                                           unilateral: true
+  end
+
+  it { is_expected.to respond_to :import_only }
+
+  it { is_expected.to have_attributes commodity_code: wizardstore['commodity_code'] }
+  it { is_expected.to have_attributes trade_country_name: country.description }
+
+  describe '#skipped?' do
+    subject { instance.skipped? }
+
+    it { is_expected.to be false }
+
+    context 'with non GSP selected' do
+      let(:schemes) { build_list :rules_of_origin_scheme, 2, unilateral: false }
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/models/rules_of_origin/steps/originating_spec.rb
+++ b/spec/models/rules_of_origin/steps/originating_spec.rb
@@ -22,5 +22,11 @@ RSpec.describe RulesOfOrigin::Steps::Originating do
     subject { instance.scheme_title }
 
     it { is_expected.to eql schemes.first.title }
+
+    context 'with multiple schemes' do
+      include_context 'with rules of origin store', :importing, scheme_count: 2, chosen_scheme: 2
+
+      it { is_expected.to eql schemes.second.title }
+    end
   end
 end

--- a/spec/models/rules_of_origin/steps/scheme_spec.rb
+++ b/spec/models/rules_of_origin/steps/scheme_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe RulesOfOrigin::Steps::Scheme do
 
   it { is_expected.to respond_to :scheme_code }
 
-  describe '#scheme_codes' do
-    subject { instance.scheme_codes }
+  describe '#available_scheme_codes' do
+    subject { instance.available_scheme_codes }
 
     it { is_expected.to eql schemes.map(&:scheme_code) }
   end
@@ -49,7 +49,7 @@ RSpec.describe RulesOfOrigin::Steps::Scheme do
       it 'persists the scheme count to avoid API calls for skipped? checks' do
         instance.skipped?
 
-        expect(wizardstore['scheme_codes']).to eq schemes.map(&:scheme_code)
+        expect(wizardstore['available_scheme_codes']).to eq schemes.map(&:scheme_code)
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe RulesOfOrigin::Steps::Scheme do
       it 'persists the scheme count to avoid API calls for skipped? checks' do
         instance.skipped?
 
-        expect(wizardstore['scheme_codes']).to eq schemes.map(&:scheme_code)
+        expect(wizardstore['available_scheme_codes']).to eq schemes.map(&:scheme_code)
       end
     end
   end

--- a/spec/models/rules_of_origin/steps/scheme_spec.rb
+++ b/spec/models/rules_of_origin/steps/scheme_spec.rb
@@ -45,24 +45,12 @@ RSpec.describe RulesOfOrigin::Steps::Scheme do
       let(:schemes) { build_list :rules_of_origin_scheme, 1 }
 
       it { is_expected.to be true }
-
-      it 'persists the scheme count to avoid API calls for skipped? checks' do
-        instance.skipped?
-
-        expect(wizardstore['available_scheme_codes']).to eq schemes.map(&:scheme_code)
-      end
     end
 
     context 'with multiple schemes' do
       let(:schemes) { build_list :rules_of_origin_scheme, 2 }
 
       it { is_expected.to be false }
-
-      it 'persists the scheme count to avoid API calls for skipped? checks' do
-        instance.skipped?
-
-        expect(wizardstore['available_scheme_codes']).to eq schemes.map(&:scheme_code)
-      end
     end
   end
 end

--- a/spec/support/shared_context/rules_of_origin_wizard.rb
+++ b/spec/support/shared_context/rules_of_origin_wizard.rb
@@ -1,4 +1,4 @@
-shared_context 'with rules of origin store' do |state|
+shared_context 'with rules of origin store' do |*traits, scheme_count: 1, **store_attributes|
   before do
     allow(GeographicalArea).to receive(:find).with(wizardstore['country_code'])
                                              .and_return(country)
@@ -8,18 +8,23 @@ shared_context 'with rules of origin store' do |state|
                    .and_return(schemes)
   end
 
+  let(:country) { build :geographical_area, :japan }
+
   let(:wizardstore) do
-    build :rules_of_origin_wizard_store, state, schemes:, country_code: country.id
+    build :rules_of_origin_wizard_store, *traits, schemes:,
+                                                  country_code: country.id,
+                                                  **store_attributes
   end
 
-  let(:country) { build :geographical_area, :japan }
-  let(:schemes) { build_list :rules_of_origin_scheme, 1, countries: [country.id] }
+  let(:schemes) do
+    build_list :rules_of_origin_scheme, scheme_count, countries: [country.id]
+  end
 end
 
-shared_context 'with rules of origin form step' do |step, state|
+shared_context 'with rules of origin form step' do |step, *traits|
   subject { render_page && rendered }
 
-  include_context 'with rules of origin store', state
+  include_context 'with rules of origin store', *traits
   include_context 'with govuk form builder'
 
   let(:wizard) { RulesOfOrigin::Wizard.new wizardstore, step }

--- a/spec/support/shared_context/rules_of_origin_wizard.rb
+++ b/spec/support/shared_context/rules_of_origin_wizard.rb
@@ -24,15 +24,14 @@ end
 shared_context 'with rules of origin form step' do |step, *traits|
   subject { render_page && rendered }
 
+  before { allow(view).to receive(:step_path).and_return '/' }
+
   include_context 'with rules of origin store', *traits
-  include_context 'with govuk form builder'
 
   let(:wizard) { RulesOfOrigin::Wizard.new wizardstore, step }
   let(:current_step) { wizard.find_current_step }
 
   let :render_page do
-    view.form_for current_step, url: '/' do |form|
-      render "rules_of_origin/steps/#{current_step.key}", form:, wizard:
-    end
+    render "rules_of_origin/steps/#{current_step.key}", current_step:, wizard:
   end
 end

--- a/spec/support/shared_context/wizard.rb
+++ b/spec/support/shared_context/wizard.rb
@@ -1,10 +1,3 @@
-shared_context 'with govuk form builder' do
-  before do
-    allow(view).to receive(:default_form_builder)
-                   .and_return GOVUKDesignSystemFormBuilder::FormBuilder
-  end
-end
-
 shared_context 'with wizard store' do
   let(:backingstore) { {} }
   let(:wizardstore) { ::WizardSteps::Store.new backingstore }

--- a/spec/views/rules_of_origin/steps/_import_only_html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_import_only_html.erb_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/steps/_import_only', type: :view do
+  include_context 'with rules of origin form step', 'import_only'
+
+  it { is_expected.to have_css 'h1', text: /importing .* the United Kingdom .* GSP scheme/im }
+  it { is_expected.to have_css '.govuk-caption-xl', text: /trading .* \d{10} with Japan/i }
+  it { is_expected.to have_css 'p', text: /Japan .* unilateral/m }
+  it { is_expected.to have_link 'Generalised System of Preferences (GSP)' }
+
+  xit { is_expected.to have_css 'p', text: /export goods to Japan/ }
+  xit { is_expected.to have_css 'p a[href]', text: /Find out about the product-specific rules/ }
+end

--- a/spec/views/rules_of_origin/steps/_import_only_html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_import_only_html.erb_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe 'rules_of_origin/steps/_import_only', type: :view do
   it { is_expected.to have_css 'p', text: /Japan .* unilateral/m }
   it { is_expected.to have_link 'Generalised System of Preferences (GSP)' }
 
-  xit { is_expected.to have_css 'p', text: /export goods to Japan/ }
-  xit { is_expected.to have_css 'p a[href]', text: /Find out about the product-specific rules/ }
+  it { is_expected.to have_css 'p', text: /export goods to Japan/ }
+  it { is_expected.to have_css 'p a[href]', text: /Find out about the product-specific rules/ }
 end

--- a/spec/views/rules_of_origin/steps/show.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/show.html.erb_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'rules_of_origin/steps/show', type: :view do
   subject { render && rendered }
 
   include_context 'with rules of origin store'
-  include_context 'with govuk form builder'
 
   before do
     allow(view).to receive(:wizard).and_return wizard


### PR DESCRIPTION
### Jira link

[HOTT-1653](https://transformuk.atlassian.net/browse/HOTT-1653)

### What?

I have added/removed/altered:

- [x] Added an import only step which is shown when the user is using a GSP scheme 
- [x] Made the Import/Export step conditional on the user using a non GSP scheme
- [x] Refactored the step form handling to allow content outside of the form
- [x] Refactored step selection to cache the rules of origin on the wizard for the lifecycle of the page request

### Why?

I am doing this because:

- We wish to show a different step when the user is using a GSP scheme
- The GSP screen has content after the 'continue' button
- The rules of origin maybe required by multiple steps when calculating next/previous screens so caching on the wizard avoids repeated API calls as part of the page request

### Note

There's a missing link and disabled spec on the page - just waiting on the URL, will add it before any merge

### Screenshot

![Screenshot from 2022-06-09 16-56-36](https://user-images.githubusercontent.com/10818/172891671-6f8e2053-14de-4433-b868-89f5ac943827.png)

