### PR TITLE
HOTT-1643 Added wholly obtained definition step

### DIFF
--- a/app/models/rules_of_origin/article.rb
+++ b/app/models/rules_of_origin/article.rb
@@ -1,0 +1,7 @@
+require 'api_entity'
+
+class RulesOfOrigin::Article
+  include ApiEntity
+
+  attr_accessor :article, :content
+end

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -11,6 +11,7 @@ class RulesOfOrigin::Scheme
   has_many :rules, class_name: 'RulesOfOrigin::Rule'
   has_many :links, class_name: 'RulesOfOrigin::Link'
   has_many :proofs, class_name: 'RulesOfOrigin::Proof'
+  has_many :articles, class_name: 'RulesOfOrigin::Article'
 
   class << self
     def all(heading_code, country_code, opts = {})
@@ -19,5 +20,9 @@ class RulesOfOrigin::Scheme
         country_code:,
       )
     end
+  end
+
+  def article(article)
+    articles.find { |a| a.article == article }
   end
 end

--- a/app/models/rules_of_origin/steps/wholly_obtained_definition.rb
+++ b/app/models/rules_of_origin/steps/wholly_obtained_definition.rb
@@ -6,6 +6,14 @@ module RulesOfOrigin
       def scheme_title
         chosen_scheme.title
       end
+
+      def wholly_obtained_text
+        chosen_scheme.article('wholly-obtained')&.content
+      end
+
+      def wholly_obtained_vessels_text
+        chosen_scheme.article('wholly-obtained-vessels')&.content
+      end
     end
   end
 end

--- a/app/models/rules_of_origin/steps/wholly_obtained_definition.rb
+++ b/app/models/rules_of_origin/steps/wholly_obtained_definition.rb
@@ -1,0 +1,11 @@
+module RulesOfOrigin
+  module Steps
+    class WhollyObtainedDefinition < Base
+      self.section = 'originating'
+
+      def scheme_title
+        chosen_scheme.title
+      end
+    end
+  end
+end

--- a/app/models/rules_of_origin/wizard.rb
+++ b/app/models/rules_of_origin/wizard.rb
@@ -6,6 +6,7 @@ module RulesOfOrigin
       Steps::ImportExport,
       Steps::ImportOnly,
       Steps::Originating,
+      Steps::WhollyObtainedDefinition,
       Steps::End,
     ]
 

--- a/app/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb
+++ b/app/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb
@@ -12,7 +12,9 @@
   </p>
 
   <div class="tariff-markdown">
-    <%= govspeak form.object.wholly_obtained_text %>
+    <div class="lettered-list">
+      <%= govspeak form.object.wholly_obtained_text %>
+    </div>
 
     <%= render 'shared/details', summary: t('.vessel_definition'),
                                  content: govspeak(form.object.wholly_obtained_vessels_text) %>

--- a/app/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb
+++ b/app/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb
@@ -12,11 +12,11 @@
   </p>
 
   <div class="tariff-markdown">
-    <%= govspeak 'TODO: external md file' %>
-  </div>
+    <%= govspeak form.object.wholly_obtained_text %>
 
-  <%= render 'shared/details', summary: t('.vessel_definition'),
-                               content: 'TODO: markdown file' %>
+    <%= render 'shared/details', summary: t('.vessel_definition'),
+                                 content: govspeak(form.object.wholly_obtained_vessels_text) %>
+  </div>
 
   <h3 class="govuk-heading-s">
     <%= t 'rules_of_origin.steps.common.next_step' %>

--- a/app/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb
+++ b/app/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb
@@ -1,0 +1,28 @@
+<%= rules_of_origin_form_for(current_step) do |form| %>
+  <span class="govuk-caption-xl">
+    <%= t '.caption' %>
+  </span>
+
+  <h1 class="govuk-heading-l">
+    <%= t '.title', scheme_title: form.object.scheme_title %>
+  </h1>
+
+  <p class="govuk-body-l">
+    <%= t '.lead_para' %>
+  </p>
+
+  <div class="tariff-markdown">
+    <%= govspeak 'TODO: external md file' %>
+  </div>
+
+  <%= render 'shared/details', summary: t('.vessel_definition'),
+                               content: 'TODO: markdown file' %>
+
+  <h3 class="govuk-heading-s">
+    <%= t 'rules_of_origin.steps.common.next_step' %>
+  </h3>
+
+  <div class="tariff-markdown">
+    <%= govspeak t '.next_step_md', scheme_title: form.object.scheme_title %>
+  </div>
+<% end %>

--- a/app/views/shared/_details.html.erb
+++ b/app/views/shared/_details.html.erb
@@ -1,0 +1,10 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      <%= summary %>
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <%= content %>
+  </div>
+</details>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -56,3 +56,4 @@ $govuk-images-path: '~govuk-frontend/govuk/assets/images/';
 @import '../src/stylesheets/help';
 @import '../src/stylesheets/customs_duties_explainer';
 @import '../src/stylesheets/step-by-step-nav' ;
+@import '../src/stylesheets/lists';

