### PR TITLE
HOTT-2178: Hide chief measure condition guidance

### DIFF
--- a/app/models/measure_condition_dialog.rb
+++ b/app/models/measure_condition_dialog.rb
@@ -15,7 +15,7 @@ class MeasureConditionDialog
   CONFIG_FILE_NAME = 'db/measure_condition_dialog_config.yaml'.freeze
 
   class << self
-    def build(declarable, measure)
+    def build(declarable, measure, anchor = 'import')
       config = config_for(
         declarable.goods_nomenclature_item_id,
         measure.additional_code.code,
@@ -38,7 +38,7 @@ class MeasureConditionDialog
                 else
                   {
                     partial: 'measures/measure_condition_modal_default',
-                    locals: { measure: },
+                    locals: { measure:, anchor: },
                   }
                 end
 

--- a/app/views/measure_conditions/_permutation_group.html.erb
+++ b/app/views/measure_conditions/_permutation_group.html.erb
@@ -25,6 +25,7 @@
   </table>
 
   <%= render 'measures/guidance_table',
+             anchor: anchor,
              measure_conditions_with_guidance: permutation_group
                                                  .permutations
                                                  .flat_map(&:measure_conditions)

--- a/app/views/measure_conditions/_permutation_group.html.erb
+++ b/app/views/measure_conditions/_permutation_group.html.erb
@@ -25,7 +25,7 @@
   </table>
 
   <%= render 'measures/guidance_table',
-             anchor: anchor,
+             include_chief_guidance: anchor == 'export',
              measure_conditions_with_guidance: permutation_group
                                                  .permutations
                                                  .flat_map(&:measure_conditions)

--- a/app/views/measures/_guidance_table.html.erb
+++ b/app/views/measures/_guidance_table.html.erb
@@ -10,7 +10,9 @@
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Document code</th>
           <th scope="col" class="govuk-table__header">CDS guidance</th>
-          <th scope="col" class="govuk-table__header">CHIEF guidance</th>
+          <% if anchor == 'export' %>
+            <th scope="col" class="govuk-table__header">CHIEF guidance</th>
+          <% end %>
         </tr>
       </thead>
 
@@ -23,9 +25,12 @@
             <td class="govuk-table__cell tariff-markdown">
               <%= govspeak mc.guidance_cds %>
             </td>
-            <td class="govuk-table__cell tariff-markdown">
-              <%= govspeak mc.guidance_chief %>
-            </td>
+
+            <% if anchor == 'export' %>
+              <td class="govuk-table__cell tariff-markdown">
+                <%= govspeak mc.guidance_chief %>
+              </td>
+            <% end %>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/measures/_guidance_table.html.erb
+++ b/app/views/measures/_guidance_table.html.erb
@@ -1,40 +1,40 @@
 <% if measure_conditions_with_guidance.any? %>
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">Guidance for completing Box 44 or Data Element 2/3</span>
-  </summary>
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">Guidance for completing Box 44 or Data Element 2/3</span>
+    </summary>
 
-  <div class="govuk-details__text  govuk-!-font-size-16">
-    <table class="govuk-table govuk-!-margin-bottom-2">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Document code</th>
-          <th scope="col" class="govuk-table__header">CDS guidance</th>
-          <% if anchor == 'export' %>
-            <th scope="col" class="govuk-table__header">CHIEF guidance</th>
-          <% end %>
-        </tr>
-      </thead>
-
-      <tbody class="govuk-table__body">
-        <% measure_conditions_with_guidance.each do |mc| %>
+    <div class="govuk-details__text  govuk-!-font-size-16">
+      <table class="govuk-table govuk-!-margin-bottom-2">
+        <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">
-              <%= mc.document_code %>
-            </td>
-            <td class="govuk-table__cell tariff-markdown">
-              <%= govspeak mc.guidance_cds %>
-            </td>
-
-            <% if anchor == 'export' %>
-              <td class="govuk-table__cell tariff-markdown">
-                <%= govspeak mc.guidance_chief %>
-              </td>
+            <th scope="col" class="govuk-table__header">Document code</th>
+            <th scope="col" class="govuk-table__header">CDS guidance</th>
+            <% if include_chief_guidance %>
+              <th scope="col" class="govuk-table__header">CHIEF guidance</th>
             <% end %>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</details>
+        </thead>
+
+        <tbody class="govuk-table__body">
+          <% measure_conditions_with_guidance.each do |mc| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <%= mc.document_code %>
+              </td>
+              <td class="govuk-table__cell tariff-markdown">
+                <%= govspeak mc.guidance_cds %>
+              </td>
+
+              <% if include_chief_guidance %>
+                <td class="govuk-table__cell tariff-markdown">
+                  <%= govspeak mc.guidance_chief %>
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </details>
 <% end %>

--- a/app/views/measures/_measure_condition_modal.html.erb
+++ b/app/views/measures/_measure_condition_modal.html.erb
@@ -1,5 +1,5 @@
 <div class='conditions' id='<%= measure.id %>' data-popup='<%= measure.destination %>-<%= measure.id %>-conditions'>
   <article>
-    <%= render MeasureConditionDialog.build(declarable, measure).options %>
+    <%= render MeasureConditionDialog.build(declarable, measure, anchor).options %>
   </article>
 </div>

--- a/app/views/measures/_measure_condition_modal_default.html.erb
+++ b/app/views/measures/_measure_condition_modal_default.html.erb
@@ -6,7 +6,9 @@
 
 <% if measure.permutations_enabled? %>
   <%= render partial: 'measure_conditions/permutation_group',
-             collection: measure.measure_condition_permutation_groups %>
+             collection: measure.measure_condition_permutation_groups,
+             locals: { anchor: anchor }
+  %>
 <% else %>
   <% measure.grouped_measure_conditions.each do |condition_group, conditions| %>
     <%= render partial: "measure_conditions/measure_condition_code_#{condition_group[:partial_type]}",
@@ -14,7 +16,7 @@
   <% end %>
 
   <%= render 'measures/guidance_table',
-      measure_conditions_with_guidance: measure.measure_conditions_with_guidance
+      measure_conditions_with_guidance: measure.measure_conditions_with_guidance, anchor: anchor
   %>
 <% end %>
 
@@ -25,11 +27,11 @@
   </h3>
 
   <p>
-    The use of 999L allows a CDS waiver code to be declared for prohibited and restricted goods, 
-    allowing declarants to confirm that the goods are not subject to specific licencing measures. 
+    The use of 999L allows a CDS waiver code to be declared for prohibited and restricted goods,
+    allowing declarants to confirm that the goods are not subject to specific licencing measures.
     You must enter ‘CDS Waiver’ in the additional documentation field for this commodity item.
   </p>
-  
+
   <p>
     This waiver cannot be used for goods that are imported/exported or moved to/from Northern Ireland.
   </p>

--- a/app/views/measures/_measure_condition_modal_default.html.erb
+++ b/app/views/measures/_measure_condition_modal_default.html.erb
@@ -16,7 +16,8 @@
   <% end %>
 
   <%= render 'measures/guidance_table',
-      measure_conditions_with_guidance: measure.measure_conditions_with_guidance, anchor: anchor
+    measure_conditions_with_guidance: measure.measure_conditions_with_guidance,
+    include_chief_guidance: anchor == 'export'
   %>
 <% end %>
 

--- a/app/views/measures/_measure_references.html.erb
+++ b/app/views/measures/_measure_references.html.erb
@@ -1,5 +1,5 @@
 <% if measure.has_measure_conditions? %>
-  <%= render partial: 'measures/measure_condition_modal', locals: { declarable: declarable, measure: measure } %>
+  <%= render partial: 'measures/measure_condition_modal', locals: { declarable: declarable, measure:, anchor: } %>
 <% end %>
 
 <% if measure.has_measure_footnotes? %>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -95,13 +95,13 @@
   </div>
 
   <div id="import-measure-references">
-    <%= render partial: 'measures/measure_references', collection: declarable.import_measures, as: 'measure', locals: { declarable: declarable } %>
+    <%= render partial: 'measures/measure_references', collection: declarable.import_measures, as: 'measure', locals: { declarable: declarable, anchor: 'import' } %>
     <% if TradeTariffFrontend::ServiceChooser.xi? && uk_declarable.present? %>
-      <%= render partial: 'measures/measure_references', collection: uk_declarable.import_measures.import_controls, as: 'measure', locals: { declarable: declarable } %>
-      <%= render partial: 'measures/measure_references', collection: uk_declarable.import_measures.vat_excise, as: 'measure', locals: { declarable: declarable } %>
+      <%= render partial: 'measures/measure_references', collection: uk_declarable.import_measures.import_controls, as: 'measure', locals: { declarable: declarable, anchor: 'import' } %>
+      <%= render partial: 'measures/measure_references', collection: uk_declarable.import_measures.vat_excise, as: 'measure', locals: { declarable: declarable, anchor: 'import' } %>
     <% end %>
   </div>
   <div id="export-measure-references">
-    <%= render partial: 'measures/measure_references', collection: declarable.export_measures, as: 'measure', locals: { declarable: declarable } %>
+    <%= render partial: 'measures/measure_references', collection: declarable.export_measures, as: 'measure', locals: { declarable: declarable, anchor: 'export' } %>
   </div>
 </div>

--- a/spec/models/measure_condition_dialog_spec.rb
+++ b/spec/models/measure_condition_dialog_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe MeasureConditionDialog do
-  subject(:dialog) { described_class.build(declarable, measure) }
+  subject(:dialog) { described_class.build(declarable, measure, 'export' ) }
 
   before do
     stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
@@ -64,7 +64,10 @@ RSpec.describe MeasureConditionDialog do
       it 'returns the default modal partial options' do
         expected_options = {
           partial: 'measures/measure_condition_modal_default',
-          locals: { measure: },
+          locals: {
+            measure:,
+            anchor: 'export',
+          },
         }
 
         expect(dialog.options).to eq(expected_options)

--- a/spec/models/measure_condition_dialog_spec.rb
+++ b/spec/models/measure_condition_dialog_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe MeasureConditionDialog do
-  subject(:dialog) { described_class.build(declarable, measure, 'export' ) }
+  subject(:dialog) { described_class.build(declarable, measure, 'export') }
 
   before do
     stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))

