### PR TITLE
HOTT-1737: Hides VAT overview measures when on XI service

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -45,6 +45,16 @@ module CommoditiesHelper
     end
   end
 
+  def vat_overview_measure_duty_amounts(commodity)
+    vat_overview_measures = commodity.overview_measures.vat
+
+    duty_amounts = vat_overview_measures.map do |vat_measure|
+      "#{vat_measure.amount}%"
+    end
+
+    safe_join(duty_amounts, ' or ').presence || '&nbsp;'.html_safe
+  end
+
   private
 
   def chapter_and_heading_codes(code)

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -31,6 +31,7 @@ class Measure
   has_one :goods_nomenclature, polymorphic: true
 
   delegate :erga_omnes?, to: :geographical_area
+  delegate :amount, to: :duty_expression
 
   class << self
     def grouped_measure_types

--- a/app/views/commodities/_commodity.html.erb
+++ b/app/views/commodities/_commodity.html.erb
@@ -16,14 +16,16 @@
       <div class="description open" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></div>
 
       <div class="commodity__info">
-        <div class="vat" aria-describedby="commodity-vat-title">
-          <% vats = commodity.overview_measures.vat %>
-          <% if vats.count > 0 %>
-            <%= vats.map { |m| m.duty_expression.amount.to_i.to_s + "%" }.join(" or ").html_safe %>
-          <% else %>
-            &nbsp;
-          <% end %>
-        </div>
+        <% if TradeTariffFrontend::ServiceChooser.uk? %>
+          <div class="vat" aria-describedby="commodity-vat-title">
+            <% vats = commodity.overview_measures.vat %>
+            <% if vats.count > 0 %>
+              <%= vats.map { |m| m.duty_expression.amount.to_i.to_s + "%" }.join(" or ").html_safe %>
+            <% else %>
+              &nbsp;
+            <% end %>
+          </div>
+        <% end %>
         <div class="duty" aria-describedby="commodity-duty-title">
           <% tcd = commodity.overview_measures.third_country_duties %>
           <% if tcd.count > 0 %>

--- a/app/views/commodities/_commodity.html.erb
+++ b/app/views/commodities/_commodity.html.erb
@@ -18,12 +18,7 @@
       <div class="commodity__info">
         <% if TradeTariffFrontend::ServiceChooser.uk? %>
           <div class="vat" aria-describedby="commodity-vat-title">
-            <% vats = commodity.overview_measures.vat %>
-            <% if vats.count > 0 %>
-              <%= vats.map { |m| m.duty_expression.amount.to_i.to_s + "%" }.join(" or ").html_safe %>
-            <% else %>
-              &nbsp;
-            <% end %>
+            <%= vat_overview_measure_duty_amounts(commodity) %>
           </div>
         <% end %>
         <div class="duty" aria-describedby="commodity-duty-title">

--- a/app/views/shared/_commodity_tree.html.erb
+++ b/app/views/shared/_commodity_tree.html.erb
@@ -5,7 +5,9 @@
       <span>The number following each commodity's description is its commodity code.</span>
       <em class="description">Description</em>
       <div class="commodity-tree__additional-info">
-        <em class="vat" id="commodity-vat-title">VAT</em>
+        <% if TradeTariffFrontend::ServiceChooser.uk? %>
+          <em class="vat" id="commodity-vat-title">VAT</em>
+        <% end %>
         <em class="duty" id="commodity-duty-title">Third country duty</em>
         <em class="supplementary-units" id="commodity-supplementary-title">Supplementary unit</em>
         <em class="commcode">Commodity code</em>

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
 
     import_measures { [] }
     export_measures { [] }
+    overview_measures { [] }
 
     meta do
       {
@@ -29,6 +30,23 @@ FactoryBot.define do
           'zero_mfn_duty' => false,
         },
       }
+    end
+
+    trait :with_a_vat_overview_measure do
+      overview_measures do
+        [
+          attributes_for(:measure, :vat),
+        ]
+      end
+    end
+
+    trait :with_vat_overview_measures do
+      overview_measures do
+        [
+          attributes_for(:measure, :vat),
+          attributes_for(:measure, :vat),
+        ]
+      end
     end
   end
 end

--- a/spec/factories/duty_expression_factory.rb
+++ b/spec/factories/duty_expression_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     trait :vat do
       base { '20.0%' }
-      formatted_base { "20.0%" }
+      formatted_base { '20.0%' }
       description { 'VAT' }
     end
   end

--- a/spec/factories/duty_expression_factory.rb
+++ b/spec/factories/duty_expression_factory.rb
@@ -6,5 +6,11 @@ FactoryBot.define do
     trait :supplementary do
       description { 'Number of items' }
     end
