### PR TITLE
HOTT-2018 change presentation of blocking periods

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -130,10 +130,7 @@ module ApplicationHelper
   end
 
   def govuk_date_range(from, to)
-    from = from.to_date if from.respond_to?(:to_date)
-    to = to.to_date if to.respond_to?(:to_date)
-
-    "#{from.to_formatted_s(:long)} to #{to.to_formatted_s(:long)}"
+    "#{from.to_date.to_formatted_s(:long)} to #{to.to_date.to_formatted_s(:long)}"
   end
 
   def paragraph_if_content(content)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -129,6 +129,13 @@ module ApplicationHelper
     end
   end
 
+  def govuk_date_range(from, to)
+    from = from.to_date if from.respond_to?(:to_date)
+    to = to.to_date if to.respond_to?(:to_date)
+
+    "#{from.to_formatted_s(:long)} to #{to.to_formatted_s(:long)}"
+  end
+
   def paragraph_if_content(content)
     tag.p(content) if content.present?
   end

--- a/app/helpers/quota_definition_helper.rb
+++ b/app/helpers/quota_definition_helper.rb
@@ -1,30 +1,5 @@
 module QuotaDefinitionHelper
   def start_and_end_dates_for(definition)
-    start_date = definition.validity_start_date
-    end_date = definition.validity_end_date
-
-    "#{start_date.to_formatted_s(:gov)} to #{end_date.to_formatted_s(:gov)}"
-  end
-
-  def suspension_period_dates_for(definition)
-    if definition.suspension_period_start_date.present? && definition.suspension_period_end_date.present?
-      start_date = definition.suspension_period_start_date
-      end_date = definition.suspension_period_end_date
-
-      "#{start_date.to_formatted_s(:gov)} to #{end_date.to_formatted_s(:gov)}"
-    else
-      'n/a'
-    end
-  end
-
-  def blocking_period_dates_for(definition)
-    if definition.blocking_period_start_date.present? && definition.blocking_period_end_date.present?
-      start_date = definition.blocking_period_start_date
-      end_date = definition.blocking_period_end_date
-
-      "#{start_date.to_formatted_s(:gov)} to #{end_date.to_formatted_s(:gov)}"
-    else
-      'n/a'
-    end
+    govuk_date_range definition.validity_start_date, definition.validity_end_date
   end
 end

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -52,5 +52,13 @@ class OrderNumber
     def geographical_areas
       order_number&.geographical_areas.presence || measures&.map(&:geographical_area) || []
     end
+
+    def suspension_period?
+      suspension_period_start_date.present? && suspension_period_end_date.present?
+    end
+
+    def blocking_period?
+      blocking_period_start_date.present? && blocking_period_end_date.present?
+    end
   end
 end

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -53,14 +53,33 @@
             <th scope="col" class='govuk-table__header'>Last allocation date</th>
             <td class="numerical govuk-table__cell numerical"><%= quota_definition.last_allocation_date.to_formatted_s(:gov) || 'n/a' %></td>
           </tr>
-          <tr class="govuk-table__row">
-            <th scope="col" class='govuk-table__header'>Suspension period</th>
-            <td class="numerical govuk-table__cell numerical"><%= suspension_period_dates_for(quota_definition) %></td>
-          </tr>
-          <tr class="govuk-table__row">
-            <th scope="col" class='govuk-table__header'>Blocking period</th>
-            <td class="numerical govuk-table__cell numerical"><%= blocking_period_dates_for(quota_definition) %></td>
-          </tr>
+
+          <% if quota_definition.suspension_period? %>
+            <tr class="govuk-table__row">
+              <th scope="col" class='govuk-table__header'>Suspension period</th>
+              <td class="numerical govuk-table__cell numerical">
+                <%= govuk_date_range quota_definition.suspension_period_start_date,
+                                     quota_definition.suspension_period_end_date %>
+              </td>
+            </tr>
+          <% end %>
+
+          <% if quota_definition.blocking_period? %>
+            <tr class="govuk-table__row">
+              <th scope="col" class='govuk-table__header'>Blocking period</th>
+              <td class="numerical govuk-table__cell numerical">
+                <%= govuk_date_range quota_definition.blocking_period_start_date,
+                                     quota_definition.blocking_period_end_date %>
+              </td>
+            </tr>
+          <% end %>
+
+          <% unless quota_definition.suspension_period? || quota_definition.blocking_period? %>
+            <tr class="govuk-table__row">
+              <th scope="col" class='govuk-table__header'>Suspension / blocking periods</th>
+              <td class="numerical govuk-table__cell numerical">n/a</td>
+            </tr>
+          <% end %>
         </tbody>
       </table>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -309,6 +309,41 @@ RSpec.describe ApplicationHelper, type: :helper do
     it_behaves_like 'a from to expression', nil, nil, nil
   end
 
