### PR TITLE
Update project smoke test specification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,8 +286,7 @@ commands:
             CYPRESS_SPACE: "<< parameters.space >>"
           command: |
             cd trade-tariff-testing
-
-            yarn run cypress run --spec "/*/**/HOTT-Shared/devSmokeTestCI.spec.js"
+            yarn run dev-tariff-frontend-smoketests
 
   sentry-release:
     steps:


### PR DESCRIPTION
### What?

See https://github.com/trade-tariff/trade-tariff-testing/pull/804

I have added/removed/altered:

- [x] Altered repo smoke test invocation to rely on cypress-suite-defined test run

### Why?

I am doing this because:

- This reflects a change/inversion of the dependencies about who knows what to run for each project and means we can validate cypress changes more robustly

