### PR TITLE
fixes staging smoketests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,6 +595,7 @@ workflows:
             - build_live
 
       - smoketest_staging:
+          context: trade-tariff
           filters:
             branches:
               only:


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds context to staging smoketests

### Why?

I am doing this because:

- This is required to run the staging smoke tests
