### PR TITLE
HOTT-1788 Never show the RoO Wizard on XI

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -110,7 +110,7 @@ module TradeTariffFrontend
   end
 
   def roo_wizard?
-    ENV['ROO_WIZARD'] == 'true'
+    ENV['ROO_WIZARD'] == 'true' && TradeTariffFrontend::ServiceChooser.uk?
   end
 
   def basic_auth?


### PR DESCRIPTION
### Jira link

[HOTT-1788](https://transformuk.atlassian.net/browse/HOTT-1788)

### What?

I have added/removed/altered:

- [x] Always disable RoO Wizard on XI

### Why?

I am doing this because:

- We don't have data for XI yet

### Deployment risks (optional)

- Low risk, feature flagged off in production anyway at the moment