--- a/app/webpacker/src/stylesheets/_lists.scss
+++ b/app/webpacker/src/stylesheets/_lists.scss
@@ -1,0 +1,7 @@
+.lettered-list ol, ol.lettered_list {
+  list-style-type: lower-alpha;
+
+  ol {
+    list-style-type: lower-roman;
+  }
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -253,6 +253,7 @@ en:
         steps:
           import_export: Are you importing or exporting?
           originating: How to work out if your goods are classed as 'originating'
+          wholly_obtained_definition: How 'wholly obtained' is defined
 
       import_only:
         caption: Trading commodity %{commodity_code} with %{trade_country_name}
@@ -306,3 +307,20 @@ en:
         next_step_md: |
           Click on the 'Continue' button to view the definition of
           '**wholly obtained**' in the %{scheme_title}.
+
+      wholly_obtained_definition:
+        caption: Are your goods originating?
+        title: How 'wholly obtained' is defined in the %{scheme_title}
+        lead_para: |
+          Your goods are treated as 'wholly obtained' if they are exclusively
+          produced in a country covered in a trade agreement, without
+          incorporating materials from any other country.
+        vessel_definition: Read more about how vessels and factory ships are defined
+        next_step_md: |
+          In determining originating status for a good, it can be important to
+          know which parts or contributing processes count towards the
+          originating status.
+
+          Click on the 'Continue' button to see which parts and processes
+          should be included or disregarded in determining originating status
+          for the %{scheme_title}.

--- a/spec/factories/rules_of_origin_article_factory.rb
+++ b/spec/factories/rules_of_origin_article_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :rules_of_origin_article, class: 'RulesOfOrigin::Article' do
+    sequence(:article) { |n| "article-#{n}" }
+    sequence(:content) { |n| "### Article #{n}\n\n* markdown list\n" }
+  end
+end

--- a/spec/factories/rules_of_origin_scheme_factory.rb
+++ b/spec/factories/rules_of_origin_scheme_factory.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     transient do
       rule_count { 3 }
       link_count { 2 }
+      article_count { 1 }
     end
 
     sequence(:scheme_code) { |n| "SC#{n}" }
@@ -14,5 +15,6 @@ FactoryBot.define do
     introductory_notes { "## Introductory notes\n\nDetails of introductory notes" }
     rules { attributes_for_list :rules_of_origin_rule, rule_count }
     links { attributes_for_list :rules_of_origin_link, link_count }
+    articles { attributes_for_list :rules_of_origin_article, article_count }
   end
 end

--- a/spec/factories/rules_of_origin_wizard_store_factory.rb
+++ b/spec/factories/rules_of_origin_wizard_store_factory.rb
@@ -24,5 +24,10 @@ FactoryBot.define do
       with_chosen_scheme
       import_or_export { 'export' }
     end
+
+    trait :originating do
+      with_chosen_scheme
+      importing
+    end
   end
 end

--- a/spec/models/rules_of_origin/article_spec.rb
+++ b/spec/models/rules_of_origin/article_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe RulesOfOrigin::Article do
+  it { is_expected.to respond_to :article }
+  it { is_expected.to respond_to :content }
+end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe RulesOfOrigin::Scheme do
   it { is_expected.to respond_to :introductory_notes }
   it { is_expected.to respond_to :rules }
   it { is_expected.to respond_to :links }
+  it { is_expected.to respond_to :articles }
 
   describe '.all' do
     let(:json_response) { response_data.to_json }
@@ -57,6 +58,14 @@ RSpec.describe RulesOfOrigin::Scheme do
                   },
                 ],
               },
+              articles: {
+                data: [
+                  {
+                    id: 'EU/test-article',
+                    type: 'rules_of_origin_article',
+                  },
+                ],
+              },
             },
           },
         ],
@@ -86,6 +95,14 @@ RSpec.describe RulesOfOrigin::Scheme do
               summary: 'proof',
               url: 'https://www.gov.uk/',
               subtext: 'subtext',
+            },
+          },
+          {
+            id: 'EU/test-article',
+            type: 'rules_of_origin_article',
+            attributes: {
+              article: 'test-article',
+              content: 'Hello',
             },
           },
         ],
@@ -246,6 +263,35 @@ RSpec.describe RulesOfOrigin::Scheme do
         it { is_expected.to have_attributes url: 'https://www.gov.uk/' }
         it { is_expected.to have_attributes subtext: 'subtext' }
       end
+    end
+
+    describe 'articles' do
+      include_context 'with mocked response'
+
+      it { expect(schemes.first.articles.length).to be 1 }
+
+      context 'with first article' do
+        subject { schemes.first.articles.first }
+
+        it { is_expected.to have_attributes article: 'test-article' }
+        it { is_expected.to have_attributes content: 'Hello' }
+      end
+    end
+  end
+
+  describe '#article' do
+    let(:scheme) { build(:rules_of_origin_scheme) }
+
+    context 'with matching article' do
+      subject { scheme.article scheme.articles.first.article }
+
+      it { is_expected.to have_attributes article: scheme.articles.first.article }
+    end
+
+    context 'with non matching article' do
+      subject { scheme.article 'unknown-missing' }
+
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/models/rules_of_origin/steps/wholly_obtained_definition_spec.rb
+++ b/spec/models/rules_of_origin/steps/wholly_obtained_definition_spec.rb
@@ -16,4 +16,38 @@ RSpec.describe RulesOfOrigin::Steps::WhollyObtainedDefinition do
       it { is_expected.to eql schemes.second.title }
     end
   end
