### PR TITLE
HOTT-1979 fix padding in banner

### DIFF
--- a/app/views/news_items/_header_banner.html.erb
+++ b/app/views/news_items/_header_banner.html.erb
@@ -1,5 +1,5 @@
 <% if news_item.present? %>
-<div class="hott-header-banner">
+<div class="tariff-header-banner">
   <div class="govuk-width-container">
     <%= format_news_item_content news_item.content %>
   </div>

--- a/app/webpacker/src/stylesheets/_header_banner.scss
+++ b/app/webpacker/src/stylesheets/_header_banner.scss
@@ -1,4 +1,4 @@
-.govuk-header .hott-header-banner {
+.govuk-header .tariff-header-banner {
   padding: govuk-spacing(2) 0;
   border-top: govuk-spacing(2) solid $govuk-brand-colour;
 

--- a/app/webpacker/src/stylesheets/_header_banner.scss
+++ b/app/webpacker/src/stylesheets/_header_banner.scss
@@ -2,6 +2,10 @@
   padding: govuk-spacing(2) 0;
   border-top: govuk-spacing(2) solid $govuk-brand-colour;
 
+  > .govuk-width-container > *:first-child {
+    margin-top: 0;
+  }
+
   p, div, h1, h2, h3 {
     color: govuk-colour("white");
   }

--- a/spec/views/layout/application.html.erb_spec.rb
+++ b/spec/views/layout/application.html.erb_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe 'layouts/application', type: :view do
   let(:cookies_policy) { Cookies::Policy.new }
 
   context 'with header banner' do
-    it { is_expected.to have_css 'header.govuk-header > .hott-header-banner' }
+    it { is_expected.to have_css 'header.govuk-header > .tariff-header-banner' }
   end
 end

--- a/spec/views/news_items/_header_banner.html.erb_spec.rb
+++ b/spec/views/news_items/_header_banner.html.erb_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe 'news_items/_header_banner', type: :view do
 
   let(:news_item) { build :news_item, content: 'Important news for [[SERVICE_NAME]]' }
 
-  it { is_expected.to have_css '.hott-header-banner .govuk-width-container p', count: 1 }
+  it { is_expected.to have_css '.tariff-header-banner .govuk-width-container p', count: 1 }
   it { is_expected.to have_css 'p', text: 'Important news for UK' }
 
   context 'without any news' do
     let(:news_item) { nil }
 
-    it { is_expected.not_to have_css '.hott-header-banner' }
+    it { is_expected.not_to have_css '.tariff-header-banner' }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-1979

### What?

I have added/removed/altered:

- [x] Fixed the padding when there are headings in the page banner
- [x] Renamed hott-header-banner to tariff-header-banner

### Why?

I am doing this because:

- The current banner has excess padding on the heading
- The css class is inconsistent with the namespacing of the rest of the site

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None

### Screenshots

![Screenshot from 2022-09-21 16-01-52](https://user-images.githubusercontent.com/10818/191540047-78530f18-2b3f-43a4-9694-083f220e0870.png)
![Screenshot from 2022-09-21 16-01-37](https://user-images.githubusercontent.com/10818/191540074-5cba9ba9-a8b9-42ef-afda-54ccbe759e6f.png)

