### PR TITLE
HOTT-1794 Critical footnotes

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -41,6 +41,10 @@ module Declarable
     no_heading? && no_entry_price_system?
   end
 
+  def critical_footnotes
+    @critical_footnotes = footnotes.select(&:critical_warning?)
+  end
+
   def meursing_code?
     meta&.dig('duty_calculator', 'meursing_code')
   end

--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -4,6 +4,8 @@ class Footnote
   include ApiEntity
   include HasGoodsNomenclature
 
+  CRITICAL_WARNING_REGEX = /^CR/
+
   collection_path '/footnotes'
 
   attr_accessor :code, :footnote_type_id, :footnote_id, :description, :formatted_description, :extra_large_measures
@@ -15,5 +17,9 @@ class Footnote
     measures
       .map(&:goods_nomenclature)
       .concat(goods_nomenclatures)
+  end
+
+  def critical_warning?
+    code =~ CRITICAL_WARNING_REGEX
   end
 end

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -7,6 +7,10 @@
 
 <%= render 'commodities/header', commodity_code: declarable.code %>
 
+<% declarable.critical_footnotes.each do |footnote| %>
+  <%= render 'footnotes/critical_warning', footnote: footnote %>
+<% end %>
+
 <%= render 'shared/context_tables/commodity' %>
 
 <%= render 'goods_nomenclatures/ancestors', goods_nomenclature: declarable %>

--- a/app/views/footnotes/_critical_warning.html.erb
+++ b/app/views/footnotes/_critical_warning.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      <%= footnote.description.html_safe %>
+  </strong>
+</div>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, goods_nomenclature_title(@heading) %>
 
+
 <% content_for :head do %>
   <meta name="description" content="<%= @heading %>">
   <link rel='alternate' type='application/json' href='<%= heading_url(@heading, format: :json) %>' title='Heading information page in JSON format' />
@@ -9,6 +10,10 @@
   <%= render 'commodities/header', commodity_code: (@heading.page_heading + '000000') %>
 <% else %>
   <%= page_header @heading.page_heading %>
+<% end %>
+
+<% @heading.critical_footnotes.each do |footnote| %>
+  <%= render 'footnotes/critical_warning', footnote: footnote %>
 <% end %>
 
 <%= render 'shared/context_tables/heading' %>

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Commodity do
   end
 
   it_behaves_like 'a declarable' do
-    subject(:declarable) { build(:commodity, import_measures: measures) }
+    subject(:declarable) { build(:commodity, import_measures: measures, footnotes:) }
   end
 
   describe 'parent/children relationships' do

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe Heading do
   end
 
   it_behaves_like 'a declarable' do
-    subject(:declarable) { build(:heading, import_measures: measures) }
+    subject(:declarable) { build(:heading, import_measures: measures, footnotes:) }
+
+    let(:footnotes) { [] }
   end
 
   describe '#heading' do

--- a/spec/support/shared_examples/a_declarable.rb
+++ b/spec/support/shared_examples/a_declarable.rb
@@ -57,5 +57,13 @@ RSpec.shared_examples 'a declarable' do
         expect(declarable.supplementary_unit_description(country: '1011')).to eq('Supplementary unit')
       end
     end
+
+    describe '#critical_footnotes' do
+      context 'when there are not footnotes having critical warning'
+        it 'returns empty array' do
+          expect(declarable.critical_footnotes).to eq([])
+        end
+      end
+    end
   end
 end

--- a/spec/support/shared_examples/a_declarable.rb
+++ b/spec/support/shared_examples/a_declarable.rb
@@ -2,6 +2,7 @@ RSpec.shared_examples 'a declarable' do
   it { is_expected.to respond_to(:declarable) }
 
   let(:measures) { [] }
+  let(:footnotes) { [] }
 
   describe '#supplementary_unit' do
     context 'when there is a supplementary measure' do
@@ -59,7 +60,17 @@ RSpec.shared_examples 'a declarable' do
     end
 
     describe '#critical_footnotes' do
-      context 'when there are not footnotes having critical warning'
+      context 'when there are critical footnotes' do
+        let(:footnotes) { [attributes_for(:footnote, code: 'CR123')] }
+
+        it 'returns the critical footnotes' do
+          expect(declarable.critical_footnotes.first.code).to eq('CR123')
+        end
+      end
+
+      context 'when there are NOT Critical footnotes' do
+        let(:footnotes) { [attributes_for(:footnote, code: 'NC456')] }
+
         it 'returns empty array' do
           expect(declarable.critical_footnotes).to eq([])
         end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1794

### What?
Add support for footnotes having Critical Warnings (which are footnote with code: 'CR')

I have added/removed/altered:

- [x] Added critical footnote partial 
- [x] Added method to filter critical footnotes

### Why?
Some footnotes are critical and must be shown on top of the page.
