### PR TITLE
HOTT-2020 Updated quota definitions dialog

### DIFF
--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -1,10 +1,10 @@
 <%= link_to order_number.number, "##{order_number.id}", class: 'reference numerical', title: 'Opens in a popup', 'data-popup-ref' => "#{order_number.id}" %>&nbsp;
 
-<div class='popup govuk-visually-hidden' data-popup='<%= order_number.id %>'>
+<div class="popup govuk-visually-hidden" data-popup="<%= order_number.id %>">
   <article>
     <% if order_number.definition.present? %>
       <table class="govuk-table govuk-table-m">
-        <h2 class="govuk-heading-m"><%= "Quota #{order_number.number}"%></h2>
+        <h2 class="govuk-heading-m">Quota order number <%= order_number.number %></h2>
 
         <% if order_number.show_warning? %>
           <div class="govuk-warning-text">
@@ -17,16 +17,29 @@
         <% end %>
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
-            <th scope="col" class='govuk-table__header'>Quota order number</th>
-            <td class="numerical govuk-table__cell numerical"><%= order_number.number %></td>
-          </tr>
-          <tr class="govuk-table__row">
-            <th scope="col" class='govuk-table__header'>Current balance</th>
-            <td class="numerical govuk-table__cell numerical"><%= "#{quota_definition.balance} #{quota_definition.measurement_unit}" %></td>
+            <th scope="col" class='govuk-table__header'>
+              Balance
+              <span class="govuk-!-font-weight-regular">
+                (as of <%= @search.date.to_formatted_s :short %>)
+              </div>
+            </th>
+            <td class="numerical govuk-table__cell numerical">
+              <%= number_with_precision quota_definition.balance, precision: 3, delimiter: ',' %>
+              <%= quota_definition.measurement_unit %>
+              <% unless @search.date.today? %>
+                <br />
+                <%= link_to url_for(day: Date.today.day, month: Date.today.month, year: Date.today.year, anchor: order_number.id) do %>
+                  View balance for <%= Date.today.to_formatted_s :short %>
+                <% end %>
+              <% end %>
+            </td>
           </tr>
           <tr class="govuk-table__row">
             <th scope="col" class='govuk-table__header'>Opening balance</th>
-            <td class="numerical govuk-table__cell numerical"><%= "#{quota_definition.initial_volume} #{quota_definition.measurement_unit}" %></td>
+            <td class="numerical govuk-table__cell numerical">
+              <%= number_with_precision quota_definition.initial_volume, precision: 3, delimiter: ',' %>
+              <%= quota_definition.measurement_unit %>
+            </td>
           </tr>
           <tr class="govuk-table__row">
             <th scope="col" class='govuk-table__header'>Status</th>

--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -448,14 +448,23 @@
                       that.open($(this));
                       return false;
                   });
-
-                  if ($linkElm.attr("href") === hash) {
-                      tabId = $linkElm.closest(".tab-pane").attr("id");
-                      tabId = tabId.replace(/(\w+)-enhanced/, "tab-$1");
-                      $('#' + tabId + ' a').trigger('click');
-                      that.open($(linkElm));
-                  }
               });
+
+              if (window.location.hash.length > 0) {
+                var anchor = window.location.hash.split('#')[1] ;
+
+                var popupLink = context.querySelector('a[data-popup-ref="' + anchor + '"]') ;
+                if (popupLink) {
+                  // switch to tab which contains the link
+                  var containingTabId = $(popupLink).parents('.govuk-tabs__panel').attr('id') ;
+                  if (containingTabId) {
+                    $('.govuk-tabs__list-item a[href="' + containingTabId  + '"]').trigger('click') ;
+                  }
+
+                  // click link for popup
+                  $(popupLink).trigger('click');
+                }
+              }
           }
       },
       /**


### PR DESCRIPTION
### Jira link

HOTT-2020

### What?

I have added/removed/altered:

- [x] Format balances to 3 decimal places with comma separators
- [x] Show the day the balance is for
- [x] Added link for todays balance when not viewing todays
- [x] Removed duplicate order number row from table
- [x] Fixed JS errors on page load
- [x] Enabled showing pop ups automatically if they are included in the anchor

### Why?

I am doing this because:

- The larger balances can be hard to read
- It is not clear which days balance a user is viewing
- Making it easier to view todays balance if the user is viewing another days
- Our javascript initializers were failing, preventing other JS enhancements from working
- If loading a page with an anchor for a pop up we expect the popup to show automatically

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None

### Screenshot

![Screenshot from 2022-09-22 16-54-57](https://user-images.githubusercontent.com/10818/191794871-8c2af68f-e472-4fcf-80c7-5afeac0bc5a5.png)

