### PR TITLE
HOTT-1645 Added components definition step

### DIFF
--- a/app/models/rules_of_origin/steps/components_definition.rb
+++ b/app/models/rules_of_origin/steps/components_definition.rb
@@ -1,0 +1,23 @@
+module RulesOfOrigin
+  module Steps
+    class ComponentsDefinition < Base
+      self.section = 'originating'
+
+      def scheme_title
+        chosen_scheme.title
+      end
+
+      def neutral_elements_text
+        chosen_scheme.article('neutral-elements')&.content
+      end
+
+      def packaging_text
+        chosen_scheme.article('packaging')&.content
+      end
+
+      def accessories_text
+        chosen_scheme.article('accessories')&.content
+      end
+    end
+  end
+end

--- a/app/models/rules_of_origin/wizard.rb
+++ b/app/models/rules_of_origin/wizard.rb
@@ -7,6 +7,7 @@ module RulesOfOrigin
       Steps::ImportOnly,
       Steps::Originating,
       Steps::WhollyObtainedDefinition,
+      Steps::ComponentsDefinition,
       Steps::WhollyObtained,
       Steps::End,
     ]

--- a/app/views/rules_of_origin/steps/_components_definition.html.erb
+++ b/app/views/rules_of_origin/steps/_components_definition.html.erb
@@ -1,0 +1,54 @@
+<%= rules_of_origin_form_for(current_step) do |form| %>
+  <span class="govuk-caption-xl">
+    <%= t '.caption' %>
+  </span>
+
+  <h1 class="govuk-heading-l">
+    <%= t '.title', scheme_title: form.object.scheme_title %>
+  </h1>
+
+  <p class="govuk-body-l">
+    <%= t '.lead_para' %>
+  </p>
+
+  <div class="govuk-inset-text tariff-markdown">
+    <%= govspeak t('.additional_info_md') %>
+  </div>
+
+  <h3 class="govuk-heading-s">
+    <%= t '.neutral_elements.title', scheme_title: form.object.scheme_title %>
+  </h3>
+
+  <div class="tariff-markdown">
+    <%= govspeak form.object.neutral_elements_text %>
+
+    <%= render 'shared/details', summary: t('.neutral_elements.example.summary'),
+                                 content: govspeak(t('.neutral_elements.example.content_md')) %>
+  </div>
+
+  <h3 class="govuk-heading-s">
+    <%= t '.packaging', scheme_title: form.object.scheme_title %>
+  </h3>
+
+  <div class="tariff-markdown">
+    <%= govspeak form.object.packaging_text %>
+  </div>
+
+  <% if form.object.accessories_text %>
+    <h3 class="govuk-heading-s">
+      <%= t '.accessories', scheme_title: form.object.scheme_title %>
+    </h3>
+
+    <div class="tariff-markdown">
+      <%= govspeak form.object.accessories_text %>
+    </div>
+  <% end %>
+
+  <h3 class="govuk-heading-s">
+    <%= t 'rules_of_origin.steps.common.next_step' %>
+  </h3>
+
+  <p>
+    <%= t '.next_step' %>
+  </p>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,6 +278,7 @@ en:
           import_export: Are you importing or exporting?
           originating: How to work out if your goods are classed as 'originating'
           wholly_obtained_definition: How 'wholly obtained' is defined
+          components_definition: What components do you need to take into account?
           wholly_obtained: Are your goods wholly obtained?
 
       import_only:
@@ -349,3 +350,42 @@ en:
           Click on the 'Continue' button to see which parts and processes
           should be included or disregarded in determining originating status
           for the %{scheme_title}.
+
+      components_definition:
+        caption: Are your goods originating?
+        title: What components do you need to take into account?
+        lead_para: |
+          In determining whether a product originates in a given country, you
+          should disregard the origin of neutral elements, meaning equipment and
+          materials used in the production, but not physically incorporated into
+          the final product, such as fuel, tools or machinery.
+        additional_info_md: |
+          Depending on the rules of the trade agreement, you may also discount:
+
+          - **packing materials and containers** for shipment used during transportation,
+          - **packaging materials used for retail sale** when classified with the product
+          - **accessories, spare parts, tools and information materials** if they are
+            invoiced and delivered with your product.
+        neutral_elements:
+          title: Neutral elements in the %{scheme_title}
+          example:
+            summary: Example of neutral elements
+            content_md: |
+              - A part is manufactured in a plant in country A.
+              - It is to be exported to country B under A-B FTA.
+              - The rule of origin for this part requires non-originating
+                materials not to exceed 40% of the final value of the part.
+              - Machines used to manufacture the part, spare parts used in the
+                maintenance of these machines and the fuel used to run these
+                machines are all originating in a non-FTA third country C.
+              - Similarly, the safety equipment and protective clothing used by
+                the factory workers comes from non-FTA countries.
+              - While calculating the value added rule of origin, the
+                non-originating machines, spare parts used to maintain them,
+                fuel, safety equipment and protective clothing are disregarded
+                or calculated as originating (depending on the agreement).
+        packaging: Packing materials in the %{scheme_title}
+        accessories: Accessories, spare parts and tools in the %{scheme_title}
+        next_step:
+          Click on the 'Continue' button to indicate if your goods are wholly
+          obtained, based on the rules of the %{scheme_title}.

