### PR TITLE
HOTT-1803 Subdivision Other option

### DIFF
--- a/app/models/rules_of_origin/steps/product_specific_rules.rb
+++ b/app/models/rules_of_origin/steps/product_specific_rules.rb
@@ -15,7 +15,7 @@ module RulesOfOrigin
       end
 
       def rules
-        subdivided_rules? ? subdivision_rules : all_rules
+        use_subdivision_rules? ? subdivision_rules : non_subdivision_rules
       end
 
       def declarable_description
@@ -36,12 +36,12 @@ module RulesOfOrigin
         options.map(&:resource_id)
       end
 
-      def subdivided_rules?
-        !@wizard.find('subdivisions').skipped?
+      def use_subdivision_rules?
+        !(@wizard.find('subdivisions').skipped? || @store['subdivision_id'] == 'other')
       end
 
-      def all_rules
-        chosen_scheme.v2_rules
+      def non_subdivision_rules
+        chosen_scheme.rule_sets.reject(&:subdivision).flat_map(&:rules)
       end
 
       def subdivision_rules

--- a/app/models/rules_of_origin/steps/subdivisions.rb
+++ b/app/models/rules_of_origin/steps/subdivisions.rb
@@ -11,7 +11,15 @@ module RulesOfOrigin
       end
 
       def options
-        chosen_scheme.rule_sets.select(&:subdivision)
+        subdivided = rule_sets_with_subdivisions
+
+        if subdivided.none?
+          []
+        elsif rule_sets_without_subdivisions.any?
+          subdivided + [other_option]
+        else
+          subdivided
+        end
       end
 
       def declarable_description
@@ -19,6 +27,18 @@ module RulesOfOrigin
       end
 
     private
+
+      def rule_sets_with_subdivisions
+        chosen_scheme.rule_sets.select(&:subdivision)
+      end
+
+      def rule_sets_without_subdivisions
+        chosen_scheme.rule_sets.reject(&:subdivision)
+      end
+
+      def commodity
+        @commodity ||= Commodity.find(commodity_code)
+      end
 
       def available_subdivisions
         options.map(&:resource_id)
@@ -30,6 +50,14 @@ module RulesOfOrigin
 
       def insufficient_processing?
         @store['sufficient_processing'] == 'no'
+      end
+
+      def other_option
+        Struct.new(:resource_id, :subdivision).new('other', other_option_text)
+      end
+
+      def other_option_text
+        I18n.t "helpers.label.#{model_name.singular}.subdivision_id_options.other"
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -303,6 +303,9 @@ en:
         sufficient_processing_options:
           'yes': 'Yes'
           'no': 'No'
+      rules_of_origin_steps_subdivisions:
+        subdivision_id_options:
+          other: All other products
       rules_of_origin_steps_product_specific_rules:
         rule_options:
           none: Your goods do not meet any of these rules.

--- a/spec/factories/rules_of_origin/scheme_factory.rb
+++ b/spec/factories/rules_of_origin/scheme_factory.rb
@@ -46,6 +46,10 @@ FactoryBot.define do
       end
     end
 
+    trait :other_subdivision do
+      mixed_subdivision
+    end
+
     trait :single_wholly_obtained_rule do
       rule_sets do
         attributes_for_list \

--- a/spec/factories/rules_of_origin/scheme_factory.rb
+++ b/spec/factories/rules_of_origin/scheme_factory.rb
@@ -35,6 +35,17 @@ FactoryBot.define do
       end
     end
 
+    trait :mixed_subdivision do
+      rule_set_count { 3 }
+
+      rule_sets do
+        attributes_for_list(:rules_of_origin_rule_set, rule_set_count - 1,
+                            :subdivided,
+                            rule_count: v2_rule_count) +
+          attributes_for_list(:rules_of_origin_rule_set, 1, rule_count: v2_rule_count)
+      end
+    end
+
     trait :single_wholly_obtained_rule do
       rule_sets do
         attributes_for_list \

--- a/spec/factories/rules_of_origin/wizard_store_factory.rb
+++ b/spec/factories/rules_of_origin/wizard_store_factory.rb
@@ -63,6 +63,15 @@ FactoryBot.define do
       subdivision_id { schemes.first.rule_sets.second.resource_id }
     end
 
+    trait :other_subdivision do
+      schemes do
+        build_list :rules_of_origin, 2, :mixed_subdivision
+      end
+
+      sufficient_processing
+      subdivision_id { 'other' }
+    end
+
     trait :rules_met do
       sufficient_processing
       rule { schemes.first.rule_sets.first.rules.first.resource_id }

--- a/spec/models/rules_of_origin/steps/product_specific_rules_spec.rb
+++ b/spec/models/rules_of_origin/steps/product_specific_rules_spec.rb
@@ -95,5 +95,11 @@ RSpec.describe RulesOfOrigin::Steps::ProductSpecificRules do
 
       it { is_expected.to eql schemes.first.rule_sets.second.rules }
     end
+
+    context 'with other subdivision chosen' do
+      include_context 'with rules of origin store', :other_subdivision
+
+      it { is_expected.to eql schemes.first.rule_sets.last.rules }
+    end
   end
 end

--- a/spec/support/shared_context/rules_of_origin_wizard.rb
+++ b/spec/support/shared_context/rules_of_origin_wizard.rb
@@ -17,7 +17,7 @@ shared_context 'with rules of origin store' do |*traits, scheme_count: 1, scheme
   end
 
   let(:schemes) do
-    shared_traits = traits & %i[subdivided]
+    shared_traits = traits & %i[subdivided other_subdivision]
 
     build_list :rules_of_origin_scheme,
                scheme_count,


### PR DESCRIPTION
### Jira link

HOTT-1803

### What?

I have added/removed/altered:

- [x] Added an other option to the Subdivision screen when there are a mixture of rulesets with and without subdivisions
- [x] Changed the Product Specific Rules screen so it shows all rules belonging to relevant rulesets without subdivisions when the subdivision_id is set to 'other'

### Why?

I am doing this because:

- Previously if there was a mixture of rule sets with subdivisions and without, the user had no means to select the rules from the rulesets without subdivision


### Deployment risks (optional)

- Low, feature flagged off
