### PR TITLE
HOTT-1919: Removes quota warning text for known issue quotas

### DIFF
--- a/app/models/order_number.rb
+++ b/app/models/order_number.rb
@@ -2,12 +2,6 @@ require 'api_entity'
 require 'order_number/definition'
 
 class OrderNumber
-  ORDER_NUMBERS_WITH_KNOWN_ISSUES = %w[
-    052012
-    052105
-    052106
-  ].freeze
-
   include ApiEntity
 
   attr_accessor :number
@@ -28,25 +22,10 @@ class OrderNumber
   end
 
   def warning_text
-    if known_data_issues?
-      I18n.t('quota_definition.order_number.known_issues')
-    else
-      definition.description
-    end
+    definition.description
   end
 
   def show_warning?
-    starts_with_05? || known_data_issues?
-  end
-
-  private
-
-  def starts_with_05?
     definition.description && number.start_with?('05')
-  end
-
-  # TODO: Remove me. QAM has issues with loading quotas with a hierarchy at the moment and is decrement quotas too quickly
-  def known_data_issues?
-    number.in?(ORDER_NUMBERS_WITH_KNOWN_ISSUES)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,11 +103,6 @@ en:
   measure_type_duties:
     1080:
       103: 'n/a'
-  quota_definition:
-    order_number:
-      known_issues: >-
-        There is currently a known issue with the balance and status of this quota. We are working hard to resolve this issue as soon as possible. Until further notice the quota remains ‘open’ and quota claims should be submitted as normal.
-
   service_banner:
     service_name:
       uk: "UK Integrated Online Tariff"

--- a/spec/models/order_number_spec.rb
+++ b/spec/models/order_number_spec.rb
@@ -65,18 +65,6 @@ RSpec.describe OrderNumber do
     end
 
     it_behaves_like 'an order number that shows warnings' do
-      let(:definition) { build(:definition, number: '052012') }
-    end
-
-    it_behaves_like 'an order number that shows warnings' do
-      let(:definition) { build(:definition, number: '052105') }
-    end
-
-    it_behaves_like 'an order number that shows warnings' do
-      let(:definition) { build(:definition, number: '052106') }
-    end
-
-    it_behaves_like 'an order number that shows warnings' do
       let(:definition) { build(:definition, number: '05foo', description: 'flibble') }
     end
 
@@ -99,12 +87,6 @@ RSpec.describe OrderNumber do
 
   describe '#warning_text' do
     subject(:warning_text) { definition.order_number.warning_text }
-
-    context 'when the quota definition order number has known issues' do
-      let(:definition) { build(:definition, number: '052106') }
-
-      it { is_expected.to match(/There is currently a known issue/) }
-    end
 
     context 'when the quota definition order number has a description' do
       let(:definition) { build(:definition, number: '052000', description: 'flibble') }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1919

### What?

I have added/removed/altered:

- [x] Removed known issues warning text in the quota views
- [x] Removed now-defunct test coverage for this behaviour

### Why?

I am doing this because:

- This is no longer required
