### PR TITLE
HOTT-1649 Added Sufficient Processing step

### DIFF
--- a/app/models/rules_of_origin/steps/sufficient_processing.rb
+++ b/app/models/rules_of_origin/steps/sufficient_processing.rb
@@ -1,0 +1,25 @@
+module RulesOfOrigin
+  module Steps
+    class SufficientProcessing < Base
+      OPTIONS = %w[yes no].freeze
+
+      self.section = 'originating'
+
+      attribute :sufficient_processing
+
+      validates :sufficient_processing, inclusion: { in: OPTIONS }
+
+      def options
+        OPTIONS
+      end
+
+      def insufficient_processing_text
+        chosen_scheme.article('insufficient-processing')&.content
+      end
+
+      def skipped?
+        @store['wholly_obtained'] != 'no'
+      end
+    end
+  end
+end

--- a/app/models/rules_of_origin/wizard.rb
+++ b/app/models/rules_of_origin/wizard.rb
@@ -13,6 +13,7 @@ module RulesOfOrigin
       Steps::ProofsOfOrigin,
       Steps::NotWhollyObtained,
       Steps::PartsComponents,
+      Steps::SufficientProcessing,
       Steps::End,
     ]
 

--- a/app/views/rules_of_origin/steps/_import_only.html.erb
+++ b/app/views/rules_of_origin/steps/_import_only.html.erb
@@ -26,7 +26,7 @@
 </h3>
 
 <div class="tariff-markdown">
-  <%= simple_format t '.export_information', trade_country_name: current_step.trade_country_name %>
+  <%= govspeak t '.export_information', trade_country_name: current_step.trade_country_name %>
 </div>
 
 <p>

--- a/app/views/rules_of_origin/steps/_scheme.html.erb
+++ b/app/views/rules_of_origin/steps/_scheme.html.erb
@@ -9,7 +9,7 @@
                   trade_country: form.object.trade_country_name)
         },
         hint: {
-          text: simple_format(t('helpers.hint.rules_of_origin_steps_scheme.scheme_code',
-                              trade_country: form.object.trade_country_name))
+          text: govspeak(t('helpers.hint.rules_of_origin_steps_scheme.scheme_code',
+                           trade_country: form.object.trade_country_name))
         } %>
 <% end %>

--- a/app/views/rules_of_origin/steps/_sufficient_processing.html.erb
+++ b/app/views/rules_of_origin/steps/_sufficient_processing.html.erb
@@ -1,0 +1,32 @@
+<%= rules_of_origin_form_for(current_step) do |form| %>
+  <span class="govuk-caption-xl">
+    <%= t '.caption' %>
+  </span>
+
+  <h1 class="govuk-heading-xl">
+    <%= t '.title' %>
+  </h1>
+
+  <div class="tariff-markdown tariff-markdown--with-lead-paragraph">
+    <%= govspeak t '.body' %>
+
+    <%= render 'shared/details', summary: t('.operations.summary'),
+                                 content: govspeak(t('.operations.content')) %>
+  </div>
+
+  <div id="insufficient-processing-article">
+    <h3 class="govuk-heading-m">
+      <%= t '.insufficient_processing', scheme_title: form.object.scheme_title %>
+    </h3>
+
+    <div class="tariff-markdown lettered-list">
+      <%= govspeak form.object.insufficient_processing_text %>
+    </div>
+  </div>
+
+  <%= form.govuk_collection_radio_buttons \
+        :sufficient_processing,
+        form.object.options,
+        :to_sym,
+        legend: { size: 'm', tag: nil } %>
+<% end %>

--- a/app/webpacker/src/stylesheets/_markdown.scss
+++ b/app/webpacker/src/stylesheets/_markdown.scss
@@ -30,7 +30,7 @@
     @extend .govuk-section-break--visible;
   }
 
