### PR TITLE
HOTT-2006 Enabled error reporting from Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,7 @@
 Sentry.init do |config|
-  config.rails.report_rescued_exceptions = false
-
   config.breadcrumbs_logger = [:active_support_logger]
+
+  config.excluded_exceptions += %w[
+    Faraday::ResourceNotFound
+  ]
 end


### PR DESCRIPTION
### Jira link

HOTT-2006

### What?

I have added/removed/altered:

- [x] Report errors when they are rescued by rails' default error handling middleware

### Why?

I am doing this because:

- It can indicate legimate issues which we wish to address

### Deployment risks (optional)

- Changes our error reporting behaviour
