### PR TITLE
HOTT-1637: Bumps trade-tariff orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
   cloudfoundry: circleci/cloudfoundry@1.0
   slack: circleci/slack@4.3.0
   queue: eddiewebb/queue@1.6.4
-  tariff: trade-tariff/trade-tariff-ci-orb@0 # can also change to @dev:<gitsha> for specific version or @dev:alpha to test dev branches
+  tariff: trade-tariff/trade-tariff-ci-orb@0.1.6 # can also change to @dev:<gitsha> for specific version or @dev:alpha to test dev branches
 
 commands:
   cf_deploy_docker:


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1637

### What?

I have added/removed/altered:

- [x] Bumps the trade-tariff-orb

### Why?

I am doing this because:

- Reflects a change to the orb where the file cli has been dereferenced (see https://github.com/trade-tariff/trade-tariff-ci-orb/pull/12)
