### PR TITLE
HOTT-1709 Added valid proofs of origin step

### DIFF
--- a/app/models/rules_of_origin/steps/proofs_of_origin.rb
+++ b/app/models/rules_of_origin/steps/proofs_of_origin.rb
@@ -1,0 +1,11 @@
+module RulesOfOrigin
+  module Steps
+    class ProofsOfOrigin < Base
+      self.section = 'proofs'
+
+      def skipped?
+        @store['wholly_obtained'] == 'no'
+      end
+    end
+  end
+end

--- a/app/models/rules_of_origin/wizard.rb
+++ b/app/models/rules_of_origin/wizard.rb
@@ -10,6 +10,7 @@ module RulesOfOrigin
       Steps::ComponentsDefinition,
       Steps::WhollyObtained,
       Steps::OriginRequirementsMet,
+      Steps::ProofsOfOrigin,
       Steps::NotWhollyObtained,
       Steps::PartsComponents,
       Steps::End,

--- a/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
+++ b/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
@@ -1,0 +1,53 @@
+<span class="govuk-caption-xl">
+  <%= t (current_step.exporting? ? '.caption.exporting' : '.caption.importing'),
+        commodity_code: current_step.commodity_code,
+        trade_country_name: current_step.trade_country_name %>
+</span>
+
+<h1 class="govuk-heading-l">
+  <%= t '.title' %>
+</h1>
+
+<p>
+  <%= t '.body' %>
+</p>
+
+<div id="proofs-overview">
+  <h3 class="govuks-heading-s">
+    <%= t '.overview.subtitle' %>
+  </h3>
+
+  <p>
+    <%= t '.overview.body' %>
+  </p>
+
+  <ul class="govuk-list" id="body-links">
+    <li>
+      <%= link_to t('.links.statement'),
+                  'https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration',
+                  target: '_blank',
+                  rel: 'noreferrer noopener' %>
+    </li>
+
+    <li>
+      <%= link_to t('.links.knowledge'),
+                  'https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#importers-knowledge',
+                  target: '_blank',
+                  rel: 'noreferrer noopener' %>
+    </li>
+  </ul>
+</div>
+
+<h3 class="govuk-heading-s">
+  <%= t 'rules_of_origin.steps.common.next_step' %>
+</h3>
+
+<ul class="govuk-list" id="next-steps">
+  <li>
+    <%= link_to t('.links.requirements'), step_path(:proof_requirements) %>
+  </li>
+
+  <li>
+    <%= link_to t('.links.verifications'), step_path(:proof_verifications) %>
+  </li>
+<ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,6 +290,7 @@ en:
           origin_requirements_met: Origin requirements met
           not_wholly_obtained: Your goods are not wholly obtained
           parts_components: Including parts or components from other countries
+          proofs_of_origin: Valid proofs of origin
 
       import_only:
         caption: Trading commodity %{commodity_code} with %{trade_country_name}
@@ -409,11 +410,30 @@ en:
         panel:
           Based on your responses, your product appears to meet the rules of
           origin requirements for the %{scheme_title}.
-        body: |
+        body:
           To benefit from a preferential tariff or quota, originating products
           should be accompanied by an appropriate proof confirming their origin.
         links:
           proofs: See valid proofs of origin
+          requirements: See detailed processes and requirements for proving the origin for goods
+          verifications: How proofs of origin are verified
+
+      proofs_of_origin:
+        caption:
+          importing: Importing commodity %{commodity_code} from %{trade_country_name}
+          exporting: Exporting commodity %{commodity_code} from %{trade_country_name}
+        title: Valid proofs of origin
+        body:
+          To benefit from a preferential tariff or quota, originating products
+          should be accompanied by an appropriate proof confirming their origin.
+        overview:
+          subtitle: Proof of origin - overview
+          body:
+             There are 2 way to provide proofs of origin. Click on an option to
+             see an overview of that proof.
+        links:
+          statement: Statement on origin (opens in new tab)
+          knowledge: Importer's knowledge (opens in new tab)
           requirements: See detailed processes and requirements for proving the origin for goods
           verifications: How proofs of origin are verified
 

--- a/spec/models/rules_of_origin/steps/proofs_of_origin_spec.rb
+++ b/spec/models/rules_of_origin/steps/proofs_of_origin_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe RulesOfOrigin::Steps::ProofsOfOrigin do
+  include_context 'with rules of origin store', :originating
+  include_context 'with wizard step', RulesOfOrigin::Wizard
+
+  describe '#skipped' do
+    subject { instance.skipped? }
+
+    it { is_expected.to be false }
+
+    context "when 'wholly_obtained' set to 'yes'" do
+      include_context 'with rules of origin store', :wholly_obtained
+
+      it { is_expected.to be false }
+    end
+
+    context "when 'wholly_obtained' set to 'no'" do
+      include_context 'with rules of origin store', :not_wholly_obtained
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/views/rules_of_origin/steps/_proofs_of_origin.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_proofs_of_origin.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/steps/_origin_requirements_met', type: :view do
+  include_context 'with rules of origin form step',
+                  'proofs_of_origin',
+                  :wholly_obtained
+
+  it { is_expected.to have_css 'span.govuk-caption-xl', text: %r{(Im|Ex)porting.* #{wizardstore['commodity_code']}.*Japan} }
+  it { is_expected.to have_css 'h1', text: /valid proofs/i }
+  it { is_expected.to have_css 'p', text: /preferential tariff/ }
+  it { is_expected.to have_css '#proofs-overview h3', text: /overview/ }
+  it { is_expected.to have_css '#proofs-overview p', text: /provide proof/ }
+  it { is_expected.to have_css '#proofs-overview a', count: 2 }
+  it { is_expected.to have_css 'h3', text: /Next/i }
+  it { is_expected.to have_css '#next-steps a', count: 2 }
+end


### PR DESCRIPTION
### Jira link

[HOTT-1709](https://transformuk.atlassian.net/browse/HOTT-1709)

### What?

I have added/removed/altered:

- [x] Added "valid proofs of origin" informational step

### Why?

I am doing this because:

- the user needs the opportunity to see this content

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, feature flagged off
