### PR TITLE
HOTT-2180: Fix block style and font size of spelling corrections

### DIFF
--- a/app/webpacker/src/stylesheets/_search-results.scss
+++ b/app/webpacker/src/stylesheets/_search-results.scss
@@ -4,8 +4,6 @@
 
 .non-corrected-search-results {
   color: $govuk-secondary-text-colour;
-  display: block;
-  font-size: 10px !important;
 }
 
 .search-results {
@@ -58,7 +56,7 @@
       padding: 1em 0 0.5em !important;
       margin: 0 !important;
     }
-    
+
     ul {
       list-style-type: none;
       padding: 0;
@@ -101,7 +99,7 @@
 
           .line-text {
             padding-left: 0 !important;
-            
+
             @media (min-width: $desktop-min-width) {
               padding-left: 0;
               padding-top: 0em;
@@ -127,8 +125,6 @@
       min-height: $chapter-code-height;
       background-color: $highlight-colour;
       position: relative;
-      
-
 
       a {
         display: block;
@@ -139,6 +135,5 @@
         }
       }
     }
-    
   }
 }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2180

### What?

**Before**

![image](https://user-images.githubusercontent.com/8156884/198554537-1ea66e7b-5d08-4909-b82b-a7cf2f5d76ae.png)

**After**

![image](https://user-images.githubusercontent.com/8156884/198554508-9b47f16e-8e75-46be-9b8a-dc2b9fa43201.png)

I have added/removed/altered:

- [x] Adjusted style of spelling correction component

### Why?

I am doing this because:

- This is preferred by Matt
