### PR TITLE
HOTT-1752: Quota Popup Warning Text

### DIFF
--- a/app/helpers/quota_definition_helper.rb
+++ b/app/helpers/quota_definition_helper.rb
@@ -1,8 +1,4 @@
 module QuotaDefinitionHelper
-  def show_warning?(order_number)
-    order_number.definition.description && order_number.number.start_with?('05')
-  end
-
   def start_and_end_dates_for(definition)
     start_date = definition.validity_start_date
     end_date = definition.validity_end_date

--- a/app/models/order_number.rb
+++ b/app/models/order_number.rb
@@ -2,6 +2,12 @@ require 'api_entity'
 require 'order_number/definition'
 
 class OrderNumber
+  ORDER_NUMBERS_WITH_KNOWN_ISSUES = %w[
+    052012
+    052105
+    052106
+  ].freeze
+
   include ApiEntity
 
   attr_accessor :number
@@ -19,5 +25,27 @@ class OrderNumber
   def definition
     return @definition if @definition
     return casted_by if casted_by.is_a?(OrderNumber::Definition)
+  end
+
+  def warning_text
+    if known_data_issues?
+      I18n.t('quota_definition.order_number.known_issues')
+    else
+      definition.description
+    end
+  end
+
+  def show_warning?
+    starts_with_05? || known_data_issues?
+  end
+
+  private
+
+  def starts_with_05?
+    definition.description && number.start_with?('05')
+  end
+
+  def known_data_issues?
+    number.in?(ORDER_NUMBERS_WITH_KNOWN_ISSUES)
   end
 end

--- a/app/models/order_number.rb
+++ b/app/models/order_number.rb
@@ -45,6 +45,7 @@ class OrderNumber
     definition.description && number.start_with?('05')
   end
 
+  # TODO: Remove me. QAM has issues with loading quotas with a hierarchy at the moment and is decrement quotas too quickly
   def known_data_issues?
     number.in?(ORDER_NUMBERS_WITH_KNOWN_ISSUES)
   end

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -36,9 +36,17 @@ class OrderNumber
     has_many :measures
 
     delegate :present?, to: :status
+    delegate :warning_text, :show_warning?, to: :order_number, allow_nil: true
 
     def id
       @id ||= quota_definition_sid
+    end
+
+    def order_number
+      # Returns the order number when loaded via the quota tools page
+      return @order_number if @order_number
+      # Returns the order number when the definition is loaded as part of a declarable response
+      return casted_by if casted_by.is_a?(OrderNumber)
     end
 
     def geographical_areas

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -5,12 +5,13 @@
     <% if order_number.definition.present? %>
       <table class="govuk-table govuk-table-m">
         <h2 class="govuk-heading-m"><%= "Quota #{order_number.number}"%></h2>
-        <% if show_warning?(order_number) %>
+
+        <% if order_number.show_warning? %>
           <div class="govuk-warning-text">
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
           <strong class="govuk-warning-text__text">
             <span class="govuk-warning-text__assistive">Warning</span>
-            <%= quota_definition.description %>
+            <%= quota_definition.warning_text %>
           </strong>
           </div>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,11 @@ en:
   measure_type_duties:
     1080:
       103: 'n/a'
+  quota_definition:
+    order_number:
+      known_issues: >-
+        There is currently a known issue with the balance and status of this quota. We are working hard to resolve this issue as soon as possible. Until further notice the quota remains ‘open’ and quota claims should be submitted as normal.
+
   service_banner:
     service_name:
       uk: "UK Integrated Online Tariff"

--- a/spec/factories/order_number_definition_factory.rb
+++ b/spec/factories/order_number_definition_factory.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :definition, class: 'OrderNumber::Definition' do
+    transient do
+      number { Forgery(:basic).number(exactly: 6).to_s }
+    end
+
     quota_definition_sid { Forgery(:basic).number }
     initial_volume { '54000.0' }
     validity_start_date { '2021-01-01T00:00:00.000Z' }
@@ -15,6 +19,6 @@ FactoryBot.define do
     suspension_period_end_date { nil }
     blocking_period_start_date { nil }
     blocking_period_end_date { nil }
