### PR TITLE
HOTT-1746 Check for permutations before rendering

### DIFF
--- a/app/presenters/measure_presenter.rb
+++ b/app/presenters/measure_presenter.rb
@@ -48,6 +48,7 @@ class MeasurePresenter < SimpleDelegator
   end
 
   def permutations_enabled?
-    measure_condition_permutation_groups.any?
+    measure_condition_permutation_groups.any? &&
+      measure_condition_permutation_groups.all? { |pg| pg.permutations.any? }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-1746

### What?

I have added/removed/altered:

- [x] Check for presence of permutations with permutation groups

### Why?

I am doing this because:

- Currently we are rendering blank tables in certain edge cases