--- a/spec/views/measures/_guidance_table.html.erb_spec.rb
+++ b/spec/views/measures/_guidance_table.html.erb_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 RSpec.describe 'measures/guidance_table', type: :view do
   subject { render_page && rendered }
 
-  let(:render_page) { render 'measures/guidance_table', measure_conditions_with_guidance:, anchor: }
+  let(:render_page) { render 'measures/guidance_table', measure_conditions_with_guidance:, include_chief_guidance: }
 
-  context 'when the page anchor is `export`' do
+  context 'when the page include_chief_guidance is `true`' do
     let(:measure_conditions_with_guidance) { build_list :measure_condition, 2, :with_guidance }
-    let(:anchor) { 'export' }
+    let(:include_chief_guidance) { true }
 
     it { is_expected.to have_css 'details summary', text: /Guidance for completing/ }
     it { is_expected.to have_css 'table tbody tr', count: 2 }
@@ -22,9 +22,9 @@ RSpec.describe 'measures/guidance_table', type: :view do
     end
   end
 
-  context 'when the page anchor is `import`' do
+  context 'when the page include_chief_guidance is `import`' do
     let(:measure_conditions_with_guidance) { build_list :measure_condition, 2, :with_guidance }
-    let(:anchor) { 'import' }
+    let(:include_chief_guidance) { false }
 
     it { is_expected.to have_css 'details summary', text: /Guidance for completing/ }
     it { is_expected.to have_css 'table tbody tr', count: 2 }

