### PR TITLE
HOTT-2117 Always use old RoO tab on XI service

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -62,7 +62,7 @@
   <!-- Rules of Origin tab -->
   <div class="govuk-tabs__panel" id="rules-of-origin">
     <%- if @search.filtered_by_country? && @search.geographical_area -%>
-      <%= render (TradeTariffFrontend.roo_wizard? ? 'rules_of_origin/tab' : 'rules_of_origin/legacy_tab'),
+      <%= render (TradeTariffFrontend.roo_wizard? && TradeTariffFrontend::ServiceChooser.uk? ? 'rules_of_origin/tab' : 'rules_of_origin/legacy_tab'),
                  country_code: @search.country,
                  country_name: @search.geographical_area.description,
                  commodity_code: declarable.code,

--- a/spec/views/measures/_measures.html.erb_spec.rb
+++ b/spec/views/measures/_measures.html.erb_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'measures/_measures', type: :view, vcr: {
 
       context 'with roo_wizard feature flag' do
         it_behaves_like 'measures with rules of origin tab'
-        it_behaves_like 'roo_wizard tab'
+        it_behaves_like 'legacy roo tab'
         it { is_expected.to have_css '#rules-of-origin h2', text: 'rules of origin for trading' }
       end
 


### PR DESCRIPTION
### Jira link

HOTT-2117

### What?

I have added/removed/altered:

- [x] Always show the legacy rules of origin tab on the XI service

### Why?

I am doing this because:

- We don't have the XI data to support the new RoO tab yet

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, should just mean the feature flag has no effect for XI when it is turned on in production
