### PR TITLE
HOTT-1958 Dont redirect maintenance page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,14 +5,14 @@ class ApplicationController < ActionController::Base
   include TradeTariffFrontend::ViewContext::Controller
   include ApplicationHelper
 
+  before_action :maintenance_mode_if_active
+
   around_action :set_locale
 
   before_action :set_cache
   before_action :set_last_updated
   before_action :set_path_info
-
   before_action :set_search
-  before_action :maintenance_mode_if_active
   before_action :bots_no_index_if_historical
 
   layout :set_layout
@@ -112,9 +112,13 @@ class ApplicationController < ActionController::Base
   protected
 
   def maintenance_mode_if_active
-    if ENV['MAINTENANCE'].present? && action_name != 'maintenance'
-      redirect_to '/503'
+    if ENV['MAINTENANCE'].present? && !maintenance_mode_bypass?
+      raise TradeTariffFrontend::MaintenanceMode
     end
+  end
+
+  def maintenance_mode_bypass?
+    ENV['MAINTENANCE_BYPASS'].present? && ENV['MAINTENANCE_BYPASS'] == params[:maintenance_bypass]
   end
 
   def bots_no_index_if_historical

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,5 @@
 class ErrorsController < ApplicationController
+  skip_before_action :maintenance_mode_if_active
   skip_before_action :set_last_updated
   skip_before_action :set_path_info
   skip_before_action :set_search

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -6,4 +6,5 @@ ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   'AbstractController::ActionNotFound' => :not_found,
   'URI::InvalidURIError' => :not_found,
   'TradeTariffFrontend::FeatureUnavailable' => :not_found,
+  'TradeTariffFrontend::MaintenanceMode' => :service_unavailable,
 )

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,5 +5,6 @@ Sentry.init do |config|
     Faraday::ResourceNotFound
     WizardSteps::UnknownStep
     TradeTariffFrontend::FeatureUnavailable
+    TradeTariffFrontend::MaintenanceMode
   ]
 end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -185,4 +185,5 @@ module TradeTariffFrontend
   end
 
   class FeatureUnavailable < StandardError; end
+  class MaintenanceMode < StandardError; end
 end

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -13,11 +13,6 @@ RSpec.describe 'Error handling' do
     it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'We are experiencing technical difficulties' }
   end
 
-  shared_examples 'service unavailable' do
-    it { is_expected.to have_http_status :service_unavailable }
-    it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'Maintenance' }
-  end
-
   describe 'not found page' do
     context 'with html' do
       before { visit '/404' }
@@ -80,37 +75,6 @@ RSpec.describe 'Error handling' do
     end
   end
 
-  describe 'maintenance mode' do
-    context 'with html' do
-      before { visit '/503' }
-
-      it_behaves_like 'service unavailable'
-    end
-
-    context 'with json' do
-      before { visit '/503.json' }
-
-      it { is_expected.to have_http_status :service_unavailable }
-      it { expect(JSON.parse(page.body)).to include 'error' => 'Maintenance mode' }
-    end
-
-    context 'with something else' do
-      before { visit '/503.pdf' }
-
-      it { is_expected.to have_http_status :service_unavailable }
-      it { is_expected.to have_attributes body: 'Maintenance mode' }
-    end
-
-    context 'with new search enabled' do
-      before do
-        allow(TradeTariffFrontend).to receive(:search_banner?).and_return true
-        visit '/503'
-      end
-
-      it_behaves_like 'service unavailable'
-    end
-  end
-
   describe 'rescued exceptions' do
     include_context 'with rescued exceptions'
 
@@ -152,7 +116,7 @@ RSpec.describe 'Error handling' do
       it_behaves_like 'internal server error'
     end
 
-    context 'with feature that is unavailble' do
+    context 'with feature that is unavailable' do
       before do
         allow(NewsItem).to \
           receive(:find).and_raise(TradeTariffFrontend::FeatureUnavailable)
