### PR TITLE
HOTT-1952 Simplify exception handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,18 +17,6 @@ class ApplicationController < ActionController::Base
 
   layout :set_layout
 
-  rescue_from Faraday::ServerError, Errno::ECONNREFUSED do
-    request.format = :html
-    render_500
-  end
-
-  rescue_from(Faraday::ResourceNotFound, WizardSteps::UnknownStep,
-              ActionView::MissingTemplate, ActionController::UnknownFormat,
-              AbstractController::ActionNotFound, URI::InvalidURIError) do |_e|
-    request.format = :html
-    render_404
-  end
-
   def url_options
     return super unless search_invoked?
 
@@ -51,22 +39,6 @@ class ApplicationController < ActionController::Base
   helper_method :cookies_policy,
                 :meursing_lookup_result,
                 :is_switch_service_banner_enabled?
-
-  def render_500
-    disable_search_form
-    render template: 'errors/internal_server_error',
-           status: :internal_server_error,
-           formats: :html
-    false
-  end
-
-  def render_404
-    disable_search_form
-    render template: 'errors/not_found',
-           status: :not_found,
-           formats: :html
-    false
-  end
 
   def set_last_updated
     # rubocop:disable Naming/MemoizedInstanceVariableName

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -37,7 +37,9 @@ class SearchController < ApplicationController
   end
 
   def quota_search
-    render_404 if TradeTariffFrontend::ServiceChooser.xi?
+    if TradeTariffFrontend::ServiceChooser.xi?
+      raise TradeTariffFrontend::FeatureUnavailable
+    end
 
     form = QuotaSearchForm.new(params.permit(*QuotaSearchForm::PERMITTED_PARAMS))
     @result = QuotaSearchPresenter.new(form)

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -1,0 +1,9 @@
+ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
+  'Faraday::ResourceNotFound' => :not_found,
+  'WizardSteps::UnknownStep' => :not_found,
+  'ActionView::MissingTemplate' => :not_found,
+  'ActionController::UnknownFormat' => :not_found,
+  'AbstractController::ActionNotFound' => :not_found,
+  'URI::InvalidURIError' => :not_found,
+  'TradeTariffFrontend::FeatureUnavailable' => :not_found,
+)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,5 +3,7 @@ Sentry.init do |config|
 
   config.excluded_exceptions += %w[
     Faraday::ResourceNotFound
+    WizardSteps::UnknownStep
+    TradeTariffFrontend::FeatureUnavailable
   ]
 end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -183,4 +183,6 @@ module TradeTariffFrontend
       ]
     end
   end
+
+  class FeatureUnavailable < StandardError; end
 end

--- a/spec/controllers/chapters/changes_controller_spec.rb
+++ b/spec/controllers/chapters/changes_controller_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe Chapters::ChangesController, 'GET to #index', type: :controller d
   end
 
   describe 'chapter is not valid at given date', vcr: { cassette_name: 'chapters_changes#index_0100000000_1970-01-01' } do
-    before do
+    let :request_page do
       get :index, params: { chapter_id: chapter.short_code, as_of: Date.new(1970, 1, 1) }, format: :atom
     end
 
-    it { is_expected.to respond_with(:not_found) }
+    it { expect { request_page }.to raise_exception Faraday::ResourceNotFound }
   end
 end

--- a/spec/controllers/commodities/changes_controller_spec.rb
+++ b/spec/controllers/commodities/changes_controller_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe Commodities::ChangesController, 'GET to #index', type: :controlle
   describe 'commodity is not valid at given date', vcr: { cassette_name: 'commodities_changes#index_4302130000_2013-11-11' } do
     let!(:commodity) { Commodity.new(attributes_for(:commodity, goods_nomenclature_item_id: '4302130000')) }
 
-    before do
+    let :request_page do
       get :index, params: { commodity_id: commodity.short_code, as_of: Date.new(2013, 11, 11) }, format: :atom
     end
 
-    it { is_expected.to respond_with(:not_found) }
+    it { expect { request_page }.to raise_exception Faraday::ResourceNotFound }
   end
 end

--- a/spec/controllers/headings/changes_controller_spec.rb
+++ b/spec/controllers/headings/changes_controller_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe Headings::ChangesController, 'GET to #index', type: :controller d
   end
 
   describe 'heading is not valid at given date', vcr: { cassette_name: 'headings_changes#index_0101000000_1970-01-01' } do
