### PR TITLE
HOTT-2066 Show unknown quota dialog

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -39,15 +39,7 @@ class SearchController < ApplicationController
   def quota_search
     render_404 if TradeTariffFrontend::ServiceChooser.xi?
 
-    form = QuotaSearchForm.new(params.permit(:order_number,
-                                             :goods_nomenclature_item_id,
-                                             :geographical_area_id,
-                                             :day,
-                                             :month,
-                                             :year,
-                                             :critical,
-                                             :status,
-                                             :page))
+    form = QuotaSearchForm.new(params.permit(*QuotaSearchForm::PERMITTED_PARAMS))
     @result = QuotaSearchPresenter.new(form)
 
     respond_to do |format|

--- a/app/forms/quota_search_form.rb
+++ b/app/forms/quota_search_form.rb
@@ -6,6 +6,16 @@ class QuotaSearchForm
                    ['Not exhausted', 'not_exhausted']].freeze
   OPTIONAL_PARAMS = %i[@year @month @day @page].freeze
 
+  PERMITTED_PARAMS = %i[order_number
+                        goods_nomenclature_item_id
+                        geographical_area_id
+                        day
+                        month
+                        year
+                        critical
+                        status
+                        page].freeze
+
   attr_accessor :goods_nomenclature_item_id, :geographical_area_id, :order_number,
                 :critical, :status
   attr_writer   :page, :day, :month, :year

--- a/app/views/measures/grouped/_uk.html.erb
+++ b/app/views/measures/grouped/_uk.html.erb
@@ -26,6 +26,7 @@
 <% end %>
 
 <!-- QUOTAS -->
+<%= render 'shared/unknown_quota_definition' %>
 <% if uk_import_measures.quotas.present? %>
   <%= render partial: 'measures/grouped/table', locals: {
     caption: 'Quotas',

--- a/app/views/search/quota_search.html.erb
+++ b/app/views/search/quota_search.html.erb
@@ -11,6 +11,8 @@
 
 <%= render partial: 'search/quotas/form', locals: { search_form: @result.search_form } %>
 <% if @result.search_result&.any? %>
+  <%= render 'shared/unknown_quota_definition' %>
+
   <article class="search-results">
     <table class="govuk-table govuk-table govuk-table--responsive">
       <caption class="govuk-table__caption">

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -28,10 +28,11 @@
               <%= quota_definition.measurement_unit %>
               <% unless @search.date.today? %>
                 <br />
-                <%= link_to params.deep_dup.permit!.merge(day: Date.today.day,
-                                                          month: Date.today.month,
-                                                          year: Date.today.year,
-                                                          anchor: "order-number-#{order_number.number}") do %>
+                <%= link_to params.permit(QuotaSearchForm::PERMITTED_PARAMS)
+                                  .merge(day: Date.today.day,
+                                         month: Date.today.month,
+                                         year: Date.today.year,
+                                         anchor: "order-number-#{order_number.number}") do %>
                   View balance for <%= Date.today.to_formatted_s :short %>
                 <% end %>
               <% end %>

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -1,6 +1,6 @@
-<%= link_to order_number.number, "##{order_number.id}", class: 'reference numerical', title: 'Opens in a popup', 'data-popup-ref' => "#{order_number.id}" %>&nbsp;
+<%= link_to order_number.number, "#order-number-#{order_number.number}", class: 'reference numerical', title: 'Opens in a popup', 'data-popup-ref' => "order-number-#{order_number.number}" %>&nbsp;
 
-<div class="popup govuk-visually-hidden" data-popup="<%= order_number.id %>">
+<div class="popup govuk-visually-hidden" data-popup="order-number-<%= order_number.number %>">
   <article>
     <% if order_number.definition.present? %>
       <table class="govuk-table govuk-table-m">
@@ -28,7 +28,10 @@
               <%= quota_definition.measurement_unit %>
               <% unless @search.date.today? %>
                 <br />
-                <%= link_to url_for(day: Date.today.day, month: Date.today.month, year: Date.today.year, anchor: order_number.id) do %>
+                <%= link_to params.deep_dup.permit!.merge(day: Date.today.day,
+                                                          month: Date.today.month,
+                                                          year: Date.today.year,
+                                                          anchor: "order-number-#{order_number.number}") do %>
                   View balance for <%= Date.today.to_formatted_s :short %>
                 <% end %>
               <% end %>

--- a/app/views/shared/_unknown_quota_definition.html.erb
+++ b/app/views/shared/_unknown_quota_definition.html.erb
@@ -1,0 +1,17 @@
+<%= link_to 'Unknown quota definition', '#unknown-quota-definition',
+            class: 'reference numerical govuk-visually-hidden',
+            style: 'display: none',
+            title: 'Opens in a popup',
+            data: { popup_ref: "unknown-quota-definition" } %>
+
+<div class="popup govuk-visually-hidden" data-popup="unknown-quota-definition">
+  <article>
+    <h2 class="govuk-heading-m">
+      Quota order number <span class="unknown-quota-order-number"></span>
+    </h2>
+
+    <p>
+      This quota is not available on the selected date.
+    </p>
+  </article>
+</div>

--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -463,6 +463,14 @@
 
                   // click link for popup
                   $(popupLink).trigger('click');
+                } else {
+                  var matches = anchor.match(/^\d+-order-number-(\d+)$/) ;
+                  var unknownOrderPopupLink = $('a[data-popup-ref="unknown-quota-definition"]');
+
+                  if (matches && unknownOrderPopupLink.length > 0) {
+                    $('div[data-popup="unknown-quota-definition"] .unknown-quota-order-number').text(matches[1]);
+                    that.open(unknownOrderPopupLink) ;
+                  }
                 }
               }
           }

--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -464,7 +464,7 @@
                   // click link for popup
                   $(popupLink).trigger('click');
                 } else {
-                  var matches = anchor.match(/^\d+-order-number-(\d+)$/) ;
+                  var matches = anchor.match(/^order-number-(\d+)$/) ;
                   var unknownOrderPopupLink = $('a[data-popup-ref="unknown-quota-definition"]');
 
                   if (matches && unknownOrderPopupLink.length > 0) {


### PR DESCRIPTION
### Jira link

HOTT-2066

### What?

I have added/removed/altered:

- [x] Show an unknown quota dialog if the page anchor references an unknown quota
- [x] Changed the popup identifier to only include the quota order number

### Why?

I am doing this because:

- When viewing a historical quota, which is no longer available and choosing the 'view for [todays date]' link it would previously just not show anything
- Including the Quota Definition id in the pop ups identifier meant that a popup for a newer definition matching the same order number would not be opened automatically. There can only be one definition for an order number at any one time so the inclusion of the definition id was both extraneous and problematic.

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None
