### PR TITLE
HOTT-1675 Handle backend failures on error pages

### DIFF
--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -39,6 +39,10 @@ class NewsItem
         target: 'banner',
         per_page: 1,
       ).first
+    rescue Faraday::Error
+      # This method is used by all pages in the main template so backend
+      # failures should not prevent rendering of the frontend
+      nil
     end
 
     def updates_page
@@ -59,6 +63,10 @@ class NewsItem
     def any_updates?
       Rails.cache.fetch(updates_cache_key, expires_in: CACHE_LIFETIME) do
         updates_page.any?
+      rescue Faraday::Error
+        # This method is used by all pages in the main template so backend
+        # failures should not prevent rendering of the frontend
+        false
       end
     end
 

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 RSpec.describe NewsItem do
   # This is stubbed for _every_ spec because its in the header menu
   # Reverting it to real implementation for this spec
-  before { allow(described_class).to receive(:any_updates?).and_call_original }
+  before do
+    allow(described_class).to receive(:any_updates?).and_call_original
+    allow(described_class).to receive(:latest_banner).and_call_original
+  end
 
   it { is_expected.to respond_to :id }
   it { is_expected.to respond_to :title }
@@ -65,6 +68,15 @@ RSpec.describe NewsItem do
       end
 
       it { is_expected.to have_attributes title: /News item \d+/ }
+    end
+
+    context 'with failed connection to backend' do
+      before do
+        stub_api_request('/news_items?service=uk&target=banner&per_page=1', backend: 'uk')
+          .to_timeout
+      end
+
+      it { is_expected.to be_nil }
     end
   end
 
@@ -164,6 +176,15 @@ RSpec.describe NewsItem do
 
         it { is_expected.to be false }
       end
+    end
+
+    context 'with failed connection to backend' do
+      before do
+        stub_api_request('/news_items?service=uk&target=updates', backend: 'uk')
+          .to_timeout
+      end
+
+      it { is_expected.to be false }
     end
   end
 


### PR DESCRIPTION
### Jira link

[HOTT-1675](https://transformuk.atlassian.net/browse/HOTT-1675)

### What?

I have added/removed/altered:

- [x] Gracefully handle faraday failures from `NewsItem.any_updates?`
- [x] Gracefully handle faraday failures from `NewsItem.latest_banner`

### Why?

I am doing this because:

- These methods are used as part of the page template, including by the error pages - so if they fail, our ability to render error pages also fails. This is clearly incorrect so allow the methods to gracefully handle connectoin failure.

### Deployment risks (optional)

- Makes changes to our error page handling
