### PR TITLE
HOTT-1775: Return empty array if article content is nil

### DIFF
--- a/app/models/rules_of_origin/steps/proof_requirements.rb
+++ b/app/models/rules_of_origin/steps/proof_requirements.rb
@@ -12,6 +12,8 @@ module RulesOfOrigin
       end
 
       def processes_sections
+        return [] if processes_text.nil?
+
         @processes_sections ||= \
           processes_text.split(/^(## )/m)
                         .map(&:presence)

--- a/spec/models/rules_of_origin/steps/proof_requirements_spec.rb
+++ b/spec/models/rules_of_origin/steps/proof_requirements_spec.rb
@@ -67,6 +67,16 @@ RSpec.describe RulesOfOrigin::Steps::ProofRequirements do
 
         it { is_expected.to eql %(## Second section\n\nSection 2 content\n) }
       end
+
+      context 'with no content' do
+        subject(:sections) { instance.processes_sections }
+
+        let(:articles) { [] }
+
+        it 'returns an empty array' do
+          expect(sections).to be_empty
+        end
+      end
     end
 
     describe '#processes_section_titles' do


### PR DESCRIPTION
### Jira link

[HOTT-1775](https://transformuk.atlassian.net/browse/HOTT-1775)

### What?

I have added/removed/altered:

- [x] modified the processes_sections method to return an empty array if article content is nil


### Why?

I am doing this because:

- We were getting errors when trying to processes empty sections