### PR TITLE
Remove switching links on error pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,7 +4,7 @@ class ErrorsController < ApplicationController
   skip_before_action :set_search
   skip_before_action :bots_no_index_if_historical
 
-  before_action :disable_search_form
+  before_action :disable_search_form, :disable_switch_service_banner
 
   def not_found
     render status: :not_found


### PR DESCRIPTION
### Jira link

HOTT-1762

### What?

I have added/removed/altered:

- [x] Removed switching links on 404, 500, 503 pages

### Why?

I am doing this because:

- We don't want switching links on error pages
