### PR TITLE
HOTT-1647 Add wholly obtained step

### DIFF
--- a/app/models/rules_of_origin/steps/wholly_obtained.rb
+++ b/app/models/rules_of_origin/steps/wholly_obtained.rb
@@ -7,11 +7,20 @@ module RulesOfOrigin
 
       attribute :wholly_obtained
 
-      validates :wholly_obtained, presence: true,
-                                  inclusion: { in: OPTIONS }
+      validates_each :wholly_obtained do |record, attr, value|
+        unless value.in?(record.options)
+          record.errors.add \
+            attr,
+            I18n.t(
+              "#{i18n_scope}.errors.models.#{model_name.i18n_key}.attributes.#{attr}.inclusion",
+              service_country: record.service_country_name,
+              trade_country: record.trade_country_name,
+            )
+        end
+      end
 
-      def scheme_title
-        chosen_scheme.title
+      def options
+        OPTIONS
       end
     end
   end

--- a/app/models/rules_of_origin/steps/wholly_obtained.rb
+++ b/app/models/rules_of_origin/steps/wholly_obtained.rb
@@ -1,0 +1,18 @@
+module RulesOfOrigin
+  module Steps
+    class WhollyObtained < Base
+      OPTIONS = %w[yes no].freeze
+
+      self.section = 'originating'
+
+      attribute :wholly_obtained
+
+      validates :wholly_obtained, presence: true,
+                                  inclusion: { in: OPTIONS }
+
+      def scheme_title
+        chosen_scheme.title
+      end
+    end
+  end
+end

--- a/app/models/rules_of_origin/wizard.rb
+++ b/app/models/rules_of_origin/wizard.rb
@@ -7,6 +7,7 @@ module RulesOfOrigin
       Steps::ImportOnly,
       Steps::Originating,
       Steps::WhollyObtainedDefinition,
+      Steps::WhollyObtained,
       Steps::End,
     ]
 

--- a/app/views/rules_of_origin/steps/_wholly_obtained.html.erb
+++ b/app/views/rules_of_origin/steps/_wholly_obtained.html.erb
@@ -1,0 +1,19 @@
+<%= rules_of_origin_form_for(current_step) do |form| %>
+  <%= form.govuk_collection_radio_buttons \
+        :wholly_obtained,
+        form.object.options,
+        :to_sym,
+        -> (option) {
+          t("helpers.label.rules_of_origin_steps_wholly_obtained.wholly_obtained_options.#{option}",
+            trade_country: form.object.trade_country_name)
+        },
+        legend: {
+          text: t('helpers.legend.rules_of_origin_steps_wholly_obtained.wholly_obtained',
+                  trade_country: form.object.trade_country_name)
+        },
+        hint: {
+          text: t('helpers.hint.rules_of_origin_steps_wholly_obtained.wholly_obtained_html',
+                  definition_link_path: step_path(:wholly_obtained_definition),
+                  components_link_path: step_path(:components_definition))
+        } %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,18 +192,27 @@ en:
             import_or_export:
               inclusion: Select whether you are importing goods into %{service_country} or %{trade_country}
 
+        rules_of_origin/steps/wholly_obtained:
+          attributes:
+            wholly_obtained:
+              inclusion: Select whether your goods are wholly obtained in %{trade_country}
+
   helpers:
     legend:
       rules_of_origin_steps_scheme:
         scheme_code: Select agreement for trading with %{trade_country}
       rules_of_origin_steps_import_export:
         import_or_export: Are you importing goods into %{service_country} or into %{trade_country}?
+      rules_of_origin_steps_wholly_obtained:
+        wholly_obtained: Are your goods wholly obtained in %{trade_country}?
 
     caption:
       rules_of_origin_steps_scheme:
         scheme_code: Details of your trade
       rules_of_origin_steps_import_export:
         import_or_export: Details of your trade
+      rules_of_origin_steps_wholly_obtained:
+        wholly_obtained: Are your goods originating?
 
     hint:
       rules_of_origin_steps_scheme:
@@ -212,12 +221,27 @@ en:
           for trade with %{trade_country} via more than one trade agreement.
 
           Select the trade agreement.
+      rules_of_origin_steps_wholly_obtained:
+        wholly_obtained_html: |
+          Base your answers on the definition of
+          <a href="%{definition_link_path}">
+            wholly obtained
+          </a>
+          and the definition of
+          <a href="%{components_link_path}">
+            components that you need to take into account
+          </a>
+          on the previous screens.
 
     label:
       rules_of_origin_steps_import_export:
         import_or_export_options:
           import: I am importing goods into %{service_country} from %{trade_country}
           export: I am exporting goods from %{service_country} to %{trade_country}
