### PR TITLE
HOTT-1944 revert to tabular roo page

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -62,7 +62,7 @@
   <!-- Rules of Origin tab -->
   <div class="govuk-tabs__panel" id="rules-of-origin">
     <%- if @search.filtered_by_country? && @search.geographical_area -%>
-      <%= render 'rules_of_origin/tab',
+      <%= render (TradeTariffFrontend.roo_wizard? ? 'rules_of_origin/tab' : 'rules_of_origin/legacy_tab'),
                  country_code: @search.country,
                  country_name: @search.geographical_area.description,
                  commodity_code: declarable.code,

--- a/app/views/rules_of_origin/_introductory_notes.html.erb
+++ b/app/views/rules_of_origin/_introductory_notes.html.erb
@@ -1,0 +1,58 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">How to read rules of origin</span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <p>The rules of origin table contains:</p>
+
+    <ul class="govuk-list--bullet">
+      <li>
+        the product classification heading ('HS heading') or chapter number
+        (column 1)
+      </li>
+
+      <li>
+        a description of the product, or the headings / subheadings covered by
+        the rules (column 2)
+      </li>
+
+      <li>
+        a description of how non-originating materials must be worked or
+        processed to get country of origin status (column 3)
+      </li>
+    </ul>
+
+    <p>For each row:</p>
+
+    <ul class="govuk-list--bullet">
+      <li>
+        check column 1 to find the product classification heading or chapter
+        number for the product being exported
+      </li>
+
+      <li>check column 2 to find the description that applies to the product</li>
+
+      <li>
+        check column 3 to see how the product must
+        be worked or processed to gain country of origin status
+      </li>
+    </ul>
+
+    <p>
+      Unless preceded by ‘ex’, the rules in column 3 apply to all products that
+      come under the headings and chapters in column 1.
+    </p>
+
+    <p>
+      If the heading in column 1 starts with ‘ex’, the rules in column 3
+      will only apply to the product as described in column 2.
+    </p>
+
+    <h2 class="govuk-heading-m">Introductory notes</h2>
+
+    <div class="tariff-markdown">
+      <%= govspeak introductory_notes if introductory_notes.present? %>
+    </div>
+  </div>
+</details>

--- a/app/views/rules_of_origin/_legacy_tab.html.erb
+++ b/app/views/rules_of_origin/_legacy_tab.html.erb
@@ -1,0 +1,41 @@
+<h2 class="govuk-heading-m rules-of-origin-heading">
+  Preferential rules of origin for trading with <%= country_name %>
+  <%= country_flag_tag country_code, alt: "Flag for #{country_name}" %>
+</h2>
+
+<%= rules_of_origin_schemes_intro country_name, rules_of_origin_schemes %>
+
+<% if TradeTariffFrontend.roo_wizard? && rules_of_origin_schemes.any? %>
+  <%= render 'rules_of_origin/wizard_link',
+             country_code: country_code,
+             commodity_code: commodity_code %>
+<% end %>
+
+<%= render partial: 'rules_of_origin/scheme',
+           collection: rules_of_origin_schemes,
+           locals: {
+             country_name: country_name,
+             commodity_code: commodity_code,
+             multiple_schemes: rules_of_origin_schemes.many?
+           } %>
+
+<%= render 'rules_of_origin/non_preferential' %>
+
+<% if rules_of_origin_schemes.flat_map(&:links).any? %>
+<div id="rules-of-origin__related-content">
+  <h2 class="govuk-heading-m">
+    Related content
+  </h2>
+
+  <nav role="navigation">
+    <ul class="govuk-list govuk-list-s">
+      <% rules_of_origin_schemes.flat_map(&:links).uniq(&:id).each do |link| %>
+        <li>
+          <%= link_to link.text, link.url %>
+        </li>
+      <% end %>
+    </ul>
+  </nav>
+</div>
+<% end %>
+

