### PR TITLE
HOTT-1930 Exclude Name and Email from param logging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,3 +69,7 @@ Style/GuardClause:
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes
+
+Style/SymbolArray:
+  Exclude:
+    - config/initializers/*.rb

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,6 @@
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :email,
+  'feedback.name', 'feedback.message'
 ]


### PR DESCRIPTION
### Jira link

HOTT-1930

### What?

I have added/removed/altered:

- [x] Added additional fields to the parameter filtering for logging

### Why?

I am doing this because:

- We have data in the feedbacks model we don't want logged

### Deployment risks (optional)

- Makes changes to the parameter filtering
