### PR TITLE
HOTT-1617: Add fallback to commodity when the subheading is not found.

### DIFF
--- a/app/controllers/subheadings_controller.rb
+++ b/app/controllers/subheadings_controller.rb
@@ -30,4 +30,10 @@ class SubheadingsController < GoodsNomenclaturesController
   def set_goods_nomenclature_code
     session[:goods_nomenclature_code] = subheading.to_param
   end
+
+  rescue_from Faraday::ResourceNotFound do
+    commodity_code = params[:id].split('-').first
+
+    redirect_to commodity_url(id: commodity_code)
+  end
 end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1617

### What?
Users should be navigated to the commodity page/commodity history page 
instead of being redirected to the find commodity page.

### Why?
To improve User experience.

# Note:
After a couple of different approaches, which imply changes on the BE too,
I think this solution:
- improves navigation, falling back to the commodity in case the sub-commodity is not found
- very low impact on the code base
- no need to change BE

