### PR TITLE
HOTT-2163: Fixed error caused by empty import measures

### DIFF
--- a/app/services/pending_quota_balance_service.rb
+++ b/app/services/pending_quota_balance_service.rb
@@ -42,7 +42,7 @@ private
   end
 
   def pending_balance
-    if definition.within_first_twenty_days? && declarable.has_safeguard_measure?
+    if declarable.import_measures.any? && definition.within_first_twenty_days? && declarable.has_safeguard_measure?
       begin
         previous_period_definition&.balance
       rescue Faraday::ResourceNotFound

--- a/spec/services/pending_quota_balance_service_spec.rb
+++ b/spec/services/pending_quota_balance_service_spec.rb
@@ -152,5 +152,20 @@ RSpec.describe PendingQuotaBalanceService do
 
       it { is_expected.to eq previous_definition[:balance] }
     end
+
+    context 'with no import measures' do
+      subject { described_class.new(heading.short_code, '1010', Time.zone.today).call }
+
+      before do
+        allow(Heading).to receive(:find).with(heading.short_code, as_of: Time.zone.today)
+                                        .and_return heading
+      end
+
+      let :heading do
+        build :heading
+      end
+
+      it { is_expected.to be nil }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-<2163>](https://transformuk.atlassian.net/browse/HOTT-2163)

### What?

I have added/removed/altered:

- [ ] Fixed error caused by empty import measures

### Why?

I am doing this because:

- We were getting errors on this page in production http://localhost:3001/pending_quota_balances/0702/051104

