### PR TITLE
HOTT-1897: Use headings API for heading codes on subdivision and prod…

### DIFF
--- a/app/models/rules_of_origin/steps/base.rb
+++ b/app/models/rules_of_origin/steps/base.rb
@@ -30,11 +30,11 @@ module RulesOfOrigin
       end
 
       def find_declarable
-        if commodity_code.match? /\d{4}0{6}/
-          Heading.find(commodity_code[0, 4])
-        else
-          Commodity.find(commodity_code)
-        end
+        @find_declarable ||= if commodity_code.match?(/\d{4}0{6}/)
+                               Heading.find(commodity_code[0, 4])
+                             else
+                               Commodity.find(commodity_code)
+                             end
       end
 
       def chosen_scheme

--- a/app/models/rules_of_origin/steps/base.rb
+++ b/app/models/rules_of_origin/steps/base.rb
@@ -29,6 +29,14 @@ module RulesOfOrigin
         @store['commodity_code']
       end
 
+      def find_declarable
+        if commodity_code.match? /\d{4}0{6}/
+          Heading.find(commodity_code[0, 4])
+        else
+          Commodity.find(commodity_code)
+        end
+      end
+
       def chosen_scheme
         if @store['scheme_code']
           rules_of_origin_schemes.index_by(&:scheme_code)[@store['scheme_code']]

--- a/app/models/rules_of_origin/steps/product_specific_rules.rb
+++ b/app/models/rules_of_origin/steps/product_specific_rules.rb
@@ -3,8 +3,6 @@ module RulesOfOrigin
     class ProductSpecificRules < Base
       self.section = 'originating'
 
-      delegate :description, to: :commodity, prefix: true
-
       attribute :rule
       validates :rule, inclusion: { in: :available_rules }
 
@@ -20,11 +18,11 @@ module RulesOfOrigin
         subdivided_rules? ? subdivision_rules : all_rules
       end
 
-    private
-
-      def commodity
-        @commodity ||= Commodity.find(commodity_code)
+      def declareable_description
+        find_declarable.description
       end
+
+    private
 
       def none_option
         Struct.new(:resource_id, :rule).new('none', none_option_text)

--- a/app/models/rules_of_origin/steps/product_specific_rules.rb
+++ b/app/models/rules_of_origin/steps/product_specific_rules.rb
@@ -18,7 +18,7 @@ module RulesOfOrigin
         subdivided_rules? ? subdivision_rules : all_rules
       end
 
-      def declareable_description
+      def declarable_description
         find_declarable.description
       end
 

--- a/app/models/rules_of_origin/steps/subdivisions.rb
+++ b/app/models/rules_of_origin/steps/subdivisions.rb
@@ -3,8 +3,6 @@ module RulesOfOrigin
     class Subdivisions < Base
       self.section = 'originating'
 
-      delegate :description, to: :commodity, prefix: true
-
       attribute :subdivision_id
       validates :subdivision_id, inclusion: { in: :available_subdivisions }
 
@@ -16,11 +14,11 @@ module RulesOfOrigin
         chosen_scheme.rule_sets.select(&:subdivision)
       end
 
-    private
-
-      def commodity
-        @commodity ||= Commodity.find(commodity_code)
+      def declareable_description
+        find_declarable.description
       end
+
+    private
 
       def available_subdivisions
         options.map(&:resource_id)

--- a/app/models/rules_of_origin/steps/subdivisions.rb
+++ b/app/models/rules_of_origin/steps/subdivisions.rb
@@ -14,7 +14,7 @@ module RulesOfOrigin
         chosen_scheme.rule_sets.select(&:subdivision)
       end
 
-      def declareable_description
+      def declarable_description
         find_declarable.description
       end
 

--- a/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
+++ b/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
@@ -15,4 +15,4 @@
 <% end %>
 
 <%= render 'about_commodity', commodity_code: current_step.commodity_code,
-                              description: current_step.commodity_description %>
+                              description: current_step.declareable_description %>

--- a/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
+++ b/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
@@ -15,4 +15,4 @@
 <% end %>
 
 <%= render 'about_commodity', commodity_code: current_step.commodity_code,
-                              description: current_step.declareable_description %>
+                              description: current_step.declarable_description %>

--- a/app/views/rules_of_origin/steps/_subdivisions.html.erb
+++ b/app/views/rules_of_origin/steps/_subdivisions.html.erb
@@ -11,4 +11,4 @@
 <% end %>
 
 <%= render 'about_commodity', commodity_code: current_step.commodity_code,
-                              description: current_step.declareable_description %>
+                              description: current_step.declarable_description %>

--- a/app/views/rules_of_origin/steps/_subdivisions.html.erb
+++ b/app/views/rules_of_origin/steps/_subdivisions.html.erb
@@ -11,4 +11,4 @@
 <% end %>
 
 <%= render 'about_commodity', commodity_code: current_step.commodity_code,
-                              description: current_step.commodity_description %>
+                              description: current_step.declareable_description %>

--- a/spec/models/rules_of_origin/steps/base_spec.rb
+++ b/spec/models/rules_of_origin/steps/base_spec.rb
@@ -90,4 +90,33 @@ RSpec.describe RulesOfOrigin::Steps::Base do
       it { is_expected.to eq('the UK') }
     end
   end
