### PR TITLE
HOTT-1674 Don't show search on ErrorsController pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,5 +1,10 @@
 class ErrorsController < ApplicationController
-  before_action :disable_last_updated_footnote
+  skip_before_action :set_last_updated
+  skip_before_action :set_path_info
+  skip_before_action :set_search
+  skip_before_action :bots_no_index_if_historical
+
+  before_action :disable_search_form
 
   def not_found
     render status: :not_found


### PR DESCRIPTION
### Jira link

[HOTT-1674](https://transformuk.atlassian.net/browse/HOTT-1674)

### What?

I have added/removed/altered:

- [x] Removed processing of most before_actions from errors controller

### Why?

I am doing this because:

- We don't need to process params from URLs we do not recognise
