### PR TITLE
HOTT-2131: Renamed news heading and breadcrumb

### DIFF
--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_header 'Latest news' %>
+<%= page_header t('breadcrumb.news') %>
 
 <% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs t('breadcrumb.news'), [[t('breadcrumb.home'), home_path]] %>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_header 'Latest news' %>
+<%= page_header t('breadcrumb.news') %>
 
 <% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs truncate(@news_item.title),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,7 +91,7 @@ en:
     help_goods_classification: 2022 UK goods classification
     browse: Browse
     tools: Tools
-    news: News
+    news: News bulletin
     quotas: Quotas
     certificates: Certificate
     additional_codes: Additional codes


### PR DESCRIPTION
### Jira link

[HOTT-<2131>](https://transformuk.atlassian.net/browse/HOTT-2131)

### What?

I have added/removed/altered:

- [x] Renamed news heading and breadcrumb

### Why?

I am doing this because:

- We needed to update it
<img width="828" alt="Screenshot 2022-10-24 at 14 33 38" src="https://user-images.githubusercontent.com/12201130/197539108-b5e386d3-1266-46f9-8e68-077557709e15.png">

<img width="693" alt="Screenshot 2022-10-24 at 14 33 47" src="https://user-images.githubusercontent.com/12201130/197539065-939b5f3b-15a2-40bf-b518-5b9bd130ac91.png">

