### PR TITLE
HOTT-2017 show pending balance

### DIFF
--- a/app/controllers/pending_quota_balances_controller.rb
+++ b/app/controllers/pending_quota_balances_controller.rb
@@ -1,0 +1,7 @@
+class PendingQuotaBalancesController < ApplicationController
+  def show
+    pqb = PendingQuotaBalanceService.new(params[:commodity_id], params[:order_number], @search.date)
+
+    render json: pqb.call
+  end
+end

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -98,6 +98,10 @@ module Declarable
     code.gsub(/(00|0000)$/, '')
   end
 
+  def has_safeguard_measure?
+    import_measures.any?(&:safeguard?)
+  end
+
   private
 
   def supplementary_measures

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -32,6 +32,7 @@ class Measure
 
   delegate :erga_omnes?, to: :geographical_area
   delegate :amount, to: :duty_expression
+  delegate :supplementary?, :safeguard?, to: :measure_type
 
   class << self
     def grouped_measure_types
@@ -127,8 +128,6 @@ class Measure
   def quotas?
     grouped_measure_types[:quotas].include?(measure_type.id)
   end
-
-  delegate :supplementary?, to: :measure_type
 
   def import?
     import

--- a/app/models/measure_collection.rb
+++ b/app/models/measure_collection.rb
@@ -65,6 +65,10 @@ class MeasureCollection < SimpleDelegator
     new(select(&:supplementary?))
   end
 
+  def find_by_quota_order_number(number)
+    quotas.find { |m| m.order_number.number == number }
+  end
+
   private
 
   def tariff_preferences

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -5,6 +5,7 @@ class MeasureType
 
   SUPPLEMENTARY_MEASURE_TYPES = %w[109 110 111].freeze
   SUPPLEMENTARY_IMPORT_ONLY_MEASURE_TYPES = %w[110].freeze
