### PR TITLE
HOTT-2023: Fix bug in roo wizard link

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -32,7 +32,10 @@ module Declarable
                   :declarable,
                   :meta
 
+    meta_attribute :duty_calculator, :zero_mfn_duty
+
     alias_method :declarable?, :declarable
+    alias_method :zero_mfn_duty?, :zero_mfn_duty
 
     delegate :numeral, to: :section, prefix: true
     delegate :code, :short_code, to: :chapter, prefix: true

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -67,7 +67,7 @@
                  country_name: @search.geographical_area.description,
                  commodity_code: declarable.code,
                  rules_of_origin_schemes: rules_of_origin_schemes,
-                 import_trade_summary: declarable.import_trade_summary %>
+                 declarable: declarable %>
     <%- else -%>
       <%= render 'rules_of_origin/without_country' %>
     <%- end -%>

--- a/app/views/rules_of_origin/_legacy_tab.html.erb
+++ b/app/views/rules_of_origin/_legacy_tab.html.erb
@@ -9,7 +9,8 @@
   <%= render 'rules_of_origin/wizard_link',
              country_code: country_code,
              commodity_code: commodity_code,
-             import_trade_summary: import_trade_summary %>
+             declarable: declarable
+           %>
 <% end %>
 
 <%= render partial: 'rules_of_origin/scheme',

--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -17,10 +17,10 @@
     <%= rules_of_origin_schemes_intro country_name, rules_of_origin_schemes %>
 
     <%= render 'rules_of_origin/import_trade_summary',
-               import_trade_summary: import_trade_summary
+               import_trade_summary: declarable.import_trade_summary
     %>
 
-    <% if import_trade_summary.no_preferential_duties? %>
+    <% if declarable.import_trade_summary.no_preferential_duties? %>
       <p class="tariff-inset-information">
         As there is neither a preferential tariff nor a preferential quota present for this commodity, the 'Check rules of origin' tool is not available.
       </p>
@@ -29,7 +29,7 @@
         <%= render 'rules_of_origin/wizard_link',
                    country_code: country_code,
                    commodity_code: commodity_code,
-                   import_trade_summary: import_trade_summary
+                   declarable: declarable
         %>
       <% end %>
     <% end %>

--- a/app/views/rules_of_origin/_wizard_link.html.erb
+++ b/app/views/rules_of_origin/_wizard_link.html.erb
@@ -7,7 +7,7 @@
   <strong>considered</strong> originating.
 </p>
 
-<% if import_trade_summary.preferential_duties? %>
+<% if declarable.zero_mfn_duty? && declarable.import_trade_summary.preferential_duties? %>
   <div class="tariff-breadcrumbs">
     <p>As the third country duty is zero, you do not need to apply for a preferential tariff or
     comply with preferential rules of origin.</p>

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :commodity do
+    transient do
+      zero_mfn_duty { false }
+    end
+
     heading { attributes_for(:heading) }
     chapter { attributes_for(:chapter) }
     section { attributes_for(:section) }
@@ -30,7 +34,7 @@ FactoryBot.define do
           'meursing_code' => false,
           'source' => 'uk',
           'trade_defence' => false,
-          'zero_mfn_duty' => false,
+          'zero_mfn_duty' => zero_mfn_duty,
         },
       }
     end
@@ -53,9 +57,17 @@ FactoryBot.define do
     end
 
     trait :with_import_trade_summary do
+      transient do
+        preferential_tariff_duty { '10 %' }
+        preferential_quota_duty {}
+      end
+
       import_trade_summary do
-        attributes_for(:import_trade_summary,
-                       preferential_tariff_duty: '10 %')
+        attributes_for(
+          :import_trade_summary,
+          preferential_tariff_duty:,
+          preferential_quota_duty:,
+        )
       end
     end
 

--- a/spec/views/rules_of_origin/_legacy_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_legacy_tab.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'rules_of_origin/_legacy_tab', type: :view do
            country_name: 'France',
            commodity_code: '2203000100',
            rules_of_origin_schemes: schemes,