@@ -161,17 +125,6 @@ RSpec.describe 'Error handling' do
       end
 
       it_behaves_like 'not found'
-    end
-
-    context 'when maintenance is enabled' do
-      before do
-        allow(NewsItem).to \
-          receive(:find).and_raise(TradeTariffFrontend::MaintenanceMode)
-
-        visit '/news/9999'
-      end
-
-      it_behaves_like 'service unavailable'
     end
   end
 end

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -162,5 +162,16 @@ RSpec.describe 'Error handling' do
 
       it_behaves_like 'not found'
     end
+
+    context 'when maintenance is enabled' do
+      before do
+        allow(NewsItem).to \
+          receive(:find).and_raise(TradeTariffFrontend::MaintenanceMode)
+
+        visit '/news/9999'
+      end
+
+      it_behaves_like 'service unavailable'
+    end
   end
 end

--- a/spec/features/maintenance_mode_spec.rb
+++ b/spec/features/maintenance_mode_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+RSpec.describe 'Maintenance mode' do
+  subject { page }
+
+  shared_examples 'service unavailable' do
+    it { is_expected.to have_http_status :service_unavailable }
+    it { is_expected.to have_css '.govuk-main-wrapper h1', text: 'Maintenance' }
+  end
+
+  describe 'maintenance mode page' do
+    context 'with html' do
+      before { visit '/503' }
+
+      it_behaves_like 'service unavailable'
+    end
+
+    context 'with json' do
+      before { visit '/503.json' }
+
+      it { is_expected.to have_http_status :service_unavailable }
+      it { expect(JSON.parse(page.body)).to include 'error' => 'Maintenance mode' }
+    end
+
+    context 'with something else' do
+      before { visit '/503.pdf' }
+
+      it { is_expected.to have_http_status :service_unavailable }
+      it { is_expected.to have_attributes body: 'Maintenance mode' }
+    end
+
+    context 'with new search enabled' do
+      before do
+        allow(TradeTariffFrontend).to receive(:search_banner?).and_return true
+        visit '/503'
+      end
+
+      it_behaves_like 'service unavailable'
+    end
+  end
+
+  describe 'visiting a page whilst maintenance mode is enabled' do
+    include_context 'with rescued exceptions'
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('MAINTENANCE').and_return true
+    end
+
+    context 'without bypass enabled' do
+      before { visit '/news' }
+
+      it_behaves_like 'service unavailable'
+    end
+
+    context 'with bypass enabled' do
+      before do
+        allow(ENV).to receive(:[]).with('MAINTENANCE_BYPASS').and_return 'bypass'
+      end
+
+      context 'without bypass param' do
+        before { visit '/news' }
+
+        it_behaves_like 'service unavailable'
+      end
+
+      context 'with wrong bypass param' do
+        before { visit '/news?maintenance_bypass=something' }
+
+        it_behaves_like 'service unavailable'
+      end
+
+      context 'with correct bypass param' do
+        before do
+          allow(NewsItem).to receive(:updates_page).and_return []
+          visit '/news?maintenance_bypass=bypass'
+        end
+
+        it { is_expected.to have_http_status :success }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-1958

### What?

I have added/removed/altered:

- [x] Use exception handling to show maintenance page
- [x] Bump priority of before action checking for maintenance mode
- [x] Support bypass env var to allow testing whilst still in maintenance mode

### Why?

I am doing this because:

- If we redirect the user to `/503` then even after we remove maintenance mode, if they refresh their page they will still be show the 503 page leaving them unaware the site is back available
- If the backend is uncontactable for any reason, then the user would see the 500 page instead of the 503 page even when the site has been placed into maintenance mode
- We need to be able to test if the site is working correctly whilst still in maintance mode for the general public

### Deployment risks (optional)

- Changes how our maintenance page works - which needs to be reliable when we are making the service unavailable for any reason
