### PR TITLE
HOTT-1942 Only show earlier steps

### DIFF
--- a/app/models/rules_of_origin/sidebar_section.rb
+++ b/app/models/rules_of_origin/sidebar_section.rb
@@ -12,7 +12,7 @@ module RulesOfOrigin
       @steps.values
     end
 
-    def active?
+    def current?
       @steps.keys.include? @wizard.current_key
     end
   end

--- a/app/models/rules_of_origin/wizard.rb
+++ b/app/models/rules_of_origin/wizard.rb
@@ -19,8 +19,6 @@ module RulesOfOrigin
       Steps::ProofRequirements,
       Steps::ProofVerification,
       Steps::RulesNotMet,
-      Steps::NotWhollyObtained,
-      Steps::SufficientProcessing,
     ]
 
     def sections

--- a/app/models/rules_of_origin/wizard.rb
+++ b/app/models/rules_of_origin/wizard.rb
@@ -22,15 +22,30 @@ module RulesOfOrigin
     ]
 
     def sections
-      @sections ||= steps.select(&:section)
-                         .group_by(&:section)
-                         .map { |name, steps| SidebarSection.new(self, name, steps) }
+      @sections ||= steps_for_sections.map do |name, steps|
+        SidebarSection.new(self, name, steps)
+      end
     end
 
     def rules_of_origin_schemes
       @rules_of_origin_schemes ||=
         RulesOfOrigin::Scheme.all(@store['commodity_code'],
                                   @store['country_code'])
+    end
+
+  private
+
+    def steps_for_sections
+      current_and_earlier_steps.select(&:section).group_by(&:section)
+    end
+
+    def current_and_earlier_steps
+      earlier_steps << find_current_step
+    end
+
+    def earlier_steps
+      earlier_keys.map(&method(:find))
+                  .reject(&:skipped?)
     end
   end
 end

--- a/app/views/rules_of_origin/steps/_sidebar_section.html.erb
+++ b/app/views/rules_of_origin/steps/_sidebar_section.html.erb
@@ -1,6 +1,6 @@
 <li id="<%= sidebar_section.name %>"
-    <%= 'data-show' if sidebar_section.active? %>
-    class="app-step-nav__step js-step <%= 'app-step-nav__step--active' if sidebar_section.active? %>">
+    <%= 'data-show' if sidebar_section.current? %>
+    class="app-step-nav__step js-step <%= 'app-step-nav__step--active' if sidebar_section.current? %>">
   <div class="app-step-nav__header js-toggle-panel" data-position="<%= sidebar_section_counter + 1 %>">
     <h3 class="app-step-nav__title">
       <span class="app-step-nav__circle app-step-nav__circle--number">

--- a/spec/models/rules_of_origin/sidebar_section_spec.rb
+++ b/spec/models/rules_of_origin/sidebar_section_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe RulesOfOrigin::SidebarSection do
   it { is_expected.to respond_to :name }
   it { is_expected.to respond_to :steps }
 
-  describe '#active?' do
-    subject { instance.active? }
+  describe '#current?' do
+    subject { instance.current? }
 
     context 'with step in this section' do
       it { is_expected.to be true }

--- a/spec/models/rules_of_origin/wizard_spec.rb
+++ b/spec/models/rules_of_origin/wizard_spec.rb
@@ -1,14 +1,38 @@
 require 'spec_helper'
 
 RSpec.describe RulesOfOrigin::Wizard do
-  subject(:instance) { described_class.new(store, 'import_export') }
-
-  let(:store) { build :rules_of_origin_wizard_store }
-
   describe '#sections' do
     subject(:sections) { instance.sections }
 
-    it { is_expected.to all be_instance_of RulesOfOrigin::SidebarSection }
-    it { expect(sections.map(&:name)).to eql %w[details originating proofs] }
+    context 'with current_step in middle of wizard' do
+      include_context 'with rules of origin store', 'not_wholly_obtained'
+
+      let(:instance) { described_class.new(wizardstore, 'not_wholly_obtained') }
+
+      it { is_expected.to all be_instance_of RulesOfOrigin::SidebarSection }
+      it { expect(sections.map(&:name)).to include 'details' }
+      it { expect(sections.map(&:name)).to include 'originating' }
+      it { expect(sections.map(&:name)).not_to include 'proofs' }
+
+      context 'with section steps' do
+        subject { sections.find(&:current?).steps.map(&:key) }
+
+        it { is_expected.to include 'not_wholly_obtained' }
+        it { is_expected.not_to include 'cumulation' }
+      end
+    end
+
+    context 'with conditional steps' do
+      subject :section_step_keys do
+        instance.sections.index_by(&:name)['originating'].steps.map(&:key)
+      end
+
+      include_context 'with rules of origin store', 'insufficient_processing'
+
+      let(:instance) { described_class.new(wizardstore, 'rules_not_met') }
+
+      it { is_expected.to include 'rules_not_met' }
+      it { is_expected.not_to include 'product_specific_rules' }
+    end
   end
 end

--- a/spec/views/rules_of_origin/steps/_sidebar_section.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_sidebar_section.html.erb_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe 'rules_of_origin/steps/_sidebar_section', type: :view do
 
   context 'when rendering current_step' do
     let :render_page do
-      render 'rules_of_origin/steps/sidebar_section', object: sections['originating'],
+      render 'rules_of_origin/steps/sidebar_section', sidebar_section: sections['details'],
                                                       sidebar_section_counter: 1,
                                                       current_step:
-
-      it { is_expected.to have_css 'li.app-step-nav.app-step-nav__step--active' }
-      it { is_expected.to have_css 'li ol li.app-step-nav__list-item--active' }
     end
+
+    it { is_expected.to have_css 'li.app-step-nav__step.app-step-nav__step--active' }
+    it { is_expected.to have_css 'li ol li.app-step-nav__list-item--active' }
   end
 
   context 'when addition info available' do

--- a/spec/views/rules_of_origin/steps/_sidebar_section.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_sidebar_section.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe 'rules_of_origin/steps/_sidebar_section', type: :view do
-  include_context 'with rules of origin form step', 'import_export'
+  include_context 'with rules of origin form step', 'origin_requirements_met'
 
   let(:sections) { wizard.sections.index_by(&:name) }
 
@@ -23,7 +23,7 @@ RSpec.describe 'rules_of_origin/steps/_sidebar_section', type: :view do
 
   context 'when rendering current_step' do
     let :render_page do
-      render 'rules_of_origin/steps/sidebar_section', sidebar_section: sections['details'],
+      render 'rules_of_origin/steps/sidebar_section', sidebar_section: sections['proofs'],
                                                       sidebar_section_counter: 1,
                                                       current_step:
     end


### PR DESCRIPTION
### Jira link

HOTT-1942

### What?

I have added/removed/altered:

- [x] Fixed an existing spec that was being run because of syntax errors
- [x] Removed extraneous steps in the list on the RulesOfOrigin::Wizard
- [x] Only show earlier steps in the step-by-step sidebar 

### Why?

I am doing this because:

- The spec was clearly wrong
- The extra steps look like an earlier merge error
- We only wish to show the steps we know the user has taken in the sidebar

### Have you? (optional)

- [x] Reviewed view changes with stake holders

### Deployment risks (optional)

- Low, feature flagged off