-    before do
+    let :request_page do
       get :index, params: { heading_id: heading.short_code, as_of: Date.new(1970, 1, 1) }, format: :atom
     end
 
-    it { is_expected.to respond_with(:not_found) }
+    it { expect { request_page }.to raise_exception Faraday::ResourceNotFound }
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -15,22 +15,6 @@ RSpec.describe PagesController, type: :controller do
     end
   end
 
-  context 'when asked with no format' do
-    subject(:search) { get :opensearch }
-
-    it 'does not raise ActionController::UnknownFormat' do
-      expect(search).to render_template('errors/not_found')
-    end
-  end
-
-  context 'with unsupported format' do
-    subject(:search) { get :opensearch, format: :json }
-
-    it 'does not raise ActionController::UnknownFormat' do
-      expect(search).to render_template('errors/not_found')
-    end
-  end
-
   describe 'GET #privacy' do
     subject(:response) { get :privacy }
 

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -333,13 +333,13 @@ end
 
 RSpec.describe SearchController, 'GET to #quota_search', type: :controller, vcr: { cassette_name: 'search#quota_search', allow_playback_repeats: true } do
   context 'with xi as the service choice' do
-    before do
+    let :request_page do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:xi?).and_return(true)
 
       get :quota_search, params: { goods_nomenclature_item_id: '0301919011' }, format: :html
     end
 
-    it { is_expected.to respond_with(:not_found) }
+    it { expect { request_page }.to raise_exception TradeTariffFrontend::FeatureUnavailable }
   end
 
   context 'without search params' do

--- a/spec/controllers/search_quotas_controller_spec.rb
+++ b/spec/controllers/search_quotas_controller_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe SearchController, '#quota_search', type: :controller, vcr: { cass
   before { TradeTariffFrontend::ServiceChooser.service_choice = nil }
 
   context 'with xi as the service choice' do
-    before do
+    let :request_page do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:xi?).and_return(true)
       TradeTariffFrontend::ServiceChooser.service_choice = 'xi'
 
       get :quota_search, params: { goods_nomenclature_item_id: '0301919011' }, format: :html
     end
 
-    it { is_expected.to respond_with(:not_found) }
+    it { expect { request_page }.to raise_exception TradeTariffFrontend::FeatureUnavailable }
   end
 
   context 'without search params' do

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe 'Error handling' do
+  subject { page }
+
+  describe 'not found page' do
+    before { visit '/404' }
+
+    it { is_expected.to have_http_status :not_found }
+    it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'Page not found' }
+  end
+
+  describe 'exception page' do
+    before { visit '/500' }
+
+    it { is_expected.to have_http_status :internal_server_error }
+    it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'We are experiencing technical difficulties' }
+  end
+
+  describe 'maintenance mode' do
+    before { visit '/503' }
+
+    it { is_expected.to have_http_status :service_unavailable }
+    it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'Maintenance' }
+  end
+end

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -3,24 +3,89 @@ require 'spec_helper'
 RSpec.describe 'Error handling' do
   subject { page }
 
+  shared_examples 'not found' do
+    it { is_expected.to have_http_status :not_found }
+    it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'Page not found' }
+  end
+
+  shared_examples 'internal server error' do
+    it { is_expected.to have_http_status :internal_server_error }
+    it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'We are experiencing technical difficulties' }
+  end
+
+  shared_examples 'service unavailable' do
+    it { is_expected.to have_http_status :service_unavailable }
+    it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'Maintenance' }
+  end
+
   describe 'not found page' do
     before { visit '/404' }
 
-    it { is_expected.to have_http_status :not_found }
-    it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'Page not found' }
+    it_behaves_like 'not found'
   end
 
   describe 'exception page' do
     before { visit '/500' }
 
-    it { is_expected.to have_http_status :internal_server_error }
-    it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'We are experiencing technical difficulties' }
+    it_behaves_like 'internal server error'
   end
 
   describe 'maintenance mode' do
     before { visit '/503' }
 
