### PR TITLE
HOTT-2202 Link to new steps

### DIFF
--- a/app/models/rules_of_origin/steps/origin_requirements_met.rb
+++ b/app/models/rules_of_origin/steps/origin_requirements_met.rb
@@ -15,6 +15,10 @@ module RulesOfOrigin
         !!chosen_scheme.article('non-alteration')&.content&.present?
       end
 
+      def direct_transport_available?
+        !!chosen_scheme.article('direct-transport')&.content&.present?
+      end
+
     private
 
       def not_wholly_obtained?

--- a/app/models/rules_of_origin/steps/origin_requirements_met.rb
+++ b/app/models/rules_of_origin/steps/origin_requirements_met.rb
@@ -11,6 +11,10 @@ module RulesOfOrigin
         !!chosen_scheme.article('duty-drawback')&.content&.present?
       end
 
+      def non_alteration_available?
+        !!chosen_scheme.article('non-alteration')&.content&.present?
+      end
+
     private
 
       def not_wholly_obtained?

--- a/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
+++ b/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
@@ -33,9 +33,16 @@
   <li>
     <%= link_to t('.links.verification'), step_path(:proof_verification) %>
   </li>
+
   <% if current_step.duty_drawback_available? %>
     <li>
       <%= link_to t('.links.duty_drawback'), step_path(:duty_drawback) %>
+    </li>
+  <% end %>
+
+  <% if current_step.non_alteration_available? %>
+    <li>
+      <%= link_to t('.links.non_alteration'), step_path(:non_alteration_rule) %>
     </li>
   <% end %>
 <ul>

--- a/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
+++ b/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
@@ -45,4 +45,10 @@
       <%= link_to t('.links.non_alteration'), step_path(:non_alteration_rule) %>
     </li>
   <% end %>
+
+  <% if current_step.direct_transport_available? %>
+    <li>
+      <%= link_to t('.links.direct_transport'), step_path(:direct_transport_rule) %>
+    </li>
+  <% end %>
 <ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,6 +501,7 @@ en:
           verification: How proofs of origin are verified
           duty_drawback: Find out about duty drawback
           non_alteration: Find out about the non-alteration rule
+          direct_transport: Find out about the direct transport rule
 
       proofs_of_origin:
         title: Valid proofs of origin

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -500,6 +500,7 @@ en:
           requirements: See detailed processes and requirements for proving the origin for goods
           verification: How proofs of origin are verified
           duty_drawback: Find out about duty drawback
+          non_alteration: Find out about the non-alteration rule
 
       proofs_of_origin:
         title: Valid proofs of origin

--- a/spec/models/rules_of_origin/steps/origin_requirements_met_spec.rb
+++ b/spec/models/rules_of_origin/steps/origin_requirements_met_spec.rb
@@ -73,4 +73,20 @@ RSpec.describe RulesOfOrigin::Steps::OriginRequirementsMet do
       it { is_expected.to be false }
     end
   end
+
+  describe 'direct_transport_available?' do
+    subject { instance.direct_transport_available? }
+
+    context 'with article' do
+      let :articles do
+        attributes_for_list :rules_of_origin_article, 1, article: 'direct-transport'
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'without article' do
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/rules_of_origin/steps/origin_requirements_met_spec.rb
+++ b/spec/models/rules_of_origin/steps/origin_requirements_met_spec.rb
@@ -57,4 +57,20 @@ RSpec.describe RulesOfOrigin::Steps::OriginRequirementsMet do
       it { is_expected.to be false }
     end
   end
+
+  describe 'non_alteration_available?' do
+    subject { instance.non_alteration_available? }
+
+    context 'with article' do
+      let :articles do
+        attributes_for_list :rules_of_origin_article, 1, article: 'non-alteration'
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'without article' do
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/views/rules_of_origin/steps/_origin_requirements_met.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_origin_requirements_met.html.erb_spec.rb
@@ -28,4 +28,13 @@ RSpec.describe 'rules_of_origin/steps/_origin_requirements_met', type: :view do
     it { is_expected.to have_css '#next-steps a', count: 4 }
     it { is_expected.to have_css '#next-steps a', text: /non-alteration/ }
   end
+
+  context 'with direct transport rule available' do
+    let :articles do
+      attributes_for_list :rules_of_origin_article, 1, article: 'direct-transport'
+    end
+
+    it { is_expected.to have_css '#next-steps a', count: 4 }
+    it { is_expected.to have_css '#next-steps a', text: /direct transport/ }
+  end
 end

--- a/spec/views/rules_of_origin/steps/_origin_requirements_met.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_origin_requirements_met.html.erb_spec.rb
@@ -17,5 +17,15 @@ RSpec.describe 'rules_of_origin/steps/_origin_requirements_met', type: :view do
     end
 
     it { is_expected.to have_css '#next-steps a', count: 4 }
+    it { is_expected.to have_css '#next-steps a', text: /duty/ }
+  end
+
+  context 'with non alteration rule available' do
+    let :articles do
+      attributes_for_list :rules_of_origin_article, 1, article: 'non-alteration'
+    end
+
+    it { is_expected.to have_css '#next-steps a', count: 4 }
+    it { is_expected.to have_css '#next-steps a', text: /non-alteration/ }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-2202

### What?

I have added/removed/altered:

- [x] Added link to the new non-alteration rule step
- [x] Added link to the new direct transport rule step

### Why?

I am doing this because:

- We want the user to discover the new pages from the Origin Requirements Met step

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, feature flagged off

### Screenshot

![image](https://user-images.githubusercontent.com/10818/200356353-7217169d-40ab-4afe-ade7-bca1c77d6184.png)
![image](https://user-images.githubusercontent.com/10818/200356405-142bc61d-1bc6-4ec0-b664-10c850b5d5ce.png)
