### PR TITLE
Display scheme title on components definition page

### DIFF
--- a/app/views/rules_of_origin/steps/_components_definition.html.erb
+++ b/app/views/rules_of_origin/steps/_components_definition.html.erb
@@ -49,6 +49,6 @@
   </h3>
 
   <p>
-    <%= t '.next_step' %>
+    <%= t '.next_step', scheme_title: form.object.scheme_title %>
   </p>
 <% end %>

--- a/spec/views/rules_of_origin/steps/_components_definition.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_components_definition.html.erb_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'rules_of_origin/steps/_components_definition', type: :view do
   it { is_expected.to have_css 'h3', text: %r{Accessories} }
   it { is_expected.to have_css '.tariff-markdown > p', text: 'accessory article' }
   it { is_expected.to have_css 'h3', text: /Next step/ }
+  it { is_expected.to have_css 'p', text: %r{Click on the 'Continue' button.*#{schemes.first.title}} }
   it { is_expected.to have_css 'form button[type=submit]' }
 
   context 'without accesories article' do


### PR DESCRIPTION
### Jira link

HOTT-1730

### What?

I have added/removed/altered:

- [x] Displayed scheme title on components definition page

### Why?

I am doing this because:

- The scheme title was missing
