### PR TITLE
HOTT-2175 Add origin reference docs to proof verification step

### DIFF
--- a/app/models/rules_of_origin/article.rb
+++ b/app/models/rules_of_origin/article.rb
@@ -4,4 +4,16 @@ class RulesOfOrigin::Article
   include ApiEntity
 
   attr_accessor :article, :content
+
+  def text
+    content.sub(/{{.*}}/i, '') if content
+  end
+
+  def ord_reference
+    content.scan(/{{(.*)}}/i).first&.first&.strip if content
+  end
+
+  def ord_reference?
+    !ord_reference.nil?
+  end
 end

--- a/app/views/rules_of_origin/steps/_proof_verification.html.erb
+++ b/app/views/rules_of_origin/steps/_proof_verification.html.erb
@@ -8,6 +8,11 @@
 
 <div class="tariff-markdown">
   <div class="numbered-then-lettered-list">
-    <%= govspeak current_step.verification_text %>
+    <%= govspeak remove_article_reference(current_step.verification_text) %>
   </div>
 </div>
+
+<%= render 'shared/origin_reference_document',
+      origin_reference_document: current_step.origin_reference_document,
+      article_match: find_article_reference(current_step.verification_text) \
+      if find_article_reference(current_step.verification_text) %>

--- a/spec/factories/rules_of_origin/article_factory.rb
+++ b/spec/factories/rules_of_origin/article_factory.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory :rules_of_origin_article, class: 'RulesOfOrigin::Article' do
     sequence(:article) { |n| "article-#{n}" }
     sequence(:content) { |n| "### Article #{n}\n\n* markdown list\n" }
+
+    trait :ord_reference do
+      content { "### Some information\n\n{{ articles 32 to 33 }}" }
+    end
   end
 end

--- a/spec/models/rules_of_origin/article_spec.rb
+++ b/spec/models/rules_of_origin/article_spec.rb
@@ -3,4 +3,54 @@ require 'spec_helper'
 RSpec.describe RulesOfOrigin::Article do
   it { is_expected.to respond_to :article }
   it { is_expected.to respond_to :content }
+
+  describe '#text' do
+    subject { instance.text }
+
+    context 'without ord reference' do
+      let(:instance) { build :rules_of_origin_article }
+
+      it { is_expected.to eql instance.content }
+    end
+
+    context 'with ord reference' do
+      let(:instance) { build :rules_of_origin_article, :ord_reference }
+
+      it { is_expected.not_to eql instance.content }
+      it { is_expected.to match '### Some information' }
+      it { is_expected.not_to match '{{' }
+    end
+  end
+
+  describe 'ord_reference' do
+    subject { instance.ord_reference }
+
+    context 'without ord reference' do
+      let(:instance) { build :rules_of_origin_article }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with ord reference' do
+      let(:instance) { build :rules_of_origin_article, :ord_reference }
+
+      it { is_expected.to eql 'articles 32 to 33' }
+    end
+  end
+
+  describe 'ord_reference?' do
+    subject { instance.ord_reference? }
+
+    context 'without ord reference' do
+      let(:instance) { build :rules_of_origin_article }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with ord reference' do
+      let(:instance) { build :rules_of_origin_article, :ord_reference }
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/views/rules_of_origin/steps/_cumulation.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_cumulation.html.erb_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'rules_of_origin/steps/_cumulation', type: :view, vcr: { cassette
 
     it { is_expected.to have_css '.downloadable-document__text', text: article_reference }
     it { is_expected.to have_css '.downloadable-document__text', text: schemes.first.origin_reference_document.ord_title }
-    it { is_expected.to have_css 'a[href]', text: /Download rules of origin reference document/ }
+    it { is_expected.to have_link 'Download rules of origin reference document' }
     it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_version }
     it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_date }
 
@@ -62,7 +62,7 @@ RSpec.describe 'rules_of_origin/steps/_cumulation', type: :view, vcr: { cassette
 
       it { is_expected.to have_css '.downloadable-document__text', text: article_reference }
       it { is_expected.to have_css '.downloadable-document__text', text: schemes.first.origin_reference_document.ord_title }
-      it { is_expected.to have_css 'a[href]', text: /Download rules of origin reference document/ }
+      it { is_expected.to have_link 'Download rules of origin reference document' }
       it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_version }
       it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_date }
     end

--- a/spec/views/rules_of_origin/steps/_proof_verification.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_proof_verification.html.erb_spec.rb
@@ -12,4 +12,16 @@ RSpec.describe 'rules_of_origin/steps/_proof_verification', type: :view do
   it { is_expected.to have_css 'span.govuk-caption-xl', text: /obtaining and verifying/i }
   it { is_expected.to have_css 'h1', text: /Verification.*Japan/ }
   it { is_expected.to have_css '.tariff-markdown *' }
+
+  context 'with article reference' do
+    let(:article_reference) { 'article 123' }
+
+    let :articles do
+      attributes_for_list :rules_of_origin_article, 1,
+                          article: 'verification',
+                          content: "Some content\n\n{{ #{article_reference} }}"
+    end
+
+    it { is_expected.to have_link 'Download rules of origin reference document' }
+  end
 end

--- a/spec/views/rules_of_origin/steps/_sufficient_processing.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_sufficient_processing.html.erb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'rules_of_origin/steps/_sufficient_processing', type: :view do
 
     it { is_expected.to have_css '.downloadable-document__text', text: article_reference }
     it { is_expected.to have_css '.downloadable-document__text', text: schemes.first.origin_reference_document.ord_title }
-    it { is_expected.to have_css 'a[href]', text: /Download rules of origin reference document/ }
+    it { is_expected.to have_link 'Download rules of origin reference document' }
     it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_version }
     it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_date }
   end

--- a/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_wholly_obtained_definition.html.erb_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'rules_of_origin/steps/_wholly_obtained_definition', type: :view 
 
     it { is_expected.to have_css '.downloadable-document__text', text: article_reference }
     it { is_expected.to have_css '.downloadable-document__text', text: schemes.first.origin_reference_document.ord_title }
-    it { is_expected.to have_css 'a[href]', text: /Download rules of origin reference document/ }
+    it { is_expected.to have_link 'Download rules of origin reference document' }
     it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_version }
     it { is_expected.to have_css '.subtext', text: schemes.first.origin_reference_document.ord_date }
 


### PR DESCRIPTION
### Jira link

HOTT-2175

### What?

I have added/removed/altered:

- [x] Include origin reference docs on proof verification step

### Why?

I am doing this because:

- They should be showing and are not

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, feature flagged off
