### PR TITLE
HOTT-1980: Added condition to handle missing wholly obtained vessels …

### DIFF
--- a/app/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb
+++ b/app/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb
@@ -21,7 +21,7 @@
 
     <%= render 'shared/details', summary: t('.vessel_definition'),
                                  content: govspeak(form.object.wholly_obtained_vessels_text),
-                                 origin_reference_document: form.object.origin_reference_document %>
+                                 origin_reference_document: form.object.origin_reference_document if form.object.wholly_obtained_vessels_text.present? %>
   </div>
 
   <h3 class="govuk-heading-s">

--- a/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
@@ -46,4 +46,10 @@ RSpec.describe 'rules_of_origin/steps/_wholly_obtained_definition', type: :view 
 
     it { is_expected.to have_css '.downloadable-document__text', text: article_reference_2 }
   end
+
+  context 'when wholly obtained vessels article does not exist' do
+    let(:articles) { [] }
+
+    it { is_expected.not_to have_css 'details.govuk-details summary' }
+  end
 end


### PR DESCRIPTION
…articles

### Jira link

[HOTT-<1980>](https://transformuk.atlassian.net/browse/HOTT-1980)

### What?

I have added/removed/altered:

- [ ] Added condition to handle missing wholly obtained vessels articles

### Why?

I am doing this because:

- the view was displaying an empty dropdown
<img width="1030" alt="Screenshot 2022-09-21 at 11 43 04" src="https://user-images.githubusercontent.com/12201130/191484538-a4e88e28-1d8c-47cf-a9e7-5ed36bf595b6.png">
<img width="1029" alt="Screenshot 2022-09-21 at 11 42 41" src="https://user-images.githubusercontent.com/12201130/191484564-841ad610-6059-4c3b-b73e-c1c6f8147caa.png">
