### PR TITLE
HOTT-2140: Improvement for facet filter tag

### DIFF
--- a/app/views/beta/search_results/_sidebar.html.erb
+++ b/app/views/beta/search_results/_sidebar.html.erb
@@ -4,9 +4,11 @@
       <strong>
         Results are filtered by:
       </strong>
-      <% applied_filter_classifications.each do |facet_classification_statistic|  %>
-        <%= disapply_filter_link_for(facet_classification_statistic) %>
-      <% end %>
+      <div class="facet-classifications-tag-container">
+        <% applied_filter_classifications.each do |facet_classification_statistic|  %>
+          <%= disapply_filter_link_for(facet_classification_statistic) %>
+        <% end %>
+      </div>
     <% end %>
 
     <% if unapplied_filter_classifications.any? %>

--- a/app/webpacker/src/stylesheets/_search.scss
+++ b/app/webpacker/src/stylesheets/_search.scss
@@ -32,3 +32,9 @@
     text-decoration: underline;
   }
 }
+
+div.facet-classifications-tag-container {
+  @media (max-width: $mobile-max-width) {
+    display: inline;
+  }
+}

--- a/app/webpacker/src/stylesheets/_search.scss
+++ b/app/webpacker/src/stylesheets/_search.scss
@@ -34,7 +34,7 @@
 }
 
 div.facet-classifications-tag-container {
-  @media (max-width: $mobile-max-width) {
+  @include govuk-media-query($until: tablet) {
     display: inline;
   }
 }


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-2140

### What?
Move the Facet filter tag to a  different line - Only for desktop view.

### Why?
Cosmetic improvement.

# Outcomes:
## In the desktop view the facet filter is moved to the next line below.
<img width="995" alt="Screenshot 2022-10-14 at 16 50 04" src="https://user-images.githubusercontent.com/58971/195888564-ae411b12-bce7-4c48-9587-a435e70c8c61.png">

## In the mobile view the filter stays on the same line since the commodity code list has been moved to a block below.
<img width="446" alt="Screenshot 2022-10-14 at 16 50 13" src="https://user-images.githubusercontent.com/58971/195888721-5b730d77-03a7-4023-8581-6824417b1237.png">

