### PR TITLE
HOTT-2118 Process markdown in Product Specific Rules

### DIFF
--- a/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
+++ b/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
@@ -3,7 +3,7 @@
         :rule,
         form.object.options,
         :resource_id,
-        ->(option) { option.rule.html_safe } %>
+        ->(option) { govspeak option.rule } %>
 
   <div class="tariff-markdown">
     <%= govspeak t '.body', scheme_title: form.object.scheme_title %>

--- a/spec/views/rules_of_origin/steps/_product_specific_rules.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_product_specific_rules.html.erb_spec.rb
@@ -26,4 +26,22 @@ RSpec.describe 'rules_of_origin/steps/_product_specific_rules', type: :view do
 
     it { is_expected.to have_css '.govuk-error-message', text: /Select whether/i }
   end
+
+  context 'with markdown in rule' do
+    let :schemes do
+      build_list :rules_of_origin_scheme, 1,
+                 countries: [country.id],
+                 rule_sets:,
+                 articles:
+    end
+
+    let(:rule_sets) { attributes_for_list :rules_of_origin_rule_set, 1, rules: }
+
+    let :rules do
+      attributes_for_list :rules_of_origin_v2_rule, 1,
+                          rule: '[Chapter&nbsp;1](/some/where)'
+    end
+
+    it { is_expected.to have_css 'fieldset label a', text: /Chapter.*1/ }
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-2118

### What?

I have added/removed/altered:

- [x] Added processing markdown in Product Specific Rules in the Rules of Origin wizard

### Why?

I am doing this because:

- the source data has changed from using raw HTML to using a mix of raw HTML and markdown

### Deployment risks (optional)

- None, feature flagged off

### Screenshots

![Screenshot from 2022-10-11 12-16-01](https://user-images.githubusercontent.com/10818/195076217-877176a8-2f13-4aff-b18c-d5432dfc7eca.png)

