### PR TITLE
[WIP] HOTT-1746 fix incorrect jsonapi parsing

### DIFF
--- a/app/presenters/measure_presenter.rb
+++ b/app/presenters/measure_presenter.rb
@@ -48,7 +48,6 @@ class MeasurePresenter < SimpleDelegator
   end
 
   def permutations_enabled?
-    measure_condition_permutation_groups.any? &&
-      measure_condition_permutation_groups.all? { |pg| pg.permutations.any? }
+    measure_condition_permutation_groups.any?
   end
 end

--- a/lib/tariff_jsonapi_parser.rb
+++ b/lib/tariff_jsonapi_parser.rb
@@ -62,7 +62,7 @@ class TariffJsonapiParser
     relationships.each do |name, values|
       parent[name] = case values['data']
                      when Array
-                       find_and_parse_multiple_included(name, values['data'])
+                       find_and_parse_multiple_included(name, values['data']).compact
                      when Hash
                        find_and_parse_included(name, values.dig('data', 'id'), values.dig('data', 'type'))
                      else
@@ -86,8 +86,7 @@ class TariffJsonapiParser
     return nil if id.blank? || type.blank?
 
     found_resource = find_included(id, type)
-
-    return {} if found_resource.blank?
+    return unless found_resource
 
     parse_resource(found_resource)
   rescue NoMethodError
@@ -100,6 +99,8 @@ class TariffJsonapiParser
   end
 
   def find_included(id, type)
-    @attributes['included']&.find { |r| r['id'].to_s == id.to_s && r['type'].to_s == type.to_s } || {}
+    @attributes['included']&.find do |r|
+      r['id'].to_s == id.to_s && r['type'].to_s == type.to_s
+    end
   end
 end

--- a/spec/lib/tariff_jsonapi_parser_spec.rb
+++ b/spec/lib/tariff_jsonapi_parser_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe TariffJsonapiParser do
         it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
-        it { is_expected.to include 'parts' => [{}] }
+        it { is_expected.to include 'parts' => [] }
       end
 
       context 'with invalid relationships' do
@@ -118,7 +118,7 @@ RSpec.describe TariffJsonapiParser do
         it { is_expected.to include 'meta' => { 'foo' => 'bar' } }
         it { is_expected.to include 'name' => 'Joe' }
         it { is_expected.to include 'age' => 21 }
-        it { is_expected.to include 'parts' => [{}] }
+        it { is_expected.to include 'parts' => [] }
       end
 
       context 'with invalid relationships' do


### PR DESCRIPTION
### Jira link

HOTT-1746

### What?

I have added/removed/altered:

- [x] Reverted to extra checks for whether to fall back to the old permutation modals
- [x] Corrected JSON-API parsing to not return an empty hash when a referenced relationship is missing from the includes

### Why?

I am doing this because:

- The fallback was not working and I put a temporary stopgap fix in place
- The fallback was not working because of incorrect parsing of the JSON source data

### Deployment risks (optional)

- Changes a fundamental part of our API parsing
