### PR TITLE
HOTT-1926: Added missing origin reference documents to partials

### DIFF
--- a/app/views/rules_of_origin/steps/_about_commodity.html.erb
+++ b/app/views/rules_of_origin/steps/_about_commodity.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/details', summary: t('.summary') do %>
+<%= render 'shared/details', summary: t('.summary'), origin_reference_document: nil do %>
   <%# full key necessary for i18n because we're inside shared/details %>
   <p>
     <%= t 'rules_of_origin.steps.about_commodity.content',

--- a/app/views/rules_of_origin/steps/_components_definition.html.erb
+++ b/app/views/rules_of_origin/steps/_components_definition.html.erb
@@ -25,7 +25,8 @@
                                                    article_match: find_article_reference(form.object.neutral_elements_text) if find_article_reference(form.object.neutral_elements_text) %>
 
     <%= render 'shared/details', summary: t('.neutral_elements.example.summary'),
-                                 content: govspeak(t('.neutral_elements.example.content_md')) %>
+                                 content: govspeak(t('.neutral_elements.example.content_md')),
+                                 origin_reference_document: nil %>
   </div>
 
   <h3 class="govuk-heading-s">

--- a/app/views/rules_of_origin/steps/_cumulation.html.erb
+++ b/app/views/rules_of_origin/steps/_cumulation.html.erb
@@ -38,7 +38,8 @@
 
   <%= render 'shared/details', summary: t('.scheme.summary',
                                           scheme_title: form.object.scheme_title),
-                               content: govspeak(form.object.scheme_details) %>
+                               content: govspeak(form.object.scheme_details),
+                               origin_reference_document: form.object.origin_reference_document %>
 
   <div class="govuk-warning-text">
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/rules_of_origin/steps/_not_wholly_obtained.html.erb
+++ b/app/views/rules_of_origin/steps/_not_wholly_obtained.html.erb
@@ -19,7 +19,8 @@
     <%= govspeak t('.psr.body_md', trade_country_name: form.object.trade_country_name) %>
 
     <%= render 'shared/details', summary: t('.psr.details.summary'),
-                                 content: govspeak(t('.psr.details.content_md')) %>
+                                 content: govspeak(t('.psr.details.content_md')),
+                                 origin_reference_document: nil %>
   </div>
 
   <h3 class="govuk-heading-s">

--- a/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
+++ b/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
@@ -9,7 +9,8 @@
     <%= govspeak t '.body', scheme_title: form.object.scheme_title %>
 
     <%= render 'shared/details', summary: t('.notes'),
-                                 content: govspeak(form.object.chosen_scheme.introductory_notes) %>
+                                 content: govspeak(form.object.chosen_scheme.introductory_notes),
+                                 origin_reference_document: nil %>
   </div>
 <% end %>
 

--- a/app/views/rules_of_origin/steps/_rules_not_met.html.erb
+++ b/app/views/rules_of_origin/steps/_rules_not_met.html.erb
@@ -55,7 +55,8 @@
     <%= govspeak t('.sets.part1') %>
 
     <%= render 'shared/details', summary: t('.sets.details.summary'),
-                                 content: tag.p(t('.sets.details.content')) %>
+                                 content: tag.p(t('.sets.details.content')),
+                                 origin_reference_document: nil %>
 
     <%= govspeak t('.sets.part2') %>
   </div>

--- a/app/views/rules_of_origin/steps/_sufficient_processing.html.erb
+++ b/app/views/rules_of_origin/steps/_sufficient_processing.html.erb
@@ -11,7 +11,8 @@
     <%= govspeak t '.body' %>
 
     <%= render 'shared/details', summary: t('.operations.summary'),
-                                 content: govspeak(t('.operations.content')) %>
+                                 content: govspeak(t('.operations.content')),
+                                 origin_reference_document: nil %>
   </div>
 
   <div id="insufficient-processing-article">
@@ -20,7 +21,9 @@
     </h3>
 
     <div class="tariff-markdown lettered-list">
-      <%= govspeak form.object.insufficient_processing_text %>
+      <%= govspeak remove_article_reference(form.object.insufficient_processing_text) %>
+      <%= render 'shared/origin_reference_document', origin_reference_document: form.object.origin_reference_document,
+                                                     article_match: find_article_reference(form.object.insufficient_processing_text) if find_article_reference(form.object.insufficient_processing_text) %>
     </div>
   </div>
 