--- a/app/views/rules_of_origin/_proofs.html.erb
+++ b/app/views/rules_of_origin/_proofs.html.erb
@@ -1,0 +1,47 @@
+<div class="rules-of-origin__proofs">
+  <% if proofs.any? %>
+    <% if scheme_title %>
+      <span class="govuk-caption-l">
+        <%= scheme_title %>
+      </span>
+    <% end %>
+
+    <h3 class="govuk-heading-m">
+      Proving originating status and claiming preferential treatment
+    </h3>
+
+    <p>
+      The customs authority of the importing party will grant preferential
+      tariff treatment, based on a claim made by the importer, to goods that
+      originate in the other party that meet the conditions of the Trade
+      Agreement
+    </p>
+
+    <% if proofs.many? %>
+      <p>
+        A claim can be made if the importer has one of the following proofs of
+        origin:
+      </p>
+    <% else %>
+      <p>
+        A claim can be made if the importer has the following proof of origin:
+      </p>
+    <% end %>
+
+    <% proofs.each do |proof| %>
+      <ul class="govuk-list govuk-list--bullet govuk-list--spaced rules-of-origin__proofs__content">
+        <li>
+          <%= link_to proof.summary, proof.url %>
+        </li>
+
+        <% if proof.subtext.present? %>
+          <p>
+            <%= proof.subtext %>
+          </p>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <%= t "rules_of_origin.preferential_treatment.#{@search.geographical_area.id}_html", default: '' %>
+  <% end %>
+</div>

--- a/app/views/rules_of_origin/_rules_table.html.erb
+++ b/app/views/rules_of_origin/_rules_table.html.erb
@@ -1,0 +1,45 @@
+<p>
+  If your product has been produced using any non-originating materials, the
+  product has to fulfil the following product-specific rule to be considered
+  originating in the <%= rules_of_origin_service_name %> or <%= country_name %>.
+</p>
+
+<p>
+  If there are alternative rules, your product needs to comply with only one
+  of them.
+</p>
+
+<table class="govuk-table govuk-table--responsive commodity-rules-of-origin">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">
+        Heading
+      </th>
+
+      <th class="govuk-table__header" scope="col">
+        Description
+      </th>
+
+      <th class="govuk-table__header" scope="col">
+        Rule
+      </th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% rules.each do |rule| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell" data-label="Heading">
+        <%= restrict_wrapping replace_non_breaking_space(rule.heading) %>
+      </td>
+
+      <td class="govuk-table__cell" data-label="Description">
+        <%= rule.description %>
+      </td>
+
+      <td class="govuk-table__cell tariff-markdown responsive-full-width" data-label="Rule">
+        <%= govspeak rules_of_origin_tagged_descriptions rule.rule %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/rules_of_origin/_scheme.html.erb
+++ b/app/views/rules_of_origin/_scheme.html.erb
@@ -1,0 +1,27 @@
+<div class="rules-of-origin__scheme govuk-!-margin-bottom-7">
+  <h3 class="govuk-heading-m">
+    <% if multiple_schemes %>
+      <span class="govuk-caption-l">
+        <%= scheme.title %>
+      </span>
+    <% end %>
+
+    Product-specific rules for commodity <%= commodity_code %>
+  </h3>
+
+  <%- if scheme.rules.any? -%>
+    <%= render 'rules_of_origin/rules_table', country_name: country_name,
+                                              rules: scheme.rules %>
+
+    <%= render 'rules_of_origin/introductory_notes',
+               introductory_notes: scheme.introductory_notes %>
+  <%- else -%>
+    <p>
+      There are no product-specific rules for commodity <%= commodity_code %>
+    </p>
+  <%- end -%>
+
+  <%= render 'rules_of_origin/proofs',
+              proofs: scheme.proofs,
+              scheme_title: (multiple_schemes ? scheme.title : nil) %>
+</div>

--- a/app/views/rules_of_origin/_wizard_link.html.erb
+++ b/app/views/rules_of_origin/_wizard_link.html.erb
@@ -3,7 +3,8 @@
 </h3>
 
 <p>
-  Use this tool to determine whether your trade fulfils the rules of origin and can therefore be <strong>considered</strong> as originating.
+  Work out if your trade fulfils the rules of origin and can therefore be
+  <strong>considered</strong> originating.
 </p>
 
 <p>