+  describe '#govuk_date_range' do
+    let(:from) { Date.parse('2022-01-01') }
+    let(:to) { Date.parse('2022-06-01') }
+
+    context 'with TimeWithZone' do
+      subject { govuk_date_range from.in_time_zone, to.in_time_zone }
+
+      it { is_expected.to eql '1 January 2022 to 1 June 2022' }
+    end
+
+    context 'with String Dates' do
+      subject { govuk_date_range from.to_s, to.to_s }
+
+      it { is_expected.to eql '1 January 2022 to 1 June 2022' }
+    end
+
+    context 'with String Dates with Times' do
+      subject { govuk_date_range "#{from} 01:01:00", "#{to} 01:02:00" }
+
+      it { is_expected.to eql '1 January 2022 to 1 June 2022' }
+    end
+
+    context 'with XML Time Strings' do
+      subject { govuk_date_range from.xmlschema, to.xmlschema }
+
+      it { is_expected.to eql '1 January 2022 to 1 June 2022' }
+    end
+
+    context 'with Dates' do
+      subject { govuk_date_range from, to }
+
+      it { is_expected.to eql '1 January 2022 to 1 June 2022' }
+    end
+  end
+
   describe '#paragraph_if_content' do
     subject { paragraph_if_content content }
 

--- a/spec/helpers/quota_definition_helper_spec.rb
+++ b/spec/helpers/quota_definition_helper_spec.rb
@@ -8,36 +8,4 @@ RSpec.describe QuotaDefinitionHelper, type: :helper do
       expect(helper.start_and_end_dates_for(definition)).to eq('1 January 2021 to 31 December 2021')
     end
   end
-
-  describe '#supension_period_dates_for' do
-    let(:definition) { build(:definition) }
-
-    it 'returns n/a' do
-      expect(helper.suspension_period_dates_for(definition)).to eq('n/a')
-    end
-
-    context 'when the suspension period dates are defined' do
-      let(:definition) { build(:definition, suspension_period_start_date: '2021-01-01T00:00:00.000Z', suspension_period_end_date: '2021-12-31T00:00:00.000Z') }
-
-      it 'returns a properly formatted from and to date' do
-        expect(helper.suspension_period_dates_for(definition)).to eq('1 January 2021 to 31 December 2021')
-      end
-    end
-  end
-
-  describe '#blocking_period_dates_for' do
-    let(:definition) { build(:definition) }
-
-    it 'returns n/a' do
-      expect(helper.blocking_period_dates_for(definition)).to eq('n/a')
-    end
-
-    context 'when the suspension period dates are defined' do
-      let(:definition) { build(:definition, blocking_period_start_date: '2021-01-01T00:00:00.000Z', blocking_period_end_date: '2021-12-31T00:00:00.000Z') }
-
-      it 'returns a properly formatted from and to date' do
-        expect(helper.blocking_period_dates_for(definition)).to eq('1 January 2021 to 31 December 2021')
-      end
-    end
-  end
 end

--- a/spec/models/order_number/definition_spec.rb
+++ b/spec/models/order_number/definition_spec.rb
@@ -38,4 +38,84 @@ RSpec.describe OrderNumber::Definition do
   it_behaves_like 'an entity that has goods nomenclatures' do
     let(:entity) { build(:definition, measures:) }
   end
