### PR TITLE
HOTT-1881: Display correct country name if exporting/importing

### DIFF
--- a/app/models/rules_of_origin/steps/base.rb
+++ b/app/models/rules_of_origin/steps/base.rb
@@ -21,6 +21,10 @@ module RulesOfOrigin
                                                 .description
       end
 
+      def country_name
+        exporting? ? service_country_name : trade_country_name
+      end
+
       def commodity_code
         @store['commodity_code']
       end

--- a/app/views/rules_of_origin/steps/_wholly_obtained.html.erb
+++ b/app/views/rules_of_origin/steps/_wholly_obtained.html.erb
@@ -1,15 +1,17 @@
 <%= rules_of_origin_form_for(current_step) do |form| %>
+  <% country_name = current_step.exporting? ? form.object.service_country_name : form.object.trade_country_name %>
+  
   <%= form.govuk_collection_radio_buttons \
         :wholly_obtained,
         form.object.options,
         :to_sym,
         -> (option) {
           t("helpers.label.rules_of_origin_steps_wholly_obtained.wholly_obtained_options.#{option}",
-            trade_country: form.object.trade_country_name)
+            trade_country: country_name)
         },
         legend: {
           text: t('helpers.legend.rules_of_origin_steps_wholly_obtained.wholly_obtained',
-                  trade_country: form.object.trade_country_name)
+                  trade_country: country_name)
         },
         hint: {
           text: t('helpers.hint.rules_of_origin_steps_wholly_obtained.wholly_obtained_html',

--- a/app/views/rules_of_origin/steps/_wholly_obtained.html.erb
+++ b/app/views/rules_of_origin/steps/_wholly_obtained.html.erb
@@ -1,17 +1,15 @@
 <%= rules_of_origin_form_for(current_step) do |form| %>
-  <% country_name = current_step.exporting? ? form.object.service_country_name : form.object.trade_country_name %>
-  
   <%= form.govuk_collection_radio_buttons \
         :wholly_obtained,
         form.object.options,
         :to_sym,
         -> (option) {
           t("helpers.label.rules_of_origin_steps_wholly_obtained.wholly_obtained_options.#{option}",
-            trade_country: country_name)
+            trade_country: form.object.country_name)
         },
         legend: {
           text: t('helpers.legend.rules_of_origin_steps_wholly_obtained.wholly_obtained',
-                  trade_country: country_name)
+                  trade_country: form.object.country_name)
         },
         hint: {
           text: t('helpers.hint.rules_of_origin_steps_wholly_obtained.wholly_obtained_html',

--- a/spec/features/rules_of_origin_wizard_spec.rb
+++ b/spec/features/rules_of_origin_wizard_spec.rb
@@ -35,7 +35,40 @@ RSpec.feature 'Rules of Origin wizard', type: :feature do
       expect(page).to have_css 'h1', text: /What components/
       click_on 'Continue'
 
-      expect(page).to have_css 'h1', text: /Are your goods wholly obtained/
+      expect(page).to have_css 'h1', text: /Are your goods wholly obtained in Japan/
+      expect(page).to have_css 'label', text: /Yes, my goods are wholly obtained in Japan/
+      expect(page).to have_css 'label', text: /No, my goods are not wholly obtained in Japan/
+      choose 'Yes, my goods are wholly obtained'
+      click_on 'Continue'
+
+      expect(page).to have_css 'h1', text: /Origin requirements met/
+      click_on 'See valid proofs of origin'
+
+      expect(page).to have_css 'h1', text: 'Valid proofs of origin'
+    end
+
+    scenario 'Exporting - Wholly obtained' do
+      visit commodity_path(commodity, country: 'JP', anchor: 'rules-of-origin')
+
+      expect(page).to have_css 'h2', text: 'Preferential rules of origin for trading with Japan'
+      click_on 'Check rules of origin'
+
+      expect(page).to have_css 'h1', text: /Are you importing goods.*UK.*Japan\?/
+      choose 'I am exporting goods'
+      click_on 'Continue'
+
+      expect(page).to have_css 'h1', text: /are classed as 'originating'/
+      click_on 'Continue'
+
+      expect(page).to have_css 'h1', text: /How 'wholly obtained' is defined/
+      click_on 'Continue'
+
+      expect(page).to have_css 'h1', text: /What components/
+      click_on 'Continue'
+
+      expect(page).to have_css 'h1', text: /Are your goods wholly obtained in the UK/
+      expect(page).to have_css 'label', text: /Yes, my goods are wholly obtained in the UK/
+      expect(page).to have_css 'label', text: /No, my goods are not wholly obtained in the UK/
       choose 'Yes, my goods are wholly obtained'
       click_on 'Continue'
 

--- a/spec/features/rules_of_origin_wizard_spec.rb
+++ b/spec/features/rules_of_origin_wizard_spec.rb
@@ -35,40 +35,7 @@ RSpec.feature 'Rules of Origin wizard', type: :feature do
       expect(page).to have_css 'h1', text: /What components/
       click_on 'Continue'
 
-      expect(page).to have_css 'h1', text: /Are your goods wholly obtained in Japan/
-      expect(page).to have_css 'label', text: /Yes, my goods are wholly obtained in Japan/
-      expect(page).to have_css 'label', text: /No, my goods are not wholly obtained in Japan/
-      choose 'Yes, my goods are wholly obtained'
-      click_on 'Continue'
-
-      expect(page).to have_css 'h1', text: /Origin requirements met/
-      click_on 'See valid proofs of origin'
-
-      expect(page).to have_css 'h1', text: 'Valid proofs of origin'
-    end
-
-    scenario 'Exporting - Wholly obtained' do
-      visit commodity_path(commodity, country: 'JP', anchor: 'rules-of-origin')
-
-      expect(page).to have_css 'h2', text: 'Preferential rules of origin for trading with Japan'
-      click_on 'Check rules of origin'
-
-      expect(page).to have_css 'h1', text: /Are you importing goods.*UK.*Japan\?/
-      choose 'I am exporting goods'
-      click_on 'Continue'
-
-      expect(page).to have_css 'h1', text: /are classed as 'originating'/
-      click_on 'Continue'
-
-      expect(page).to have_css 'h1', text: /How 'wholly obtained' is defined/
-      click_on 'Continue'
-
-      expect(page).to have_css 'h1', text: /What components/
-      click_on 'Continue'
-
-      expect(page).to have_css 'h1', text: /Are your goods wholly obtained in the UK/
-      expect(page).to have_css 'label', text: /Yes, my goods are wholly obtained in the UK/
-      expect(page).to have_css 'label', text: /No, my goods are not wholly obtained in the UK/
+      expect(page).to have_css 'h1', text: /Are your goods wholly obtained/
       choose 'Yes, my goods are wholly obtained'
       click_on 'Continue'
 

--- a/spec/models/rules_of_origin/steps/base_spec.rb
+++ b/spec/models/rules_of_origin/steps/base_spec.rb
@@ -68,4 +68,26 @@ RSpec.describe RulesOfOrigin::Steps::Base do
       it { is_expected.to be true }
     end
   end
+
+  describe '#country_name' do
+    subject(:country_name) { instance.country_name }
+
+    context 'with unilateral scheme so import_only' do
+      let(:schemes) { build_list :rules_of_origin_scheme, 1, unilateral: true }
+
+      it { is_expected.to eq('Japan') }
+    end
+
+    context 'when importing' do
+      include_context 'with rules of origin store', :importing
+
+      it { is_expected.to eq('Japan') }
+    end
+
+    context 'when exporting' do
+      include_context 'with rules of origin store', :exporting
+
+      it { is_expected.to eq('the UK') }
+    end
+  end
 end


### PR DESCRIPTION
…ed page

### Jira link

[HOTT-1881](https://transformuk.atlassian.net/browse/HOTT-1881)

### What?

I have added/removed/altered:

- [ ] Displayed correct country name if exporting/importing on wholly obtained page

### Why?

I am doing this because:

- It was deploying the wrong country name

### Have you? (optional)

- [ ] Validated mobile responsive behaviour of view changes
