### PR TITLE
HOTT-1866: Rules text now uses html_safe

### DIFF
--- a/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
+++ b/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
@@ -3,7 +3,7 @@
         :rule,
         form.object.options,
         :resource_id,
-        :rule %>
+        ->(option) { option.rule.html_safe } %>
 
   <div class="tariff-markdown">
     <%= govspeak t '.body', scheme_title: form.object.scheme_title %>


### PR DESCRIPTION
### Jira link

[HOTT-1866](https://transformuk.atlassian.net/browse/HOTT-1866)

### What?

I have added/removed/altered:

- [ ] used html_safe to display each rule

### Why?

I am doing this because:

- We want rules to be displayed using HTML