### PR TITLE
HOTT-2002: Added guides to search results

### DIFF
--- a/app/helpers/image_guides_helper.rb
+++ b/app/helpers/image_guides_helper.rb
@@ -1,6 +1,6 @@
 module ImageGuidesHelper
   def image_for_guide(guide_name, **kwargs)
-    guide_filename = "#{guide_name.downcase}.png"
+    guide_filename = guide_name.downcase
 
     image_pack_tag "guides/#{guide_filename}", **kwargs.merge(class: 'image-guide')
   rescue Webpacker::Manifest::MissingEntryError

--- a/app/models/beta/search/guide.rb
+++ b/app/models/beta/search/guide.rb
@@ -7,7 +7,8 @@ module Beta
 
       attr_accessor :title,
                     :url,
-                    :strapline
+                    :strapline,
+                    :image
     end
   end
 end

--- a/app/views/beta/search_results/_sidebar.html.erb
+++ b/app/views/beta/search_results/_sidebar.html.erb
@@ -35,6 +35,6 @@
 
     <% end %>
 
-    <%= render "search/guide_section", guide: guide if guide %>
+    <%= render "search/guide_section", guide: guide if guide.present? %>
   </nav>
 </div>

--- a/app/views/beta/search_results/_sidebar.html.erb
+++ b/app/views/beta/search_results/_sidebar.html.erb
@@ -34,5 +34,7 @@
       </div>
 
     <% end %>
+
+    <%= render "search/guide_section", guide: guide if guide %>
   </nav>
 </div>

--- a/app/views/beta/search_results/show.html.erb
+++ b/app/views/beta/search_results/show.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-row">
     <% if @search_result.facet_filter_statistics.any? %>
       <div class="govuk-grid-column-one-third">
-        <%= render 'sidebar'  %>
+        <%= render 'sidebar', guide: @search_result.guide %>
       </div>
       <div class="govuk-grid-column-two-thirds">
         <% if @search_result.multiple_headings_view? %>

--- a/app/views/search/_guide_section.html.erb
+++ b/app/views/search/_guide_section.html.erb
@@ -1,13 +1,13 @@
 <div class="guide xgovuk-visually-hidden">
   <div>
-    <%= image_for_guide('vegetables') %>
+    <%= image_for_guide(guide.image) %>
   </div>
   <div>
     <span class="govuk-caption-m">Classification guide</span>
-    <h2 class="govuk-heading-m"><%= @guide.title %></h2>
-    <p class="govuk-body-s"><%= @guide.strapline %></p>
+    <h2 class="govuk-heading-m"><%= guide.title %></h2>
+    <p class="govuk-body-s"><%= guide.strapline %></p>
     <p class="govuk-body-s">
-      <%= link_to("View classification guide for #{@guide.title} (opens in new tab)", @guide.url, target: "_blank") %>
+      <%= link_to("View classification guide for #{guide.title} (opens in new tab)", guide.url, target: "_blank") %>
     </p>
   </div>
 </div>

--- a/spec/factories/guide_factory.rb
+++ b/spec/factories/guide_factory.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     title { 'Herbal medicines' }
     url { 'Get help to classify herbal medicines' }
     strapline { 'This is the guide for Herbal medicines' }
-    image { 'medicines.png'}
+    image { 'medicines.png' }
   end
 end

--- a/spec/factories/guide_factory.rb
+++ b/spec/factories/guide_factory.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { 'Herbal medicines' }
     url { 'Get help to classify herbal medicines' }
     strapline { 'This is the guide for Herbal medicines' }
+    image { 'medicines.png'}
   end
 end

--- a/spec/helpers/image_guides_helper_spec.rb
+++ b/spec/helpers/image_guides_helper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ImageGuidesHelper, type: :helper do
     before { allow(Sentry).to receive(:capture_message).and_return(true) }
 
     context 'when image for the guides does exist' do
-      subject(:rendered) { helper.image_for_guide('audio') }
+      subject(:rendered) { helper.image_for_guide('audio.png') }
 
       it 'includes the relevant image' do
         expect(rendered).to \
@@ -14,7 +14,7 @@ RSpec.describe ImageGuidesHelper, type: :helper do
     end
 
     context 'with alt text' do
-      subject(:rendered) { helper.image_for_guide('audio', alt: 'alt text') }
+      subject(:rendered) { helper.image_for_guide('audio.png', alt: 'alt text') }
 
       it 'includes the alt text' do
         expect(rendered).to have_css('img.image-guide[alt="alt text"]')

--- a/spec/models/beta/search/guide_spec.rb
+++ b/spec/models/beta/search/guide_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Beta::Search::Guide do
   it {
     expect(guide).to have_attributes(title: 'Herbal medicines',
                                      url: 'Get help to classify herbal medicines',
-                                     strapline: 'This is the guide for Herbal medicines')
+                                     strapline: 'This is the guide for Herbal medicines',
+                                     image: 'medicines.png')
   }
 end

--- a/spec/views/beta/search_results/show.html.erb_spec.rb
+++ b/spec/views/beta/search_results/show.html.erb_spec.rb
@@ -25,4 +25,20 @@ RSpec.describe 'beta/search_results/show', type: :view do
     it { is_expected.to render_template('beta/search_results/_search_results') }
     it { is_expected.not_to render_template('beta/search_results/_sidebar') }
   end
+
+  context 'when guide exists' do
+    let(:search_result) { build(:search_result) }
+
+    it { is_expected.to render_template('search/_guide_section') }
+
+    context "when guide doesn't exist" do
+      let(:search_result) { build(:search_result) }
+
+      before do
+        search_result.guide = nil
+      end
+
+      it { is_expected.not_to render_template('search/_guide_section') }
+    end
+  end
 end

--- a/spec/views/beta/search_results/show.html.erb_spec.rb
+++ b/spec/views/beta/search_results/show.html.erb_spec.rb
@@ -30,15 +30,15 @@ RSpec.describe 'beta/search_results/show', type: :view do
     let(:search_result) { build(:search_result) }
 
     it { is_expected.to render_template('search/_guide_section') }
+  end
 
-    context "when guide doesn't exist" do
-      let(:search_result) { build(:search_result) }
+  context "when guide doesn't exist" do
+    let(:search_result) { build(:search_result) }
 
-      before do
-        search_result.guide = nil
-      end
-
-      it { is_expected.not_to render_template('search/_guide_section') }
+    before do
+      search_result.guide = nil
     end
+
+    it { is_expected.not_to render_template('search/_guide_section') }
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-<2002>](https://transformuk.atlassian.net/browse/HOTT-2002)

### What?

I have added/removed/altered:

- [ ] Added guides to search results

### Why?

I am doing this because:

- this allows us to display useful information to users alongside search results

### Have you? (optional)
- [ ] Validated mobile responsive behaviour of view changes

<img width="606" alt="Screenshot 2022-09-26 at 14 08 45" src="https://user-images.githubusercontent.com/12201130/192284733-3e74bbc0-c5f2-49ee-8b0c-06b5ad8c15d8.png">