+
+  describe '#wholly_obtained_text' do
+    subject { instance.wholly_obtained_text }
+
+    context 'with matching article' do
+      let(:articles) do
+        attributes_for_list :rules_of_origin_article, 1, article: 'wholly-obtained'
+      end
+
+      it { is_expected.to eql articles.first[:content] }
+    end
+
+    context 'without matching article' do
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#wholly_obtained_vessels_text' do
+    subject { instance.wholly_obtained_vessels_text }
+
+    context 'with matching article' do
+      let(:articles) do
+        attributes_for_list :rules_of_origin_article, 1, article: 'wholly-obtained-vessels'
+      end
+
+      it { is_expected.to eql articles.first[:content] }
+    end
+
+    context 'without matching article' do
+      let(:articles) { [] }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/models/rules_of_origin/steps/wholly_obtained_definition_spec.rb
+++ b/spec/models/rules_of_origin/steps/wholly_obtained_definition_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe RulesOfOrigin::Steps::WhollyObtainedDefinition do
+  include_context 'with rules of origin store', :originating
+  include_context 'with wizard step', RulesOfOrigin::Wizard
+
+  describe '#scheme_title' do
+    subject { instance.scheme_title }
+
+    it { is_expected.to eql schemes.first.title }
+
+    context 'with multiple schemes' do
+      include_context 'with rules of origin store', :importing, scheme_count: 2,
+                                                                chosen_scheme: 2
+
+      it { is_expected.to eql schemes.second.title }
+    end
+  end
+end

--- a/spec/support/shared_context/rules_of_origin_wizard.rb
+++ b/spec/support/shared_context/rules_of_origin_wizard.rb
@@ -17,8 +17,11 @@ shared_context 'with rules of origin store' do |*traits, scheme_count: 1, **stor
   end
 
   let(:schemes) do
-    build_list :rules_of_origin_scheme, scheme_count, countries: [country.id]
+    build_list :rules_of_origin_scheme, scheme_count, countries: [country.id],
+                                                      articles:
   end
+
+  let(:articles) { [] }
 end
 
 shared_context 'with rules of origin form step' do |step, *traits|

--- a/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
@@ -5,10 +5,19 @@ RSpec.describe 'rules_of_origin/steps/_wholly_obtained_defintion', type: :view d
                   'wholly_obtained_definition',
                   :originating
 
+  let :articles do
+    [
+      attributes_for(:rules_of_origin_article,
+                     article: 'wholly-obtained',
+                     content: "## Title\n\n1. Numbered list\n"),
+      attributes_for(:rules_of_origin_article, article: 'wholly-obtained-vessels'),
+    ]
+  end
+
   it { is_expected.to have_css 'span.govuk-caption-xl', text: /originating/i }
   it { is_expected.to have_css 'h1', text: %r{wholly obtained.+#{schemes.first.title}} }
-  xit { is_expected.to have_css 'p.govuk-body-l', text: %r{wholly obtained.*Japan.*#{schemes.first.title}} }
-  xit { is_expected.to have_css '.tariff-markdown ol li' }
+  it { is_expected.to have_css 'p.govuk-body-l', text: /wholly obtained/ }
+  it { is_expected.to have_css '.tariff-markdown ol li' }
   it { is_expected.to have_css 'details.govuk-details summary' }
   it { is_expected.to have_css 'details.govuk-details div.govuk-details__text' }
   it { is_expected.to have_css '.tariff-markdown p', text: %r{#{schemes.first.title}} }

--- a/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/steps/_wholly_obtained_defintion', type: :view do
+  include_context 'with rules of origin form step',
+                  'wholly_obtained_definition',
+                  :originating
+
+  it { is_expected.to have_css 'span.govuk-caption-xl', text: /originating/i }
+  it { is_expected.to have_css 'h1', text: %r{wholly obtained.+#{schemes.first.title}} }
+  xit { is_expected.to have_css 'p.govuk-body-l', text: %r{wholly obtained.*Japan.*#{schemes.first.title}} }
+  xit { is_expected.to have_css '.tariff-markdown ol li' }
+  it { is_expected.to have_css 'details.govuk-details summary' }
+  it { is_expected.to have_css 'details.govuk-details div.govuk-details__text' }
+  it { is_expected.to have_css '.tariff-markdown p', text: %r{#{schemes.first.title}} }
+end


### PR DESCRIPTION
### Jira link

HOTT-1643

### What?

I have added/removed/altered:

- [x] Added step to Rules of Origin wizard to show the wholly obtained definition

### Why?

I am doing this because:

- We need to explain what wholly obtained means to the user prior to asking them if their goods count as wholly obtained

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None, feature flagged

### Notes

- Relies on Articles being exposed within the RoO API from the backend - if not present it will continue to work but will not show the expected article content.