### PR TITLE
HOTT-2092: Expose the preference_codes API v2.

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -52,6 +52,7 @@ module TradeTariffFrontend
       measure_condition_codes
       measure_actions
       quota_order_numbers
+      preference_codes
       healthcheck
     ]
   end


### PR DESCRIPTION
### Jira link

### What?
Expose the preference_codes API v2.

### Why?
It's not possible to access the preference_codes API.
