### PR TITLE
HOTT-2174 Only show importing message after choosing whether to import

### DIFF
--- a/app/models/rules_of_origin/steps/base.rb
+++ b/app/models/rules_of_origin/steps/base.rb
@@ -25,7 +25,7 @@ module RulesOfOrigin
         exporting? ? service_country_name : trade_country_name
       end
 
-      def direction_text
+      def trade_direction
         exporting? ? 'export' : 'import'
       end
 

--- a/app/models/rules_of_origin/steps/base.rb
+++ b/app/models/rules_of_origin/steps/base.rb
@@ -25,7 +25,13 @@ module RulesOfOrigin
         exporting? ? service_country_name : trade_country_name
       end
 
+      def trade_direction_chosen?
+        !trade_direction.nil?
+      end
+
       def trade_direction
+        return unless chosen_scheme.unilateral || @store['import_or_export'].present?
+
         exporting? ? 'export' : 'import'
       end
 

--- a/app/models/rules_of_origin/steps/cumulation.rb
+++ b/app/models/rules_of_origin/steps/cumulation.rb
@@ -8,8 +8,7 @@ module RulesOfOrigin
       end
 
       def scheme_details
-        article = exporting? ? 'cumulation-export' : 'cumulation-import'
-        chosen_scheme.article(article)&.content
+        chosen_scheme.article("cumulation-#{trade_direction}")&.content
       end
 
       def map_path

--- a/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
+++ b/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
@@ -1,5 +1,5 @@
 <span class="govuk-caption-xl">
-  <%= t (current_step.exporting? ? 'rules_of_origin.shared.caption.exporting' : 'rules_of_origin.shared.caption.importing'),
+  <%= t "rules_of_origin.shared.caption.#{current_step.trade_direction}ing",
         commodity_code: current_step.commodity_code,
         service_country_name: current_step.service_country_name,
         trade_country_name: current_step.trade_country_name %>

--- a/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
+++ b/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
@@ -1,5 +1,5 @@
 <span class="govuk-caption-xl">
-  <%= t (current_step.exporting? ? 'rules_of_origin.shared.caption.exporting' : 'rules_of_origin.shared.caption.importing'),
+  <%= t "rules_of_origin.shared.caption.#{current_step.trade_direction}ing",
         commodity_code: current_step.commodity_code,
         service_country_name: current_step.service_country_name,
         trade_country_name: current_step.trade_country_name %>

--- a/app/views/rules_of_origin/steps/_rules_not_met.html.erb
+++ b/app/views/rules_of_origin/steps/_rules_not_met.html.erb
@@ -1,5 +1,5 @@
 <span class="govuk-caption-xl">
-  <%= t (current_step.exporting? ? 'rules_of_origin.shared.caption.exporting' : 'rules_of_origin.shared.caption.importing'),
+  <%= t "rules_of_origin.shared.caption.#{current_step.trade_direction}ing",
         commodity_code: current_step.commodity_code,
         service_country_name: current_step.service_country_name,
         trade_country_name: current_step.trade_country_name %>

--- a/app/views/rules_of_origin/steps/_sidebar_section.html.erb
+++ b/app/views/rules_of_origin/steps/_sidebar_section.html.erb
@@ -17,8 +17,8 @@
     </h3>
   </div>
 
-  <div class="app-step-nav__panel js-panel js-hidden" id="step-panel-check-youre-allowed-to-drive-1">
-    <%= t("rules_of_origin.steps.sections.import_or_export_options.#{current_step.direction_text}_html",
+  <div class="app-step-nav__panel js-panel js-hidden">
+    <%= t("rules_of_origin.steps.sections.import_or_export_options.#{current_step.trade_direction}_html",
           trade_country: current_step.trade_country_name,
           service_country: current_step.service_country_name,
           commodity_link: link_to(current_step.commodity_code, return_to_commodity_path),

--- a/app/views/rules_of_origin/steps/_sidebar_section.html.erb
+++ b/app/views/rules_of_origin/steps/_sidebar_section.html.erb
@@ -22,7 +22,7 @@
           trade_country: current_step.trade_country_name,
           service_country: current_step.service_country_name,
           commodity_link: link_to(current_step.commodity_code, return_to_commodity_path),
-          default: nil) %>
+          default: nil) if current_step.trade_direction_chosen? %>
 
     <ol class="app-step-nav__list " data-length="<%= sidebar_section.steps.length %>">
       <% sidebar_section.steps.each.with_index do |step, index| %>

--- a/spec/models/rules_of_origin/steps/base_spec.rb
+++ b/spec/models/rules_of_origin/steps/base_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe RulesOfOrigin::Steps::Base do
     end
   end
 
-  describe '#direction_text' do
-    subject(:direction_text) { instance.direction_text }
+  describe '#trade_direction' do
+    subject { instance.trade_direction }
 
     context 'with unilateral scheme so import_only' do
       let(:schemes) { build_list :rules_of_origin_scheme, 1, unilateral: true }

--- a/spec/models/rules_of_origin/steps/base_spec.rb
+++ b/spec/models/rules_of_origin/steps/base_spec.rb
@@ -111,6 +111,34 @@ RSpec.describe RulesOfOrigin::Steps::Base do
 
       it { is_expected.to eq('export') }
     end
+
+    context 'when not yet chosen' do
+      include_context 'with rules of origin store'
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#trade_direction_chosen?' do
+    subject { instance.trade_direction_chosen? }
+
+    context 'with unilateral scheme so import_only' do
+      let(:schemes) { build_list :rules_of_origin_scheme, 1, unilateral: true }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when exporting' do
+      include_context 'with rules of origin store', :exporting
+
+      it { is_expected.to be true }
+    end
+
+    context 'when not yet chosen' do
+      include_context 'with rules of origin store'
+
+      it { is_expected.to be false }
+    end
   end
 
   describe '#find_declarable' do

--- a/spec/views/rules_of_origin/steps/_sidebar_section.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_sidebar_section.html.erb_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'rules_of_origin/steps/_sidebar_section', type: :view do
   it { is_expected.to have_css 'li .app-step-nav__panel ol li' }
   it { is_expected.not_to have_css 'li.app-step-nav.app-step-nav__step--active' }
   it { is_expected.not_to have_css 'li ol li.app-step-nav__list-item--active' }
+  it { is_expected.not_to have_css '.app-step-nav__panel > p' }
 
   context 'when rendering current_step' do
     let :render_page do
@@ -33,6 +34,10 @@ RSpec.describe 'rules_of_origin/steps/_sidebar_section', type: :view do
   end
 
   context 'when addition info available' do
+    include_context 'with rules of origin form step',
+                    'origin_requirements_met',
+                    :originating
+
     let :render_page do
       render 'rules_of_origin/steps/sidebar_section',
              sidebar_section: sections['details'],


### PR DESCRIPTION
### Jira link

HOTT-2174

### What?

I have added/removed/altered:

- [x] Renamed `RulesOfOrigin::Steps::Base#direction_text` to `#trade_direction`
- [x] Changed `trade_direction` to return nil if direction has not been chosen
- [x] Added `trade_direction_chosen?` convenience method
- [x] Don't show the 'importing' message in the sidebar if the the user has not yet chosen a trade direction
- [x] Replaced some conditionals with interpolation of the renamed `#trade_direction` method

### Why?

I am doing this because:

- Make it clear that `trade_direction` can be used as data rather then content
- We don't want to show the user an incorrect message saying they are importing when we don't yet know that
- The conditionals replacement was just a code simplification

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, feature flagged off
