### PR TITLE
HOTT-1689 drop permutations feature flag

### DIFF
--- a/app/presenters/measure_presenter.rb
+++ b/app/presenters/measure_presenter.rb
@@ -48,6 +48,6 @@ class MeasurePresenter < SimpleDelegator
   end
 
   def permutations_enabled?
-    TradeTariffFrontend.permutations? && measure_condition_permutation_groups.any?
+    measure_condition_permutation_groups.any?
   end
 end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -105,10 +105,6 @@ module TradeTariffFrontend
     ENV['SEARCH_BANNER'].to_s == 'true'
   end
 
-  def permutations?
-    ENV['PERMUTATIONS'].to_s == 'true'
-  end
-
   def welsh?
     ENV['WELSH'].to_s == 'true'
   end


### PR DESCRIPTION
### Jira link

[HOTT-1689](https://transformuk.atlassian.net/browse/HOTT-1689)

### What?

I have added/removed/altered:

- [x] Dropped the permuations feature flag

### Why?

I am doing this because:

- We have now deployed permutations dialogs to production