### PR TITLE
HOTT-1785 Changed back on final req met screens

### DIFF
--- a/app/models/rules_of_origin/steps/proof_requirements.rb
+++ b/app/models/rules_of_origin/steps/proof_requirements.rb
@@ -4,7 +4,7 @@ module RulesOfOrigin
       self.section = 'proofs'
 
       def skipped?
-        @store['wholly_obtained'] == 'no'
+        true
       end
 
       def processes_text

--- a/app/models/rules_of_origin/steps/proof_verification.rb
+++ b/app/models/rules_of_origin/steps/proof_verification.rb
@@ -4,7 +4,7 @@ module RulesOfOrigin
       self.section = 'proofs'
 
       def skipped?
-        @store['wholly_obtained'] == 'no'
+        true
       end
 
       def verification_text

--- a/app/models/rules_of_origin/steps/proofs_of_origin.rb
+++ b/app/models/rules_of_origin/steps/proofs_of_origin.rb
@@ -4,7 +4,7 @@ module RulesOfOrigin
       self.section = 'proofs'
 
       def skipped?
-        @store['wholly_obtained'] == 'no'
+        true
       end
     end
   end

--- a/spec/models/rules_of_origin/steps/proof_requirements_spec.rb
+++ b/spec/models/rules_of_origin/steps/proof_requirements_spec.rb
@@ -6,22 +6,10 @@ RSpec.describe RulesOfOrigin::Steps::ProofRequirements do
 
   it_behaves_like 'an article accessor', :processes_text, 'origin_processes'
 
-  describe '#skipped' do
+  describe '#skipped?' do
     subject { instance.skipped? }
 
-    it { is_expected.to be false }
-
-    context "when 'wholly_obtained' set to 'yes'" do
-      include_context 'with rules of origin store', :wholly_obtained
-
-      it { is_expected.to be false }
-    end
-
-    context "when 'wholly_obtained' set to 'no'" do
-      include_context 'with rules of origin store', :not_wholly_obtained
-
-      it { is_expected.to be true }
-    end
+    it { is_expected.to be true }
   end
 
   describe 'processes article content' do

--- a/spec/models/rules_of_origin/steps/proof_verification_spec.rb
+++ b/spec/models/rules_of_origin/steps/proof_verification_spec.rb
@@ -4,22 +4,10 @@ RSpec.describe RulesOfOrigin::Steps::ProofVerification do
   include_context 'with rules of origin store', :originating
   include_context 'with wizard step', RulesOfOrigin::Wizard
 
-  describe '#skipped' do
+  describe '#skipped?' do
     subject { instance.skipped? }
 
-    it { is_expected.to be false }
-
-    context "when 'wholly_obtained' set to 'yes'" do
-      include_context 'with rules of origin store', :wholly_obtained
-
-      it { is_expected.to be false }
-    end
-
-    context "when 'wholly_obtained' set to 'no'" do
-      include_context 'with rules of origin store', :not_wholly_obtained
-
-      it { is_expected.to be true }
-    end
+    it { is_expected.to be true }
   end
 
   it_behaves_like 'an article accessor', :verification_text, 'verification'

--- a/spec/models/rules_of_origin/steps/proofs_of_origin_spec.rb
+++ b/spec/models/rules_of_origin/steps/proofs_of_origin_spec.rb
@@ -7,18 +7,6 @@ RSpec.describe RulesOfOrigin::Steps::ProofsOfOrigin do
   describe '#skipped' do
     subject { instance.skipped? }
 
-    it { is_expected.to be false }
-
-    context "when 'wholly_obtained' set to 'yes'" do
-      include_context 'with rules of origin store', :wholly_obtained
-
-      it { is_expected.to be false }
-    end
-
-    context "when 'wholly_obtained' set to 'no'" do
-      include_context 'with rules of origin store', :not_wholly_obtained
-
-      it { is_expected.to be true }
-    end
+    it { is_expected.to be true }
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1785](https://transformuk.atlassian.net/browse/HOTT-1785)

### What?

I have added/removed/altered:

- [x] Updated back link behaviour on exit screens for Origin Requirements Met path


### Why?

I am doing this because:

- They should always go back to Origin Requirements Met, even if navigated via sibling final screens

### Deployment risks (optional)

- Low, feature flagged off