+
+    trait :vat do
+      base { '20.0%' }
+      formatted_base { "80.50 EUR / <abbr title='Hectokilogram'>Hectokilogram</abbr>" }
+      description { 'VAT' }
+    end
   end
 end

--- a/spec/factories/duty_expression_factory.rb
+++ b/spec/factories/duty_expression_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     trait :vat do
       base { '20.0%' }
-      formatted_base { "80.50 EUR / <abbr title='Hectokilogram'>Hectokilogram</abbr>" }
+      formatted_base { "20.0%" }
       description { 'VAT' }
     end
   end

--- a/spec/factories/heading_factory.rb
+++ b/spec/factories/heading_factory.rb
@@ -24,5 +24,18 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :with_subheading_and_commodity do
+      transient do
+        producline_suffix {}
+      end
+
+      commodities do
+        subheading = attributes_for(:commodity, producline_suffix:, number_indents: 2)
+        commodity =  attributes_for(:commodity, producline_suffix:, parent_sid: subheading[:goods_nomenclature_sid], number_indents: 3)
+
+        [subheading, commodity]
+      end
+    end
   end
 end

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -21,6 +21,8 @@ FactoryBot.define do
 
     trait :vat do
       vat { true }
+      measure_type { attributes_for(:measure_type, :vat) }
+      duty_expression { attributes_for(:duty_expression, :vat) }
     end
 
     trait :erga_omnes do

--- a/spec/factories/measure_type_factory.rb
+++ b/spec/factories/measure_type_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     description { Forgery(:basic).text }
 
     trait :vat do
+      id { '305' }
       description { 'VAT' }
     end
 

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -157,4 +157,29 @@ RSpec.describe CommoditiesHelper, type: :helper do
 
     it { is_expected.to eql 'commodity-ancestors__ancestor-23' }
   end
+
+  describe '#vat_overview_measure_duty_amounts' do
+    subject(:vat_overview_measure_duty_amounts) { helper.vat_overview_measure_duty_amounts(commodity) }
+
+    context 'when there are no vat overview measures' do
+      let(:commodity) { build(:commodity) }
+
+      it { is_expected.to eq('&nbsp;') }
+      it { is_expected.to be_html_safe }
+    end
+
+    context 'when there is 1 vat overview measure' do
+      let(:commodity) { build(:commodity, :with_a_vat_overview_measure) }
+
+      it { is_expected.to eq('20%') }
+      it { is_expected.to be_html_safe }
+    end
+
+    context 'when there is more than 1 vat overview measure' do
+      let(:commodity) { build(:commodity, :with_vat_overview_measures) }
+
+      it { is_expected.to eq('20% or 20%') }
+      it { is_expected.to be_html_safe }
+    end
+  end
 end

--- a/spec/views/commodities/_commodity.html.erb_spec.rb
+++ b/spec/views/commodities/_commodity.html.erb_spec.rb
@@ -6,61 +6,78 @@ RSpec.describe 'commodities/_commodity', type: :view do
     rendered
   end
 
-  describe 'for commodity' do
-    context 'with children' do
-      let(:heading) { build :heading, commodities: [parent, child] }
+  let(:uk_service) { true }
+  let(:commodity) { build :commodity }
 
-      let(:parent) do
-        attributes_for :commodity, producline_suffix: producline_suffix,
-                                   number_indents: 2
+  before do
+    allow(TradeTariffFrontend::ServiceChooser).to receive(:uk?).and_return(uk_service)
+  end
+
+  context 'when on the uk service' do
+    let(:uk_service) { true }
+
+    it { is_expected.to have_css 'div.vat', count: 1 }
+  end
+
+  context 'when not on the uk service' do
+    let(:uk_service) { false }
+
+    it { is_expected.not_to have_css 'div.vat', count: 1 }
+  end
+
+  context 'when the commodity has children' do
+    let(:heading) { build :heading, commodities: [parent, child] }
+
+    let(:parent) do
+      attributes_for :commodity, producline_suffix:,
+                                 number_indents: 2
+    end
+
+    let(:child) do
+      attributes_for :commodity, producline_suffix:,
+                                 parent_sid: parent[:goods_nomenclature_sid],
+                                 number_indents: 3
+    end
+
+    let(:commodity) { heading.commodities.first }
+
+    context 'with producline_suffix of 80' do
+      let(:producline_suffix) { '80' }
+
+      it 'will show the commodity code' do
+        expect(rendered_page).to have_css \
+          'li.has_children > .sub_heading_commodity_code_block .segmented-commodity-code'
       end
 
