### PR TITLE
HOTT-2190 Link glossary terms from rules page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,10 @@ class PagesController < ApplicationController
   before_action :disable_search_form,
                 :disable_last_updated_footnote
 
+  def glossary
+    @glossary = Pages::Glossary.new(params[:id])
+  end
+
   def cn2021_cn2022
     @chapters = Chapter.all
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,7 @@ class PagesController < ApplicationController
                 :disable_last_updated_footnote
 
   def glossary
-    @glossary = Pages::Glossary.new(params[:id])
+    @glossary = Pages::Glossary.find(params[:id])
   end
 
   def cn2021_cn2022

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -148,4 +148,16 @@ module ApplicationHelper
   def glossary_term(term)
     link_to term, glossary_path(term.to_s.underscore)
   end
+
+  def link_glossary_terms(content)
+    content.gsub %r{\(([A-Z][A-Za-z]+)\)} do |match|
+      term = Regexp.last_match.captures[0]
+
+      if Pages::Glossary.pages.include? term.underscore
+        "([#{term}](/glossary/#{term.underscore}))"
+      else
+        match
+      end
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -144,4 +144,8 @@ module ApplicationHelper
   def back_link(url, text = t('navigation.back'), **options)
     link_to text, url, **options.merge(class: 'govuk-back-link')
   end
+
+  def glossary_term(term)
+    link_to term, glossary_path(term.to_s.underscore)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -142,7 +142,12 @@ module ApplicationHelper
   end
 
   def back_link(url, text = t('navigation.back'), **options)
-    link_to text, url, **options.merge(class: 'govuk-back-link')
+    options = options.merge(class: 'govuk-back-link')
+    if options.delete(:javascript)
+      options[:onclick] = 'window.history.go(-1); return false;'
+    end
+
+    link_to text, url, **options
   end
 
   def glossary_term(term)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -140,4 +140,8 @@ module ApplicationHelper
   def paragraph_if_content(content)
     tag.p(content) if content.present?
   end
+
+  def back_link(url, text = t('navigation.back'), **options)
+    link_to text, url, **options.merge(class: 'govuk-back-link')
+  end
 end

--- a/app/helpers/meursing_lookup_steps_helper.rb
+++ b/app/helpers/meursing_lookup_steps_helper.rb
@@ -12,7 +12,7 @@ module MeursingLookupStepsHelper
     "Meursing lookup: #{step.key}"
   end
 
-  def back_link
-    link_to 'Back', meursing_lookup_step_path(wizard.previous_key), class: 'govuk-back-link' if wizard.previous_key
+  def meursing_back_link
+    back_link meursing_lookup_step_path(wizard.previous_key) if wizard.previous_key
   end
 end

--- a/app/models/pages/glossary.rb
+++ b/app/models/pages/glossary.rb
@@ -1,34 +1,37 @@
 module Pages
   class Glossary
-    SAFE_TERM = %r{\A[a-z0-9_]+\z}
-    PAGE_ROOT = 'pages/glossary'.freeze
-    VIEW_ROOT = Rails.root.join('app/views/pages/glossary')
+    PAGE_GLOB = Rails.root.join('app/views/pages/glossary/_*.html.erb')
 
     attr_reader :term
 
-    def initialize(term)
-      raise UnsafePageTerm unless term.match? SAFE_TERM
+    class << self
+      def pages
+        @pages ||= Dir[PAGE_GLOB].map do |f|
+          File.basename(f, '.html.erb').slice(1..)
+        end
+      end
 
+      def find(term)
+        raise UnknownPage unless pages.include?(term)
+
+        new(term)
+      end
+
+    private
+
+      def templates
+        Dir[Rails.root.join('app/views/pages/glossary/_*.html.erb')]
+      end
+    end
+
+    def initialize(term)
       @term = term
     end
 
     def page
-      raise UnknownPage unless page_exists?
-
-      page_template
+      "pages/glossary/#{term}"
     end
 
-    class UnsafePageTerm < StandardError; end
     class UnknownPage < StandardError; end
-
-  private
-
-    def page_template
-      File.join(PAGE_ROOT, term)
-    end
-
-    def page_exists?
-      VIEW_ROOT.join("_#{term}.html.erb").file?
-    end
   end
 end

