### PR TITLE
HOTT-1786 Support multiple wizard sessions

### DIFF
--- a/app/controllers/rules_of_origin/steps_controller.rb
+++ b/app/controllers/rules_of_origin/steps_controller.rb
@@ -13,10 +13,10 @@ module RulesOfOrigin
 
     before_action :check_session_data,
                   except: :index,
-                  if: -> { params[:id] != 'start' }
+                  if: -> { params[:id] != wizard_class.steps.first.key }
 
     def show
-      if params[:id] == 'start'
+      if params[:id] == wizard_class.steps.first.key
         redirect_to return_to_commodity_path
       else
         super
@@ -37,17 +37,22 @@ module RulesOfOrigin
     end
 
     def check_session_data
-      if service_name != wizard_store['service'] ||
-          params['commodity'].blank? ||
-          params['country'].blank?
-
+      if service_has_changed? || blank_session_identifier_params?
         redirect_to return_to_commodity_path
         wizard_store.purge!
       end
     end
 
+    def service_has_changed?
+      service_name != wizard_store['service']
+    end
+
+    def blank_session_identifier_params?
+      params['commodity'].blank? || params['country'].blank?
+    end
+
     def return_to_commodity_path
-      return find_commodity_path if params['commodity'].blank?
+      return find_commodity_path if blank_session_identifier_params?
 
       commodity_path(params['commodity'],
                      country: params['country'],

--- a/app/controllers/rules_of_origin/steps_controller.rb
+++ b/app/controllers/rules_of_origin/steps_controller.rb
@@ -13,10 +13,10 @@ module RulesOfOrigin
 
     before_action :check_session_data,
                   except: :index,
-                  if: -> { params[:id] != wizard_class.steps.first.key }
+                  if: -> { params[:id] != 'start' }
 
     def show
-      if params[:id] == wizard_class.steps.first.key
+      if params[:id] == 'start'
         redirect_to return_to_commodity_path
       else
         super
@@ -30,11 +30,16 @@ module RulesOfOrigin
     end
 
     def step_path(step_id = params[:id], ...)
-      rules_of_origin_step_path(step_id, ...)
+      rules_of_origin_step_path(params['commodity'],
+                                params['country'],
+                                step_id,
+                                ...)
     end
 
     def check_session_data
-      if service_name != wizard_store['service']
+      if service_name != wizard_store['service'] ||
+          params['commodity'].blank? ||
+          params['country'].blank?
 
         redirect_to return_to_commodity_path
         wizard_store.purge!
@@ -42,10 +47,10 @@ module RulesOfOrigin
     end
 
     def return_to_commodity_path
-      return find_commodity_path if wizard_store['commodity_code'].blank?
+      return find_commodity_path if params['commodity'].blank?
 
-      commodity_path(wizard_store['commodity_code'],
-                     country: wizard_store['country_code'],
+      commodity_path(params['commodity'],
+                     country: params['country'],
                      anchor: 'rules-of-origin')
     end
     helper_method :return_to_commodity_path

--- a/app/controllers/rules_of_origin/steps_controller.rb
+++ b/app/controllers/rules_of_origin/steps_controller.rb
@@ -26,7 +26,7 @@ module RulesOfOrigin
     private
 
     def wizard_store_key
-      :rules_of_origin
+      "rules_of_origin-#{params['commodity']}-#{params['country']}"
     end
 
     def step_path(step_id = params[:id], ...)

--- a/app/views/rules_of_origin/_wizard_link.html.erb
+++ b/app/views/rules_of_origin/_wizard_link.html.erb
@@ -8,8 +8,11 @@
 
 <p>
   <%= form_with model: RulesOfOrigin::Wizard.steps.first,
-                url: rules_of_origin_step_path(RulesOfOrigin::Wizard.steps.first.key),
+                url: rules_of_origin_step_path(commodity_code,
+                                               country_code,
+                                               RulesOfOrigin::Wizard.steps.first.key),
                 method: :patch do |f| %>
+
 
     <%= f.hidden_field :service, value: TradeTariffFrontend::ServiceChooser.service_name %>
     <%= f.hidden_field :commodity_code, value: commodity_code %>

--- a/app/views/rules_of_origin/_wizard_link.html.erb
+++ b/app/views/rules_of_origin/_wizard_link.html.erb
@@ -9,7 +9,7 @@
 <p>
   <%= form_with model: RulesOfOrigin::Wizard.steps.first,
                 url: rules_of_origin_step_path(RulesOfOrigin::Wizard.steps.first.key),
-                method: :put do |f| %>
+                method: :patch do |f| %>
 
     <%= f.hidden_field :service, value: TradeTariffFrontend::ServiceChooser.service_name %>
     <%= f.hidden_field :commodity_code, value: commodity_code %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,9 +83,9 @@ Rails.application.routes.draw do
 
   if TradeTariffFrontend.roo_wizard?
     namespace :rules_of_origin, path: nil do
-      get '/rules_of_origin/', to: 'steps#index', as: :steps
-      get '/rules_of_origin/:id', to: 'steps#show', as: :step
-      patch '/rules_of_origin/:id', to: 'steps#update', as: nil
+      get '/rules_of_origin/:commodity/:country', to: 'steps#index', as: :steps
+      get '/rules_of_origin/:commodity/:country/:id', to: 'steps#show', as: :step
+      patch '/rules_of_origin/:commodity/:country/:id', to: 'steps#update', as: nil
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,9 @@ Rails.application.routes.draw do
 
   if TradeTariffFrontend.roo_wizard?
     namespace :rules_of_origin, path: nil do
-      resources :steps, path: '/rules_of_origin', only: %i[index show update]
+      get '/rules_of_origin/', to: 'steps#index', as: :steps
+      get '/rules_of_origin/:id', to: 'steps#show', as: :step
+      patch '/rules_of_origin/:id', to: 'steps#update', as: nil
     end
   end
 

--- a/spec/requests/rules_of_origin/steps_controller_spec.rb
+++ b/spec/requests/rules_of_origin/steps_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe RulesOfOrigin::StepsController, type: :request do
     include_context 'with rules of origin store'
 
     before do
-      put rules_of_origin_step_path(first_step.key), params: {
+      patch rules_of_origin_step_path(first_step.key), params: {
         first_step.model_name.singular => initial_params,
       }
     end

--- a/spec/requests/rules_of_origin/steps_controller_spec.rb
+++ b/spec/requests/rules_of_origin/steps_controller_spec.rb
@@ -3,26 +3,33 @@ require 'spec_helper'
 RSpec.describe RulesOfOrigin::StepsController, type: :request do
   subject { response }
 
-  let(:first_step) { RulesOfOrigin::Wizard.steps.first }
-  let(:second_step) { RulesOfOrigin::Wizard.steps.second } # first is Start/init step
-  let(:initial_params) { { country_code: 'JP', commodity_code: '6004100091', service: 'uk' } }
-  let(:return_path) { commodity_path('6004100091', country: 'JP', anchor: 'rules-of-origin') }
+  let(:first_step_path) { rules_of_origin_step_path(commodity_code, country_code, 'start') }
+  let(:second_step_path) { rules_of_origin_step_path(commodity_code, country_code, 'scheme') } # first is Start/init step
+  let(:return_path) { commodity_path(commodity_code, country: country_code, anchor: 'rules-of-origin') }
+  let(:commodity_code) { '6004100091' }
+  let(:country_code) { 'JP' }
 
   describe 'GET #index' do
-    before { get rules_of_origin_steps_path }
+    before { get rules_of_origin_steps_path(commodity_code, country_code) }
 
-    it { is_expected.to redirect_to rules_of_origin_step_path(first_step.key) }
+    it { is_expected.to redirect_to first_step_path }
   end
 
   describe 'GET #show without initialized session' do
     context 'with first step' do
-      before { get rules_of_origin_step_path(first_step.key) }
+      before { get first_step_path }
 
-      it { is_expected.to redirect_to find_commodity_path }
+      it { is_expected.to redirect_to return_path }
     end
 
     context 'with later step' do
-      before { get rules_of_origin_step_path(second_step.key) }
+      before { get second_step_path }
+
+      it { is_expected.to redirect_to return_path }
+    end
+
+    context 'with missing params' do
+      before { get rules_of_origin_step_path(' ', ' ', 'start') }
 
       it { is_expected.to redirect_to find_commodity_path }
     end
@@ -32,26 +39,30 @@ RSpec.describe RulesOfOrigin::StepsController, type: :request do
     include_context 'with rules of origin store'
 
     before do
-      patch rules_of_origin_step_path(first_step.key), params: {
-        first_step.model_name.singular => initial_params,
+      patch first_step_path, params: {
+        RulesOfOrigin::Wizard.steps.first.model_name.singular => {
+          country_code:,
+          commodity_code:,
+          service: 'uk',
+        },
       }
     end
 
     context 'with valid step' do
-      before { get rules_of_origin_step_path second_step.key }
+      before { get second_step_path }
 
       it { is_expected.to have_http_status :success }
       it { is_expected.to have_attributes body: /Details of your trade/ }
     end
 
     context 'with an invalid step' do
-      before { get rules_of_origin_step_path :invalid }
+      before { get rules_of_origin_step_path commodity_code, country_code, :invalid }
 
       it { is_expected.to have_http_status :not_found }
     end
 
     context 'with changed service' do
-      before { get "/xi#{rules_of_origin_step_path(second_step.key)}" }
+      before { get "/xi#{second_step_path}" }
 
       it { is_expected.to redirect_to return_path }
     end

--- a/spec/views/rules_of_origin/_wizard_link.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_wizard_link.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'rules_of_origin/wizard_link', type: :view do
 
   it { is_expected.to have_css 'h3' }
   it { is_expected.to have_css 'p', text: /trade fulfils/ }
-  it { is_expected.to have_css %(form[action="#{rules_of_origin_step_path(step.key)}"]) }
+  it { is_expected.to have_css %(form[action="#{rules_of_origin_step_path('1234567890', 'JP', step.key)}"]) }
   it { is_expected.to have_css %(form input[name="#{prefix}[commodity_code]"][value="1234567890"]) }
   it { is_expected.to have_css %(form input[name="#{prefix}[country_code]"][value="JP"]) }
   it { is_expected.to have_css %(form input[name="#{prefix}[service]"][value="uk"]) }

--- a/spec/views/rules_of_origin/steps/show.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/show.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'rules_of_origin/steps/show', type: :view do
     allow(view).to receive(:wizard).and_return wizard
     allow(view).to receive(:current_step).and_return current_step
     allow(view).to receive(:step_path).and_return \
-      rules_of_origin_step_path(current_step.key)
+      rules_of_origin_step_path('1234567890', 'JP', current_step.key)
     allow(view).to receive(:return_to_commodity_path).and_return '/'
   end
 


### PR DESCRIPTION
### Jira link

HOTT-1786

### What?

I have added/removed/altered:

- [x] Updated routing for rules of origin wizard to include country and commodity
- [x] Used the country and commodity in the session data identifier

### Why?

I am doing this because:

- It will allow multiple concurrent sessions of the Rules of Origin wizard provided they are for different commodities and/or countries

### Deployment risks (optional)

- low, feature flagged off