-    it { is_expected.to have_http_status :service_unavailable }
-    it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'Maintenance' }
+    it_behaves_like 'service unavailable'
+  end
+
+  describe 'rescued exceptions' do
+    include_context 'with rescued exceptions'
+
+    context 'with unknown url' do
+      before { visit '/unknown' }
+
+      it_behaves_like 'not found'
+    end
+
+    context 'with non existant resource' do
+      before do
+        stub_api_request('/news_items/9999', backend: 'uk')
+          .and_return jsonapi_error_response(404)
+
+        visit '/news/9999'
+      end
+
+      it_behaves_like 'not found'
+    end
+
+    context 'with faraday connection error' do
+      before do
+        stub_api_request('/news_items/9999', backend: 'uk').to_timeout
+
+        visit '/news/9999'
+      end
+
+      it_behaves_like 'internal server error'
+    end
+
+    context 'with other error' do
+      before do
+        allow(NewsItem).to \
+          receive(:find).and_raise(StandardError, 'Something went wrong')
+
+        visit '/news/9999'
+      end
+
+      it_behaves_like 'internal server error'
+    end
+
+    context 'with feature that is unavailble' do
+      before do
+        allow(NewsItem).to \
+          receive(:find).and_raise(TradeTariffFrontend::FeatureUnavailable)
+
+        visit '/news/9999'
+      end
+
+      it_behaves_like 'not found'
+    end
   end
 end

--- a/spec/requests/rules_of_origin/steps_controller_spec.rb
+++ b/spec/requests/rules_of_origin/steps_controller_spec.rb
@@ -55,6 +55,14 @@ RSpec.describe RulesOfOrigin::StepsController, type: :request do
       it { is_expected.to have_attributes body: /Details of your trade/ }
     end
 
+    context 'with an invalid step' do
+      before { get rules_of_origin_step_path commodity_code, country_code, :invalid }
+
+      include_context 'with rescued exceptions'
+
+      it { is_expected.to have_http_status :not_found }
+    end
+
     context 'with changed service' do
       before { get "/xi#{second_step_path}" }
 

--- a/spec/requests/rules_of_origin/steps_controller_spec.rb
+++ b/spec/requests/rules_of_origin/steps_controller_spec.rb
@@ -55,12 +55,6 @@ RSpec.describe RulesOfOrigin::StepsController, type: :request do
       it { is_expected.to have_attributes body: /Details of your trade/ }
     end
 
-    context 'with an invalid step' do
-      before { get rules_of_origin_step_path commodity_code, country_code, :invalid }
-
-      it { is_expected.to have_http_status :not_found }
-    end
-
     context 'with changed service' do
       before { get "/xi#{second_step_path}" }
 

--- a/spec/support/shared_context/rescue_exceptions.rb
+++ b/spec/support/shared_context/rescue_exceptions.rb
@@ -1,0 +1,20 @@
+RSpec.shared_context 'with rescued exceptions' do
+  # In the tests, RSpec reuses an instance of Rack::Test::Request across all
+  # specs, this reads these config values in instantiation time and is then used
+  # for the entire duration of the test suite run
+  #
+  # This shared context changes those values for the duration of a single spec
+  # to allow testing exceptions are rescued appropriately
+  around do |example|
+    orig_show_exceptions = Rails.application.env_config['action_dispatch.show_exceptions']
+    orig_detailed_exceptions = Rails.application.env_config['action_dispatch.show_detailed_exceptions']
+
+    Rails.application.env_config['action_dispatch.show_exceptions'] = true
+    Rails.application.env_config['action_dispatch.show_detailed_exceptions'] = false
+
+    example.run
+
+    Rails.application.env_config['action_dispatch.show_detailed_exceptions'] = orig_detailed_exceptions
+    Rails.application.env_config['action_dispatch.show_exceptions'] = orig_show_exceptions
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-1952

### What?

I have added/removed/altered:

- [x] Added spec for errors pages to ensure they can render and render the correct content
- [x] Added specs to ensure raised exceptions in controller code are rescued by `ActionDispatch::ShowExceptions` middleware correctly
- [x] Removed custom exception rescue behaviour and use the built in rails exception handling
- [x] Configured the rails exception handling to behave correctly for the additional exceptions we were previously overriding
- [x] Enabled error reporting to sentry for exceptions rescued by the 500 and 404 pages 
- [x] Added a shared context to enable rescuing exceptions for a single spec

### Why?

I am doing this because:

- We previously had to make updates to the errors in two places but this wasn't obvious and often only one would happen
- Nothing was checking the error pages themselves rendered correctly
- Developers would not see the default rails exception pages, which would obscure the source of errors - most notable a missing or misnamed partial would result in the branded Page Not Found screen - confusing for new developers.
- We were previously only reporting really low level errors to sentry

### Deployment risks (optional)

- Makes changes to our handling and reporting of exceptions