-           import_trade_summary: build(:import_trade_summary)
+           declarable: build(:commodity, :with_import_trade_summary)
   end
 
   let :rules_data do

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -8,24 +8,14 @@ RSpec.describe 'rules_of_origin/_tab', type: :view do
            country_code: 'FR',
            country_name: 'France',
            commodity_code: '2203000100',
-           rules_of_origin_schemes: schemes,
-           declarable: build(:commodity, :with_import_trade_summary, preferential_tariff_duty:, preferential_quota_duty:)
+           rules_of_origin_schemes:,
+           declarable: build(:commodity, import_trade_summary:)
   end
 
-  let :rules_data do
-    attributes_for_list :rules_of_origin_rule,
-                        1,
-                        rule: "Manufacture\n\n* From materials"
-  end
-
-  let(:schemes) do
-    build_list :rules_of_origin_scheme, 1, rules: rules_data, fta_intro:
-  end
-
+  let(:rules) { attributes_for_list :rules_of_origin_rule, 1, rule: "Manufacture\n\n* From materials" }
+  let(:rules_of_origin_schemes) { [build(:rules_of_origin_scheme, rules:, fta_intro:)] }
   let(:fta_intro) { "## Free Trade Agreement\n\nDetails of agreement" }
-
-  let(:preferential_tariff_duty) { nil }
-  let(:preferential_quota_duty) { nil }
+  let(:import_trade_summary) { attributes_for(:import_trade_summary) }
 
   it 'includes the countries name in the title' do
     expect(rendered_page).to \
@@ -44,16 +34,12 @@ RSpec.describe 'rules_of_origin/_tab', type: :view do
     expect(rendered_page).to have_css '#rules-of-origin__intro--bloc-scheme'
   end
 
-  context 'with matched rules of origin' do
-    let(:first_rule) { schemes[0].rules[0] }
-
-    it 'includes the non-preferential bloc' do
-      expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
-    end
+  it 'includes the non-preferential bloc' do
+    expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
   end
 
   context 'without matched rules' do
-    let(:rules_data) { [] }
+    let(:rules) { [] }
 
     it 'does not shows rules table' do
       expect(rendered_page).not_to have_css 'table.govuk-table'
@@ -65,15 +51,13 @@ RSpec.describe 'rules_of_origin/_tab', type: :view do
   end
 
   context 'with country specific scheme' do
-    let(:schemes) do
-      build_list :rules_of_origin_scheme, 1, rules: rules_data, countries: %w[FR]
-    end
+    let(:rules_of_origin_schemes) { build_list :rules_of_origin_scheme, 1, rules:, countries: %w[FR] }
 
     it { is_expected.to have_css '#rules-of-origin__intro--country-scheme' }
   end
 
   context 'with no scheme' do
-    let(:schemes) { [] }
+    let(:rules_of_origin_schemes) { [] }
 
     it { is_expected.to have_css '#rules-of-origin__intro--no-scheme' }
     it { is_expected.not_to have_css '.rules-of-origin__scheme' }
@@ -84,8 +68,8 @@ RSpec.describe 'rules_of_origin/_tab', type: :view do
   end
 
   context 'with multiple schemes' do
-    let(:schemes) do
-      build_list :rules_of_origin_scheme, 3, rules: rules_data,
+    let(:rules_of_origin_schemes) do
+      build_list :rules_of_origin_scheme, 3, rules:,
                                              fta_intro:
     end
 
@@ -104,18 +88,20 @@ RSpec.describe 'rules_of_origin/_tab', type: :view do
 
   describe 'import trade summary duty box' do
     context 'when preferential tariff duty is present' do
-      let(:preferential_tariff_duty) { '1.00 %' }
+      let(:import_trade_summary) { attributes_for(:import_trade_summary, preferential_tariff_duty: '1.00 %') }
 
       it { expect(rendered_page).to have_css '.preferential-tariff-duty' }
     end
 
     context 'when preferential quota duty is present' do
