### PR TITLE
HOTT-1711 Added verification of proof step

### DIFF
--- a/app/models/rules_of_origin/steps/proof_verification.rb
+++ b/app/models/rules_of_origin/steps/proof_verification.rb
@@ -1,0 +1,15 @@
+module RulesOfOrigin
+  module Steps
+    class ProofVerification < Base
+      self.section = 'proofs'
+
+      def skipped?
+        @store['wholly_obtained'] == 'no'
+      end
+
+      def verification_text
+        chosen_scheme.article('verification')&.content
+      end
+    end
+  end
+end

--- a/app/models/rules_of_origin/wizard.rb
+++ b/app/models/rules_of_origin/wizard.rb
@@ -11,6 +11,7 @@ module RulesOfOrigin
       Steps::WhollyObtained,
       Steps::OriginRequirementsMet,
       Steps::ProofsOfOrigin,
+      Steps::ProofVerification,
       Steps::NotWhollyObtained,
       Steps::PartsComponents,
       Steps::End,

--- a/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
+++ b/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
@@ -30,6 +30,6 @@
     <%= link_to t('.links.requirements'), step_path(:proof_requirements) %>
   </li>
   <li>
-    <%= link_to t('.links.verifications'), step_path(:proof_verifications) %>
+    <%= link_to t('.links.verification'), step_path(:proof_verification) %>
   </li>
 <ul>

--- a/app/views/rules_of_origin/steps/_proof_verification.html.erb
+++ b/app/views/rules_of_origin/steps/_proof_verification.html.erb
@@ -1,0 +1,13 @@
+<span class="govuk-caption-xl">
+  <%= t '.caption' %>
+</span>
+
+<h1 class="govuk-heading-l">
+  <%= t '.title', trade_country_name: current_step.trade_country_name %>
+</h1>
+
+<div class="tariff-markdown">
+  <div class="numbered-then-lettered-list">
+    <%= govspeak current_step.verification_text %>
+  </div>
+</div>

--- a/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
+++ b/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
@@ -48,6 +48,6 @@
   </li>
 
   <li>
-    <%= link_to t('.links.verifications'), step_path(:proof_verifications) %>
+    <%= link_to t('.links.verification'), step_path(:proof_verification) %>
   </li>
 <ul>

--- a/app/webpacker/src/stylesheets/_lists.scss
+++ b/app/webpacker/src/stylesheets/_lists.scss
@@ -1,7 +1,13 @@
-.lettered-list ol, ol.lettered_list {
+.lettered-list ol, ol.lettered-list {
   list-style-type: lower-alpha;
 
   ol {
     list-style-type: lower-roman;
+  }
+}
+
+.numbered-then-lettered-list ol, ol.numbered-then-lettered-list {
+  ol {
+    list-style-type: lower-alpha;
   }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@
 en:
   generic:
     warning: Warning
+    back_to_top: Back to top
 
   meta_description: "Search for import and export commodity codes and for tax, duty and licences that apply to your goods"
 
@@ -291,6 +292,7 @@ en:
           not_wholly_obtained: Your goods are not wholly obtained
           parts_components: Including parts or components from other countries
           proofs_of_origin: Valid proofs of origin
+          proof_verification: How proofs of origin are verified
 
       import_only:
         caption: Trading commodity %{commodity_code} with %{trade_country_name}
@@ -416,7 +418,7 @@ en:
         links:
           proofs: See valid proofs of origin
           requirements: See detailed processes and requirements for proving the origin for goods
-          verifications: How proofs of origin are verified
+          verification: How proofs of origin are verified
 
       proofs_of_origin:
         caption:
@@ -435,7 +437,11 @@ en:
           statement: Statement on origin (opens in new tab)
           knowledge: Importer's knowledge (opens in new tab)
           requirements: See detailed processes and requirements for proving the origin for goods
-          verifications: How proofs of origin are verified
+          verification: How proofs of origin are verified
+
+      proof_verification:
+        caption: Obtaining and verifying proofs of origin
+        title: Verification for proving the origin for goods coming from %{trade_country_name}
 
       not_wholly_obtained:
         caption: Are your goods originating?

--- a/spec/models/rules_of_origin/steps/proof_verification_spec.rb
+++ b/spec/models/rules_of_origin/steps/proof_verification_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe RulesOfOrigin::Steps::ProofVerification do
+  include_context 'with rules of origin store', :originating
+  include_context 'with wizard step', RulesOfOrigin::Wizard
+
+  describe '#skipped' do
+    subject { instance.skipped? }
+
+    it { is_expected.to be false }
+
+    context "when 'wholly_obtained' set to 'yes'" do
+      include_context 'with rules of origin store', :wholly_obtained
+
+      it { is_expected.to be false }
+    end
+
+    context "when 'wholly_obtained' set to 'no'" do
+      include_context 'with rules of origin store', :not_wholly_obtained
+
+      it { is_expected.to be true }
+    end
+  end
+
+  it_behaves_like 'an article accessor', :verification_text, 'verification'
+end

--- a/spec/views/rules_of_origin/steps/_proof_verification.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_proof_verification.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/steps/_proof_verification', type: :view do
+  include_context 'with rules of origin form step',
+                  'proof_verification',
+                  :wholly_obtained
+
+  let :articles do
+    attributes_for_list :rules_of_origin_article, 1, article: 'verification'
+  end
+
+  it { is_expected.to have_css 'span.govuk-caption-xl', text: /obtaining and verifying/i }
+  it { is_expected.to have_css 'h1', text: /Verification.*Japan/ }
+  it { is_expected.to have_css '.tariff-markdown *' }
+end


### PR DESCRIPTION
### Jira link

[HOTT-1711](https://transformuk.atlassian.net/browse/HOTT-1711)

### What?

I have added/removed/altered:

- [x] Added Verification of proof step
- [x] Fixes an incorrect CSS selector for lettered lists
- [x] Adds another variant of html lists which is numbered followed by lettered

### Why?

I am doing this because:

- It is another content step in the RoO wizard process

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, hidden behind feature flag

### Screenshots

![Screenshot 2022-07-14 at 17-25-38 Rules of Origin Proof verification](https://user-images.githubusercontent.com/10818/179030935-64f28316-687b-42eb-ac5c-1788afbc553c.png)

