### PR TITLE
HOTT-2204 direct transport rule

### DIFF
--- a/app/models/rules_of_origin/steps/direct_transport_rule.rb
+++ b/app/models/rules_of_origin/steps/direct_transport_rule.rb
@@ -1,0 +1,15 @@
+module RulesOfOrigin
+  module Steps
+    class DirectTransportRule < Base
+      self.section = 'proofs'
+
+      def skipped?
+        true
+      end
+
+      def direct_transport_text
+        chosen_scheme.article('direct-transport')&.content
+      end
+    end
+  end
+end

--- a/app/models/rules_of_origin/wizard.rb
+++ b/app/models/rules_of_origin/wizard.rb
@@ -20,6 +20,7 @@ module RulesOfOrigin
       Steps::ProofVerification,
       Steps::DutyDrawback,
       Steps::NonAlterationRule,
+      Steps::DirectTransportRule,
       Steps::RulesNotMet,
       Steps::Tolerances,
     ]

--- a/app/views/rules_of_origin/steps/_direct_transport_rule.html.erb
+++ b/app/views/rules_of_origin/steps/_direct_transport_rule.html.erb
@@ -1,0 +1,26 @@
+<span class="govuk-caption-xl">
+  <%= t '.caption' %>
+</span>
+
+<h1 class="govuk-heading-l">
+  <%= t '.title', scheme_title: current_step.scheme_title %>
+</h1>
+
+<div class="tariff-markdown tariff-markdown--with-lead-paragraph" id="intro">
+  <%= govspeak t '.intro_md' %>
+</div>
+
+<% if current_step.direct_transport_text.present? %>
+  <div class="tariff-markdown numbered-then-lettered-list" id="direct-transport-rule">
+    <%= govspeak remove_article_reference(current_step.direct_transport_text) %>
+  </div>
+
+  <%= render 'shared/origin_reference_document',
+      origin_reference_document: current_step.origin_reference_document,
+      article_match: find_article_reference(current_step.direct_transport_text) \
+      if find_article_reference(current_step.direct_transport_text) %>
+<% else %>
+  <div class="govuk-inset-text tariff-markdown" id="unavailable">
+    <%= govspeak t '.unavailable_md', scheme_title: current_step.scheme_title %>
+  </div>
+<% end %>

--- a/app/webpacker/src/stylesheets/_lists.scss
+++ b/app/webpacker/src/stylesheets/_lists.scss
@@ -11,6 +11,10 @@ ol.lettered-list {
 ol.numbered-then-lettered-list {
   ol {
     list-style-type: lower-alpha;
+
+    ol {
+      list-style-type: lower-roman;
+    }
   }
 }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -374,6 +374,7 @@ en:
           proof_verification: How proofs of origin are verified
           duty_drawback: Duty drawback
           non_alteration_rule: Non alteration rule
+          direct_transport_rule: Direct transport rule
           tolerances: Tolerances
 
       import_only:
@@ -573,6 +574,19 @@ en:
           agreement.
 
           There is no non-alteration rule in the %{scheme_title}.
+
+      direct_transport_rule:
+        caption: Obtaining and verifying proofs of origin
+        title: Direct transport rule for %{scheme_title}
+        intro_md: |
+          The purpose of the direct transport rule is to ensure that the goods
+          arriving in the country of import are the same as those which left the
+          country of export without alteration.
+        unavailable_md: |
+          The direct transport rule depends on the specifics of the trade
+          agreement.
+
+          There is no direct transport rule in the %{scheme_title}.
 
       not_wholly_obtained:
         caption: Are your goods originating?

--- a/spec/models/rules_of_origin/steps/direct_transport_rule_spec.rb
+++ b/spec/models/rules_of_origin/steps/direct_transport_rule_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe RulesOfOrigin::Steps::DirectTransportRule do
+  include_context 'with rules of origin store', :originating
+  include_context 'with wizard step', RulesOfOrigin::Wizard
+
+  describe '#skipped?' do
+    subject { instance.skipped? }
+
+    it { is_expected.to be true }
+  end
+
+  it_behaves_like 'an article accessor', :direct_transport_text, 'direct-transport'
+end

--- a/spec/views/rules_of_origin/steps/_direct_transport_rule.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_direct_transport_rule.html.erb_spec.rb
@@ -1,36 +1,36 @@
 require 'spec_helper'
 
-RSpec.describe 'rules_of_origin/steps/_non_alteration_rule', type: :view do
+RSpec.describe 'rules_of_origin/steps/_direct_transport_rule', type: :view do
   include_context 'with rules of origin form step',
-                  'non_alteration_rule',
+                  'direct_transport_rule',
                   :wholly_obtained
 
   let :articles do
-    attributes_for_list :rules_of_origin_article, 1, article: 'non-alteration'
+    attributes_for_list :rules_of_origin_article, 1, article: 'direct-transport'
   end
 
   it { is_expected.to have_css 'span.govuk-caption-xl', text: /obtaining and verifying/i }
-  it { is_expected.to have_css 'h1', text: /Non-alteration.*Japan/ }
+  it { is_expected.to have_css 'h1', text: /Direct transport.*#{schemes.first.title}/ }
   it { is_expected.to have_css '#intro.tariff-markdown *' }
-  it { is_expected.to have_css '#non-alteration-rule.tariff-markdown *' }
+  it { is_expected.to have_css '#direct-transport-rule.tariff-markdown *' }
   it { is_expected.not_to have_css 'details', text: /Origin Reference Document/i }
   it { is_expected.not_to have_css '#unavailable' }
 
-  context 'without non alteration article' do
+  context 'without direct transport article' do
     let(:articles) { [] }
 
-    it { is_expected.not_to have_css '#non-alteration-rule' }
+    it { is_expected.not_to have_css '#direct-transport-rule' }
     it { is_expected.to have_css '#unavailable.tariff-markdown *' }
   end
 
   context 'with origin reference document reference' do
     let :articles do
       attributes_for_list :rules_of_origin_article, 1,
-                          article: 'non-alteration',
+                          article: 'direct-transport',
                           content: "This includes a reference\n\n{{ article 12 }}"
     end
 
-    it { is_expected.not_to have_css '#non-alteration-rule', text: /\{\{/ }
+    it { is_expected.not_to have_css '#direct-transport-rule', text: /\{\{/ }
     it { is_expected.to have_css 'details', text: /Origin Reference Document/i }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-2204

### What?

I have added/removed/altered:

- [x] Added DirectTransportRule
- [x] Changed nested lists with the 'numbered-then-lettered' css class to show as lower-roman

### Why?

I am doing this because:

- We wish to expose this content to our users
- Third tiered lists should be showing as `i`, `ii`, `iii`, `iv`, etc

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, feature flagged off

### Screenshot

![image](https://user-images.githubusercontent.com/10818/200363867-a47bc35f-dfea-4cad-a578-1ede80641d6a.png)
