### PR TITLE
HOTT-2209 Use released versions of capybara

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ end
 
 group :test do
   gem 'brakeman'
-  gem 'capybara', github: 'teamcapybara/capybara', branch: 'master'
+  gem 'capybara'
   gem 'factory_bot_rails'
   gem 'forgery'
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,21 +16,6 @@ GIT
       actionpack (>= 6.1)
       activesupport (>= 6.1)
 
-GIT
-  remote: https://github.com/teamcapybara/capybara.git
-  revision: 2d05c203d79bca7b3b093c37f866ee41f294925b
-  branch: master
-  specs:
-    capybara (3.38.0)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -138,6 +123,15 @@ GEM
     brakeman (5.3.1)
     builder (3.2.4)
     byebug (11.1.3)
+    capybara (3.38.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -445,7 +439,7 @@ DEPENDENCIES
   aws-sdk-rails
   bootsnap
   brakeman
-  capybara!
+  capybara
   connection_pool
   dotenv-rails
   factory_bot_rails


### PR DESCRIPTION
### Jira link

HOTT-2209

### What?

I have added/removed/altered:

- [x] Revert to using released versions of Capybara

### Why?

I am doing this because:

- It was a temporary hack to upgrade to Puma 6 and is no longer necessary

### Deployment risks (optional)

- Low, only impacts testing code