--- a/spec/factories/rules_of_origin_wizard_store_factory.rb
+++ b/spec/factories/rules_of_origin_wizard_store_factory.rb
@@ -33,5 +33,9 @@ FactoryBot.define do
     trait :wholly_obtained_definition do
       originating
     end
+
+    trait :components_definition do
+      wholly_obtained_definition
+    end
   end
 end

--- a/spec/models/rules_of_origin/steps/components_definition_spec.rb
+++ b/spec/models/rules_of_origin/steps/components_definition_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe RulesOfOrigin::Steps::WhollyObtainedDefinition do
-  include_context 'with rules of origin store', :originating
+RSpec.describe RulesOfOrigin::Steps::ComponentsDefinition do
+  include_context 'with rules of origin store', :wholly_obtained_definition
   include_context 'with wizard step', RulesOfOrigin::Wizard
 
   describe '#scheme_title' do
@@ -17,8 +17,7 @@ RSpec.describe RulesOfOrigin::Steps::WhollyObtainedDefinition do
     end
   end
 
-  it_behaves_like 'an article accessor', :wholly_obtained_text, 'wholly-obtained'
-  it_behaves_like 'an article accessor',
-                  :wholly_obtained_vessels_text,
-                  'wholly-obtained-vessels'
+  it_behaves_like 'an article accessor', :neutral_elements_text, 'neutral-elements'
+  it_behaves_like 'an article accessor', :packaging_text, 'packaging'
+  it_behaves_like 'an article accessor', :accessories_text, 'accessories'
 end

--- a/spec/models/rules_of_origin/steps/wholly_obtained_spec.rb
+++ b/spec/models/rules_of_origin/steps/wholly_obtained_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe RulesOfOrigin::Steps::WhollyObtained do
-  include_context 'with rules of origin store', :wholly_obtained_definition
+  include_context 'with rules of origin store', :components_definition
   include_context 'with wizard step', RulesOfOrigin::Wizard
 
   it { is_expected.to respond_to :wholly_obtained }

--- a/spec/support/shared_context/rules_of_origin_wizard.rb
+++ b/spec/support/shared_context/rules_of_origin_wizard.rb
@@ -41,3 +41,21 @@ shared_context 'with rules of origin form step' do |step, *traits|
     render "rules_of_origin/steps/#{current_step.key}", current_step:, wizard:
   end
 end
+
+shared_examples_for 'an article accessor' do |method_name, article|
+  describe "##{method_name}" do
+    subject { instance.public_send(method_name) }
+
+    context 'with matching article' do
+      let(:articles) { attributes_for_list :rules_of_origin_article, 1, article: }
+
+      it { is_expected.to eql articles.first[:content] }
+    end
+
+    context 'without matching article' do
+      let(:articles) { [] }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/views/rules_of_origin/steps/_components_definition.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_components_definition.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/steps/_components_definition', type: :view do
+  include_context 'with rules of origin form step',
+                  'components_definition',
+                  :wholly_obtained_definition
+
+  let :articles do
+    [
+      attributes_for(:rules_of_origin_article, article: 'neutral-elements'),
+      attributes_for(:rules_of_origin_article, article: 'packaging', content: 'packaging article'),
+      attributes_for(:rules_of_origin_article, article: 'accessories', content: 'accessory article'),
+    ]
+  end
+
+  it { is_expected.to have_css 'span.govuk-caption-xl', text: /originating/i }
+  it { is_expected.to have_css 'h1', text: /components/ }
+  it { is_expected.to have_css 'p.govuk-body-l', text: /neutral elements/ }
+  it { is_expected.to have_css '.govuk-inset-text *' }
+  it { is_expected.to have_css 'h3', text: %r{elements.*#{schemes.first.title}} }
+  it { is_expected.to have_css '.tariff-markdown details summary', text: /neutral/ }
+  it { is_expected.to have_css '.tariff-markdown details .govuk-details__text ul' }
+  it { is_expected.to have_css 'h3', text: %r{Packing materials.*#{schemes.first.title}} }
+  it { is_expected.to have_css '.tariff-markdown > p', text: 'packaging article' }
+  it { is_expected.to have_css 'h3', text: %r{Accessories} }
+  it { is_expected.to have_css '.tariff-markdown > p', text: 'accessory article' }
+  it { is_expected.to have_css 'h3', text: /Next step/ }
+  it { is_expected.to have_css 'form button[type=submit]' }
+
+  context 'without accesories article' do
+    let(:articles) { [] }
+
+    it { is_expected.not_to have_css 'h3', text: %r{Accessories} }
+  end
+end

--- a/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'rules_of_origin/steps/_wholly_obtained_defintion', type: :view do
+RSpec.describe 'rules_of_origin/steps/_wholly_obtained_definition', type: :view do
   include_context 'with rules of origin form step',
                   'wholly_obtained_definition',
                   :originating


### PR DESCRIPTION
### Jira link

[HOTT-1645](https://transformuk.atlassian.net/browse/HOTT-1645)

### What?

I have added/removed/altered:

- [x] Added an informational `components` definition step to RoO

### Why?

I am doing this because:

- We want to provide this information to the user before they need to make their choice

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, hidden behind feature flag