-      let(:child) do
-        attributes_for :commodity, producline_suffix: producline_suffix,
-                                   parent_sid: parent[:goods_nomenclature_sid],
-                                   number_indents: 3
-      end
-
-      let(:commodity) { heading.commodities.first }
-
-      context 'with producline_suffix of 80' do
-        let(:producline_suffix) { '80' }
-
-        it 'will show the commodity code' do
-          expect(rendered_page).to have_css \
-            'li.has_children > .sub_heading_commodity_code_block .segmented-commodity-code'
-        end
-
-        it 'shows the children with their codes' do
-          expect(rendered_page).to have_css \
-            'li.has_children ul.govuk-list > li .commodity__info .segmented-commodity-code',
-            count: 1
-        end
-      end
-
-      context 'with producline_suffix of 10' do
-        let(:producline_suffix) { '10' }
-
-        it { is_expected.to have_css 'li.has_children > .sub_heading_commodity_code_block' }
-
-        it 'will not show the commodity code' do
-          expect(rendered_page).not_to have_css \
-            'li.has_children > .sub_heading_commodity_code_block .segmented-commodity-code'
-        end
-
-        it 'shows the children with their codes' do
-          expect(rendered_page).to have_css \
-            'li.has_children ul.govuk-list > li .commodity__info .segmented-commodity-code',
-            count: 1
-        end
+      it 'shows the children with their codes' do
+        expect(rendered_page).to have_css \
+          'li.has_children ul.govuk-list > li .commodity__info .segmented-commodity-code',
+          count: 1
       end
     end
 
-    context 'without children' do
-      let(:commodity) { build :commodity }
+    context 'with producline_suffix of 10' do
+      let(:producline_suffix) { '10' }
 
-      it { is_expected.to have_css 'li .commodity__info .segmented-commodity-code' }
-      it { is_expected.not_to have_css 'li.has_children' }
+      it { is_expected.to have_css 'li.has_children > .sub_heading_commodity_code_block' }
+
+      it 'will not show the commodity code' do
+        expect(rendered_page).not_to have_css \
+          'li.has_children > .sub_heading_commodity_code_block .segmented-commodity-code'
+      end
+
+      it 'shows the children with their codes' do
+        expect(rendered_page).to have_css \
+          'li.has_children ul.govuk-list > li .commodity__info .segmented-commodity-code',
+          count: 1
+      end
     end
+  end
+
+  context 'when the commodity does not have children' do
+    let(:commodity) { build :commodity }
+
+    it { is_expected.to have_css 'li .commodity__info .segmented-commodity-code' }
+    it { is_expected.not_to have_css 'li.has_children' }
   end
 end

--- a/spec/views/commodities/_commodity.html.erb_spec.rb
+++ b/spec/views/commodities/_commodity.html.erb_spec.rb
@@ -6,23 +6,18 @@ RSpec.describe 'commodities/_commodity', type: :view do
     rendered
   end
 
-  let(:uk_service) { true }
   let(:commodity) { build :commodity }
 
-  before do
-    allow(TradeTariffFrontend::ServiceChooser).to receive(:uk?).and_return(uk_service)
-  end
-
   context 'when on the uk service' do
-    let(:uk_service) { true }
+    include_context 'with UK service'
 
     it { is_expected.to have_css 'div.vat', count: 1 }
   end
 
   context 'when not on the uk service' do
-    let(:uk_service) { false }
+    include_context 'with XI service'
 
-    it { is_expected.not_to have_css 'div.vat', count: 1 }
+    it { is_expected.not_to have_css 'div.vat' }
   end
 
   context 'when the commodity has children' do

--- a/spec/views/commodities/_commodity.html.erb_spec.rb
+++ b/spec/views/commodities/_commodity.html.erb_spec.rb
@@ -26,20 +26,7 @@ RSpec.describe 'commodities/_commodity', type: :view do
   end
 
   context 'when the commodity has children' do
-    let(:heading) { build :heading, commodities: [parent, child] }
-
-    let(:parent) do
-      attributes_for :commodity, producline_suffix:,
-                                 number_indents: 2
-    end
-
-    let(:child) do
-      attributes_for :commodity, producline_suffix:,
-                                 parent_sid: parent[:goods_nomenclature_sid],
-                                 number_indents: 3
-    end
-
-    let(:commodity) { heading.commodities.first }
+    let(:commodity) { build(:heading, :with_subheading_and_commodity, producline_suffix:).commodities.first }
 
     context 'with producline_suffix of 80' do
       let(:producline_suffix) { '80' }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1737

### What?

I have added/removed/altered:

- [x] Added conditional hiding of heading commodity VAT overview measures when on XI
- [x] Added test coverage for this change
- [x] Removes unused nesting in spec

### Why?

I am doing this because:

- This is required because we currently only return CHIEF VAT measures for headings in XI which are technically out of date
