### PR TITLE
HOTT-2162: Adds ability to use original search query

### DIFF
--- a/app/controllers/beta/search_results_controller.rb
+++ b/app/controllers/beta/search_results_controller.rb
@@ -77,23 +77,34 @@ module Beta
     ].freeze
 
     def show
-      @search_result = Beta::Search::PerformSearchService.new(query, filters).call
+      @search_result = Beta::Search::PerformSearchService.new(query_options, filters).call
 
       redirect_to @search_result.redirect_to if @search_result.redirect?
     end
 
     private
 
+    def query_options
+      {
+        q: query,
+        spell:,
+      }
+    end
+
     def query
       @query ||= search_params[:q].presence || ''
     end
 
+    def spell
+      search_params[:spell].presence || '1'
+    end
+
     def filters
-      @filters ||= params[:filter]&.permit(*POSSIBLE_FILTERS) || {}
+      @filters ||= params[:filter]&.permit(*POSSIBLE_FILTERS).to_h || {}
     end
 
     def search_params
-      params.permit(:q, :filters)
+      params.permit(:q, :filters, :spell)
     end
   end
 end

--- a/app/helpers/search_results_helper.rb
+++ b/app/helpers/search_results_helper.rb
@@ -8,6 +8,13 @@ module SearchResultsHelper
     link_html
   end
 
+  def uncorrected_search_link_for(original_search_query)
+    path_options = uncorrected_url_options
+    path = perform_search_path(path_options)
+
+    link_to(original_search_query, path)
+  end
+
   def disapply_filter_link_for(filterable)
     path_options = disapply_url_options_for(filterable.filterable_key.to_sym)
     path = perform_search_path(path_options)
@@ -43,6 +50,15 @@ module SearchResultsHelper
   end
 
   private
+
+  def uncorrected_url_options
+    filters = @filters.to_h.symbolize_keys
+    options = sanitized_url_options
+    options.merge!(spell: '0')
+    options.merge!(q: @query)
+    options.deep_merge!(filter: filters)
+    options
+  end
 
   def filtered_url_options_for(filter)
     filters = @filters.to_h.symbolize_keys

--- a/app/models/beta/search/search_query_parser_result.rb
+++ b/app/models/beta/search/search_query_parser_result.rb
@@ -11,6 +11,10 @@ module Beta
                     :nouns,
                     :noun_chunks,
                     :verbs
+
+      def spelling_corrected?
+        original_search_query != corrected_search_query
+      end
     end
   end
 end

--- a/app/models/beta/search/search_result.rb
+++ b/app/models/beta/search/search_result.rb
@@ -16,6 +16,8 @@ module Beta
 
       alias_method :redirect?, :redirect
 
+      delegate :spelling_corrected?, :original_search_query, :corrected_search_query, to: :search_query_parser_result
+
       has_many :chapter_statistics, class_name: 'Beta::Search::ChapterStatistic'
       has_many :heading_statistics, class_name: 'Beta::Search::HeadingStatistic', wrapper: Beta::Search::HeadingStatisticCollection
       has_many :hits, polymorphic: true, wrapper: Beta::Search::HitsCollection

--- a/app/services/beta/search/perform_search_service.rb
+++ b/app/services/beta/search/perform_search_service.rb
@@ -6,8 +6,8 @@ module Beta
     class PerformSearchService
       include Retriable
 
-      def initialize(query, filters = {})
-        @query = query
+      def initialize(query_options, filters = {})
+        @query_options = query_options
         @filters = filters
       end
 
@@ -24,7 +24,7 @@ module Beta
       private
 
       def query_params
-        @query_params = { q: @query }.merge(filter_query)
+        @query_params = @query_options.merge(filter_query)
         @query_params.to_query
       end
 

--- a/app/views/beta/search_results/show.html.erb
+++ b/app/views/beta/search_results/show.html.erb
@@ -8,10 +8,20 @@
 <% end %>
 
 <%= page_header "Search results for
-                &lsquo;#{h @search_result.search_query_parser_result.corrected_search_query}&rsquo;".html_safe
+                &lsquo;#{h @search_result.corrected_search_query}&rsquo;".html_safe
 %>
 
 <section id="beta-search-results-<%= @search_result.resource_id %>">