--- a/app/views/rules_of_origin/intros/_country.html.erb
+++ b/app/views/rules_of_origin/intros/_country.html.erb
@@ -1,5 +1,12 @@
-<div id="rules-of-origin__intro--country-scheme">
+<div class="govuk-inset-text" id="rules-of-origin__intro--country-scheme">
   <p>
-    In order to qualify for preferential tariff treatment under the <%= scheme.title %>, the product must originate in the <strong><%= rules_of_origin_service_name %></strong> or <strong><%= country_name %></strong>.
+    In order to qualify for the lower or zero preferential tariff under the
+    <strong><%= scheme.title %></strong>, the product must originate in the
+    <%= rules_of_origin_service_name %> or <%= country_name %>.
+  </p>
+
+  <p>
+    You do not need to apply for a preferential tariff (or comply with
+    preferential rules of origin) if the MFN duty for your product is zero.
   </p>
 </div>

--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe 'measures/_measures', type: :view, vcr: {
     it { is_expected.to have_css '.govuk-tabs__panel#footnotes', count: 1 }
   end
 
+  shared_examples 'roo_wizard tab' do
+    it { is_expected.to render_template('rules_of_origin/_tab') }
+    it { is_expected.not_to render_template('rules_of_origin/_legacy_tab') }
+  end
+
+  shared_examples 'legacy roo tab' do
+    it { is_expected.not_to render_template('rules_of_origin/_tab') }
+    it { is_expected.to render_template('rules_of_origin/_legacy_tab') }
+  end
+
   it { is_expected.to render_template('declarables/_consigned') }
   it { is_expected.to render_template('footnotes/_footnote') }
   it { is_expected.to render_template('measure_conditions/_permutation_group') }
@@ -79,8 +89,17 @@ RSpec.describe 'measures/_measures', type: :view, vcr: {
     context 'with country selected' do
       let(:search) { build(:search, q: '0101300000', country: 'FR') }
 
-      it_behaves_like 'measures with rules of origin tab'
-      it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
+      context 'with roo_wizard feature flag' do
+        it_behaves_like 'measures with rules of origin tab'
+        it_behaves_like 'roo_wizard tab'
+        it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
+      end
+
+      context 'without roo_wizard feature flag' do
+        before { allow(TradeTariffFrontend).to receive(:roo_wizard?).and_return false }
+
+        it_behaves_like 'legacy roo tab'
+      end
     end
   end
 
@@ -101,8 +120,17 @@ RSpec.describe 'measures/_measures', type: :view, vcr: {
     context 'with country selected' do
       let(:search) { build(:search, q: '0101300000', country: 'FR') }
 
-      it_behaves_like 'measures with rules of origin tab'
-      it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
+      context 'with roo_wizard feature flag' do
+        it_behaves_like 'measures with rules of origin tab'
+        it_behaves_like 'roo_wizard tab'
+        it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
+      end
+
+      context 'without roo_wizard feature flag' do
+        before { allow(TradeTariffFrontend).to receive(:roo_wizard?).and_return false }
+
+        it_behaves_like 'legacy roo tab'
+      end
     end
   end
 

--- a/spec/views/rules_of_origin/_legacy_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_legacy_tab.html.erb_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/_legacy_tab', type: :view do
+  subject(:rendered_page) { render_page && rendered }
+
+  let :render_page do
+    render 'rules_of_origin/legacy_tab',
+           country_code: 'FR',
+           country_name: 'France',
+           commodity_code: '2203000100',
+           rules_of_origin_schemes: schemes
+  end
+
+  let :rules_data do
+    attributes_for_list :rules_of_origin_rule,
+                        1,
+                        rule: "Manufacture\n\n* From materials"
+  end
+
+  let(:schemes) do
+    build_list :rules_of_origin_scheme, 1, rules: rules_data, fta_intro:
+  end
+
+  let(:fta_intro) { "## Free Trade Agreement\n\nDetails of agreement" }
+
+  it 'includes the countries name in the title' do
+    expect(rendered_page).to \
+      have_css 'h2', text: 'Preferential rules of origin for trading with France'
+  end
+
+  it 'shows the flag' do
+    expect(rendered_page).to have_css 'h2 .country-flag[src*="flags/fr"]'
+  end
+
+  it 'references the commodity code' do
+    expect(rendered_page).to have_css 'h3', text: /for commodity 2203000100/
+  end
+
+  it 'includes links in the sidebar' do
+    expect(rendered_page).to have_css '#rules-of-origin__related-content nav li'
+  end
+
+  it 'includes the bloc intro' do
+    expect(rendered_page).to have_css '#rules-of-origin__intro--bloc-scheme'
+  end
+
+  it 'includes the schemes' do
+    expect(rendered_page).to have_css '.rules-of-origin__scheme', count: 1
+  end
+
+  context 'with matched rules of origin' do
+    let(:first_rule) { schemes[0].rules[0] }
+
+    it 'shows rules table' do
+      expect(rendered_page).to have_css 'table.govuk-table'
+    end
+
+    it 'includes the non-preferential bloc' do
+      expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
+    end
+  end
+
+  context 'without matched rules' do
+    let(:rules_data) { [] }
+
+    it 'does not shows rules table' do
+      expect(rendered_page).not_to have_css 'table.govuk-table'
+    end
+
+    it 'shows no matched rules message' do
+      expect(rendered_page).to \
+        have_css 'p', text: /no product-specific rules for commodity \d{10}/
+    end
+
+    it 'includes the non-preferential bloc' do
+      expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
+    end
+  end
+
+  context 'with country specific scheme' do
+    let(:schemes) do
+      build_list :rules_of_origin_scheme, 1, rules: rules_data, countries: %w[FR]
+    end
+
+    it { is_expected.to have_css '#rules-of-origin__intro--country-scheme' }
+  end
+
+  context 'with no scheme' do
+    let(:schemes) { [] }
+
+    it { is_expected.to have_css '#rules-of-origin__intro--no-scheme' }
+    it { is_expected.not_to have_css '.rules-of-origin__scheme' }
+
+    it 'includes the non-preferential bloc' do
+      expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
+    end
+  end
+
+  context 'with multiple schemes' do
+    let(:schemes) do
+      build_list :rules_of_origin_scheme, 3, rules: rules_data,
+                                             fta_intro:
+    end
+
+    it { is_expected.to have_css '.rules-of-origin__scheme', count: 3 }
+
+    it 'includes one non-preferential bloc' do
+      expect(rendered_page).to have_css '.rules-of-origin__non-preferential', count: 1
+    end
+  end
+
+  context 'with blank fta_intro field' do
+    let(:fta_intro) { '' }
+
+    it 'does not show details of fta field' do
+      expect(rendered_page).not_to have_css '.rules-of-origin-fta'
+    end
+  end
+end

--- a/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/_proofs', type: :view, vcr: { cassette_name: 'geographical_areas#countries' } do
+  subject(:rendered_page) { render_page && rendered }
+
+  # 'UA' stands for Ukraine, it is a country with RoR preferential_treatment
+  before { assign :search, Search.new(country: 'UA') }
+
+  let(:render_page) do
+    render 'rules_of_origin/proofs', proofs:, scheme_title: nil
+  end
+
+  context 'with no proofs' do
+    let(:proofs) { [] }
+
+    it { is_expected.to have_css '.rules-of-origin__proofs', text: '' }
+    it { is_expected.not_to have_css '.rules-of-origin__proofs__content' }
+  end
+
+  context 'with 1 proof' do
+    let(:proofs) { build_list :rules_of_origin_proof, 1 }
+
+    it { is_expected.to have_css '.rules-of-origin__proofs' }
+    it { is_expected.to have_css 'p', text: /has the following proof/ }
+    it { is_expected.to have_css '.rules-of-origin__proofs__content', count: 1 }
+  end
+
+  context 'with multiple proofs' do
+    let(:proofs) { build_list :rules_of_origin_proof, 3 }
+
+    it { is_expected.to have_css '.rules-of-origin__proofs' }
+    it { is_expected.to have_css 'p', text: /has one of the following proofs/ }
+    it { is_expected.to have_css '.rules-of-origin__proofs__content', count: 3 }
+  end
+end

--- a/spec/views/rules_of_origin/_rules_table.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_rules_table.html.erb_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/_rules_table', type: :view do
+  subject(:rendered_page) { render_page && rendered }
+
+  let(:country_name) { 'Kenya' }
+  let(:scheme) { build :rules_of_origin_scheme }
+
+  let :rules do
+    build_list :rules_of_origin_rule, 3, rule: "Manufacture\n\n* From materials"
+  end
+
+  let :render_page do
+    render 'rules_of_origin/rules_table', rules:,
+                                          country_name:
+  end
+
+  it 'shows rules table' do
+    expect(rendered_page).to have_css 'table.govuk-table'
+  end
+
+  it 'shows row per rule' do
+    expect(rendered_page).to have_css 'tbody tr', count: 3
+  end
+
+  it 'show rule heading' do
+    expect(rendered_page).to \
+      have_css 'tbody tr td', text: rules.first.heading
+  end
+
+  it 'shows rule description' do
+    expect(rendered_page).to \
+      have_css 'tbody tr td', text: rules.first.description
+  end
+
+  it 'formats the rule detail markdown' do
+    expect(rendered_page).to \
+      have_css '.tariff-markdown ul li', text: 'From materials'
+  end
+
+  context 'with UK service' do
+    include_context 'with UK service'
+
+    it 'references the country in the introductory text' do
+      expect(rendered_page).to \
+        have_css 'p', text: /originating in the UK or #{country_name}/
+    end
+  end
+
+  context 'with XI service' do
+    include_context 'with XI service'
+
+    it 'references the country in the introductory text' do
+      expect(rendered_page).to \
+        have_css 'p', text: /originating in the EU or #{country_name}/
+    end
+  end
+end

--- a/spec/views/rules_of_origin/_scheme.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_scheme.html.erb_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/_scheme', type: :view do
+  subject(:rendered_page) { render_page && rendered }
+
+  let(:country_name) { 'Kenya' }
+  let(:commodity_code) { '0302111000' }
+  let(:multiple_schemes) { true }
+  let(:scheme) { build :rules_of_origin_scheme }
+
+  let :render_page do
+    render 'rules_of_origin/scheme', scheme:,
+                                     country_name:,
+                                     commodity_code:,
+                                     multiple_schemes:
+  end
+
+  it 'includes comm code' do
+    expect(rendered_page).to have_css '.rules-of-origin__scheme h3',
+                                      text: /rules for commodity 0302111000/
+  end
+
+  describe 'scheme caption' do
+    context 'with single scheme' do
+      let(:multiple_schemes) { false }
+
+      it { is_expected.not_to have_css 'h3 span' }
+    end
+
+    context 'with multiple schemes' do
+      it { is_expected.to have_css 'h3 span' }
+    end
+  end
+
+  it { is_expected.to have_css 'table.commodity-rules-of-origin' }
+  it { is_expected.not_to have_css 'p', text: /no product-specific rules/ }
+
+  it 'includes the introductory_notes section' do
+    expect(rendered_page).to have_css 'details .tariff-markdown p',
+                                      text: /Details of introductory notes/
+  end
+
+  context 'with no rules' do
+    let(:scheme) { build :rules_of_origin_scheme, rule_count: 0 }
+
+    it { is_expected.not_to have_css 'table.commodity-rules-of-origin' }
+    it { is_expected.not_to have_css 'details.govuk-details' }
+    it { is_expected.to have_css 'p', text: /no product-specific rules/ }
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-1944

### What?

I have added/removed/altered:

- [x] Reverted removal of existing RoO table which occurred in #988 
- [x] Conditionalised display of RoO tab to use the new tab only when the feature flag is enabled

### Why?

I am doing this because:

- We do not currently display rules of origin data when the feature flag is removed

### Have you? (optional)

- [ ] Reviewed view changes with stake holders

### Deployment risks (optional)

- Reverts changes to RoO tab