### PR TITLE
HOTT-2093 Show HTML in description

### DIFF
--- a/app/views/search/certificate_search.html.erb
+++ b/app/views/search/certificate_search.html.erb
@@ -30,7 +30,7 @@
             <strong>Description:</strong>
           </dt>
           <dd class="govuk-summary-list__value">
-            <%= certificate.formatted_description %>
+            <%= sanitize certificate.formatted_description %>
           </dd>
         </div>
       </dl>
@@ -87,7 +87,9 @@
                       <%= link_to(segmented_commodity_code(goods_nomenclature.goods_nomenclature_item_id), polymorphic_path(goods_nomenclature)) %>
                     </th>
 
-                    <td class="govuk-table__cell"><%= goods_nomenclature.formatted_description %></td>
+                    <td class="govuk-table__cell">
+                      <%= sanitize goods_nomenclature.formatted_description %>
+                    </td>
                   </tr>
                 <% end %>
               </tbody>


### PR DESCRIPTION
### Jira link

HOTT-2093

### What?

I have added/removed/altered:

- [x] Show html in `formatted_description` for goods nomenclature and certificate description

### Why?

I am doing this because:

- raw html was showing in the certificate search results

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None

### Before

![Screenshot from 2022-10-06 15-07-11](https://user-images.githubusercontent.com/10818/194334760-78c1711f-9e61-4ced-be31-b3ac1a44a193.png)

### After

![Screenshot from 2022-10-06 15-17-40](https://user-images.githubusercontent.com/10818/194337194-1da43b3d-94b1-4e09-9cac-546b3696fe11.png)