--- a/spec/views/measures/_guidance_table.html.erb_spec.rb
+++ b/spec/views/measures/_guidance_table.html.erb_spec.rb
@@ -3,21 +3,39 @@ require 'spec_helper'
 RSpec.describe 'measures/guidance_table', type: :view do
   subject { render_page && rendered }
 
-  let :render_page do
-    render 'measures/guidance_table', measure_conditions_with_guidance: conditions
+  let(:render_page) { render 'measures/guidance_table', measure_conditions_with_guidance:, anchor: }
+
+  context 'when the page anchor is `export`' do
+    let(:measure_conditions_with_guidance) { build_list :measure_condition, 2, :with_guidance }
+    let(:anchor) { 'export' }
+
+    it { is_expected.to have_css 'details summary', text: /Guidance for completing/ }
+    it { is_expected.to have_css 'table tbody tr', count: 2 }
+    it { is_expected.to have_css 'table tbody td', text: measure_conditions_with_guidance.first.document_code }
+    it { is_expected.to have_css 'table tbody td', text: /Guidance CDS/ }
+    it { is_expected.to have_css 'table tbody td', text: /Guidance CHIEF/ }
+
+    context 'with no conditions' do
+      let(:measure_conditions_with_guidance) { [] }
+
+      it { is_expected.not_to have_css 'details' }
+    end
   end
 
-  let(:conditions) { build_list :measure_condition, 2, :with_guidance }
+  context 'when the page anchor is `import`' do
+    let(:measure_conditions_with_guidance) { build_list :measure_condition, 2, :with_guidance }
+    let(:anchor) { 'import' }
 
-  it { is_expected.to have_css 'details summary', text: /Guidance for completing/ }
-  it { is_expected.to have_css 'table tbody tr', count: 2 }
-  it { is_expected.to have_css 'table tbody td', text: conditions.first.document_code }
-  it { is_expected.to have_css 'table tbody td', text: /Guidance CDS/ }
-  it { is_expected.to have_css 'table tbody td', text: /Guidance CHIEF/ }
+    it { is_expected.to have_css 'details summary', text: /Guidance for completing/ }
+    it { is_expected.to have_css 'table tbody tr', count: 2 }
+    it { is_expected.to have_css 'table tbody td', text: measure_conditions_with_guidance.first.document_code }
+    it { is_expected.to have_css 'table tbody td', text: /Guidance CDS/ }
+    it { is_expected.not_to have_css 'table tbody td', text: /Guidance CHIEF/ }
 
-  context 'with no conditions' do
-    let(:conditions) { [] }
+    context 'with no conditions' do
+      let(:measure_conditions_with_guidance) { [] }
 
-    it { is_expected.not_to have_css 'details' }
+      it { is_expected.not_to have_css 'details' }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2178

### What?

**Import**

![image](https://user-images.githubusercontent.com/8156884/198667153-30b49d71-d093-4e98-a044-688212ef9aa2.png)

**Export**

![image](https://user-images.githubusercontent.com/8156884/198667376-38dda0f9-544c-4406-a169-fec41f9279ce.png)

I have added/removed/altered:

- [x] Exclude chief guidance on import tab measure condition modals
- [x] Add some coverage for this behaviour

### Why?

I am doing this because:

- We're decommissioning chief for import measures and this is a requirement to avoid confusing traders
