### PR TITLE
HOTT-1952 Handle non html types in exceptions app

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -7,14 +7,26 @@ class ErrorsController < ApplicationController
   before_action :disable_search_form, :disable_switch_service_banner
 
   def not_found
-    render status: :not_found
+    respond_to do |format|
+      format.html { render status: :not_found }
+      format.json { render json: { error: 'Resource not found' }, status: :not_found }
+      format.all { render status: :not_found, plain: 'Resource not found' }
+    end
   end
 
   def internal_server_error
-    render status: :internal_server_error
+    respond_to do |format|
+      format.html { render status: :internal_server_error }
+      format.json { render json: { error: 'Internal server error' }, status: :internal_server_error }
+      format.all { render status: :internal_server_error, plain: 'Internal server error' }
+    end
   end
 
   def maintenance
-    render status: :service_unavailable
+    respond_to do |format|
+      format.html { render status: :service_unavailable }
+      format.json { render json: { error: 'Maintenance mode' }, status: :service_unavailable }
+      format.all { render status: :service_unavailable, plain: 'Maintenance mode' }
+    end
   end
 end

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -19,21 +19,69 @@ RSpec.describe 'Error handling' do
   end
 
   describe 'not found page' do
-    before { visit '/404' }
+    context 'with html' do
+      before { visit '/404' }
 
-    it_behaves_like 'not found'
+      it_behaves_like 'not found'
+    end
+
+    context 'with json' do
+      before { visit '/404.json' }
+
+      it { is_expected.to have_http_status :not_found }
+      it { expect(JSON.parse(page.body)).to include 'error' => 'Resource not found' }
+    end
+
+    context 'with something else' do
+      before { visit '/404.pdf' }
+
+      it { is_expected.to have_http_status :not_found }
+      it { is_expected.to have_attributes body: 'Resource not found' }
+    end
   end
 
   describe 'exception page' do
-    before { visit '/500' }
+    context 'with html' do
+      before { visit '/500' }
 
-    it_behaves_like 'internal server error'
+      it_behaves_like 'internal server error'
+    end
+
+    context 'with json' do
+      before { visit '/500.json' }
+
+      it { is_expected.to have_http_status :internal_server_error }
+      it { expect(JSON.parse(page.body)).to include 'error' => 'Internal server error' }
+    end
+
+    context 'with something else' do
+      before { visit '/500.pdf' }
+
+      it { is_expected.to have_http_status :internal_server_error }
+      it { is_expected.to have_attributes body: 'Internal server error' }
+    end
   end
 
   describe 'maintenance mode' do
-    before { visit '/503' }
+    context 'with html' do
+      before { visit '/503' }
 
-    it_behaves_like 'service unavailable'
+      it_behaves_like 'service unavailable'
+    end
+
+    context 'with json' do
+      before { visit '/503.json' }
+
+      it { is_expected.to have_http_status :service_unavailable }
+      it { expect(JSON.parse(page.body)).to include 'error' => 'Maintenance mode' }
+    end
+
+    context 'with something else' do
+      before { visit '/503.pdf' }
+
+      it { is_expected.to have_http_status :service_unavailable }
+      it { is_expected.to have_attributes body: 'Maintenance mode' }
+    end
   end
 
   describe 'rescued exceptions' do


### PR DESCRIPTION
This led to an odd behaviour previously where an unhandled exception would cascade up to the errors app, then trigger a ActionView::MissingTemplate exception in turn triggering the (now removed) rescue_from in ApplicationController and result in the 404 page

### Jira link

HOTT-1952

### What?

I have added/removed/altered:

- [x] Added error handler behaviour for non html content types

### Why?

I am doing this because:

- Previously these were triggering an ActionView::MissingTemplate resulting in the user seeing a 404 page for an unhandled exception on non HTML formats (eg JSON)

### Deployment risks (optional)

- Low, changes a unhandled exception in a JSON endpoint to return a 500 json document instead of a 404 html document
