### PR TITLE
HOTT-1782 Filter Product Specific Rules by ruleset

### DIFF
--- a/app/models/rules_of_origin/steps/product_specific_rules.rb
+++ b/app/models/rules_of_origin/steps/product_specific_rules.rb
@@ -13,7 +13,11 @@ module RulesOfOrigin
       end
 
       def options
-        @options ||= chosen_scheme.v2_rules + [none_option]
+        @options ||= rules + [none_option]
+      end
+
+      def rules
+        subdivided_rules? ? subdivision_rules : all_rules
       end
 
     private
@@ -32,6 +36,24 @@ module RulesOfOrigin
 
       def available_rules
         options.map(&:resource_id)
+      end
+
+      def subdivided_rules?
+        !@wizard.find('subdivisions').skipped?
+      end
+
+      def all_rules
+        chosen_scheme.v2_rules
+      end
+
+      def subdivision_rules
+        subdivision_rule_set.rules
+      end
+
+      def subdivision_rule_set
+        chosen_scheme.rule_sets.find do |rs|
+          rs.resource_id == @store['subdivision_id']
+        end
       end
     end
   end

--- a/spec/factories/rules_of_origin/scheme_factory.rb
+++ b/spec/factories/rules_of_origin/scheme_factory.rb
@@ -25,6 +25,8 @@ FactoryBot.define do
     end
 
     trait :with_subdivided_rule_sets do
+      rule_set_count { 3 }
+
       rule_sets do
         attributes_for_list :rules_of_origin_rule_set, rule_set_count,
                             :subdivided,

--- a/spec/factories/rules_of_origin/scheme_factory.rb
+++ b/spec/factories/rules_of_origin/scheme_factory.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
                           rule_count: v2_rule_count
     end
 
-    trait :with_subdivided_rule_sets do
+    trait :subdivided do
       rule_set_count { 3 }
 
       rule_sets do

--- a/spec/factories/rules_of_origin/wizard_store_factory.rb
+++ b/spec/factories/rules_of_origin/wizard_store_factory.rb
@@ -56,7 +56,7 @@ FactoryBot.define do
 
     trait :subdivided do
       schemes do
-        build_list :rules_of_origin_scheme, 2, :with_subdivided_rule_sets
+        build_list :rules_of_origin_scheme, 2, :subdivided
       end
 
       sufficient_processing

--- a/spec/factories/rules_of_origin/wizard_store_factory.rb
+++ b/spec/factories/rules_of_origin/wizard_store_factory.rb
@@ -53,5 +53,14 @@ FactoryBot.define do
       not_wholly_obtained
       sufficient_processing { 'no' }
     end
+
+    trait :subdivided do
+      schemes do
+        build_list :rules_of_origin_scheme, 2, :with_subdivided_rule_sets
+      end
+
+      sufficient_processing
+      subdivision_id { schemes.first.rule_sets.second.resource_id }
+    end
   end
 end

--- a/spec/models/rules_of_origin/steps/product_specific_rules_spec.rb
+++ b/spec/models/rules_of_origin/steps/product_specific_rules_spec.rb
@@ -54,4 +54,18 @@ RSpec.describe RulesOfOrigin::Steps::ProductSpecificRules do
 
     it { is_expected.to eql schemes.first.v2_rules.map(&:resource_id) + %w[none] }
   end
+
+  describe '#rules' do
+    subject { instance.rules }
+
+    context 'with no subdivision chosen' do
+      it { is_expected.to eql schemes.first.v2_rules }
+    end
+
+    context 'with subdivision' do
+      include_context 'with rules of origin store', :subdivided
+
+      it { is_expected.to eql schemes.first.rule_sets.second.rules }
+    end
+  end
 end

--- a/spec/models/rules_of_origin/steps/subdivisions_spec.rb
+++ b/spec/models/rules_of_origin/steps/subdivisions_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe RulesOfOrigin::Steps::Subdivisions do
   include_context 'with rules of origin store',
                   :sufficient_processing,
-                  scheme_traits: %i[with_subdivided_rule_sets]
+                  scheme_traits: %i[subdivided]
   include_context 'with wizard step', RulesOfOrigin::Wizard
 
   it { is_expected.to respond_to :subdivision_id }
@@ -28,7 +28,7 @@ RSpec.describe RulesOfOrigin::Steps::Subdivisions do
       context "when 'sufficient_processing' set to 'no'" do
         include_context 'with rules of origin store',
                         :insufficient_processing,
-                        scheme_traits: %i[with_subdivided_rule_sets]
+                        scheme_traits: %i[subdivided]
 
         it { is_expected.to be true }
       end

--- a/spec/support/shared_context/rules_of_origin_wizard.rb
+++ b/spec/support/shared_context/rules_of_origin_wizard.rb
@@ -17,6 +17,10 @@ shared_context 'with rules of origin store' do |*traits, scheme_count: 1, scheme
   end
 
   let(:schemes) do
+    if traits.include?(:subdivided)
+      scheme_traits << :with_subdivided_rule_sets
+    end
+
     build_list :rules_of_origin_scheme,
                scheme_count,
                *scheme_traits,

--- a/spec/support/shared_context/rules_of_origin_wizard.rb
+++ b/spec/support/shared_context/rules_of_origin_wizard.rb
@@ -17,13 +17,11 @@ shared_context 'with rules of origin store' do |*traits, scheme_count: 1, scheme
   end
 
   let(:schemes) do
-    if traits.include?(:subdivided)
-      scheme_traits << :with_subdivided_rule_sets
-    end
+    shared_traits = traits & %i[subdivided]
 
     build_list :rules_of_origin_scheme,
                scheme_count,
-               *scheme_traits,
+               *(scheme_traits + shared_traits),
                countries: [country.id],
                articles:
   end


### PR DESCRIPTION
### Jira link

[HOTT-1782](https://transformuk.atlassian.net/browse/HOTT-1782)

### What?

I have added/removed/altered:

- [x] Filter the list of rules for the user by the chosen rule set

### Why?

I am doing this because:

- If the user has been shown the rule set subdivisions step, then they will have chosen a subdivision so rules from other subdivisions are not valid

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, feature flagged off

### Screenshot

![Screenshot from 2022-07-25 14-29-47](https://user-images.githubusercontent.com/10818/180789776-04947087-b5de-4010-b8da-df6cf0f608c2.png)