+
+  describe 'suspension_period?' do
+    subject { order_definition.suspension_period? }
+
+    context 'with start and end dates' do
+      let :order_definition do
+        build :definition, suspension_period_start_date: Date.yesterday.xmlschema,
+                           suspension_period_end_date: Date.tomorrow.xmlschema
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'with only start date' do
+      let :order_definition do
+        build :definition, suspension_period_start_date: Date.yesterday.xmlschema,
+                           suspension_period_end_date: nil
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'with only end date' do
+      let :order_definition do
+        build :definition, suspension_period_start_date: nil,
+                           suspension_period_end_date: Date.tomorrow.xmlschema
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'with no start or end dates' do
+      let :order_definition do
+        build :definition, suspension_period_start_date: nil,
+                           suspension_period_end_date: nil
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe 'blocking_period?' do
+    subject { definition.blocking_period? }
+
+    context 'with start and end dates' do
+      let :definition do
+        build :definition, blocking_period_start_date: Date.yesterday.xmlschema,
+                           blocking_period_end_date: Date.tomorrow.xmlschema
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'with only start date' do
+      let :definition do
+        build :definition, blocking_period_start_date: Date.yesterday.xmlschema,
+                           blocking_period_end_date: nil
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'with only end date' do
+      let :definition do
+        build :definition, blocking_period_start_date: nil,
+                           blocking_period_end_date: Date.tomorrow.xmlschema
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'with no start or end dates' do
+      let :definition do
+        build :definition, blocking_period_start_date: nil,
+                           blocking_period_end_date: nil
+      end
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/views/shared/_quota_definition.html.erb_spec.rb
+++ b/spec/views/shared/_quota_definition.html.erb_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe 'shared/_quota_definition', type: :view do
+  subject(:rendered_page) { render_page && rendered }
+
+  before { assign :search, Search.new }
+
+  let :render_page do
+    render 'shared/quota_definition', order_number:, quota_definition:
+  end
+
+  let(:quota_definition) { build :definition }
+  let(:order_number) { quota_definition.order_number }
+
+  it { is_expected.to have_css 'table h2', text: /Quota order number \d+/ }
+
+  context 'with no suspension or blocking periods' do
+    it { is_expected.to have_css 'th', text: 'Suspension / blocking periods' }
+  end
+
+  context 'with only suspension period' do
+    let :quota_definition do
+      build :definition, suspension_period_start_date: Date.yesterday.xmlschema,
+                         suspension_period_end_date: Date.tomorrow.xmlschema
+    end
+
+    it { is_expected.to have_css 'th', text: 'Suspension period' }
+    it { is_expected.not_to have_css 'th', text: 'Blocking period' }
+  end
+
+  context 'with only blocking period' do
+    let :quota_definition do
+      build :definition, blocking_period_start_date: Date.yesterday.xmlschema,
+                         blocking_period_end_date: Date.tomorrow.xmlschema
+    end
+
+    it { is_expected.to have_css 'th', text: 'Blocking period' }
+    it { is_expected.not_to have_css 'th', text: 'Suspension period' }
+  end
+
+  context 'with both blocking and suspension periods' do
+    let :quota_definition do
+      build :definition, suspension_period_start_date: Date.yesterday.xmlschema,
+                         suspension_period_end_date: Date.tomorrow.xmlschema,
+                         blocking_period_start_date: Date.yesterday.xmlschema,
+                         blocking_period_end_date: Date.tomorrow.xmlschema
+    end
+
+    it { is_expected.to have_css 'th', text: 'Suspension period' }
+    it { is_expected.to have_css 'th', text: 'Blocking period' }
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-2018

### What?

I have added/removed/altered:

- [x] Show a combined row 'n/a' row when there are neither blocking nor suspension periods
- [x] Otherwise show only the applicable blocking suspension periods rows
- [x] Added a generalised helper for display of date ranges to replace the quota period specific ones
- [x] Added a view spec to test the quota definition overlay with different data scenarios

### Why?

I am doing this because:

- It simplifies the page for users
- We no longer required the suspension and blocking period specific helpers
- The view spec ensures the page renders with different data scenarios

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Screenshots

![Screenshot from 2022-09-23 11-33-24](https://user-images.githubusercontent.com/10818/191943099-7f5e9b99-2aa6-4677-8dbf-3ede99cbf76c.png)
![Screenshot from 2022-09-23 11-32-59](https://user-images.githubusercontent.com/10818/191943102-600f83de-bdf3-48c9-afb2-73ca925175f7.png)
![Screenshot from 2022-09-23 11-32-36](https://user-images.githubusercontent.com/10818/191943104-aaffa08f-244a-4fc3-845b-0e73f1925b2c.png)
![Screenshot from 2022-09-23 10-45-09](https://user-images.githubusercontent.com/10818/191943109-d0bfdbbe-49c0-4f32-b8a2-af9ed6e2f9ee.png)