-  &--with-lead-paragraph p:first-of-type {
+  &--with-lead-paragraph > p:first-of-type {
     @extend .govuk-body-l;
   }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,6 +211,11 @@ en:
             wholly_obtained:
               inclusion: Select whether your goods are wholly obtained in %{trade_country}
 
+        rules_of_origin/steps/sufficient_processing:
+          attributes:
+            sufficient_processing:
+              inclusion: Select whether non-originating parts have been subject to sufficient processing
+
   helpers:
     legend:
       rules_of_origin_steps_scheme:
@@ -219,6 +224,10 @@ en:
         import_or_export: Are you importing goods into %{service_country} or into %{trade_country}?
       rules_of_origin_steps_wholly_obtained:
         wholly_obtained: Are your goods wholly obtained in %{trade_country}?
+      rules_of_origin_steps_sufficient_processing:
+        sufficient_processing:
+          Have non-originating parts been subject to sufficient processing to
+          qualify for preferential treatment?
 
     caption:
       rules_of_origin_steps_scheme:
@@ -256,6 +265,10 @@ en:
         wholly_obtained_options:
           'yes': Yes, my goods are wholly obtained in %{trade_country}
           'no': No, my goods are not wholly obtained in %{trade_country}
+      rules_of_origin_steps_sufficient_processing:
+        sufficient_processing_options:
+          'yes': 'Yes'
+          'no': 'No'
 
   rules_of_origin:
     preferential_treatment:
@@ -298,6 +311,7 @@ en:
           origin_requirements_met: Origin requirements met
           not_wholly_obtained: Your goods are not wholly obtained
           parts_components: Including parts or components from other countries
+          sufficient_processing: "Minimal operations: Have non-originating parts been sufficiently processed?"
           proofs_of_origin: Valid proofs of origin
 
       import_only:
@@ -318,7 +332,8 @@ en:
           apply to your import from %{trade_country_name}.
         exporting_to: Exporting goods to %{trade_country_name}
         export_information: |
-          If you would like to export goods to %{trade_country_name}, then MFN duties will apply.
+          If you would like to export goods to %{trade_country_name}, then MFN
+          duties will apply.
 
           For Most-Favoured Nation (MFN) duties, anti-dumping, anti-subsidies or
           safeguard measures, origin marking, non-preferential rules of origin
@@ -552,3 +567,39 @@ en:
           Click on the 'Continue' button to view the definition of 'minimal
           operations' in the %{scheme_title}. Any non-originating parts must be
           sufficiently processed to count as originating.
+
+      sufficient_processing:
+        caption: Are your goods originating?
+        title: |
+          Minimal operations: Have non-originating parts been sufficiently
+          processed?
+        body: |
+          In order to qualify for preferential treatment, non-originating parts
+          must be sufficiently processed to count as originating.
+
+          Manufacturing and processing operations must be more than simple
+          operations or processes, and must need special skills, machines,
+          apparatus or equipment especially produced or installed to carry out
+          the manufacture or process.
+
+          Some operations are regarded as too minor to confer originating status
+          to non-originating materials that are used in the production of your
+          goods. These operations are referred to as 'insufficient processing'
+          and are specific to each trade agreement.
+        operations:
+          summary: What are simple operations?
+          content: |
+            Some of the listed operations can be clearly identified as
+            insufficient operations, such as the affixing of a label on the
+            product. However, there are also some operations that need to be
+            assessed further as they contain the term ‘simple’, for example
+            ‘simple assembly’.
+
+            ‘Simple’ usually describes activities which do not need special
+            skills, machines, apparatus, or equipment especially produced or
+            installed for carrying out the activity. This term may be further
+            defined so that the skills, machines, apparatus, or tools used must
+            also contribute to the product’s essential characteristics or
+            properties.
+        insufficient_processing: |
+          'Insufficient processing' operations according to the %{scheme_title}

--- a/spec/models/rules_of_origin/steps/sufficient_processing_spec.rb
+++ b/spec/models/rules_of_origin/steps/sufficient_processing_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe RulesOfOrigin::Steps::SufficientProcessing do
+  include_context 'with rules of origin store', :originating
+  include_context 'with wizard step', RulesOfOrigin::Wizard
+
+  it_behaves_like 'an article accessor',
+                  :insufficient_processing_text,
+                  'insufficient-processing'
+
+  it { is_expected.to respond_to :sufficient_processing }
+  it { is_expected.to have_attributes options: %w[yes no] }
+
+  describe 'validation' do
+    it { is_expected.to allow_value('yes').for :sufficient_processing }
+    it { is_expected.to allow_value('no').for :sufficient_processing }
+    it { is_expected.not_to allow_value('random').for :sufficient_processing }
+    it { is_expected.not_to allow_value('').for :sufficient_processing }
+    it { is_expected.not_to allow_value(nil).for :sufficient_processing }
+  end
+
+  describe '#skipped?' do
+    subject { instance.skipped? }
+
+    it { is_expected.to be true }
+
+    context "when 'wholly_obtained' set to 'yes'" do
+      include_context 'with rules of origin store', :wholly_obtained
+
+      it { is_expected.to be true }
+    end
+
+    context "when 'wholly_obtained' set to 'no'" do
+      include_context 'with rules of origin store', :not_wholly_obtained
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/views/rules_of_origin/steps/_sufficient_processing.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_sufficient_processing.html.erb_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/steps/_sufficient_processing', type: :view do
+  include_context 'with rules of origin form step', 'sufficient_processing'
+
+  let :articles do
+    attributes_for_list :rules_of_origin_article, 1,
+                        article: 'insufficient-processing'
+  end
+
+  it { is_expected.to have_css 'form > h1', text: /Have non-originating parts/ }
+  it { is_expected.to have_css 'fieldset legend.govuk-fieldset__legend--m', text: /Have non-originating parts/ }
+  it { is_expected.to have_css 'input[type="radio"]', count: 2 }
+  it { is_expected.to have_css '.tariff-markdown p' }
+  it { is_expected.to have_css 'details.govuk-details summary' }
+  it { is_expected.to have_css 'details.govuk-details div.govuk-details__text *' }
+  it { is_expected.to have_css '#insufficient-processing-article h3' }
+  it { is_expected.to have_css '#insufficient-processing-article .tariff-markdown *' }
+
+  context 'with invalid submission' do
+    before { current_step.validate }
+
+    it { is_expected.to have_css '.govuk-error-message', text: /Select whether/i }
+  end
+end


### PR DESCRIPTION
Also includes drive by fixes for
* nested p tags in tariff-markdown--with-lead-paragraph css
* simple_format inserting line breaks for content from translation files
(switched to processing as markdown)

### Jira link

[HOTT-1649](https://transformuk.atlassian.net/browse/HOTT-1649)

### What?

I have added/removed/altered:

- [x] Added the Sufficient Processing screen
- [x] Fixed the `tariff-markdown--with-lead-paragraph` CSS to only apply to the first directly nested paragraph
- [x] Replaced the use of `simple_format` on earlier steps with `govspeak` 

### Why?

I am doing this because:

- We want to ask the user if their products have had sufficient processing
- The CSS selector was incorrectly enlarging the first paragraph in the details element on the new step
- The `simple_format` helper inserts line breaks for the line breaks in the yaml file we don't want

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, screen is feature flagged off at present
