### PR TITLE
HOTT-2168: Use service_name method to display service name

### DIFF
--- a/app/views/measure_types/preference_codes/show.html.erb
+++ b/app/views/measure_types/preference_codes/show.html.erb
@@ -3,7 +3,7 @@
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <span class="govuk-caption-xl">The UK Integrated Online Tariff</span>
+      <span class="govuk-caption-xl">The <%= service_name %></span>
       <h1 class="govuk-heading-l"><%= @measure_type.description %></h1>
 
       <h2 class="govuk-heading-m">


### PR DESCRIPTION
### Jira link

[HOTT-<TODO>](https://transformuk.atlassian.net/browse/HOTT-2168)

### What?

I have added/removed/altered:

- [ ] Used service_name method to display service name

### Why?

I am doing this because:

- We were using static text which was displaying the incorrect service name on XI

<img width="585" alt="Screenshot 2022-10-21 at 13 12 47" src="https://user-images.githubusercontent.com/12201130/197193047-c3065ed7-3d03-4937-9006-d9798363019a.png">

<img width="610" alt="Screenshot 2022-10-21 at 13 13 27" src="https://user-images.githubusercontent.com/12201130/197193161-331c8c6f-ef63-4f10-9d8f-047faf2f60b5.png">
