### PR TITLE
HOTT-2156 Hide the Rules Not Met cumulation section

### DIFF
--- a/app/models/rules_of_origin/steps/rules_not_met.rb
+++ b/app/models/rules_of_origin/steps/rules_not_met.rb
@@ -19,6 +19,10 @@ module RulesOfOrigin
         chosen_scheme.article('tolerances')&.content
       end
 
+      def show_cumulation_section?
+        !@wizard.find('cumulation').skipped?
+      end
+
     private
 
       def skipped_for_multiple_rules?

--- a/app/views/rules_of_origin/steps/_rules_not_met.html.erb
+++ b/app/views/rules_of_origin/steps/_rules_not_met.html.erb
@@ -65,6 +65,7 @@
   </div>
 </div>
 
+<% if current_step.show_cumulation_section? %>
 <div id="cumulation-section">
   <h3 class="govuk-heading-m">
     <%= t '.cumulation.title' %>
@@ -79,6 +80,7 @@
                 step_path(:cumulation) %>.
   </p>
 </div>
+<% end %>
 
 <div id="whats-next-section" class="panel panel--coloured">
   <div class="govuk-warning-text">

--- a/spec/models/rules_of_origin/steps/rules_not_met_spec.rb
+++ b/spec/models/rules_of_origin/steps/rules_not_met_spec.rb
@@ -79,4 +79,21 @@ RSpec.describe RulesOfOrigin::Steps::RulesNotMet do
       it { is_expected.to eql 'import_export' }
     end
   end
+
+  describe '#show_cumulation_section?' do
+    subject { instance.show_cumulation_section? }
+
+    context 'when arrived via cumulation page' do
+      include_context 'with rules of origin store', :not_wholly_obtained
+
+      it { is_expected.to be true }
+    end
+
+    context 'when arrived via branch without cumulation page' do
+      include_context 'with rules of origin store', :not_wholly_obtained,
+                      scheme_traits: %i[single_wholly_obtained_rule]
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/views/rules_of_origin/steps/_rules_not_met.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_rules_not_met.html.erb_spec.rb
@@ -30,4 +30,11 @@ RSpec.describe 'rules_of_origin/steps/_rules_not_met', type: :view do
 
     it { is_expected.not_to have_css '#tolerances-section' }
   end
+
+  context 'when not passed through cumulation page' do
+    before { allow(current_step).to receive(:show_cumulation_section?).and_return false }
+
+    it { is_expected.not_to have_css '#cumulation-section h3' }
+    it { is_expected.not_to have_css '#cumulation-section a' }
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-2156

### What?

I have added/removed/altered:

- [x] Conditionally hide the cumulation section on the Rules Not Met step

### Why?

I am doing this because:

- If the only rules applicable were wholly obtained and the user states the commodity was not wholly obtained then they will never see the cumulation step so linking to it in this context is confusing

### Deployment risks (optional)

- Low, feature flagged off

### Screenshot

![Screenshot from 2022-10-26 12-03-01](https://user-images.githubusercontent.com/10818/198010281-da392daf-4392-4fb6-9c89-cebf3284e473.png)

