### PR TITLE
HOTT-1996: Updated 999L exemption text

### DIFF
--- a/app/views/measures/_measure_condition_modal_default.html.erb
+++ b/app/views/measures/_measure_condition_modal_default.html.erb
@@ -21,14 +21,17 @@
 <% if TradeTariffFrontend::ServiceChooser.uk? && measure.universal_waiver_applies %>
 <div class="universal-waiver-applies-panel">
   <h3 class="govuk-heading-m govuk-!-margin-top-6">
-    Customs Declaration Service (CDS) universal waiver
+    Customs Declaration Service (CDS) Licence Waiver
   </h3>
 
   <p>
-    Requirement for a licence is waived by entering the 999L document code and the
-    document identifier CDS WAIVER in the additional documentation field for this
-    commodity item. 999L can be used for CDS in a similar way to LIC99 on the
-    CHIEF system, when a waiver may be applied.
+    The use of 999L allows a CDS waiver code to be declared for prohibited and restricted goods, 
+    allowing declarants to confirm that the goods are not subject to specific licencing measures. 
+    You must enter ‘CDS Waiver’ in the additional documentation field for this commodity item.
+  </p>
+  
+  <p>
+    This waiver cannot be used for goods that are imported/exported or moved to/from Northern Ireland.
   </p>
 </div>
 <% end %>


### PR DESCRIPTION
### Jira link

[HOTT-<1996>](https://transformuk.atlassian.net/browse/HOTT-1996)

### What?

I have added/removed/altered:

- [ ] Updated 999L exemption text

### Why?

I am doing this because:

- the text needed to be updated

<img width="1117" alt="Screenshot 2022-09-20 at 14 38 05" src="https://user-images.githubusercontent.com/12201130/191272743-9d6997a8-1625-44a3-88f5-a63e31172d2d.png">
