### PR TITLE
HOTT-2181 Invalid date breaks the ErrorsController

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -30,4 +30,8 @@ class ErrorsController < ApplicationController
       format.all { render status: :service_unavailable, plain: 'Maintenance mode' }
     end
   end
+
+  def search_invoked?
+    false
+  end
 end

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -65,11 +65,17 @@ RSpec.describe 'Error handling' do
       it { is_expected.to have_attributes body: 'Internal server error' }
     end
 
-    context 'with new search enabled' do
+    context 'with search banner enabled' do
       before do
         allow(TradeTariffFrontend).to receive(:search_banner?).and_return true
         visit '/500'
       end
+
+      it_behaves_like 'internal server error'
+    end
+
+    context 'with invalid date' do
+      before { visit '/500?day=0&month=1&year=2022' }
 
       it_behaves_like 'internal server error'
     end


### PR DESCRIPTION
### Jira link

HOTT-2181

### What?

I have added/removed/altered:

- [x] Don't modify `ApplicationController#url_options` in ErrorsController

### Why?

I am doing this because:

- If the date is invalid, or other user supplied data is invalid, we end up unable to render the ErrorsController pages and falling back to the plain white failsafe 500 screen.

### Deployment risks (optional)

- Fixes an issue with a foundational component
