### PR TITLE
HOTT-1787 Addeds specs for uninitialised session

### DIFF
--- a/app/controllers/rules_of_origin/steps_controller.rb
+++ b/app/controllers/rules_of_origin/steps_controller.rb
@@ -3,13 +3,15 @@ module RulesOfOrigin
     include WizardSteps
     self.wizard_class = RulesOfOrigin::Wizard
 
+    delegate :service_name, to: TradeTariffFrontend::ServiceChooser
+
     before_action do
       disable_search_form
       disable_last_updated_footnote
       disable_switch_service_banner
     end
 
-    before_action :check_service_hasnt_changed,
+    before_action :check_session_data,
                   except: :index,
                   if: -> { params[:id] != wizard_class.steps.first.key }
 
@@ -31,8 +33,9 @@ module RulesOfOrigin
       rules_of_origin_step_path(step_id, ...)
     end
 
-    def check_service_hasnt_changed
-      if TradeTariffFrontend::ServiceChooser.service_name != wizard_store['service']
+    def check_session_data
+      if service_name != wizard_store['service']
+
         redirect_to return_to_commodity_path
         wizard_store.purge!
       end

--- a/spec/requests/rules_of_origin/steps_controller_spec.rb
+++ b/spec/requests/rules_of_origin/steps_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RulesOfOrigin::StepsController, type: :request do
   let(:first_step) { RulesOfOrigin::Wizard.steps.first }
   let(:second_step) { RulesOfOrigin::Wizard.steps.second } # first is Start/init step
   let(:initial_params) { { country_code: 'JP', commodity_code: '6004100091', service: 'uk' } }
+  let(:return_path) { commodity_path('6004100091', country: 'JP', anchor: 'rules-of-origin') }
 
   describe 'GET #index' do
     before { get rules_of_origin_steps_path }
@@ -13,10 +14,18 @@ RSpec.describe RulesOfOrigin::StepsController, type: :request do
     it { is_expected.to redirect_to rules_of_origin_step_path(first_step.key) }
   end
 
-  describe 'GET #show for first step' do
-    before { get rules_of_origin_step_path(first_step.key) }
+  describe 'GET #show without initialized session' do
+    context 'with first step' do
+      before { get rules_of_origin_step_path(first_step.key) }
 
-    it { is_expected.to redirect_to find_commodity_path }
+      it { is_expected.to redirect_to find_commodity_path }
+    end
+
+    context 'with later step' do
+      before { get rules_of_origin_step_path(second_step.key) }
+
+      it { is_expected.to redirect_to find_commodity_path }
+    end
   end
 
   describe 'GET #show' do
@@ -44,7 +53,7 @@ RSpec.describe RulesOfOrigin::StepsController, type: :request do
     context 'with changed service' do
       before { get "/xi#{rules_of_origin_step_path(second_step.key)}" }
 
-      it { is_expected.to redirect_to commodity_path('6004100091', country: 'JP', anchor: 'rules-of-origin') }
+      it { is_expected.to redirect_to return_path }
     end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-1787

### What?

I have added/removed/altered:

- [x] Added specs to verify existing behaviour

### Why?

I am doing this because:

- there was some confusion as to whether we redirected users if they tried to navigate straight to the wizard

### Deployment risks (optional)

- Low feature flagged off