-    order_number { attributes_for(:order_number) }
+    order_number { attributes_for(:order_number, number:) }
   end
 end

--- a/spec/helpers/quota_definition_helper_spec.rb
+++ b/spec/helpers/quota_definition_helper_spec.rb
@@ -1,34 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe QuotaDefinitionHelper, type: :helper do
-  describe '#show_warning?' do
-    let(:order_number) do
-      build(:order_number, number:, definition: attributes_for(:definition, description:))
-    end
-    let(:description) { nil }
-    let(:number) { '050000' }
-
-    context 'when there is a description and the order number starts with `05`' do
-      let(:description) { 'foo' }
-      let(:number) { '050000' }
-
-      it { expect(helper).to be_show_warning(order_number) }
-    end
-
-    context 'when there is a description and the order number does not start with 05' do
-      let(:description) { 'foo' }
-      let(:number) { '060000' }
-
-      it { expect(helper).not_to be_show_warning(order_number) }
-    end
-
-    context 'when there is no description' do
-      let(:description) { nil }
-
-      it { expect(helper).not_to be_show_warning(order_number) }
-    end
-  end
-
   describe '#start_and_end_dates_for' do
     let(:definition) { build(:definition, validity_start_date: '2021-01-01T00:00:00.000Z', validity_end_date: '2021-12-31T00:00:00.000Z') }
 

--- a/spec/models/order_number_spec.rb
+++ b/spec/models/order_number_spec.rb
@@ -50,4 +50,66 @@ RSpec.describe OrderNumber do
       it { expect(order_number.definition).to eq(nil) }
     end
   end
+
+  describe '#show_warning?' do
+    shared_examples_for 'an order number that shows warnings' do
+      subject(:show_warning?) { definition.order_number }
+
+      it { is_expected.to be_show_warning }
+    end
+
+    shared_examples_for 'an order number that does `not` show warnings' do
+      subject(:show_warning?) { definition.order_number }
+
+      it { is_expected.not_to be_show_warning }
+    end
+
+    it_behaves_like 'an order number that shows warnings' do
+      let(:definition) { build(:definition, number: '052012') }
+    end
+
+    it_behaves_like 'an order number that shows warnings' do
+      let(:definition) { build(:definition, number: '052105') }
+    end
+
+    it_behaves_like 'an order number that shows warnings' do
+      let(:definition) { build(:definition, number: '052106') }
+    end
+
+    it_behaves_like 'an order number that shows warnings' do
+      let(:definition) { build(:definition, number: '05foo', description: 'flibble') }
+    end
+
+    it_behaves_like 'an order number that does `not` show warnings' do
+      let(:definition) { build(:definition, number: '05foo', description: nil) }
+    end
+
+    it_behaves_like 'an order number that does `not` show warnings' do
+      let(:definition) { build(:definition, number: '041234') }
+    end
+
+    it_behaves_like 'an order number that does `not` show warnings' do
+      let(:definition) { build(:definition, number: nil) }
+    end
+
+    it_behaves_like 'an order number that does `not` show warnings' do
+      let(:definition) { build(:definition, number: '') }
+    end
+  end
+
+  describe '#warning_text' do
+    subject(:warning_text) { definition.order_number.warning_text }
+
+    context 'when the quota definition order number has known issues' do
+      let(:definition) { build(:definition, number: '052106') }
+
+      it { is_expected.to match(/There is currently a known issue/) }
+    end
+
+    context 'when the quota definition order number has a description' do
+      let(:definition) { build(:definition, number: '052000', description: 'flibble') }
+
+      it { is_expected.to eq('flibble') }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1752

### What?

I have added/removed/altered:

- [x] Adds convenients methods to order number model
- [x] Encapsulate the location of the order number in definition
- [x] Removes unused show_warning? helper
- [x] Update quota definition modal
- [x] Adds locales for warning text
- [x] Adds order number specs for new warning text methods

### Why?

I am doing this because:

- This is required to provide a mechanism for relevant stakeholders to be able to add warnings for broken order numbers