--- a/app/models/pages/glossary.rb
+++ b/app/models/pages/glossary.rb
@@ -1,0 +1,34 @@
+module Pages
+  class Glossary
+    SAFE_TERM = %r{\A[a-z0-9_]+\z}
+    PAGE_ROOT = 'pages/glossary'.freeze
+    VIEW_ROOT = Rails.root.join('app/views/pages/glossary')
+
+    attr_reader :term
+
+    def initialize(term)
+      raise UnsafePageTerm unless term.match? SAFE_TERM
+
+      @term = term
+    end
+
+    def page
+      raise UnknownPage unless page_exists?
+
+      page_template
+    end
+
+    class UnsafePageTerm < StandardError; end
+    class UnknownPage < StandardError; end
+
+  private
+
+    def page_template
+      File.join(PAGE_ROOT, term)
+    end
+
+    def page_exists?
+      VIEW_ROOT.join("_#{term}.html.erb").file?
+    end
+  end
+end

--- a/app/views/meursing_lookup/steps/_end.html.erb
+++ b/app/views/meursing_lookup/steps/_end.html.erb
@@ -1,4 +1,4 @@
-<%= back_link %>
+<%= meursing_back_link %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/meursing_lookup/steps/_form.html.erb
+++ b/app/views/meursing_lookup/steps/_form.html.erb
@@ -1,4 +1,4 @@
-<%= back_link %>
+<%= meursing_back_link %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/glossary.html.erb
+++ b/app/views/pages/glossary.html.erb
@@ -1,0 +1,3 @@
+<%= back_link request.referer || root_path %>
+
+<%= render @glossary.page %>

--- a/app/views/pages/glossary.html.erb
+++ b/app/views/pages/glossary.html.erb
@@ -1,3 +1,3 @@
-<%= back_link request.referer || root_path %>
+<%= back_link (request.referer || find_commodity_path) %>
 
 <%= render @glossary.page %>

--- a/app/views/pages/glossary.html.erb
+++ b/app/views/pages/glossary.html.erb
@@ -1,3 +1,3 @@
-<%= back_link (request.referer || find_commodity_path) %>
+<%= back_link (request.referer || find_commodity_path), javascript: true %>
 
 <%= render @glossary.page %>

--- a/app/views/pages/glossary.html.erb
+++ b/app/views/pages/glossary.html.erb
@@ -1,3 +1,7 @@
 <%= back_link (request.referer || find_commodity_path), javascript: true %>
 
-<%= render @glossary.page %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render @glossary.page %>
+  </div>
+</div>

--- a/app/views/pages/glossary/_exw.html.erb
+++ b/app/views/pages/glossary/_exw.html.erb
@@ -1,0 +1,34 @@
+<h1 class="govuk-heading-xl">EXW (Ex-works price)</h1>
+
+<p>"EXW" means:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    the ex-works price of the product paid or payable to the manufacturer in
+    whose undertaking the last working or processing is carried out, provided
+    that the price includes the value of all the materials used and all other
+    costs incurred in the production of a product minus any internal taxes which
+    are, or may be, repaid when the product obtained is exported; or
+  </li>
+
+  <li>
+    if there is no price paid or payable or if the actual price paid does not
+    reflect all costs related to the production of the product which are
+    actually incurred in the production of a product, the value of all the
+    materials used and all other costs incurred in the production of the product
+    in the exporting Party which:
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        include selling, general and administrative expenses, as well as profit,
+        that can be reasonably allocated to the product; and
+      </li>
+
+      <li>
+        exclude the costs of freight, insurance, all other costs incurred in
+        transporting the product and any internal taxes of the exporting Party
+        which are, or may be, repaid when the product obtained is exported;
+      </li>
+    </ul>
+  </li>
+</ul>

--- a/app/views/pages/glossary/_fob.html.erb
+++ b/app/views/pages/glossary/_fob.html.erb
@@ -1,0 +1,36 @@
+<h1 class="govuk-heading-xl">FOB (Free on board price)</h1>
+
+<p>"FOB" means:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    the free on board price of the product paid or payable to the seller
+    regardless of the mode of shipment, provided that the price includes the
+    value of all the materials used and all other costs incurred in the
+    production of a product and its transportation to the exportation port in
+    the Party, minus any internal taxes which are, or may be, repaid when the
+    product obtained is exported; or
+  </li>
+
+  <li>
+    if there is no price paid or payable or if the actual price paid does not
+    reflect all costs related to the production of the product which are
+    actually incurred in the production of a product, the value of all the
+    materials used and all other costs incurred in the production of the product
+    in the exporting Party, and its transportation to the exportation port in
+    the Party which:
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        include selling, general and administrative expenses, as well as profit,
+        that can be reasonably allocated to the product, the costs of freight
+        and insurance; and
+      </li>
+
+      <li>
+        exclude any internal taxes of the exporting Party which are, or may be,
+        repaid when the product obtained is exported;
+      </li>
+    </ul>
+  </li>
+</ul>