--- a/app/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb
+++ b/app/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb
@@ -20,7 +20,8 @@
                                                    article_match: find_article_reference(form.object.wholly_obtained_text) if find_article_reference(form.object.wholly_obtained_text) %>
 
     <%= render 'shared/details', summary: t('.vessel_definition'),
-                                 content: govspeak(form.object.wholly_obtained_vessels_text) %>
+                                 content: govspeak(form.object.wholly_obtained_vessels_text),
+                                 origin_reference_document: form.object.origin_reference_document %>
   </div>
 
   <h3 class="govuk-heading-s">

--- a/app/views/shared/_details.html.erb
+++ b/app/views/shared/_details.html.erb
@@ -5,6 +5,12 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <%= defined?(content) ? content : yield %>
+    <% if origin_reference_document %>
+      <%= govspeak remove_article_reference(content) %>
+      <%= render 'shared/origin_reference_document', origin_reference_document: origin_reference_document,
+                                                    article_match: find_article_reference(content) if find_article_reference(content) %>
+    <% else %>
+      <%= defined?(content) ? content : yield %>
+    <% end %>
   </div>
 </details>

--- a/app/views/shared/_origin_reference_document.html.erb
+++ b/app/views/shared/_origin_reference_document.html.erb
@@ -6,7 +6,7 @@
         <div class='rules-of-origin-attachment'>
             <div class='rules-of-origin-attachment-thumb'>
                 <%= link_to asset_path(origin_reference_document.document_path) do %>
-                    <svg version='1.1' viewBox='0 0 99 140' width='99' height='140' aria-hidden='false'>
+                    <svg class="rules-of-origin-ord-svg" version='1.1' viewBox='0 0 99 140' width='99' height='140' aria-hidden='false'>
                         <path d='M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z' stroke-width='0'></path>
                     </svg>
                 <% end %>

--- a/spec/views/rules_of_origin/steps/_cumulation.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_cumulation.html.erb_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'rules_of_origin/steps/_cumulation', type: :view do
       [
         attributes_for(:rules_of_origin_article,
                        article: 'cumulation-import',
-                       content: "## Title\n\n1. Numbered list\n\n {{ #{article_reference} }}")
+                       content: "## Title\n\n1. Numbered list\n\n {{ #{article_reference} }}"),
       ]
     end
 
@@ -39,14 +39,14 @@ RSpec.describe 'rules_of_origin/steps/_cumulation', type: :view do
 
     context 'when exporting' do
       include_context 'with rules of origin store', :not_wholly_obtained, :exporting
-      
+
       let(:article_reference) { 'article 123' }
 
       let :articles do
         [
           attributes_for(:rules_of_origin_article,
-                        article: 'cumulation-export',
-                        content: "## Title\n\n1. Numbered list\n\n {{ #{article_reference} }}")
+                         article: 'cumulation-export',
+                         content: "## Title\n\n1. Numbered list\n\n {{ #{article_reference} }}"),
         ]
       end
 

--- a/spec/views/rules_of_origin/steps/_cumulation.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_cumulation.html.erb_spec.rb
@@ -18,4 +18,43 @@ RSpec.describe 'rules_of_origin/steps/_cumulation', type: :view do
   it { is_expected.to have_css 'details.govuk-details div.govuk-details__text' }
   it { is_expected.to have_css 'h3.govuk-heading-s', text: /Next step/ }
   it { is_expected.to have_css '#next-step p', text: %r{#{schemes.first.title}} }
+  it { is_expected.not_to have_css '.rules-of-origin-attachment-text' }
+
+  context 'with article reference' do
+    let(:article_reference) { 'article 123' }
+
+    let :articles do
+      [
+        attributes_for(:rules_of_origin_article,
+                       article: 'cumulation-import',
+                       content: "## Title\n\n1. Numbered list\n\n {{ #{article_reference} }}")
+      ]
+    end
+
+    it { is_expected.to have_css '.rules-of-origin-attachment-text', text: article_reference }
+    it { is_expected.to have_css '.rules-of-origin-attachment-text', text: schemes.first.origin_reference_document.ord_title }
+    it { is_expected.to have_css 'a[href]', text: /Download rules of origin reference document/ }
+    it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_version }
+    it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_date }
+
+    context 'when exporting' do
+      include_context 'with rules of origin store', :not_wholly_obtained, :exporting
+      
+      let(:article_reference) { 'article 123' }
+
+      let :articles do
+        [
+          attributes_for(:rules_of_origin_article,
+                        article: 'cumulation-export',
+                        content: "## Title\n\n1. Numbered list\n\n {{ #{article_reference} }}")
+        ]
+      end
+
+      it { is_expected.to have_css '.rules-of-origin-attachment-text', text: article_reference }
+      it { is_expected.to have_css '.rules-of-origin-attachment-text', text: schemes.first.origin_reference_document.ord_title }
+      it { is_expected.to have_css 'a[href]', text: /Download rules of origin reference document/ }
+      it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_version }
+      it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_date }
+    end
+  end
 end

