### PR TITLE
HOTT-1935: Fix country name in RoO journeys

### DIFF
--- a/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
+++ b/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
@@ -1,6 +1,7 @@
 <span class="govuk-caption-xl">
-  <%= t (current_step.exporting? ? '.caption.exporting' : '.caption.importing'),
+  <%= t (current_step.exporting? ? 'rules_of_origin.shared.caption.exporting' : 'rules_of_origin.shared.caption.importing'),
         commodity_code: current_step.commodity_code,
+        service_country_name: current_step.service_country_name,
         trade_country_name: current_step.trade_country_name %>
 </span>
 

--- a/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
+++ b/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
@@ -1,6 +1,7 @@
 <span class="govuk-caption-xl">
-  <%= t (current_step.exporting? ? '.caption.exporting' : '.caption.importing'),
+  <%= t (current_step.exporting? ? 'rules_of_origin.shared.caption.exporting' : 'rules_of_origin.shared.caption.importing'),
         commodity_code: current_step.commodity_code,
+        service_country_name: current_step.service_country_name,
         trade_country_name: current_step.trade_country_name %>
 </span>
 

--- a/app/views/rules_of_origin/steps/_rules_not_met.html.erb
+++ b/app/views/rules_of_origin/steps/_rules_not_met.html.erb
@@ -1,5 +1,5 @@
 <span class="govuk-caption-xl">
-  <%= t (current_step.exporting? ? '.caption.exporting' : '.caption.importing'),
+  <%= t (current_step.exporting? ? 'rules_of_origin.shared.caption.exporting' : 'rules_of_origin.shared.caption.importing'),
         commodity_code: current_step.commodity_code,
         service_country_name: current_step.service_country_name,
         trade_country_name: current_step.trade_country_name %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -467,9 +467,6 @@ en:
           obtained, based on the rules of the %{scheme_title}.
 
       origin_requirements_met:
-        caption:
-          importing: Importing commodity %{commodity_code} from %{trade_country_name}
-          exporting: Exporting commodity %{commodity_code} to %{trade_country_name}
         title: Origin requirements met
         panel:
           Based on your responses, your product appears to meet the rules of
@@ -483,9 +480,6 @@ en:
           verification: How proofs of origin are verified
 
       proofs_of_origin:
-        caption:
-          importing: Importing commodity %{commodity_code} from %{trade_country_name}
-          exporting: Exporting commodity %{commodity_code} from %{trade_country_name}
         title: Valid proofs of origin
         body:
           To benefit from a preferential tariff or quota, originating products
@@ -661,9 +655,6 @@ en:
         notes: Introductory notes to the product-specific rules
 
       rules_not_met:
-        caption:
-          importing: Importing commodity %{commodity_code} from %{trade_country_name} to %{service_country_name}
-          exporting: Exporting commodity %{commodity_code} from %{service_country_name} to %{trade_country_name}
         title: Rules of Origin not met
         panel:
           Your product does not appear to meet the rules of origin requirements
@@ -855,3 +846,8 @@ en:
           and it would be treated as if it was of UK origin no matter how much value was added, 
           or not, in the UK.
         map_text: Originating inputs from each country are considered to be originating input in the other countries.
+
+    shared:
+      caption:
+        importing: Importing commodity %{commodity_code} from %{trade_country_name} to %{service_country_name}
+        exporting: Exporting commodity %{commodity_code} from %{service_country_name} to %{trade_country_name}

--- a/spec/views/rules_of_origin/steps/_origin_requirements_met.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_origin_requirements_met.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'rules_of_origin/steps/_origin_requirements_met', type: :view do
                   'origin_requirements_met',
                   :wholly_obtained
 
-  it { is_expected.to have_css 'span.govuk-caption-xl', text: %r{(Im|Ex)porting.* #{wizardstore['commodity_code']}.*Japan} }
+  it { is_expected.to have_css 'span.govuk-caption-xl', text: %r{(Im|Ex)porting.* #{wizardstore['commodity_code']}.*Japan.*UK} }
   it { is_expected.to have_css 'h1', text: /origin requirements met/i }
   it { is_expected.to have_css '.govuk-panel--confirmation .govuk-panel__body', count: 1 }
   it { is_expected.to have_css '.govuk-panel__body', text: %r{#{schemes.first.title}} }

--- a/spec/views/rules_of_origin/steps/_proofs_of_origin.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_proofs_of_origin.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'rules_of_origin/steps/_origin_requirements_met', type: :view do
                   'proofs_of_origin',
                   :wholly_obtained
 
-  it { is_expected.to have_css 'span.govuk-caption-xl', text: %r{(Im|Ex)porting.* #{wizardstore['commodity_code']}.*Japan} }
+  it { is_expected.to have_css 'span.govuk-caption-xl', text: %r{(Im|Ex)porting.* #{wizardstore['commodity_code']}.*Japan.*UK} }
   it { is_expected.to have_css 'h1', text: /valid proofs/i }
   it { is_expected.to have_css 'p', text: /preferential tariff/ }
   it { is_expected.to have_css '#proofs-overview h3', text: /overview/ }

--- a/spec/views/rules_of_origin/steps/_rules_not_met.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_rules_not_met.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'rules_of_origin/steps/_rules_not_met', type: :view do
                   'rules_not_met',
                   :insufficient_processing
 
-  it { is_expected.to have_css 'span.govuk-caption-xl', text: %r{(Im|Ex)porting.* #{wizardstore['commodity_code']}.*Japan} }
+  it { is_expected.to have_css 'span.govuk-caption-xl', text: %r{(Im|Ex)porting.* #{wizardstore['commodity_code']}.*Japan.*UK} }
   it { is_expected.to have_css 'h1', text: /not met/i }
   it { is_expected.to have_css '.govuk-panel--confirmation .govuk-panel__body', count: 1 }
   it { is_expected.to have_css '.govuk-panel__body', text: %r{#{schemes.first.title}} }


### PR DESCRIPTION
### Jira link

[HOTT-<1935>](https://transformuk.atlassian.net/browse/HOTT-1935)

### What?

I have added/removed/altered:

- [x] Fixed the country name in RoO journeys and refactored existing code to use the same translation

### Why?

I am doing this because:

-  We were displaying the wrong country name in RoO journeys

<img width="1091" alt="Screenshot 2022-09-15 at 15 16 35" src="https://user-images.githubusercontent.com/12201130/190427581-2553963a-3a12-4ea3-875a-b60d7e9892ad.png">
<img width="1108" alt="Screenshot 2022-09-15 at 15 16 17" src="https://user-images.githubusercontent.com/12201130/190427607-68b118e6-910b-44ae-8379-4ea54c541999.png">
<img width="1180" alt="Screenshot 2022-09-15 at 15 16 10" src="https://user-images.githubusercontent.com/12201130/190427640-826c4f4c-c866-4a8a-b71f-98b1b2b0ba52.png">

