### PR TITLE
HOTT-2030 Show the Rules of Origin button in the

### DIFF
--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -5,7 +5,7 @@
       <%= country_flag_tag country_code, alt: "Flag for #{country_name}" %>
     </h2>
 
-    <% if rules_of_origin_schemes.present? %>
+    <% if rules_of_origin_schemes.any? %>
       <p>
         Preferential tariff treatment reduces the duties you are required to pay when importing or exporting goods to or from <%= country_name %>.
       </p>
@@ -14,22 +14,21 @@
       </p>
     <% end %>
 
-    <%= rules_of_origin_schemes_intro country_name, rules_of_origin_schemes unless declarable.import_trade_summary.no_preferential_duties? %>
 
-    <%= render 'rules_of_origin/import_trade_summary',
-               import_trade_summary: declarable.import_trade_summary unless rules_of_origin_schemes.many?
-    %>
+    <% if rules_of_origin_schemes.any? %>
+      <%= rules_of_origin_schemes_intro country_name, rules_of_origin_schemes %>
 
-    <% if declarable.import_trade_summary.no_preferential_duties? %>
-      <p class="tariff-inset-information">
-        As there is neither a preferential tariff nor a preferential quota present for this commodity, the 'Check rules of origin' tool is not available.
-      </p>
-    <% elsif rules_of_origin_schemes.any? %>
+      <%= render 'rules_of_origin/import_trade_summary',
+                 import_trade_summary: declarable.import_trade_summary unless rules_of_origin_schemes.many? %>
+
       <%= render 'rules_of_origin/wizard_link',
                  country_code: country_code,
                  commodity_code: commodity_code,
-                 declarable: declarable
-      %>
+                 declarable: declarable %>
+    <% else %>
+      <p class="govuk-inset-text">
+        As there is neither a preferential tariff nor a preferential quota present for this commodity, the 'Check rules of origin' tool is not available.
+      </p>
     <% end %>
 
     <%= render 'rules_of_origin/non_preferential' %>

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -56,17 +56,6 @@ RSpec.describe 'rules_of_origin/_tab', type: :view do
     it { is_expected.to have_css '#rules-of-origin__intro--country-scheme' }
   end
 
-  context 'with no scheme' do
-    let(:rules_of_origin_schemes) { [] }
-
-    it { is_expected.to have_css '.govuk-inset-text', text: /neither a preferential/ }
-    it { is_expected.not_to have_css '.rules-of-origin__scheme' }
-
-    it 'includes the non-preferential bloc' do
-      expect(rendered_page).to have_css '.rules-of-origin__non-preferential'
-    end
-  end
-
   context 'with multiple schemes' do
     let(:rules_of_origin_schemes) do
       build_list :rules_of_origin_scheme, 3, rules:,

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'rules_of_origin/_tab', type: :view do
   context 'with no scheme' do
     let(:rules_of_origin_schemes) { [] }
 
-    it { is_expected.to have_css '#rules-of-origin__intro--no-scheme' }
+    it { is_expected.to have_css '.govuk-inset-text', text: /neither a preferential/ }
     it { is_expected.not_to have_css '.rules-of-origin__scheme' }
 
     it 'includes the non-preferential bloc' do


### PR DESCRIPTION
correct circumstances

### Jira link

HOTT-2030

### What?

I have added/removed/altered:

- [x] Changed the logic around what to show on Rules of Origin tab
- [x] UX tweak to use GovUK inset text for 'no tariff' message

### Why?

I am doing this because:

- If there were multiple preferential tariffs, we were telling the user that there weren't any - this primarily affected Vietnam

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, feature flagged off
