### PR TITLE
HOTT-2128 News collections client

### DIFF
--- a/app/models/news_collection.rb
+++ b/app/models/news_collection.rb
@@ -1,0 +1,7 @@
+require 'api_entity'
+
+class NewsCollection
+  include ApiEntity
+
+  attr_accessor :name
+end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -16,7 +16,6 @@ class NewsItem
   attr_accessor :id,
                 :slug,
                 :title,
-                :precis,
                 :content,
                 :display_style,
                 :show_on_xi,
@@ -26,6 +25,7 @@ class NewsItem
                 :show_on_banner
 
   attr_reader :start_date, :end_date
+  attr_writer :precis
 
   has_many :collections, class_name: 'NewsCollection'
 
@@ -111,5 +111,13 @@ class NewsItem
 
   def paragraphs
     @paragraphs ||= content.to_s.split(/(\r?\n)+/).map(&:presence).compact
+  end
+
+  def precis
+    @precis.presence || paragraphs.first
+  end
+
+  def content_after_precis?
+    @precis.present? ? content.present? : paragraphs.many?
   end
 end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -5,7 +5,7 @@ class NewsItem
 
   CACHE_KEY = 'news-item-any-updates'.freeze
   BANNER_CACHE_KEY = 'news-item-latest-banner'.freeze
-  CACHE_VERSION = 2
+  CACHE_VERSION = 3
   CACHE_LIFETIME = 15.minutes
   BANNER_CACHE_LIFETIME = 5.minutes
 

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -13,10 +13,21 @@ class NewsItem
 
   collection_path '/news_items'
 
-  attr_accessor :id, :title, :content, :display_style, :show_on_xi, :show_on_uk,
-                :show_on_updates_page, :show_on_home_page, :show_on_banner
+  attr_accessor :id,
+                :slug,
+                :title,
+                :precis,
+                :content,
+                :display_style,
+                :show_on_xi,
+                :show_on_uk,
+                :show_on_updates_page,
+                :show_on_home_page,
+                :show_on_banner
 
   attr_reader :start_date, :end_date
+
+  has_many :collections, class_name: 'NewsCollection'
 
   class << self
     delegate :service_name, to: TradeTariffFrontend::ServiceChooser, private: true

--- a/app/views/news_items/_latest_news.html.erb
+++ b/app/views/news_items/_latest_news.html.erb
@@ -6,9 +6,9 @@
   </div>
   <div class="govuk-notification-banner__content">
     <div class="tariff-markdown">
-      <%= format_news_item_content news_item.paragraphs.first %>
+      <%= format_news_item_content news_item.precis %>
 
-      <%- if news_item.paragraphs.many? -%>
+      <%- if news_item.content_after_precis? -%>
         <%= link_to 'Show more ...', news_item,
                     class: 'govuk-notification-banner__link' %>
       <%- end -%>

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -18,10 +18,10 @@
         </h2>
 
         <div class="tariff-markdown">
-          <%= format_news_item_content news_item.paragraphs.first %>
+          <%= format_news_item_content news_item.precis %>
         </div>
 
-        <%= link_to 'Show more ...', news_item if news_item.paragraphs.many? %>
+        <%= link_to 'Show more ...', news_item if news_item.content_after_precis? %>
       </div>
     </article>
   <% end %>

--- a/spec/factories/news_collection_factory.rb
+++ b/spec/factories/news_collection_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :news_collection do
+    sequence(:id) { |n| n }
+    sequence(:name) { |n| "Collection #{n}" }
+  end
+end

--- a/spec/factories/news_item_factory.rb
+++ b/spec/factories/news_item_factory.rb
@@ -1,6 +1,11 @@
 FactoryBot.define do
   factory :news_item do
+    transient do
+      collection_count { 0 }
+    end
+
     sequence(:id) { |n| n }
+    sequence(:slug) { |n| "slug-#{n}" }
     start_date { Time.zone.yesterday }
     sequence(:title) { |n| "News item #{n}" }
     display_style { NewsItem::DISPLAY_STYLE_REGULAR }
@@ -9,6 +14,10 @@ FactoryBot.define do
     show_on_updates_page { false }
     show_on_home_page { false }
     show_on_banner { false }
+
+    collections do
+      attributes_for_list :news_collection, collection_count
+    end
 
     content do
       <<~CONTENT
