### PR TITLE
HOTT-1901: Fix sidebar and extra content leaking into no_scheme view

### DIFF
--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -5,13 +5,14 @@
       <%= country_flag_tag country_code, alt: "Flag for #{country_name}" %>
     </h2>
 
-    <p>
-      Preferential tariff treatment reduces the duties you are required to pay when importing or exporting goods to or from <%= country_name %>
-    </p>
-
-    <p>
-      Rules of origin are the criteria which determine the national source of a product. They determine if your trade is eligible for preferential tariff treatment and may influence the rules that apply to your import or export.
-    </p>
+    <% if rules_of_origin_schemes.present? %>
+      <p>
+        Preferential tariff treatment reduces the duties you are required to pay when importing or exporting goods to or from <%= country_name %>.
+      </p>
+      <p>
+        Rules of origin are the criteria which determine the national source of a product. They determine if your trade is eligible for preferential tariff treatment and may influence the rules that apply to your import or export.
+      </p>
+    <% end %>
 
     <%= rules_of_origin_schemes_intro country_name, rules_of_origin_schemes %>
 
@@ -25,7 +26,6 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <% if rules_of_origin_schemes.flat_map(&:links).any? %>
     <div id="rules-of-origin__related-content">
       <h2 class="govuk-heading-m">
         Related content
@@ -33,15 +33,17 @@
 
       <nav role="navigation">
         <ul class="govuk-list govuk-list-s">
-          <% rules_of_origin_schemes.flat_map(&:links).uniq(&:id).each do |link| %>
-            <li>
-              <%= link_to link.text, link.url %>
-            </li>
+          <% if rules_of_origin_schemes.flat_map(&:links).any? %>
+            <% rules_of_origin_schemes.flat_map(&:links).uniq(&:id).each do |link| %>
+              <li>
+                <%= link_to link.text, link.url %>
+              </li>
+            <% end %>
+          <% else %>
+            <li><a href="https://www.gov.uk/guidance/check-your-goods-meet-the-rules-of-origin">Check your goods meet the rules of origin</a></li>
           <% end %>
         </ul>
       </nav>
     </div>
-  <% end %>
   </div>
-
 </div>

--- a/app/views/rules_of_origin/intros/_no_scheme.html.erb
+++ b/app/views/rules_of_origin/intros/_no_scheme.html.erb
@@ -1,23 +1,8 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-inset-text" id="rules-of-origin__intro--no-scheme">
-      <p>
-        There is no preferential agreement in place with <%= country_name %>,
-        therefore rules of origin are not applicable.
-      </p>
+<div class="govuk-inset-text" id="rules-of-origin__intro--no-scheme">
+  <p>
+    There is no preferential agreement in place with <%= country_name %>,
+    therefore rules of origin are not applicable.
+  </p>
 
-      <p>To view preferential rules of origin, select a country with which the <%= rules_of_origin_service_name %> has a trade agreement from the dropdown above.</p>
-    </div>
-  </div>
-
-  <div class="govuk-grid-column-one-third">
-    <aside class="app-related-items noborder govuk-!-margin-top-2" role="complementary">
-      <h2 class="govuk-heading-m" id="subsection-title">Related content</h2>
-      <nav role="navigation" aria-labelledby="subsection-title">
-        <ul class="govuk-list govuk-list-s">
-          <li><a href="https://www.gov.uk/guidance/check-your-goods-meet-the-rules-of-origin">Check your goods meet the rules of origin</a></li>   
-        </ul>
-      </nav>
-    </aside>
-  </div>
+  <p>To view preferential rules of origin, select a country with which the <%= rules_of_origin_service_name %> has a trade agreement from the dropdown above.</p>
 </div>


### PR DESCRIPTION
### Jira link

[HOTT-1901](https://transformuk.atlassian.net/browse/HOTT-1901)

### What?

I have added/removed/altered:

- [ ] Fixed sidebar and extra content leaking into no_scheme view

### Why?

I am doing this because:

- no_scheme view was broken
<img width="1349" alt="Screenshot 2022-08-26 at 16 03 56" src="https://user-images.githubusercontent.com/12201130/186935811-52024096-f449-4421-b5b8-0924879e4f06.png">