+
+  describe '#find_declarable' do
+    subject { instance.find_declarable }
+
+    before do
+      allow(Commodity).to receive(:find).with(wizardstore['commodity_code'])
+                                        .and_return(commodity)
+    end
+
+    let :commodity do
+      build :commodity, commodity_code: wizardstore['commodity_code']
+    end
+
+    it { is_expected.to eql commodity }
+
+    context 'when heading code' do
+      before do
+        wizardstore['commodity_code'] = "9302000000"
+        allow(Heading).to receive(:find).with("9302")
+                                          .and_return(heading)
+      end
+
+      let :heading do
+        build :heading, commodity_code: wizardstore['commodity_code']
+      end
+
+      it { is_expected.to eql heading }
+    end
+  end
 end

--- a/spec/models/rules_of_origin/steps/base_spec.rb
+++ b/spec/models/rules_of_origin/steps/base_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe RulesOfOrigin::Steps::Base do
 
     context 'when heading code' do
       before do
-        wizardstore['commodity_code'] = "9302000000"
-        allow(Heading).to receive(:find).with("9302")
+        wizardstore['commodity_code'] = '9302000000'
+        allow(Heading).to receive(:find).with('9302')
                                           .and_return(heading)
       end
 

--- a/spec/models/rules_of_origin/steps/product_specific_rules_spec.rb
+++ b/spec/models/rules_of_origin/steps/product_specific_rules_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe RulesOfOrigin::Steps::ProductSpecificRules do
     end
   end
 
-  describe '#commodity_description' do
-    subject { instance.commodity_description }
+  describe '#declareable_description' do
+    subject { instance.declareable_description }
 
     before do
       allow(Commodity).to receive(:find).with(wizardstore['commodity_code'])
@@ -61,6 +61,20 @@ RSpec.describe RulesOfOrigin::Steps::ProductSpecificRules do
     end
 
     it { is_expected.to eql commodity.description }
+
+    context 'when heading code' do
+      before do
+        wizardstore['commodity_code'] = "9302000000"
+        allow(Heading).to receive(:find).with("9302")
+                                          .and_return(heading)
+      end
+
+      let :heading do
+        build :heading, commodity_code: wizardstore['commodity_code']
+      end
+
+      it { is_expected.to eql heading.description }
+    end
   end
 
   describe '#options' do

--- a/spec/models/rules_of_origin/steps/product_specific_rules_spec.rb
+++ b/spec/models/rules_of_origin/steps/product_specific_rules_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe RulesOfOrigin::Steps::ProductSpecificRules do
     end
   end
 
-  describe '#declareable_description' do
-    subject { instance.declareable_description }
+  describe '#declarable_description' do
+    subject { instance.declarable_description }
 
     before do
       allow(Commodity).to receive(:find).with(wizardstore['commodity_code'])
@@ -64,8 +64,8 @@ RSpec.describe RulesOfOrigin::Steps::ProductSpecificRules do
 
     context 'when heading code' do
       before do
-        wizardstore['commodity_code'] = "9302000000"
-        allow(Heading).to receive(:find).with("9302")
+        wizardstore['commodity_code'] = '9302000000'
+        allow(Heading).to receive(:find).with('9302')
                                           .and_return(heading)
       end
 

--- a/spec/models/rules_of_origin/steps/subdivisions_spec.rb
+++ b/spec/models/rules_of_origin/steps/subdivisions_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe RulesOfOrigin::Steps::Subdivisions do
     end
   end
 
-  describe '#declareable_description' do
-    subject { instance.declareable_description }
+  describe '#declarable_description' do
+    subject { instance.declarable_description }
 
     before do
       allow(Commodity).to receive(:find).with(wizardstore['commodity_code'])
@@ -73,8 +73,8 @@ RSpec.describe RulesOfOrigin::Steps::Subdivisions do
 
     context 'when heading code' do
       before do
-        wizardstore['commodity_code'] = "9302000000"
-        allow(Heading).to receive(:find).with("9302")
+        wizardstore['commodity_code'] = '9302000000'
+        allow(Heading).to receive(:find).with('9302')
                                           .and_return(heading)
       end
 

--- a/spec/models/rules_of_origin/steps/subdivisions_spec.rb
+++ b/spec/models/rules_of_origin/steps/subdivisions_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe RulesOfOrigin::Steps::Subdivisions do
     end
   end
 
-  describe '#commodity_description' do
-    subject { instance.commodity_description }
+  describe '#declareable_description' do
+    subject { instance.declareable_description }
 
     before do
       allow(Commodity).to receive(:find).with(wizardstore['commodity_code'])
@@ -70,6 +70,20 @@ RSpec.describe RulesOfOrigin::Steps::Subdivisions do
     end
 
     it { is_expected.to eql commodity.description }
+
+    context 'when heading code' do
+      before do
+        wizardstore['commodity_code'] = "9302000000"
+        allow(Heading).to receive(:find).with("9302")
+                                          .and_return(heading)
+      end
+
+      let :heading do
+        build :heading, commodity_code: wizardstore['commodity_code']
+      end
+
+      it { is_expected.to eql heading.description }
+    end
   end
 
   describe '#options' do


### PR DESCRIPTION
…uct specific rules pages

### Jira link

[HOTT-<1897>](https://transformuk.atlassian.net/browse/HOTT-1897)

### What?

I have added/removed/altered:

- [ ] Used headings API for heading codes on subdivision and product specific rules pages

### Why?

I am doing this because:

- We were using the Commodities API previously and it was causing 404 errors

<img width="1091" alt="Screenshot 2022-08-30 at 17 42 03" src="https://user-images.githubusercontent.com/12201130/187493517-9aac8b2c-7184-401b-a3a4-b7edd5f6dfe2.png">