--- a/app/views/pages/glossary/_max_nom.html.erb
+++ b/app/views/pages/glossary/_max_nom.html.erb
@@ -1,0 +1,33 @@
+<h1 class="govuk-heading-xl">
+  MaxNOM (Maximum value of non-originating materials)
+</h1>
+
+<p>
+  "MaxNOM" means the maximum value of non-originating materials expressed as a
+  percentage.
+</p>
+
+<p>
+  If a rule requires a "maximum level of non-originating material" (MaxNOM), a
+  certain proportion of the value of the final good must be generated in one of
+  the parties to the Trade Agreement. This can include originating parts, or
+  value added in the production such as labour and manufacturing costs.
+</p>
+
+<p>For the calculation of MaxNOM , the following formula applies:</p>
+
+<blockquote>MaxNOM(%) = (VNM/EXW) x 100</blockquote>
+
+<p>where:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    <%= glossary_term 'VNM' %> means the value of non-originating materials used
+    in the production of the product
+  </li>
+
+  <li>
+    <%= glossary_term 'EXW' %> means the price paid for the product ex-works
+    (i.e. when it leaves the factory)
+  </li>
+</ul>

--- a/app/views/pages/glossary/_rvc.html.erb
+++ b/app/views/pages/glossary/_rvc.html.erb
@@ -1,0 +1,73 @@
+<h1 class="govuk-heading-xl">RVC (minimum regional value content)</h1>
+
+<p>
+  "RVC" means the minimum regional value content of a product, expressed as a
+  percentage.
+</p>
+
+<p>
+  For a minority of goods, a specific rule of origin will require the good to
+  meet an additional requirement to qualify as originating.
+</p>
+
+<p>
+  Usually, this additional requirement tests the good's regional value content
+  (RVC), which requires that a certain percentage of the good's value originates
+  in an FTA country.
+</p>
+
+<p>
+  For example, some rules may specify that a good must have at least a 35% RVC
+  based on the build-up method. To qualify for originating status under the FTA,
+  therefore, importers have to demonstrate that at least 35% of the good's value
+  originated in the territory of the other party as determined using the
+  build-up method.
+</p>
+
+<p>
+  If a rule requires an HS classification change and an RVC test, the good has
+  to meet both of these requirements to be an originating good.
+</p>
+
+<h2 class="govuk-heading-l">Calculating regional value content</h2>
+
+<p>
+  Regional Value Content may be calculated using the Build Down method or the
+  Build Up method.
+</p>
+
+<p>
+  Unless specified in the rule, exporters or producers can choose the RVC method
+  to be used.
+</p>
+
+<h3 class="govuk-heading-m">Build-down Method</h3>
+
+<blockquote>RVC = ((AV - VNM) / AV)) * 100</blockquote>
+
+<p>where:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>VC is the regional value content, expressed as a percentage;</li>
+  <li>AV is the adjusted value (the value for customs purposes), and</li>
+  <li>
+    VNM is the value of non-originating materials that are acquired and used by
+    the producer in the production of the good. VNM does not include the value
+    of a material that is self-produced
+  </li>
+</ul>
+
+<h3 class="govuk-heading-m">Build-up Method</h3>
+
+<blockquote>RVC = (VOM / AV) x 100</blockquote>
+
+<p>where:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>RVC is the regional value content, expressed as a percentage;</li>
+  <li>AV is the adjusted value (the value for customs purposes); and</li>
+  <li>
+    VOM is the value of originating materials that are acquired or self
+    produced, and used by the producer in the production of the good.
+  </li>
+</ul>