+  SAFEGUARD_TYPES = %w[696].freeze
 
   enum :measure_component_applicable_code, {
     duties_permitted: [0],
@@ -29,6 +30,10 @@ class MeasureType
 
   def supplementary_unit_import_only?
     id.in?(SUPPLEMENTARY_IMPORT_ONLY_MEASURE_TYPES)
+  end
+
+  def safeguard?
+    SAFEGUARD_TYPES.include?(id)
   end
 
   private

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -64,5 +64,11 @@ class OrderNumber
     def within_first_twenty_days?
       Time.zone.now.between? validity_start_date, validity_start_date + 20.days
     end
+
+    def first_goods_nomenclature_short_code
+      all_goods_nomenclatures.select { |gn| gn.respond_to?(:short_code) }
+                             .first
+                             &.short_code
+    end
   end
 end

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -60,5 +60,9 @@ class OrderNumber
     def blocking_period?
       blocking_period_start_date.present? && blocking_period_end_date.present?
     end
+
+    def within_first_twenty_days?
+      Time.zone.now.between? validity_start_date, validity_start_date + 20.days
+    end
   end
 end

--- a/app/services/pending_quota_balance_service.rb
+++ b/app/services/pending_quota_balance_service.rb
@@ -1,0 +1,49 @@
+class PendingQuotaBalanceService
+  attr_reader :declarable_id, :quota_order_number_id, :chosen_period
+
+  def initialize(declarable_id, quota_order_number_id, chosen_period)
+    @declarable_id = declarable_id
+    @quota_order_number_id = quota_order_number_id
+    @chosen_period = chosen_period
+  end
+
+  def call
+    pending_balance
+  end
+
+private
+
+  def declarable
+    @declarable ||= Commodity.find(declarable_id, as_of: chosen_period) # FIXME
+  end
+
+  def quota_measure
+    declarable.import_measures.find_by_quota_order_number(quota_order_number_id)
+  end
+
+  def definition
+    @definition ||= quota_measure&.order_number&.definition
+  end
+
+  def previous_period_declarable
+    @previous_period_declarable ||= Commodity.find declarable_id, as_of: previous_period # FIXME
+  end
+
+  def previous_quota_measure
+    previous_period_declarable.import_measures.find_by_quota_order_number(quota_order_number_id)
+  end
+
+  def previous_period_definition
+    previous_quota_measure&.order_number&.definition
+  end
+
+  def pending_balance
+    if definition.within_first_twenty_days? && declarable.has_safeguard_measure?
+      previous_period_definition&.balance
+    end
+  end
+
+  def previous_period
+    (definition.validity_start_date - 1.day).to_date
+  end
+end

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -18,7 +18,10 @@
     <span class='table-line'><%= measure.measure_type.description %></span>
     <% if measure.order_number.present? %>
       <span class='table-line'>
-        <%= render partial: 'shared/quota_definition', locals: { order_number: measure.order_number, quota_definition: measure.order_number&.definition} %>
+        <%= render 'shared/quota_definition',
+                   order_number: measure.order_number,
+                   quota_definition: measure.order_number&.definition,
+                   declarable_id: declarable.goods_nomenclature_item_id %>
       </span>
     <% end %>
     <% if measure.additional_code.present? %>

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -21,7 +21,7 @@
         <%= render 'shared/quota_definition',
                    order_number: measure.order_number,
                    quota_definition: measure.order_number&.definition,
-                   declarable_id: declarable.goods_nomenclature_item_id %>
+                   declarable_id: declarable.short_code %>
       </span>
     <% end %>
     <% if measure.additional_code.present? %>

--- a/app/views/search/quotas/_definition.html.erb
+++ b/app/views/search/quotas/_definition.html.erb
@@ -3,7 +3,10 @@
     <%= render 'shared/quota_definition',
                order_number: definition.order_number,
                quota_definition: definition,
-               declarable_id: definition.all_goods_nomenclatures.first&.goods_nomenclature_item_id %>
+               declarable_id: definition.all_goods_nomenclatures
+                                        .select { |gn| gn.respond_to?(:short_code) }
+                                        .first
+                                        &.short_code %>
   </td>
 
   <td class="govuk-table__cell" data-label="Commodity-code">

--- a/app/views/search/quotas/_definition.html.erb
+++ b/app/views/search/quotas/_definition.html.erb
@@ -3,10 +3,7 @@
     <%= render 'shared/quota_definition',
                order_number: definition.order_number,
                quota_definition: definition,
-               declarable_id: definition.all_goods_nomenclatures
-                                        .select { |gn| gn.respond_to?(:short_code) }
-                                        .first
-                                        &.short_code %>
+               declarable_id: definition.first_goods_nomenclature_short_code %>
   </td>
 
   <td class="govuk-table__cell" data-label="Commodity-code">

--- a/app/views/search/quotas/_definition.html.erb
+++ b/app/views/search/quotas/_definition.html.erb
@@ -1,6 +1,9 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell" data-label="Order number">
-    <%= render partial: 'shared/quota_definition', locals: { order_number: definition.order_number, quota_definition: definition } %>
+    <%= render 'shared/quota_definition',
+               order_number: definition.order_number,
+               quota_definition: definition,
+               declarable_id: definition.all_goods_nomenclatures.first&.goods_nomenclature_item_id %>
   </td>
 
   <td class="govuk-table__cell" data-label="Commodity-code">

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -48,7 +48,7 @@
           <% if quota_definition.within_first_twenty_days? && declarable_id %>
           <tr class="govuk-table__row hidden-pending-balance"
               data-controller="pending-balance"
-              data-pending-balance-url-value="<%= pending_quota_balance_path declarable_id, quota_definition.order_number.number %>">
+              data-pending-balance-url-value="<%= pending_quota_balance_path(declarable_id, quota_definition.order_number.number) %>">
             <th scope="col" class='govuk-table__header'>Pending balance</th>
             <td class="numerical govuk-table__cell numerical">
               <span data-pending-balance-target="balance"></span>

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -45,7 +45,7 @@
               <%= quota_definition.measurement_unit %>
             </td>
           </tr>
-          <% if quota_definition.within_first_twenty_days? %>
+          <% if quota_definition.within_first_twenty_days? && declarable_id %>
           <tr class="govuk-table__row hidden-pending-balance"
               data-controller="pending-balance"
               data-pending-balance-url-value="<%= pending_quota_balance_path declarable_id, quota_definition.order_number.number %>">

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -19,7 +19,7 @@
           <tr class="govuk-table__row">
             <th scope="col" class='govuk-table__header'>
               Balance
-              <span class="govuk-!-font-weight-regular">
+              <span class="govuk-!-font-weight-regular avoid-line-breaks">
                 (as of <%= @search.date.to_formatted_s :short %>)
               </div>
             </th>
@@ -45,6 +45,20 @@
               <%= quota_definition.measurement_unit %>
             </td>
           </tr>
+          <% if quota_definition.within_first_twenty_days? %>
+          <tr class="govuk-table__row hidden-pending-balance"
+              data-controller="pending-balance"
+              data-pending-balance-url-value="<%= pending_quota_balance_path declarable_id, quota_definition.order_number.number %>">
+            <th scope="col" class='govuk-table__header'>Pending balance</th>
+            <td class="numerical govuk-table__cell numerical">
+              <span data-pending-balance-target="balance"></span>
+              <%= quota_definition.measurement_unit %>
+              remains available from the previous quota period.
+              This will be transferred to the current quota period c. 20 working
+              days after the end of the previous quota period.
+            </td>
+          </tr>
+          <% end %>
           <tr class="govuk-table__row">
             <th scope="col" class='govuk-table__header'>Status</th>
             <td class="numerical govuk-table__cell"><%= quota_definition.status %></td>

--- a/app/webpacker/controllers/pending_balance_controller.js
+++ b/app/webpacker/controllers/pending_balance_controller.js
@@ -1,0 +1,61 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ 'balance' ]
+
+  static values = {
+    url: String,
+    loaded: Boolean
+  }
+
+  connect() {
+    if (this.withinPopup() && !this.loadedValue) {
+      this.loadedValue = true
+      this.fetchPendingBalance()
+    }
+  }
+
+  fetchPendingBalance() {
+    const that = this ;
+
+    let request = new XMLHttpRequest()
+    request.open('GET', this.urlValue, true)
+    request.timeout = 10 * 1000
+    request.onreadystatechange = function () {
+      if (request.readyState === XMLHttpRequest.DONE && request.status === 200) {
+        const balance = JSON.parse(request.responseText)
+        that.showBalance(balance)
+      }
+    }
+
+    request.send()
+  }
+
+  showBalance(balance) {
+    if (balance === undefined || balance === null)
+      return
+
+    this.balanceTarget.innerHTML = this.formattedBalance(balance)
+    this.showPendingRow()
+  }
+
+  formattedBalance(balance) {
+    if (!Intl || !Intl.NumberFormat)
+      return balance
+
+    const formatter = new Intl.NumberFormat('en', {
+      minimumFractionDigits: 3,
+      maximumFractionDigits: 3
+    })
+
+    return formatter.format(balance)
+  }
+
+  showPendingRow() {
+    this.element.classList.remove('hidden-pending-balance')
+  }
+
+  withinPopup() {
+    return window.jQuery(this.element).parents('#popup').length > 0
+  }
+}

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -22,7 +22,7 @@ $govuk-images-path: '~govuk-frontend/govuk/assets/images/';
 @import '../src/stylesheets/variables';
 @import '../src/stylesheets/functions';
 @import '../src/stylesheets/colors';