-      let(:preferential_quota_duty) { '1.00 %' }
+      let(:import_trade_summary) { attributes_for(:import_trade_summary, preferential_quota_duty: '1.00 %') }
 
       it { expect(rendered_page).to have_css '.preferential-quota-duty' }
     end
 
     context 'when both preferential duties are missing' do
+      let(:import_trade_summary) { attributes_for(:import_trade_summary) }
+
       it { expect(rendered_page).not_to have_css '.preferential-tariff-duty' }
       it { expect(rendered_page).not_to have_css '.preferential-quota-duty' }
 

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe 'rules_of_origin/_tab', type: :view do
            country_name: 'France',
            commodity_code: '2203000100',
            rules_of_origin_schemes: schemes,
-           import_trade_summary: build(:import_trade_summary,
-                                       preferential_tariff_duty:,
-                                       preferential_quota_duty:)
+           declarable: build(:commodity, :with_import_trade_summary, preferential_tariff_duty:, preferential_quota_duty:)
   end
 
   let :rules_data do

--- a/spec/views/rules_of_origin/_wizard_link.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_wizard_link.html.erb_spec.rb
@@ -3,19 +3,32 @@ require 'spec_helper'
 RSpec.describe 'rules_of_origin/wizard_link', type: :view do
   subject { render_page && rendered }
 
-  let :render_page do
-    render 'rules_of_origin/wizard_link', country_code: 'JP',
-                                          commodity_code: '1234567890',
-                                          import_trade_summary: build(:import_trade_summary)
+  context 'when the import trade summary has a non-zero mfn duty' do
+    let :render_page do
+      render 'rules_of_origin/wizard_link', country_code: 'JP',
+                                            commodity_code: '1234567890',
+                                            declarable: build(:commodity, :with_import_trade_summary)
+    end
+
+    let(:step) { RulesOfOrigin::Wizard.steps.first }
+    let(:prefix) { step.model_name.singular }
+
+    it { is_expected.to have_css 'h3' }
+    it { is_expected.to have_css 'p', text: /trade fulfils/ }
+    it { is_expected.to have_css %(form[action="#{rules_of_origin_step_path('1234567890', 'JP', step.key)}"]) }
+    it { is_expected.to have_css %(form input[name="#{prefix}[commodity_code]"][value="1234567890"]) }
+    it { is_expected.to have_css %(form input[name="#{prefix}[country_code]"][value="JP"]) }
+    it { is_expected.to have_css %(form input[name="#{prefix}[service]"][value="uk"]) }
+    it { is_expected.not_to have_css 'div p', text: /As the third country duty is zero/ }
   end
 
-  let(:step) { RulesOfOrigin::Wizard.steps.first }
-  let(:prefix) { step.model_name.singular }
+  context 'when the import trade summary has preferential duties and the declarable has a zero mfn duty' do
+    let :render_page do
+      render 'rules_of_origin/wizard_link', country_code: 'JP',
+                                            commodity_code: '1234567890',
+                                            declarable: build(:commodity, :with_import_trade_summary, zero_mfn_duty: true)
+    end
 
-  it { is_expected.to have_css 'h3' }
-  it { is_expected.to have_css 'p', text: /trade fulfils/ }
-  it { is_expected.to have_css %(form[action="#{rules_of_origin_step_path('1234567890', 'JP', step.key)}"]) }
-  it { is_expected.to have_css %(form input[name="#{prefix}[commodity_code]"][value="1234567890"]) }
-  it { is_expected.to have_css %(form input[name="#{prefix}[country_code]"][value="JP"]) }
-  it { is_expected.to have_css %(form input[name="#{prefix}[service]"][value="uk"]) }
+    it { is_expected.to have_css 'div p', text: /As the third country duty is zero/ }
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2023

### What?

I have added/removed/altered:

- [x] Support asking declarable whether zero mfn
- [x] Pass declarable to roo tab
- [x] Updates passing declarable to roo tabs
- [x] Support zero mfn on commodity factory
- [x] Fix bug in wizard link partial
- [x] Adds coverage for changes

### Why?

I am doing this because:

- This is required to make sure the correct message displays on the production legacy roo tab
