### PR TITLE
HOTT-2081: Renamed news heading

### DIFF
--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_header 'Latest news' %>
+<%= page_header 'News bulletin' %>
 
 <% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs t('breadcrumb.news'), [[t('breadcrumb.home'), home_path]] %>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_header 'Latest news' %>
+<%= page_header 'News bulletin' %>
 
 <% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs truncate(@news_item.title),


### PR DESCRIPTION
### Jira link

[HOTT-<2081>
](https://transformuk.atlassian.net/browse/HOTT-2081)

### What?

I have added/removed/altered:

- [ ] Renamed the news heading on index and show

### Why?

I am doing this because:

- We needed to update the heading
<img width="588" alt="Screenshot 2022-10-24 at 14 08 22" src="https://user-images.githubusercontent.com/12201130/197533042-b1ecd76d-1cba-4c92-9e94-e6953511a174.png">

<img width="789" alt="Screenshot 2022-10-24 at 14 08 35" src="https://user-images.githubusercontent.com/12201130/197533016-faee1125-e89d-4025-b07b-13f8810721eb.png">