@@ -38,6 +47,10 @@ FactoryBot.define do
 
     trait :updates_page do
       show_on_updates_page { true }
+    end
+
+    trait :with_precis do
+      precis { "first paragraph\n\nsecond paragraph" }
     end
   end
 end

--- a/spec/models/news_collection_spec.rb
+++ b/spec/models/news_collection_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe NewsCollection do
+  it { is_expected.to respond_to :name }
+end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-          .with('news-item-any-updates-uk-v2', expires_in: 15.minutes)
+          .with('news-item-any-updates-uk-v3', expires_in: 15.minutes)
       end
 
       context 'with no news items' do
@@ -171,7 +171,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-          .with('news-item-any-updates-xi-v2', expires_in: 15.minutes)
+          .with('news-item-any-updates-xi-v3', expires_in: 15.minutes)
       end
 
       context 'with no news items' do
@@ -209,7 +209,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-            .with('news-item-latest-banner-uk-v2', expires_in: 5.minutes)
+            .with('news-item-latest-banner-uk-v3', expires_in: 5.minutes)
       end
     end
 
@@ -226,7 +226,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-            .with('news-item-latest-banner-xi-v2', expires_in: 5.minutes)
+            .with('news-item-latest-banner-xi-v3', expires_in: 5.minutes)
       end
     end
   end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -291,4 +291,52 @@ RSpec.describe NewsItem do
     it { is_expected.to have_attributes length: 2 }
     it { is_expected.to all be_instance_of NewsCollection }
   end
+
+  describe '#precis' do
+    subject { news.precis }
+
+    context 'with precis' do
+      let(:news) { build :news_item, precis: "first para\n\nsecond para" }
+
+      it { is_expected.to eql "first para\n\nsecond para" }
+    end
+
+    context 'without precis' do
+      let(:news) { build :news_item, precis: '', content: 'Testing 123' }
+
+      it { is_expected.to eql 'Testing 123' }
+    end
+  end
+
+  describe '#content_after_precis?' do
+    subject { news.content_after_precis? }
+
+    context 'with precis' do
+      context 'with content' do
+        let(:news) { build :news_item, :with_precis, content: 'something' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'without content' do
+        let(:news) { build :news_item, :with_precis, content: '' }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'without precis' do
+      context 'with single paragraph content' do
+        let(:news) { build :news_item, content: 'first paragraph' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'with multiple paragraph content' do
+        let(:news) { build :news_item, content: "first paragraph\n\nsecond paragraph" }
+
+        it { is_expected.to be true }
+      end
+    end
+  end
 end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe NewsItem do
   end
 
   it { is_expected.to respond_to :id }
+  it { is_expected.to respond_to :slug }
   it { is_expected.to respond_to :title }
+  it { is_expected.to respond_to :precis }
   it { is_expected.to respond_to :content }
   it { is_expected.to respond_to :start_date }
   it { is_expected.to respond_to :end_date }
@@ -18,6 +20,7 @@ RSpec.describe NewsItem do
   it { is_expected.to respond_to :show_on_uk }
   it { is_expected.to respond_to :show_on_updates_page }
   it { is_expected.to respond_to :show_on_home_page }
+  it { is_expected.to respond_to :collections }
 
   describe '.latest_for_home_page' do
     subject { described_class.latest_for_home_page }
@@ -280,5 +283,12 @@ RSpec.describe NewsItem do
       it { is_expected.to have_attributes start_date: nil }
       it { is_expected.to have_attributes end_date: nil }
     end
+  end
+
+  context 'with collections' do
+    subject { build(:news_item, collection_count: 2).collections }
+
+    it { is_expected.to have_attributes length: 2 }
+    it { is_expected.to all be_instance_of NewsCollection }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-2128

### What?

I have added/removed/altered:

- [x] Added a NewsCollection api client
- [x] Added collections, precis and slug to the NewsItem api client
- [x] Added compatibility code to work with stories with a precis and without
- [x] Invalidate cached news items

### Why?

I am doing this because:

- We will require access to the new fields
- When we add the new fields to the admin, the user may end up creating precis fields but existing stories will lack precis until the backend data has been migrated so we need to handle news items both with and without precis on the frontend
- The structure of the NewsItem model is changing so we want to avoid reusing any cached instances

### Deployment risks (optional)

- Makes changes to news which is shown on every single page but should be a non visible, internal only change for now