+      rules_of_origin_steps_wholly_obtained:
+        wholly_obtained_options:
+          'yes': Yes, my goods are wholly obtained in %{trade_country}
+          'no': No, my goods are not wholly obtained in %{trade_country}
 
   rules_of_origin:
     preferential_treatment:
@@ -254,6 +278,7 @@ en:
           import_export: Are you importing or exporting?
           originating: How to work out if your goods are classed as 'originating'
           wholly_obtained_definition: How 'wholly obtained' is defined
+          wholly_obtained: Are your goods wholly obtained?
 
       import_only:
         caption: Trading commodity %{commodity_code} with %{trade_country_name}

--- a/spec/factories/rules_of_origin_wizard_store_factory.rb
+++ b/spec/factories/rules_of_origin_wizard_store_factory.rb
@@ -29,5 +29,9 @@ FactoryBot.define do
       with_chosen_scheme
       importing
     end
+
+    trait :wholly_obtained_definition do
+      originating
+    end
   end
 end

--- a/spec/models/rules_of_origin/steps/import_export_spec.rb
+++ b/spec/models/rules_of_origin/steps/import_export_spec.rb
@@ -6,28 +6,12 @@ RSpec.describe RulesOfOrigin::Steps::ImportExport do
 
   it { is_expected.to respond_to :import_or_export }
 
-  describe '#validation' do
-    context 'with import' do
-      let(:attributes) { { import_or_export: 'import' } }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'with export' do
-      let(:attributes) { { import_or_export: 'export' } }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'with something else' do
-      let(:attributes) { { import_or_export: 'random' } }
-
-      it { is_expected.not_to be_valid }
-    end
-
-    context 'when blank' do
-      it { is_expected.not_to be_valid }
-    end
+  describe 'validation' do
+    it { is_expected.to allow_value('import').for :import_or_export }
+    it { is_expected.to allow_value('export').for :import_or_export }
+    it { is_expected.not_to allow_value('random').for :import_or_export }
+    it { is_expected.not_to allow_value('').for :import_or_export }
+    it { is_expected.not_to allow_value(nil).for :import_or_export }
   end
 
   describe '#skipped?' do

--- a/spec/models/rules_of_origin/steps/wholly_obtained_spec.rb
+++ b/spec/models/rules_of_origin/steps/wholly_obtained_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe RulesOfOrigin::Steps::WhollyObtained do
+  include_context 'with rules of origin store', :wholly_obtained_definition
+  include_context 'with wizard step', RulesOfOrigin::Wizard
+
+  it { is_expected.to respond_to :wholly_obtained }
+
+  describe 'validation' do
+    it { is_expected.to allow_value('yes').for :wholly_obtained }
+    it { is_expected.to allow_value('no').for :wholly_obtained }
+    it { is_expected.not_to allow_value('random').for :wholly_obtained }
+    it { is_expected.not_to allow_value('').for :wholly_obtained }
+    it { is_expected.not_to allow_value(nil).for :wholly_obtained }
+  end
+end

--- a/spec/models/rules_of_origin/steps/wholly_obtained_spec.rb
+++ b/spec/models/rules_of_origin/steps/wholly_obtained_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe RulesOfOrigin::Steps::WhollyObtained do
   include_context 'with wizard step', RulesOfOrigin::Wizard
 
   it { is_expected.to respond_to :wholly_obtained }
+  it { is_expected.to have_attributes options: %w[yes no] }
 
   describe 'validation' do
     it { is_expected.to allow_value('yes').for :wholly_obtained }

--- a/spec/views/rules_of_origin/steps/_wholly_obtained.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_wholly_obtained.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/steps/_wholly_obtained', type: :view do
+  include_context 'with rules of origin form step', 'wholly_obtained'
+
+  it { is_expected.to have_css 'h1', text: /wholly obtained in Japan/ }
+  it { is_expected.to have_css 'input[type="radio"]', count: 2 }
+  it { is_expected.to have_css 'label', text: /obtained.+Japan/ }
+  it { is_expected.to have_css '.govuk-hint a' }
+
+  context 'with invalid submission' do
+    before { current_step.validate }
+
+    it { is_expected.to have_css '.govuk-error-message', text: /Select.*obtained.*Japan/i }
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-1647](https://transformuk.atlassian.net/browse/HOTT-1647)

### What?

I have added/removed/altered:

- [x] Added the 'Wholly Obtained' question step

### Why?

I am doing this because:

- We require it as part of the Rules of Origin wizard

### Have you? (optional)

- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, currently feature flagged off

