### PR TITLE
HOTT-1933 - incorrect country name displayed on wholly obtained page

### DIFF
--- a/app/views/rules_of_origin/steps/_not_wholly_obtained.html.erb
+++ b/app/views/rules_of_origin/steps/_not_wholly_obtained.html.erb
@@ -8,7 +8,7 @@
   </h1>
 
   <p class="govuk-body-l">
-    <%= t '.lead_para', trade_country_name: form.object.exporting? ? 'UK' : form.object.trade_country_name %>
+    <%= t '.lead_para', trade_country_name: form.object.country_name %>
   </p>
 
   <h3 class="govuk-heading-s">
@@ -16,7 +16,7 @@
   </h3>
 
   <div class="tariff-markdown">
-    <%= govspeak t('.psr.body_md', trade_country_name: form.object.exporting? ? 'UK' : form.object.trade_country_name) %>
+    <%= govspeak t('.psr.body_md', trade_country_name: form.object.country_name) %>
 
     <%= render 'shared/details', summary: t('.psr.details.summary'),
                                  content: govspeak(t('.psr.details.content_md')),

--- a/app/views/rules_of_origin/steps/_not_wholly_obtained.html.erb
+++ b/app/views/rules_of_origin/steps/_not_wholly_obtained.html.erb
@@ -8,7 +8,7 @@
   </h1>
 
   <p class="govuk-body-l">
-    <%= t '.lead_para', trade_country_name: 'UK' %>
+    <%= t '.lead_para', trade_country_name: form.object.exporting? ? 'UK' : form.object.trade_country_name %>
   </p>
 
   <h3 class="govuk-heading-s">
@@ -16,7 +16,7 @@
   </h3>
 
   <div class="tariff-markdown">
-    <%= govspeak t('.psr.body_md', trade_country_name: 'UK') %>
+    <%= govspeak t('.psr.body_md', trade_country_name: form.object.exporting? ? 'UK' : form.object.trade_country_name) %>
 
     <%= render 'shared/details', summary: t('.psr.details.summary'),
                                  content: govspeak(t('.psr.details.content_md')),

--- a/spec/views/rules_of_origin/steps/_not_wholly_obtained.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_not_wholly_obtained.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'rules_of_origin/steps/_not_wholly_obtained', type: :view do
 
   it { is_expected.to have_css 'span.govuk-caption-xl', text: /originating/i }
   it { is_expected.to have_css 'h1', text: /not wholly obtained/ }
-  it { is_expected.to have_css 'p.govuk-body-l', text: /not wholly obtained in UK/ }
+  it { is_expected.to have_css 'p.govuk-body-l', text: /not wholly obtained in Japan/ }
   it { is_expected.to have_css 'p', text: /product-specific rules/i }
   it { is_expected.to have_css 'details.govuk-details summary', text: /product-specific rules/ }
   it { is_expected.to have_css 'details.govuk-details div.govuk-details__text' }


### PR DESCRIPTION
### Jira link

[HOTT-1933](https://transformuk.atlassian.net/browse/HOTT-1933)

### What?

I have added/removed/altered:

- [x] Added a condition to render correct country name