### PR TITLE
HOTT-2004 Fix and specs for search banner on errors

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,7 +63,7 @@
       <%= render 'shared/govuk_logo' %>
       <%= yield :proposition_header %>
     </div>
-    <%= render 'shared/search_banner' if TradeTariffFrontend.search_banner? %>
+    <%= render 'shared/search_banner' if TradeTariffFrontend.search_banner? && @search %>
     <%= render 'news_items/header_banner', news_item: NewsItem.cached_latest_banner %>
   </header>
 

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe 'Error handling' do
       it { is_expected.to have_http_status :not_found }
       it { is_expected.to have_attributes body: 'Resource not found' }
     end
+
+    context 'with new search enabled' do
+      before do
+        allow(TradeTariffFrontend).to receive(:search_banner?).and_return true
+        visit '/404'
+      end
+
+      it_behaves_like 'not found'
+    end
   end
 
   describe 'exception page' do
@@ -60,6 +69,15 @@ RSpec.describe 'Error handling' do
       it { is_expected.to have_http_status :internal_server_error }
       it { is_expected.to have_attributes body: 'Internal server error' }
     end
+
+    context 'with new search enabled' do
+      before do
+        allow(TradeTariffFrontend).to receive(:search_banner?).and_return true
+        visit '/500'
+      end
+
+      it_behaves_like 'internal server error'
+    end
   end
 
   describe 'maintenance mode' do
@@ -81,6 +99,15 @@ RSpec.describe 'Error handling' do
 
       it { is_expected.to have_http_status :service_unavailable }
       it { is_expected.to have_attributes body: 'Maintenance mode' }
+    end
+
+    context 'with new search enabled' do
+      before do
+        allow(TradeTariffFrontend).to receive(:search_banner?).and_return true
+        visit '/503'
+      end
+
+      it_behaves_like 'service unavailable'
     end
   end
 


### PR DESCRIPTION
### Jira link

HOTT-2004

### What?

I have added/removed/altered:

- [x] Fixed bug when search banner is enabled

### Why?

I am doing this because:

- the `@search` variable is not assigned on error pages and so the search should not be shown

### Deployment risks (optional)

- Low, affects currently disable feature