-@import '../src/stylesheets/fonts';
+@import '../src/stylesheets/typography';
 @import '../src/stylesheets/header';
 @import '../src/stylesheets/footer';
 @import '../src/stylesheets/form_customisations';

--- a/app/webpacker/src/stylesheets/_quota-search.scss
+++ b/app/webpacker/src/stylesheets/_quota-search.scss
@@ -28,3 +28,7 @@
     max-width: 350px;
   }
 }
+
+.hidden-pending-balance {
+  display: none
+}

--- a/app/webpacker/src/stylesheets/_typography.scss
+++ b/app/webpacker/src/stylesheets/_typography.scss
@@ -12,3 +12,7 @@
        url("../fonts/azeret-mono-v6-latin-regular.svg#AzeretMono") format("svg");
   /* Legacy iOS */
 }
+
+.avoid-line-breaks {
+  white-space: nowrap;
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,10 @@ Rails.application.routes.draw do
     end
   end
   get '/find_commodity', to: 'find_commodities#show'
+  get '/pending_quota_balances/:commodity_id/:order_number',
+      to: 'pending_quota_balances#show',
+      as: :pending_quota_balance,
+      defaults: { format: :json }
 
   constraints TradeTariffFrontend::ApiPubConstraints.new(TradeTariffFrontend.public_api_endpoints) do
     scope 'api' do

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -99,6 +99,10 @@ FactoryBot.define do
       end
     end
 
+    trait :safeguard do
+      measure_type { attributes_for :measure_type, :safeguard }
+    end
+
     trait :unclassified do
       measure_type do
         attributes_for(:measure_type, :unclassified, description: measure_type_description).stringify_keys

--- a/spec/factories/measure_type_factory.rb
+++ b/spec/factories/measure_type_factory.rb
@@ -71,5 +71,9 @@ FactoryBot.define do
     trait :unclassified_customs_duties do
       measure_component_applicable_code { 1 }
     end
+
+    trait :safeguard do
+      id { MeasureType::SAFEGUARD_TYPES.first }
+    end
   end
 end

--- a/spec/factories/order_number_definition_factory.rb
+++ b/spec/factories/order_number_definition_factory.rb
@@ -20,5 +20,20 @@ FactoryBot.define do
     blocking_period_start_date { nil }
     blocking_period_end_date { nil }
     order_number { attributes_for(:order_number, number:) }
+
+    trait :historical do
+      validity_start_date { 4.months.ago.iso8601 }
+      validity_end_date { 1.month.ago.iso8601 }
+    end
+
+    trait :future do
+      validity_start_date { 1.month.from_now.iso8601 }
+      validity_end_date { 4.months.from_now.iso8601 }
+    end
+
+    trait :current do
+      validity_start_date { 1.month.ago.iso8601 }
+      validity_end_date { 2.months.from_now.iso8601 }
+    end
   end
 end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -203,4 +203,22 @@ RSpec.describe Commodity do
       end
     end
   end
+
+  describe '#has_safeguarding_measure?' do
+    subject { build :commodity, import_measures: [vat, measure] }
+
+    let(:vat) { attributes_for :measure, :vat }
+
+    context 'with safeguarding measures' do
+      let(:measure) { attributes_for :measure, :safeguard }
+
+      it { is_expected.to be_has_safeguard_measure }
+    end
+
+    context 'without safeguarding measure' do
+      let(:measure) { attributes_for :measure, :vat_zero }
+
+      it { is_expected.not_to be_has_safeguard_measure }
+    end
+  end
 end

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -67,4 +67,22 @@ RSpec.describe Heading do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '#has_safeguarding_measure?' do
+    subject { build :heading, import_measures: [vat, measure] }
+
+    let(:vat) { attributes_for :measure, :vat }
+
+    context 'without safeguarding measures' do
+      let(:measure) { attributes_for :measure, :safeguard }
+
+      it { is_expected.to be_has_safeguard_measure }
+    end
+
+    context 'with safeguarding measure' do
+      let(:measure) { attributes_for :measure, :vat_zero }
+
+      it { is_expected.not_to be_has_safeguard_measure }
+    end
+  end
 end

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -73,13 +73,13 @@ RSpec.describe Heading do
 
     let(:vat) { attributes_for :measure, :vat }
 
-    context 'without safeguarding measures' do
+    context 'with safeguarding measures' do
       let(:measure) { attributes_for :measure, :safeguard }
 
       it { is_expected.to be_has_safeguard_measure }
     end
 
-    context 'with safeguarding measure' do
+    context 'without safeguarding measure' do
       let(:measure) { attributes_for :measure, :vat_zero }
 
       it { is_expected.not_to be_has_safeguard_measure }

--- a/spec/models/measure_collection_spec.rb
+++ b/spec/models/measure_collection_spec.rb
@@ -127,4 +127,31 @@ RSpec.describe MeasureCollection do
 
     it { expect(collection.customs_duties.measures).to eq([third_country_measure, tariff_preference_measure, other_customs_duties_measure, unclassified_customs_measure]) }
   end
+
+  describe '#find_by_quota_order_number' do
+    subject :measure do
+      described_class.new(measures).find_by_quota_order_number '12345'
+    end
+
+    let(:measures) { [vat_measure, quota_measure] }
+    let(:vat_measure) { build :measure, :vat }
+    let(:quota_measure) { build :measure, :quotas, order_number: }
+    let(:order_number) { attributes_for :order_number, number: '12345' }
+
+    context 'with non-quota measures' do
+      let(:measures) { [vat_measure] }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with matching quota measure' do
+      it { is_expected.to eq quota_measure }
+    end
+
+    context 'without matching quota measure' do
+      let(:order_number) { attributes_for :order_number, number: '67890' }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -268,4 +268,18 @@ RSpec.describe Measure do
       end
     end
   end
+
+  describe '#safeguard?' do
+    context 'with safeguard measure' do
+      subject { build :measure, :safeguard }
+
+      it { is_expected.to be_safeguard }
+    end
+
+    context 'with non-safeguard measure' do
+      subject { build :measure }
+
+      it { is_expected.not_to be_safeguard }
+    end
+  end
 end

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -136,4 +136,18 @@ RSpec.describe MeasureType do
       it { is_expected.to eq('Bar') }
     end
   end
+
+  describe '#safeguard?' do
+    context 'with safeguard measure' do
+      subject { build :measure_type, :safeguard }
+
+      it { is_expected.to be_safeguard }
+    end
+
+    context 'with non-safeguard measure' do
+      subject { build :measure_type, :vat }
+
+      it { is_expected.not_to be_safeguard }
+    end
+  end
 end

--- a/spec/models/order_number/definition_spec.rb
+++ b/spec/models/order_number/definition_spec.rb
@@ -118,4 +118,30 @@ RSpec.describe OrderNumber::Definition do
       it { is_expected.to be false }
     end
   end
+
+  describe '#within_first_twenty_days?' do
+    context 'with future definition' do
+      subject { build :definition, :future }
+
+      it { is_expected.not_to be_within_first_twenty_days }
+    end
+
+    context 'with historical definition' do
+      subject { build :definition, :historical }
+
+      it { is_expected.not_to be_within_first_twenty_days }
+    end
+
+    context 'with current definition within first twenty days' do
+      subject { build :definition, :current, validity_start_date: 10.days.ago.iso8601 }
+
+      it { is_expected.to be_within_first_twenty_days }
+    end
+
+    context 'with current definition started more than twenty days ago' do
+      subject { build :definition, :current, validity_start_date: 21.days.ago.iso8601 }
+
+      it { is_expected.not_to be_within_first_twenty_days }
+    end
+  end
 end

--- a/spec/models/order_number/definition_spec.rb
+++ b/spec/models/order_number/definition_spec.rb
@@ -144,4 +144,73 @@ RSpec.describe OrderNumber::Definition do
       it { is_expected.not_to be_within_first_twenty_days }
     end
   end
+
+  describe '#first_goods_nomenclature_short_code' do
+    subject { definition.first_goods_nomenclature_short_code }
+
+    let(:definition) { build :definition, measures: }
+
+    context 'without any goods nomenclatures' do
+      let(:measures) { [] }
+
+      it { is_expected.to be nil }
+    end
+
+    context 'with a goods nomenclature with a short code' do
+      let :measures do
+        [
+          attributes_for(:measure, goods_nomenclature: commodity1),
+          attributes_for(:measure, goods_nomenclature: commodity2),
+        ]
+      end
+
+      let :commodity1 do
+        attributes_for :commodity, resource_type: 'Commodity'
+      end
+
+      let :commodity2 do
+        attributes_for :commodity, resource_type: 'Commodity'
+      end
+
+      it { is_expected.to eq commodity1[:goods_nomenclature_item_id] }
+    end
+
+    context 'with goods nomenclatures without short codes' do
+      let :measures do
+        [
+          attributes_for(:measure, goods_nomenclature: subheading1),
+          attributes_for(:measure, goods_nomenclature: subheading2),
+        ]
+      end
+
+      let :subheading1 do
+        attributes_for :subheading, resource_type: 'Subheading'
+      end
+
+      let :subheading2 do
+        attributes_for :subheading, resource_type: 'Subheading'
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with goods nomenclatures with a mix of short codes and not' do
+      let :measures do
+        [
+          attributes_for(:measure, goods_nomenclature: subheading),
+          attributes_for(:measure, goods_nomenclature: commodity),
+        ]
+      end
+
+      let :subheading do
+        attributes_for :subheading, resource_type: 'Subheading'
+      end
+
+      let :commodity do
+        attributes_for :commodity, resource_type: 'Commodity'
+      end
+
+      it { is_expected.to eq commodity[:goods_nomenclature_item_id] }
+    end
+  end
 end

--- a/spec/requests/pending_quota_balances_controller_spec.rb
+++ b/spec/requests/pending_quota_balances_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe PendingQuotaBalancesController, type: :request do
+  subject { make_request && response }
+
+  describe 'GET #show' do
+    before { allow(PendingQuotaBalanceService).to receive(:new).and_return service }
+
+    let(:service) { instance_double PendingQuotaBalanceService, call: '1000.0' }
+    let(:make_request) { get pending_quota_balance_path('1234567890', '123456') }
+
+    it { is_expected.to have_http_status :ok }
+    it { is_expected.to have_attributes content_type: %r{application/json} }
+  end
+end

--- a/spec/services/pending_quota_balance_service_spec.rb
+++ b/spec/services/pending_quota_balance_service_spec.rb
@@ -2,44 +2,9 @@ require 'spec_helper'
 
 RSpec.describe PendingQuotaBalanceService do
   describe '#call' do
-    subject { described_class.new(commodity.id, '1010', Time.zone.today).call }
-
-    before do
-      allow(Commodity).to receive(:find).with(commodity.id, as_of: Time.zone.today)
-                                        .and_return commodity
-      allow(Commodity).to receive(:find).with(commodity.id, as_of: (start_date - 1.day).to_date)
-                                        .and_return previous_commodity
-    end
+    subject { described_class.new(commodity.short_code, '1010', Time.zone.today).call }
 
     let(:start_date) { 5.days.ago }
-
-    let :commodity do
-      build :commodity, import_measures: [
-        attributes_for(:measure, :safeguard),
-        attributes_for(
-          :measure,
-          :quotas,
-          order_number: attributes_for(:order_number,
-                                       number: '1010',
-                                       definition: current_definition),
-        ),
-      ]
-    end
-
-    let :previous_commodity do
-      build :commodity,
-            goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-            import_measures: [
-              attributes_for(:measure, :safeguard),
-              attributes_for(
-                :measure,
-                :quotas,
-                order_number: attributes_for(:order_number,
-                                             number: '1010',
-                                             definition: previous_definition),
-              ),
-            ]
-    end
 
     let :current_definition do
       attributes_for :definition,
@@ -55,13 +20,17 @@ RSpec.describe PendingQuotaBalanceService do
                      validity_end_date: (start_date - 1.day).end_of_day.iso8601
     end
 
-    context 'with safeguard measure and inside first twenty days' do
-      it { is_expected.to eq previous_definition[:balance] }
-    end
+    context 'with Commodity' do
+      before do
+        allow(Commodity).to receive(:find).with(commodity.id, as_of: Time.zone.today)
+                                          .and_return commodity
+        allow(Commodity).to receive(:find).with(commodity.id, as_of: (start_date - 1.day).to_date)
+                                          .and_return previous_commodity
+      end
 
-    context 'without safeguard measure' do
       let :commodity do
         build :commodity, import_measures: [
+          attributes_for(:measure, :safeguard),
           attributes_for(
             :measure,
             :quotas,
@@ -72,22 +41,96 @@ RSpec.describe PendingQuotaBalanceService do
         ]
       end
 
-      it { is_expected.to be_nil }
-    end
-
-    context 'when outside of first twenty days' do
-      let(:start_date) { 30.days.ago }
-
-      it { is_expected.to be_nil }
-    end
-
-    context 'without previous balance' do
       let :previous_commodity do
-        build :commodity, goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-                          import_measures: attributes_for_list(:measure, 1, :safeguard)
+        build :commodity,
+              goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+              import_measures: [
+                attributes_for(:measure, :safeguard),
+                attributes_for(
+                  :measure,
+                  :quotas,
+                  order_number: attributes_for(:order_number,
+                                               number: '1010',
+                                               definition: previous_definition),
+                ),
+              ]
       end
 
-      it { is_expected.to be_nil }
+      context 'with safeguard measure and inside first twenty days' do
+        it { is_expected.to eq previous_definition[:balance] }
+      end
+
+      context 'without safeguard measure' do
+        let :commodity do
+          build :commodity, import_measures: [
+            attributes_for(
+              :measure,
+              :quotas,
+              order_number: attributes_for(:order_number,
+                                           number: '1010',
+                                           definition: current_definition),
+            ),
+          ]
+        end
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'when outside of first twenty days' do
+        let(:start_date) { 30.days.ago }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'without previous balance' do
+        let :previous_commodity do
+          build :commodity, goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                            import_measures: attributes_for_list(:measure, 1, :safeguard)
+        end
+
+        it { is_expected.to be_nil }
+      end
+    end
+
+    context 'with declarable Heading' do
+      subject { described_class.new(heading.short_code, '1010', Time.zone.today).call }
+
+      before do
+        allow(Heading).to receive(:find).with(heading.short_code, as_of: Time.zone.today)
+                                        .and_return heading
+        allow(Heading).to receive(:find).with(heading.short_code, as_of: (start_date - 1.day).to_date)
+                                        .and_return previous_heading
+      end
+
+      let :heading do
+        build :heading, import_measures: [
+          attributes_for(:measure, :safeguard),
+          attributes_for(
+            :measure,
+            :quotas,
+            order_number: attributes_for(:order_number,
+                                         number: '1010',
+                                         definition: current_definition),
+          ),
+        ]
+      end
+
+      let :previous_heading do
+        build :heading,
+              goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+              import_measures: [
+                attributes_for(:measure, :safeguard),
+                attributes_for(
+                  :measure,
+                  :quotas,
+                  order_number: attributes_for(:order_number,
+                                               number: '1010',
+                                               definition: previous_definition),
+                ),
+              ]
+      end
+
+      it { is_expected.to eq previous_definition[:balance] }
     end
   end
 end

--- a/spec/services/pending_quota_balance_service_spec.rb
+++ b/spec/services/pending_quota_balance_service_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+
+RSpec.describe PendingQuotaBalanceService do
+  describe '#call' do
+    subject { described_class.new(commodity.id, '1010', Time.zone.today).call }
+
+    before do
+      allow(Commodity).to receive(:find).with(commodity.id, as_of: Time.zone.today)
+                                        .and_return commodity
+      allow(Commodity).to receive(:find).with(commodity.id, as_of: (start_date - 1.day).to_date)
+                                        .and_return previous_commodity
+    end
+
+    let(:start_date) { 5.days.ago }
+
+    let :commodity do
+      build :commodity, import_measures: [
+        attributes_for(:measure, :safeguard),
+        attributes_for(
+          :measure,
+          :quotas,
+          order_number: attributes_for(:order_number,
+                                       number: '1010',
+                                       definition: current_definition),
+        ),
+      ]
+    end
+
+    let :previous_commodity do
+      build :commodity,
+            goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+            import_measures: [
+              attributes_for(:measure, :safeguard),
+              attributes_for(
+                :measure,
+                :quotas,
+                order_number: attributes_for(:order_number,
+                                             number: '1010',
+                                             definition: previous_definition),
+              ),
+            ]
+    end
+
+    let :current_definition do
+      attributes_for :definition,
+                     balance: '1000.0',
+                     validity_start_date: start_date.beginning_of_day.iso8601,
+                     validity_end_date: 10.days.from_now.end_of_day.iso8601
+    end
+
+    let :previous_definition do
+      attributes_for :definition,
+                     balance: '2000.0',
+                     validity_start_date: (start_date - 10.days).beginning_of_day.iso8601,
+                     validity_end_date: (start_date - 1.day).end_of_day.iso8601
+    end
+
+    context 'with safeguard measure and inside first twenty days' do
+      it { is_expected.to eq previous_definition[:balance] }
+    end
+
+    context 'without safeguard measure' do
+      let :commodity do
+        build :commodity, import_measures: [
+          attributes_for(
+            :measure,
+            :quotas,
+            order_number: attributes_for(:order_number,
+                                         number: '1010',
+                                         definition: current_definition),
+          ),
+        ]
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when outside of first twenty days' do
+      let(:start_date) { 30.days.ago }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'without previous balance' do
+      let :previous_commodity do
+        build :commodity, goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                          import_measures: attributes_for_list(:measure, 1, :safeguard)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-2017

### What?

I have added/removed/altered:

- [x] Added an API to query the pending balance for a commodity
- [x] Changed the quota partial to conditionally include a table row for the pending balance
- [x] Lazy low the pending balance over XHR from the new API via a Stimulus controller

### Why?

I am doing this because:

- We want to show the pending balance on the quotas overlay
- Eager loading this data via the API is difficult to do efficiently so

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Should be low risk
