### PR TITLE
HOTT-1673 dont set invalid locales

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -161,8 +161,13 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    I18n.locale = params[:locale].presence || I18n.default_locale
+    I18n.locale = locale_is_valid? ? params[:locale].to_sym : I18n.default_locale
     yield
     I18n.locale = I18n.default_locale
+  end
+
+  def locale_is_valid?
+    params[:locale].presence &&
+      I18n.available_locales.include?(params[:locale]&.to_sym)
   end
 end

--- a/spec/features/locale_spec.rb
+++ b/spec/features/locale_spec.rb
@@ -1,28 +1,30 @@
 require 'spec_helper'
 
-RSpec.describe 'Search banner' do
+RSpec.describe 'Page banner' do
   subject { page }
 
+  include_context 'with latest news stubbed'
+
   context 'without locale prefix' do
-    before { visit '/find_commodities' }
+    before { visit '/find_commodity' }
 
     it { is_expected.to have_css 'header.govuk-header a', text: 'UK Integrated Online Tariff' }
   end
 
   context 'with locale prefix' do
-    before { visit '/cy/find_commodities' }
+    before { visit '/cy/find_commodity' }
 
     it { is_expected.to have_css 'header.govuk-header a', text: 'UK Integrated Online Tariff in Welsh' }
   end
 
   context 'with service prefix' do
-    before { visit '/xi/find_commodities' }
+    before { visit '/xi/find_commodity' }
 
     it { is_expected.to have_css 'header.govuk-header a', text: 'Northern Ireland Online Tariff' }
   end
 
   context 'with locale and service prefix' do
-    before { visit '/xi/cy/find_commodities' }
+    before { visit '/xi/cy/find_commodity' }
 
     it { is_expected.to have_css 'header.govuk-header a', text: 'Northern Ireland Online Tariff in Welsh' }
   end

--- a/spec/features/locale_spec.rb
+++ b/spec/features/locale_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe 'Page banner' do
     it { is_expected.to have_css 'header.govuk-header a', text: 'UK Integrated Online Tariff in Welsh' }
   end
 
+  context 'with invalid locale prefix' do
+    before { visit '/fr/find_commodity' }
+
+    it { is_expected.to have_css 'header.govuk-header a', text: 'UK Integrated Online Tariff' }
+  end
+
+  context 'with invalid locale param' do
+    before { visit '/find_commodity?locale=fr' }
+
+    it { is_expected.to have_css 'header.govuk-header a', text: 'UK Integrated Online Tariff' }
+  end
+
   context 'with service prefix' do
     before { visit '/xi/find_commodity' }
 


### PR DESCRIPTION
### Jira link

HOTT-1673

### What?

I have added/removed/altered:

- [x] Fixed the locales feature spec to actually hit the find_commodity controller instead of the errors controller
- [x] Added specs for unknown locale
- [x] Changed locale support to only assign for known locales

### Why?

I am doing this because:

The locale param can be set via the page path or the query params

Whilst the page path naturally filters the locale by the available
locales, the query param approach does not so added manual filtering to
handle this scenario