### PR TITLE
HOTT-1720 Fix insertion of originating country name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,7 +285,8 @@ en:
           originates in %{originating_country} according to the %{scheme_title}
           and therefore eligible for preferential tariff treatment.
         conditions_md: |
-          The following products are considered as originating in Japan:
+          The following products are considered as originating in
+          %{originating_country}:
 
           * products **wholly obtained** in %{originating_country}
 


### PR DESCRIPTION
### Jira link

[HOTT-1720](https://transformuk.atlassian.net/browse/HOTT-1720)

### What?

I have added/removed/altered:

- [x] Fixed substitution of orginating country name

### Why?

I am doing this because:

- I'd mistakenly hardcoded the country name in the translation string

### Deployment risks (optional)

- None