--- a/spec/views/rules_of_origin/steps/_sufficient_processing.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_sufficient_processing.html.erb_spec.rb
@@ -16,10 +16,28 @@ RSpec.describe 'rules_of_origin/steps/_sufficient_processing', type: :view do
   it { is_expected.to have_css 'details.govuk-details div.govuk-details__text *' }
   it { is_expected.to have_css '#insufficient-processing-article h3' }
   it { is_expected.to have_css '#insufficient-processing-article .tariff-markdown *' }
+  it { is_expected.not_to have_css '.rules-of-origin-attachment-text' }
 
   context 'with invalid submission' do
     before { current_step.validate }
 
     it { is_expected.to have_css '.govuk-error-message', text: /Select whether/i }
+  end
+
+  context 'with article reference' do
+    let(:article_reference) { 'article 123' }
+    let :articles do
+      [
+        attributes_for(:rules_of_origin_article,
+                       article: 'insufficient-processing',
+                       content: "## Title\n\n1. Numbered list\n\n {{ #{article_reference} }}"),
+      ]
+    end
+
+    it { is_expected.to have_css '.rules-of-origin-attachment-text', text: article_reference }
+    it { is_expected.to have_css '.rules-of-origin-attachment-text', text: schemes.first.origin_reference_document.ord_title }
+    it { is_expected.to have_css 'a[href]', text: /Download rules of origin reference document/ }
+    it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_version }
+    it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_date }
   end
 end

--- a/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
@@ -25,12 +25,16 @@ RSpec.describe 'rules_of_origin/steps/_wholly_obtained_definition', type: :view 
 
   context 'with article reference' do
     let(:article_reference) { 'article 123' }
+    let(:article_reference_2) { 'article 2' }
+
     let :articles do
       [
         attributes_for(:rules_of_origin_article,
                        article: 'wholly-obtained',
                        content: "## Title\n\n1. Numbered list\n\n {{ #{article_reference} }}"),
-        attributes_for(:rules_of_origin_article, article: 'wholly-obtained-vessels'),
+        attributes_for(:rules_of_origin_article,
+                       article: 'wholly-obtained-vessels',
+                       content: "## Title\n\n1. Numbered list\n\n {{ #{article_reference_2} }}"),
       ]
     end
 
@@ -39,5 +43,7 @@ RSpec.describe 'rules_of_origin/steps/_wholly_obtained_definition', type: :view 
     it { is_expected.to have_css 'a[href]', text: /Download rules of origin reference document/ }
     it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_version }
     it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_date }
+
+    it { is_expected.to have_css '.rules-of-origin-attachment-text', text: article_reference_2 }
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1926](https://transformuk.atlassian.net/browse/HOTT-1926)

### What?

I have added/removed/altered:

- [x] Added missing origin reference documents to partials

### Why?

I am doing this because:

- We need to show origin reference documents on these view partials

<img width="963" alt="Screenshot 2022-08-25 at 15 29 03" src="https://user-images.githubusercontent.com/12201130/186692647-9e1a52da-9394-41d1-b3a1-e9ed1bbabdaa.png">
<img width="883" alt="Screenshot 2022-08-25 at 15 28 18" src="https://user-images.githubusercontent.com/12201130/186692747-ce602223-2b0a-4220-b906-75f2468eca33.png">
<img width="911" alt="Screenshot 2022-08-25 at 15 25 15" src="https://user-images.githubusercontent.com/12201130/186692773-43ec74a0-e46b-4aee-93e4-208131305ca3.png">