--- a/app/views/pages/glossary/_vnm.html.erb
+++ b/app/views/pages/glossary/_vnm.html.erb
@@ -1,0 +1,16 @@
+<h1 class="govuk-heading-xl">
+  VNM (Value of non-originating materials)
+</h1>
+
+<p>
+  "VNM" means the value of non-originating materials used in the manufacture of
+  the product which is its customs value at the time of importation including
+  freight, insurance where appropriate, packing and all the other costs incurred
+  in transporting the materials to the importation port in the Party where the
+  producer of the good is located.
+</p>
+
+<p>
+  Where it is not known and cannot be ascertained, the first ascertainable price
+  paid for the non-originating materials is used.
+</p>

--- a/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
+++ b/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
@@ -3,7 +3,7 @@
         :rule,
         form.object.options,
         :resource_id,
-        ->(option) { govspeak option.rule } %>
+        ->(option) { govspeak link_glossary_terms option.rule } %>
 
   <div class="tariff-markdown">
     <%= govspeak t '.body', scheme_title: form.object.scheme_title %>

--- a/app/views/rules_of_origin/steps/show.html.erb
+++ b/app/views/rules_of_origin/steps/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('.meta_title',  step: current_step.model_name.human) %>
 
 <section id="rules-of-origin-<%= current_step.key %>">
-  <%= link_to t('navigation.back'), step_path(wizard.previous_key), class: 'govuk-back-link' %>
+  <%= back_link step_path(wizard.previous_key) %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/webpacker/src/stylesheets/_markdown.scss
+++ b/app/webpacker/src/stylesheets/_markdown.scss
@@ -5,7 +5,11 @@
   h4         { @extend .govuk-heading-s }
   p          { @extend .govuk-body }
   a          { @extend .govuk-link }
