### PR TITLE
HOTT-1904: New improvements on RoR tab

### DIFF
--- a/app/models/import_trade_summary.rb
+++ b/app/models/import_trade_summary.rb
@@ -7,7 +7,11 @@ class ImportTradeSummary
                 :preferential_tariff_duty,
                 :preferential_quota_duty
 
+  def preferential_duties?
+    preferential_tariff_duty.present? || preferential_quota_duty.present?
+  end
+
   def no_preferential_duties?
-    !(preferential_tariff_duty.present? || preferential_quota_duty.present?)
+    !preferential_duties?
   end
 end

--- a/app/views/rules_of_origin/_legacy_tab.html.erb
+++ b/app/views/rules_of_origin/_legacy_tab.html.erb
@@ -8,7 +8,8 @@
 <% if TradeTariffFrontend.roo_wizard? && rules_of_origin_schemes.any? %>
   <%= render 'rules_of_origin/wizard_link',
              country_code: country_code,
-             commodity_code: commodity_code %>
+             commodity_code: commodity_code,
+             import_trade_summary: import_trade_summary %>
 <% end %>
 
 <%= render partial: 'rules_of_origin/scheme',

--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -20,10 +20,18 @@
                import_trade_summary: import_trade_summary
     %>
 
-    <% if TradeTariffFrontend.roo_wizard? && rules_of_origin_schemes.any? %>
-      <%= render 'rules_of_origin/wizard_link',
-                 country_code: country_code,
-                 commodity_code: commodity_code %>
+    <% if import_trade_summary.no_preferential_duties? %>
+      <p class="tariff-inset-information">
+        As there is neither a preferential tariff nor a preferential quota present for this commodity, the 'Check rules of origin' tool is not available.
+      </p>
+    <% else %>
+      <% if TradeTariffFrontend.roo_wizard? && rules_of_origin_schemes.any? %>
+        <%= render 'rules_of_origin/wizard_link',
+                   country_code: country_code,
+                   commodity_code: commodity_code,
+                   import_trade_summary: import_trade_summary
+        %>
+      <% end %>
     <% end %>
 
     <%= render 'rules_of_origin/non_preferential' %>

--- a/app/views/rules_of_origin/_wizard_link.html.erb
+++ b/app/views/rules_of_origin/_wizard_link.html.erb
@@ -7,6 +7,15 @@
   <strong>considered</strong> originating.
 </p>
 
+<% if import_trade_summary.preferential_duties? %>
+  <div class="tariff-breadcrumbs">
+    <p>As the third country duty is zero, you do not need to apply for a preferential tariff or
+    comply with preferential rules of origin.</p>
+
+    <p>If you would still like to continue, click the 'Check rules of origin' button.</p>
+  </div>
+<% end %>
+
 <p>
   <%= form_with model: RulesOfOrigin::Wizard.steps.first,
                 url: rules_of_origin_step_path(commodity_code,
@@ -22,5 +31,3 @@
     <%= f.button 'Check rules of origin', class: 'govuk-button' %>
   <% end %>
 </p>
-
-

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -54,7 +54,8 @@ FactoryBot.define do
 
     trait :with_import_trade_summary do
       import_trade_summary do
-        attributes_for(:import_trade_summary)
+        attributes_for(:import_trade_summary,
+                       preferential_tariff_duty: '10 %')
       end
     end
   end

--- a/spec/views/rules_of_origin/_legacy_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_legacy_tab.html.erb_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'rules_of_origin/_legacy_tab', type: :view do
            country_code: 'FR',
            country_name: 'France',
            commodity_code: '2203000100',
-           rules_of_origin_schemes: schemes
+           rules_of_origin_schemes: schemes,
+           import_trade_summary: build(:import_trade_summary)
   end
 
   let :rules_data do

--- a/spec/views/rules_of_origin/_wizard_link.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_wizard_link.html.erb_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe 'rules_of_origin/wizard_link', type: :view do
 
   let :render_page do
     render 'rules_of_origin/wizard_link', country_code: 'JP',
-                                          commodity_code: '1234567890'
+                                          commodity_code: '1234567890',
+                                          import_trade_summary: build(:import_trade_summary)
   end
 
   let(:step) { RulesOfOrigin::Wizard.steps.first }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1904

### What?
-[x] Add two new info boxes and hide 
-[x] Check RoO button if there are no preferential duties.

### Why?
We want to tell people that when they do not need to bother with a preferential tariff
AND
there is no preference and no quota for the selected country & comm code combination, there is no value in taking users through the pain of the rules of origin wizard.
