### PR TITLE
HOTT-2029: Expose measures api

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -48,6 +48,7 @@ module TradeTariffFrontend
       footnote_types
       changes
       rules_of_origin_schemes
+      measures
       measure_types
       measure_condition_codes
       measure_actions


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2029

### What?

I have added/removed/altered:

- [x] Added public endpoint for measures api

### Why?

I am doing this because:

- This is needed for the DIT team to access measures by their sid
