### PR TITLE
HOTT-1619: Update measure type description for Channel Islands

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,9 @@ en:
     1400:
       103: 'Channel Islands duty'
       105: 'Channel Islands duty'
+    1080:
+      103: 'UK-CD Customs Union'
+      105: 'UK-CD Customs Union'
   service_banner:
     service_name:
       uk: "UK Integrated Online Tariff"


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1659

### What?
Update measure type description for the Channel Islands.

### Why?

I am doing this because:

> We have been asked to alter the visible display of measure type “103” for the geographical area “1080”, which is the geo. area for “Channel Islands”


