### PR TITLE
HOTT-2125 Updated branch logic for wholly obtained

### DIFF
--- a/app/models/rules_of_origin/steps/base.rb
+++ b/app/models/rules_of_origin/steps/base.rb
@@ -61,8 +61,8 @@ module RulesOfOrigin
 
     private
 
-      def single_wholly_obtained_rule?
-        chosen_scheme.v2_rules.select(&:wholly_obtained_class?).one?
+      def only_wholly_obtained_rules?
+        chosen_scheme.v2_rules.all?(&:only_wholly_obtained_class?)
       end
     end
   end

--- a/app/models/rules_of_origin/steps/not_wholly_obtained.rb
+++ b/app/models/rules_of_origin/steps/not_wholly_obtained.rb
@@ -4,7 +4,7 @@ module RulesOfOrigin
       self.section = 'originating'
 
       def skipped?
-        @store['wholly_obtained'] == 'yes' || single_wholly_obtained_rule?
+        @store['wholly_obtained'] == 'yes' || only_wholly_obtained_rules?
       end
     end
   end

--- a/app/models/rules_of_origin/steps/rules_not_met.rb
+++ b/app/models/rules_of_origin/steps/rules_not_met.rb
@@ -4,7 +4,7 @@ module RulesOfOrigin
       self.section = 'originating'
 
       def skipped?
-        if single_wholly_obtained_rule?
+        if only_wholly_obtained_rules?
           wholly_obtained?
         else
           skipped_for_multiple_rules?

--- a/app/models/rules_of_origin/v2_rule.rb
+++ b/app/models/rules_of_origin/v2_rule.rb
@@ -12,7 +12,7 @@ class RulesOfOrigin::V2Rule
     @rule_class ||= []
   end
 
-  def wholly_obtained_class?
-    rule_class.include?(WHOLLY_OBTAINED_CLASS)
+  def only_wholly_obtained_class?
+    rule_class.one? && rule_class.include?(WHOLLY_OBTAINED_CLASS)
   end
 end

--- a/spec/models/rules_of_origin/v2_rule_spec.rb
+++ b/spec/models/rules_of_origin/v2_rule_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe RulesOfOrigin::V2Rule do
   it { is_expected.to respond_to :rule_class }
   it { is_expected.to respond_to :operator }
 
-  describe '#wholly_obtained_class?' do
-    subject { described_class.new(rule_class:).wholly_obtained_class? }
+  describe '#only_wholly_obtained_class?' do
+    subject { described_class.new(rule_class:).only_wholly_obtained_class? }
 
     context 'with no classes' do
       let(:rule_class) { nil }
@@ -20,8 +20,14 @@ RSpec.describe RulesOfOrigin::V2Rule do
       it { is_expected.to be false }
     end
 
-    context 'with wholly obtained class' do
+    context 'with multiple classes including wholly obtained' do
       let(:rule_class) { %w[A1 WO B2] }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with only wholly obtained class' do
+      let(:rule_class) { %w[WO] }
 
       it { is_expected.to be true }
     end


### PR DESCRIPTION
### Jira link

HOTT-2125

### What?

I have added/removed/altered:

- [x] Updated the branching logic for whether the user is passed through the cumulation screens after stating the product is not wholly obtained

### Why?

I am doing this because:

- Previously when there were multiple rules, some requiring wholly obtained and some not the user was not given the opportunity to choose one of the rules which did not require wholly obtained.

### Deployment risks (optional)

- Low, feature flagged off
