### PR TITLE
HOTT-2173: Support comprehensive redirects

### DIFF
--- a/app/controllers/beta/search_results_controller.rb
+++ b/app/controllers/beta/search_results_controller.rb
@@ -79,7 +79,7 @@ module Beta
     def show
       @search_result = Beta::Search::PerformSearchService.new(query_options, filters).call
 
-      redirect_to @search_result.redirect_to if @search_result.redirect?
+      redirect_to redirect_path if @search_result.redirect?
     end
 
     private
@@ -105,6 +105,10 @@ module Beta
 
     def search_params
       params.permit(:q, :filters, :spell)
+    end
+
+    def redirect_path
+      "#{@search_result.redirect_to}?#{url_options.slice(:year, :month, :day).to_query}"
     end
   end
 end

--- a/spec/controllers/beta/search_results_controller_spec.rb
+++ b/spec/controllers/beta/search_results_controller_spec.rb
@@ -23,6 +23,14 @@ if TradeTariffFrontend.beta_search_enabled?
           { 'material' => 'leather' },
         )
       end
+
+      context 'when redirected' do
+        subject(:do_response) { get :show, params: { q: '0101', year: '2022', month: '12', day: '1' } }
+
+        let(:search_result) { build(:search_result, :redirect) }
+
+        it { is_expected.to redirect_to(heading_path('0101', year: '2022', month: '12', day: '1')) }
+      end
     end
   end
 end

--- a/spec/factories/search_result_factory.rb
+++ b/spec/factories/search_result_factory.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
       meta do
         {
           'redirect' => true,
-          'redirect_to' => 'https://example.com/headings/0101',
+          'redirect_to' => '/headings/0101',
         }
       end
     end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2173

### What?

I have added/removed/altered:

- [x] Added support for date params on beta search redirect

### Why?

I am doing this because:

- This is required to make sure redirects take the find_commodities form params properly