-  blockquote { @extend .govuk-inset-text }
+
+  blockquote {
+    @extend .govuk-inset-text;
+    background: none;
+  }
 
   ul {
     @extend .govuk-list;

--- a/app/webpacker/src/stylesheets/_typography.scss
+++ b/app/webpacker/src/stylesheets/_typography.scss
@@ -16,3 +16,12 @@
 .avoid-line-breaks {
   white-space: nowrap;
 }
+
+blockquote {
+  @extend .govuk-body ;
+
+  padding: govuk-spacing(2);
+  margin-left: 0;
+  margin-right: 0;
+  background-color: govuk-colour("light-grey");
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   get 'opensearch', to: 'pages#opensearch', constraints: { format: :xml }
   get 'privacy', to: 'pages#privacy', as: 'privacy'
   get 'terms', to: 'pages#terms'
+  get 'glossary/:id', to: 'pages#glossary', as: :glossary
 
   get 'geographical_areas/:id', to: 'geographical_areas#show', as: :geographical_area
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -378,4 +378,20 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '#back_link' do
+    context 'without text label' do
+      subject { back_link '/back-page' }
+
+      it { is_expected.to have_link 'Back', href: '/back-page' }
+      it { is_expected.to have_css 'a.govuk-back-link' }
+    end
+
+    context 'with text label' do
+      subject { back_link '/back-page', 'Go back' }
+
+      it { is_expected.to have_link 'Go back', href: '/back-page' }
+      it { is_expected.to have_css 'a.govuk-back-link' }
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -385,6 +385,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       it { is_expected.to have_link 'Back', href: '/back-page' }
       it { is_expected.to have_css 'a.govuk-back-link' }
+      it { is_expected.not_to have_css 'a[onclick]' }
     end
 
     context 'with text label' do
@@ -392,6 +393,12 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       it { is_expected.to have_link 'Go back', href: '/back-page' }
       it { is_expected.to have_css 'a.govuk-back-link' }
+    end
+
+    context 'with javascript' do
+      subject { back_link '/back', javascript: true }
+
+      it { is_expected.to have_css 'a[onclick]' }
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -394,4 +394,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { is_expected.to have_css 'a.govuk-back-link' }
     end
   end
+
+  describe '#glossary_term' do
+    subject { glossary_term 'MaxNOM' }
+
+    it { is_expected.to have_link 'MaxNOM', href: '/glossary/max_nom' }
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -400,4 +400,28 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     it { is_expected.to have_link 'MaxNOM', href: '/glossary/max_nom' }
   end
+
+  describe 'link_glossary_terms' do
+    subject { link_glossary_terms content }
+
+    before { allow(Pages::Glossary).to receive(:terms).and_return %w[max_nom rvc] }
+
+    context 'with matching term' do
+      let(:content) { 'Some content (MaxNOM)' }
+
+      it { is_expected.to eql 'Some content ([MaxNOM](/glossary/max_nom))' }
+    end
+
+    context 'without matching term' do
+      let(:content) { 'Some content (NOM)' }
+
+      it { is_expected.to eql content }
+    end
+
+    context 'with multiple terms' do
+      let(:content) { 'Some (RVC) content (MaxNOM)' }
+
+      it { is_expected.to eql 'Some ([RVC](/glossary/rvc)) content ([MaxNOM](/glossary/max_nom))' }
+    end
+  end
 end

--- a/spec/helpers/meursing_lookup_steps_helper_spec.rb
+++ b/spec/helpers/meursing_lookup_steps_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe MeursingLookupStepsHelper, type: :helper do
-  describe '#back_link' do
+  describe '#meursing_back_link' do
     before do
       allow(helper).to receive(:wizard).and_return(wizard)
     end
@@ -16,13 +16,13 @@ RSpec.describe MeursingLookupStepsHelper, type: :helper do
     context 'when the wizard has a previous_key' do
       let(:previous_key) { 'starch' }
 
-      it { expect(helper.back_link).to eq('<a class="govuk-back-link" href="/meursing_lookup/steps/starch">Back</a>') }
+      it { expect(helper.meursing_back_link).to eq('<a class="govuk-back-link" href="/meursing_lookup/steps/starch">Back</a>') }
     end
 
     context 'when the wizard does not have a previous_key' do
       let(:previous_key) { nil }
 
-      it { expect(helper.back_link).to be_nil }
+      it { expect(helper.meursing_back_link).to be_nil }
     end
   end
 

--- a/spec/models/pages/glossary_spec.rb
+++ b/spec/models/pages/glossary_spec.rb
@@ -1,22 +1,30 @@
 require 'spec_helper'
 
 RSpec.describe Pages::Glossary do
-  describe '#new' do
+  describe '.new' do
+    subject { described_class.new 'test' }
+
+    it { is_expected.to have_attributes term: 'test' }
+  end
+
+  describe '#find' do
+    before { allow(described_class).to receive(:pages).and_return %w[some_term] }
+
     context 'with safe page term' do
-      subject { described_class.new 'some_term' }
+      subject { described_class.find 'some_term' }
 
       it { is_expected.to be_instance_of described_class }
       it { is_expected.to have_attributes term: 'some_term' }
     end
 
     context 'with unsafe page term' do
-      let(:unsafe) { described_class.new '../../../etc/passwd' }
+      let(:unsafe) { described_class.find '../../../etc/passwd' }
 
-      it { expect { unsafe }.to raise_exception described_class::UnsafePageTerm }
+      it { expect { unsafe }.to raise_exception described_class::UnknownPage }
     end
 
     context 'with unknown page' do
-      subject(:unknown) { described_class.new('something_random').page }
+      subject(:unknown) { described_class.find('something_random') }
 
       it { expect { unknown }.to raise_exception described_class::UnknownPage }
     end
@@ -24,9 +32,9 @@ RSpec.describe Pages::Glossary do
 
   describe '#page' do
     context 'with known page' do
-      subject { described_class.new('vnm').page }
+      subject { described_class.new('something').page }
 
-      it { is_expected.to eql 'pages/glossary/vnm' }
+      it { is_expected.to eql 'pages/glossary/something' }
     end
   end
 end

--- a/spec/models/pages/glossary_spec.rb
+++ b/spec/models/pages/glossary_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe Pages::Glossary do
+  describe '#new' do
+    context 'with safe page term' do
+      subject { described_class.new 'some_term' }
+
+      it { is_expected.to be_instance_of described_class }
+      it { is_expected.to have_attributes term: 'some_term' }
+    end
+
+    context 'with unsafe page term' do
+      let(:unsafe) { described_class.new '../../../etc/passwd' }
+
+      it { expect { unsafe }.to raise_exception described_class::UnsafePageTerm }
+    end
+
+    context 'with unknown page' do
+      subject(:unknown) { described_class.new('something_random').page }
+
+      it { expect { unknown }.to raise_exception described_class::UnknownPage }
+    end
+  end
+
+  describe '#page' do
+    context 'with known page' do
+      subject { described_class.new('vnm').page }
+
+      it { is_expected.to eql 'pages/glossary/vnm' }
+    end
+  end
+end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe PagesController, type: :request do
     context 'with unknown page' do
       let(:fetch_page) { get glossary_path('unknown_page') }
 
-      it { expect { fetch_page }.to raise_exception ActionView::Template::Error }
+      it { expect { fetch_page }.to raise_exception Pages::Glossary::UnknownPage }
     end
   end
 end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -1,14 +1,12 @@
 require 'spec_helper'
 
-RSpec.describe PagesController, type: :controller do
+RSpec.describe PagesController, type: :request do
+  subject { response }
+
   context 'when asked for XML file' do
-    render_views
+    before { get opensearch_path(format: 'xml') }
 
-    before do
-      get :opensearch, format: 'xml'
-    end
-
-    it { is_expected.to respond_with(:success) }
+    it { is_expected.to have_http_status(:ok) }
 
     it 'renders OpenSearch file successfully' do
       expect(response.body).to include 'Tariff'
@@ -16,28 +14,27 @@ RSpec.describe PagesController, type: :controller do
   end
 
   describe 'GET #privacy' do
-    subject(:response) { get :privacy }
+    before { get privacy_path }
 
     it { is_expected.to have_http_status(:ok) }
     it { is_expected.to render_template('pages/privacy') }
   end
 
   describe 'GET #help' do
-    subject(:response) { get :help }
+    before { get help_path }
 
     it { is_expected.to have_http_status(:ok) }
     it { is_expected.to render_template('pages/help') }
   end
 
   describe 'GET #cn2021_cn2022', vcr: { cassette_name: 'chapters' } do
-    subject(:response) { get :cn2021_cn2022 }
+    before { get cn2021_cn2022_path }
 
     it { is_expected.to have_http_status(:ok) }
     it { is_expected.to render_template('pages/cn2021_cn2022') }
 
     it 'assigns chapters' do
-      response
-      expect(assigns[:chapters]).not_to be_nil
+      expect(assigns[:chapters]).to be_many
     end
   end
 end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -37,4 +37,19 @@ RSpec.describe PagesController, type: :request do
       expect(assigns[:chapters]).to be_many
     end
   end
+
+  describe 'GET #glossary' do
+    context 'with known page' do
+      before { get glossary_path('vnm') }
+
+      it { is_expected.to have_http_status :ok }
+      it { is_expected.to render_template 'pages/glossary/_vnm' }
+    end
+
+    context 'with unknown page' do
+      let(:fetch_page) { get glossary_path('unknown_page') }
+
+      it { expect { fetch_page }.to raise_exception ActionView::Template::Error }
+    end
+  end
 end

--- a/spec/views/pages/glossary.html.erb_spec.rb
+++ b/spec/views/pages/glossary.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe 'pages/glossary', type: :view do
+  subject { render && rendered }
+
+  before do
+    assign :glossary, glossary
+    stub_template "pages/glossary/_#{page}.html.erb" => '<p>Test page</p>'
+  end
+
+  let(:page) { 'test-page' }
+  let(:glossary) { instance_double Pages::Glossary, page: "pages/glossary/#{page}" }
+
+  it { is_expected.to have_link 'Back' }
+  it { is_expected.to have_css 'p', text: 'Test page' }
+end

--- a/spec/views/pages/glossary.html.erb_spec.rb
+++ b/spec/views/pages/glossary.html.erb_spec.rb
@@ -12,5 +12,5 @@ RSpec.describe 'pages/glossary', type: :view do
   let(:glossary) { instance_double Pages::Glossary, page: "pages/glossary/#{page}" }
 
   it { is_expected.to have_link 'Back' }
-  it { is_expected.to have_css 'p', text: 'Test page' }
+  it { is_expected.to have_css '.govuk-grid-column-two-thirds p', text: 'Test page' }
 end


### PR DESCRIPTION
### Jira link

HOTT-2190

### What?

I have added/removed/altered:

- [x] Added glossary pages for rules of origin terms
- [x] Linked those pages from the rules of origin rules page

### Why?

I am doing this because:

- Users may require explanation of the terms

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, feature flagged off

### Screenshots
![Screenshot from 2022-11-03 15-48-29](https://user-images.githubusercontent.com/10818/199768815-8bd141ba-6790-46e3-a0a8-2dd3d252c076.png)
![image](https://user-images.githubusercontent.com/10818/199768979-31d2c2f4-d910-43c1-82a3-baf3350489a4.png)

