### PR TITLE
HOTT-2124 Don't show contradictory info on RoO tab

### DIFF
--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -14,24 +14,22 @@
       </p>
     <% end %>
 
-    <%= rules_of_origin_schemes_intro country_name, rules_of_origin_schemes %>
+    <%= rules_of_origin_schemes_intro country_name, rules_of_origin_schemes unless declarable.import_trade_summary.no_preferential_duties? %>
 
     <%= render 'rules_of_origin/import_trade_summary',
-               import_trade_summary: declarable.import_trade_summary
+               import_trade_summary: declarable.import_trade_summary unless rules_of_origin_schemes.many?
     %>
 
     <% if declarable.import_trade_summary.no_preferential_duties? %>
       <p class="tariff-inset-information">
         As there is neither a preferential tariff nor a preferential quota present for this commodity, the 'Check rules of origin' tool is not available.
       </p>
-    <% else %>
-      <% if TradeTariffFrontend.roo_wizard? && rules_of_origin_schemes.any? %>
-        <%= render 'rules_of_origin/wizard_link',
-                   country_code: country_code,
-                   commodity_code: commodity_code,
-                   declarable: declarable
-        %>
-      <% end %>
+    <% elsif rules_of_origin_schemes.any? %>
+      <%= render 'rules_of_origin/wizard_link',
+                 country_code: country_code,
+                 commodity_code: commodity_code,
+                 declarable: declarable
+      %>
     <% end %>
 
     <%= render 'rules_of_origin/non_preferential' %>

--- a/spec/factories/import_trade_summary_factory.rb
+++ b/spec/factories/import_trade_summary_factory.rb
@@ -3,5 +3,13 @@ FactoryBot.define do
     basic_third_country_duty { '<span>2.00</span>' }
     preferential_tariff_duty { nil }
     preferential_quota_duty  { nil }
+
+    trait :with_tariff_duty do
+      preferential_tariff_duty { '1.00 %' }
+    end
+
+    trait :with_quota_duty do
+      preferential_quota_duty { '1.00 %' }
+    end
   end
 end

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'rules_of_origin/_tab', type: :view do
   let(:rules) { attributes_for_list :rules_of_origin_rule, 1, rule: "Manufacture\n\n* From materials" }
   let(:rules_of_origin_schemes) { [build(:rules_of_origin_scheme, rules:, fta_intro:)] }
   let(:fta_intro) { "## Free Trade Agreement\n\nDetails of agreement" }
-  let(:import_trade_summary) { attributes_for(:import_trade_summary) }
+  let(:import_trade_summary) { attributes_for(:import_trade_summary, :with_tariff_duty) }
 
   it 'includes the countries name in the title' do
     expect(rendered_page).to \
@@ -88,13 +88,13 @@ RSpec.describe 'rules_of_origin/_tab', type: :view do
 
   describe 'import trade summary duty box' do
     context 'when preferential tariff duty is present' do
-      let(:import_trade_summary) { attributes_for(:import_trade_summary, preferential_tariff_duty: '1.00 %') }
+      let(:import_trade_summary) { attributes_for(:import_trade_summary, :with_tariff_duty) }
 
       it { expect(rendered_page).to have_css '.preferential-tariff-duty' }
     end
 
     context 'when preferential quota duty is present' do
-      let(:import_trade_summary) { attributes_for(:import_trade_summary, preferential_quota_duty: '1.00 %') }
+      let(:import_trade_summary) { attributes_for(:import_trade_summary, :with_quota_duty) }
 
       it { expect(rendered_page).to have_css '.preferential-quota-duty' }
     end


### PR DESCRIPTION
### Jira link

HOTT-2124

### What?

I have added/removed/altered:

- [x] Changed logic for when to show no preferential tariffs box and when to show Rules of Origin button

### Why?

I am doing this because:

- There are two inconsistent data sources - at present its possible to end up with both showing
- This tab is only shown when the RoO wizard is enabled, so there is no need to recheck the feature flag within the view since it will always be true

### Notes

- TBH this still isn't right because it appears that either the `trade_tariff_summary` data on the backend is incorrect, or we shouldn't be relying on it on the frontend but this can be discussed further in HOTT-2030

### Have you? (optional)

- [ ] Reviewed view changes with stake holders

### Deployment risks (optional)

- Low, feature flagged off