+  <% if @search_result.spelling_corrected? %>
+    <div id="search-results-spelling">
+      <p class="corrected-search-results">
+        Showing results for &lsquo;<%= @search_result.corrected_search_query %>&rsquo;.
+        <span class="non-corrected-search-results govuk-!-margin-top-1">
+          Search instead for &lsquo;<%= uncorrected_search_link_for(@search_result.original_search_query) %>&rsquo;.
+        </span>
+      </p>
+    </div>
+  <% end %>
   <% if @search_result.hits.commodities.present? %>
     <%= render 'with_hits' %>
   <% else %>

--- a/app/webpacker/src/stylesheets/_search-results.scss
+++ b/app/webpacker/src/stylesheets/_search-results.scss
@@ -1,3 +1,13 @@
+.corrected-search-results {
+  color: $govuk-secondary-text-colour;
+}
+
+.non-corrected-search-results {
+  color: $govuk-secondary-text-colour;
+  display: block;
+  font-size: 10px !important;
+}
+
 .search-results {
   .full-code {
     width: 171px;

--- a/spec/controllers/beta/search_results_controller_spec.rb
+++ b/spec/controllers/beta/search_results_controller_spec.rb
@@ -18,7 +18,10 @@ if TradeTariffFrontend.beta_search_enabled?
       it 'calls the PerformSearchService' do
         do_response
 
-        expect(Beta::Search::PerformSearchService).to have_received(:new).with('clothing', 'material' => 'leather')
+        expect(Beta::Search::PerformSearchService).to have_received(:new).with(
+          { q: 'clothing', spell: '1' },
+          { 'material' => 'leather' },
+        )
       end
     end
   end

--- a/spec/factories/search_query_parser_result_factory.rb
+++ b/spec/factories/search_query_parser_result_factory.rb
@@ -6,5 +6,23 @@ FactoryBot.define do
     adjectives { [] }
     nouns { ['clothing set'] }
     noun_chunks { ['clothing set'] }
+
+    trait :corrected do
+      corrected_search_query { 'halibut' }
+      original_search_query { 'halbiut' }
+      verbs { [] }
+      adjectives { [] }
+      nouns { %w[halibut] }
+      noun_chunks {}
+    end
+
+    trait :not_corrected do
+      corrected_search_query { 'halbiut' }
+      original_search_query { 'halbiut' }
+      verbs { [] }
+      adjectives { [] }
+      nouns { %w[halibut] }
+      noun_chunks {}
+    end
   end
 end

--- a/spec/factories/search_result_factory.rb
+++ b/spec/factories/search_result_factory.rb
@@ -72,5 +72,13 @@ FactoryBot.define do
     trait :no_intercept_message do
       intercept_message {}
     end
+
+    trait :spelling_corrected do
+      search_query_parser_result { attributes_for(:search_query_parser_result, :corrected) }
+    end
+
+    trait :spelling_not_corrected do
+      search_query_parser_result { attributes_for(:search_query_parser_result, :not_corrected) }
+    end
   end
 end

--- a/spec/helpers/search_results_helper_spec.rb
+++ b/spec/helpers/search_results_helper_spec.rb
@@ -89,4 +89,21 @@ RSpec.describe SearchResultsHelper, type: :helper do
       it { is_expected.to eq([]) }
     end
   end
+
+  describe '#uncorrected_search_link_for' do
+    subject(:uncorrected_search_link_for) { helper.uncorrected_search_link_for(original_search_query) }
+
+    let(:original_search_query) { 'halbiut' }
+
+    before do
+      assign(:filters, 'material' => 'leather', 'heading' => '0101')
+      assign(:query, 'halbiut')
+    end
+
+    it 'returns the original search query with a spell query param' do
+      expect(uncorrected_search_link_for).to eq(
+        '<a href="/search?filter%5Bheading%5D=0101&amp;filter%5Bmaterial%5D=leather&amp;q=halbiut&amp;spell=0">halbiut</a>',
+      )
+    end
+  end
 end

--- a/spec/models/beta/search/search_query_parser_result_spec.rb
+++ b/spec/models/beta/search/search_query_parser_result_spec.rb
@@ -11,4 +11,28 @@ RSpec.describe Beta::Search::SearchQueryParserResult do
                                                           nouns: ['clothing set'],
                                                           noun_chunks: ['clothing set'])
   }
