### PR TITLE
HOTT-2140: Fix link inside bullet points.

### DIFF
--- a/app/webpacker/src/stylesheets/_search.scss
+++ b/app/webpacker/src/stylesheets/_search.scss
@@ -1,14 +1,11 @@
 .facet-classifications {
-  list-style-type: none;
+  list-style-type: "\2014 ";
   margin: 0 0 0 2.2em;
   margin-bottom: 0;
   margin-top: 1;
   padding: 0;
 
-  li::before {
-    content: "\2014";
-    margin: 0 1em 0 0;
-  }
+  li { padding-left: 0.5em }
 }
 
 .facet-classifications-tag {


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-2140

### What?
Fix the return for long text inside the list index (bullet points).

### Why?
It looks tidier and prettier.

Before: (boooo!!!)
<img width="374" alt="Screenshot 2022-10-14 at 14 48 29" src="https://user-images.githubusercontent.com/58971/195864572-6d61935d-9f1f-46e2-a1c1-b40caf69b6ba.png">

After: (Wow, that's so cool!)
<img width="345" alt="Screenshot 2022-10-14 at 14 47 55" src="https://user-images.githubusercontent.com/58971/195864578-174950b0-2778-45ff-8280-80a0ad93deae.png">
