### PR TITLE
HOTT-1627: Use threshold_unit_type to display measure_condition requi…

### DIFF
--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -68,13 +68,14 @@ module MeasuresHelper
   def format_measure_condition_requirement(condition)
     case condition.measure_condition_class
     when 'threshold'
-      if condition.is_eps_condition?
+      case condition.threshold_unit_type
+      when 'eps'
         safe_join ['The price of your goods is greater than or equal to', condition.requirement], ' '
-      elsif condition.is_price_condition?
+      when 'price'
         safe_join ['The price of your goods does not exceed', condition.requirement], ' '
-      elsif condition.is_weight_condition?
+      when 'weight'
         safe_join ['The weight of your goods does not exceed', condition.requirement], ' '
-      elsif condition.is_volume_condition?
+      when 'volume'
         safe_join ['The volume of your goods does not exceed', condition.requirement], ' '
       else
         condition.requirement.presence || 'Condition not fulfilled'

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -3,10 +3,6 @@ require 'api_entity'
 class MeasureCondition
   include ApiEntity
 
-  WEIGHT_UNITS = %w[DTN DAP DHS GFI GRM GRT KGM KMA RET TNE].freeze
-  VOLUME_UNITS = %w[HLT KLT LPA LTR MIL MTQ].freeze
-  EPS_CONDITION = 'V'.freeze
-
   attr_accessor :condition_code,
                 :condition_measurement_unit_code,
                 :condition_monetary_unit_code,
@@ -16,7 +12,8 @@ class MeasureCondition
                 :duty_expression,
                 :certificate_description,
                 :guidance_cds,
-                :guidance_chief
+                :guidance_chief,
+                :threshold_unit_type
 
   attr_writer :requirement
   attr_reader :measure_condition_class
@@ -32,21 +29,5 @@ class MeasureCondition
   def measure_condition_class=(condition_class)
     @measure_condition_class =
       ActiveSupport::StringInquirer.new(condition_class.to_s)
-  end
-
-  def is_price_condition?
-    condition_monetary_unit_code.present?
-  end
-
-  def is_weight_condition?
-    WEIGHT_UNITS.include? condition_measurement_unit_code
-  end
-
-  def is_volume_condition?
-    VOLUME_UNITS.include? condition_measurement_unit_code
-  end
-
-  def is_eps_condition?
-    EPS_CONDITION == condition_code && is_price_condition? && is_weight_condition?
   end
 end

--- a/spec/factories/measure_condition_factory.rb
+++ b/spec/factories/measure_condition_factory.rb
@@ -25,22 +25,26 @@ FactoryBot.define do
     trait :weight do
       threshold
       condition_measurement_unit_code { 'KGM' }
+      threshold_unit_type { 'weight' }
     end
 
     trait :volume do
       threshold
       condition_measurement_unit_code { 'LTR' }
+      threshold_unit_type { 'volume' }
     end
 
     trait :price do
       threshold
       condition_monetary_unit_code { 'EUR' }
+      threshold_unit_type { 'price' }
     end
 
     trait :eps do
       weight
       price
       condition_code { 'V' }
+      threshold_unit_type { 'eps' }
     end
   end
 end

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe MeasureCondition do
   it { is_expected.to respond_to :duty_expression }
   it { is_expected.to respond_to :certificate_description }
   it { is_expected.to respond_to :measure_condition_class }
+  it { is_expected.to respond_to :threshold_unit_type }
 
   describe '#requirement' do
     it { expect(condition.requirement).to be_html_safe }
@@ -65,76 +66,6 @@ RSpec.describe MeasureCondition do
       it { is_expected.to respond_to :document? }
       it { is_expected.to have_attributes 'threshold?': false }
       it { is_expected.to have_attributes 'document?': true }
-    end
-  end
-
-  describe '#is_weight_condition?' do
-    subject { condition.is_weight_condition? }
-
-    context 'with weight unit' do
-      let(:condition) { build :measure_condition, :weight }
-
-      it { is_expected.to be true }
-    end
-
-    context 'with other unit' do
-      let(:condition) { build :measure_condition, :volume }
-
-      it { is_expected.to be false }
-    end
-  end
-
-  describe '#is_volume_condition?' do
-    subject { condition.is_volume_condition? }
-
-    context 'with volume unit' do
-      let(:condition) { build :measure_condition, :volume }
-
-      it { is_expected.to be true }
-    end
-
-    context 'with other unit' do
-      let(:condition) { build :measure_condition, :weight }
-
-      it { is_expected.to be false }
-    end
-  end
-
-  describe '#is_price_condition?' do
-    subject { condition.is_price_condition? }
-
-    context 'with price unit' do
-      let(:condition) { build :measure_condition, :price }
-
-      it { is_expected.to be true }
-    end
-
-    context 'with other unit' do
-      let(:condition) { build :measure_condition, :weight }
-
-      it { is_expected.to be false }
-    end
-
-    context 'with eps condition' do
-      let(:condition) { build :measure_condition, :eps }
-
-      it { is_expected.to be true }
-    end
-  end
-
-  describe '#is_eps_condition?' do
-    subject { condition.is_eps_condition? }
-
-    context 'with eps condition' do
-      let(:condition) { build :measure_condition, :eps }
-
-      it { is_expected.to be true }
-    end
-
-    context 'without eps condition' do
-      let(:condition) { build :measure_condition }
-
-      it { is_expected.to be false }
     end
   end
 end


### PR DESCRIPTION
…rements

Important: This PR should be merged after the backend PR because these changes can not work without the backend changes: https://github.com/trade-tariff/trade-tariff-backend/pull/776

### Jira link

[HOTT-<1627>](https://transformuk.atlassian.net/browse/HOTT-1627)

### What?

I have added/removed/altered:

- [ ] Removed logic from frontend

### Why?

I am doing this because:

- Backend now provides threshold_unit_type string, which contains the information we need to display measure condition requirements

<img width="1033" alt="Screenshot 2022-09-14 at 16 43 10" src="https://user-images.githubusercontent.com/12201130/190201327-96fd52e5-d50c-4178-abf7-1e482785ccc0.png">