+
+  describe '#spelling_corrected?' do
+    subject(:search_query_parser_result) do
+      build(
+        :search_query_parser_result,
+        corrected_search_query:,
+        original_search_query:,
+      )
+    end
+
+    context 'when the original_search_query and the corrected_search_query are the same' do
+      let(:original_search_query) { 'halbiut' }
+      let(:corrected_search_query) { 'halbiut' }
+
+      it { is_expected.not_to be_spelling_corrected }
+    end
+
+    context 'when the original_search_query and the corrected_search_query are different' do
+      let(:original_search_query) { 'halbiut' }
+      let(:corrected_search_query) { 'halibut' }
+
+      it { is_expected.to be_spelling_corrected }
+    end
+  end
 end

--- a/spec/models/beta/search/search_result_spec.rb
+++ b/spec/models/beta/search/search_result_spec.rb
@@ -58,4 +58,16 @@ RSpec.describe Beta::Search::SearchResult do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '#spelling_corrected?' do
+    it { expect(search_result.spelling_corrected?).to eq(search_result.search_query_parser_result.spelling_corrected?) }
+  end
+
+  describe '#original_search_query' do
+    it { expect(search_result.original_search_query).to eq(search_result.search_query_parser_result.original_search_query) }
+  end
+
+  describe '#corrected_search_query' do
+    it { expect(search_result.corrected_search_query).to eq(search_result.search_query_parser_result.corrected_search_query) }
+  end
 end

--- a/spec/services/beta/search/perform_search_service_spec.rb
+++ b/spec/services/beta/search/perform_search_service_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 RSpec.describe Beta::Search::PerformSearchService do
   describe '#call' do
-    subject(:call) { described_class.new(query, filters).call }
+    subject(:call) { described_class.new(query_options, filters).call }
 
     before do
       host = TradeTariffFrontend::ServiceChooser.api_host
       path = '/api/beta/search'
-      params = '?filter%5Banimal_type%5D=swine&filter%5Bgoods_nomenclature_class%5D=Commodity,Subheading&q=running%20horses'
+      params = '?filter%5Banimal_type%5D=swine&filter%5Bgoods_nomenclature_class%5D=Commodity,Subheading&q=running%20horses&spell=1'
       url = "#{host}#{path}#{params}"
 
       search_result = jsonapi_response(
@@ -18,7 +18,7 @@ RSpec.describe Beta::Search::PerformSearchService do
       stub_request(:get, url).to_return(search_result)
     end
 
-    let(:query) { 'running horses' }
+    let(:query_options) { { q: 'running horses', spell: '1' } }
     let(:filters) { { animal_type: 'swine', goods_nomenclature_class: %w[Commodity Subheading] } }
 
     it { is_expected.to be_a(Beta::Search::SearchResult) }

--- a/spec/views/beta/search_results/show.html.erb_spec.rb
+++ b/spec/views/beta/search_results/show.html.erb_spec.rb
@@ -88,4 +88,16 @@ RSpec.describe 'beta/search_results/show', type: :view do
       it { is_expected.not_to have_css('div#intercept-message') }
     end
   end
+
+  context 'when the spelling has been corrected' do
+    let(:search_result) { build(:search_result, :spelling_corrected) }
+
+    it { is_expected.to have_css('div#search-results-spelling') }
+  end
+
+  context 'when the spelling has not been corrected' do
+    let(:search_result) { build(:search_result, :spelling_not_corrected) }
+
+    it { is_expected.not_to have_css('div#search-results-spelling') }
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2169

### What?

![image](https://user-images.githubusercontent.com/8156884/197195094-028935b1-0502-4794-a930-b37aa6c8c2b1.png)


I have added/removed/altered:

- [x] Adds ability to use the original search query

### Why?

I am doing this because:

- This is required for go live
