### PR TITLE
HOTT-1840 Make quota's table responsive

### DIFF
--- a/app/views/search/quota_search.html.erb
+++ b/app/views/search/quota_search.html.erb
@@ -12,7 +12,7 @@
 <%= render partial: 'search/quotas/form', locals: { search_form: @result.search_form } %>
 <% if @result.search_result&.any? %>
   <article class="search-results">
-    <table class="govuk-table">
+    <table class="govuk-table govuk-table govuk-table--responsive">
       <caption class="govuk-table__caption">
         <h1 class="govuk-heading-l">Quota search results</h1>
       </caption>

--- a/app/views/search/quotas/_definition.html.erb
+++ b/app/views/search/quotas/_definition.html.erb
@@ -1,20 +1,31 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell">
+  <td class="govuk-table__cell" data-label="Order number">
     <%= render partial: 'shared/quota_definition', locals: { order_number: definition.order_number, quota_definition: definition } %>
   </td>
-  <td class="govuk-table__cell">
+
+  <td class="govuk-table__cell" data-label="Commodity-code">
     <% definition.all_goods_nomenclatures.each do |goods_nomenclature| %>
       <%= link_to goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature) %>
       <br>
     <% end %>
   </td>
-  <td class="govuk-table__cell">
+
+  <td class="govuk-table__cell" data-label="Country">
     <% definition.geographical_areas.uniq(&:id).select { |geographical_area| geographical_area.id.present? }.each do |geographical_area| %>
       <%= geographical_area&.long_description %>
       <br>
     <% end %>
   </td>
-  <td class="govuk-table__cell"><%= definition.validity_start_date&.strftime('%d %B %Y') %></td>
-  <td class="govuk-table__cell"><%= definition.validity_end_date&.strftime('%d %B %Y') %></td>
-  <td class="govuk-table__cell numerical"><%= definition.balance %> <%= definition.measurement_unit %></td>
+
+  <td class="govuk-table__cell" data-label="Start date">
+    <%= definition.validity_start_date&.strftime('%d %B %Y') %>
+  </td>
+
+  <td class="govuk-table__cell" data-label="End date">
+    <%= definition.validity_end_date&.strftime('%d %B %Y') %>
+  </td>
+
+  <td class="govuk-table__cell numerical" data-label="Balance">
+    <%= definition.balance %> <%= definition.measurement_unit %>
+  </td>
 </tr>


### PR DESCRIPTION
### Jira link

HOTT-1840

### What?

I have added/removed/altered:

- [x] Made the Quota Search results table responsive

### Why?

I am doing this because:

- It was too wide on mobile
 
### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Screenshots
![Screen Shot 2022-09-07 at 10 51 12](https://user-images.githubusercontent.com/10818/188849365-12300195-0a24-4ed3-b17f-2ac4abf8f1b6.png)


