### PR TITLE
HOTT-2221 Added glossary page

### DIFF
--- a/app/controllers/pages/glossary_controller.rb
+++ b/app/controllers/pages/glossary_controller.rb
@@ -3,6 +3,10 @@ module Pages
     before_action :disable_search_form,
                   :disable_last_updated_footnote
 
+    def index
+      @terms = Pages::Glossary.all
+    end
+
     def show
       @glossary = Pages::Glossary.find(params[:id])
     end

--- a/app/controllers/pages/glossary_controller.rb
+++ b/app/controllers/pages/glossary_controller.rb
@@ -1,0 +1,10 @@
+module Pages
+  class GlossaryController < ApplicationController
+    before_action :disable_search_form,
+                  :disable_last_updated_footnote
+
+    def show
+      @glossary = Pages::Glossary.find(params[:id])
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -151,7 +151,7 @@ module ApplicationHelper
   end
 
   def glossary_term(term)
-    link_to term, glossary_path(term.to_s.underscore)
+    link_to term, glossary_term_path(term.to_s.underscore)
   end
 
   def link_glossary_terms(content)
@@ -159,7 +159,7 @@ module ApplicationHelper
       term = Regexp.last_match.captures[0]
 
       if Pages::Glossary.pages.include? term.underscore
-        "([#{term}](/glossary/#{term.underscore}))"
+        "([#{term}](#{glossary_term_path(term.underscore)}))"
       else
         match
       end

--- a/app/models/pages/glossary.rb
+++ b/app/models/pages/glossary.rb
@@ -1,14 +1,20 @@
 module Pages
   class Glossary
-    PAGE_GLOB = Rails.root.join('app/views/pages/glossary/_*.html.erb')
+    PAGES = {
+      'EXW' => 'Ex-works price',
+      'FOB' => 'Free on board price',
+      'MaxNOM' => 'Maximum value of non-originating materials',
+      'RVC' => 'minimum regional value content',
+      'VNM' => 'Value of non-originating materials',
+    }.freeze
 
-    attr_reader :term
+    PAGE_KEYS = Hash[PAGES.keys.map(&:underscore).zip(PAGES.keys)].freeze
+
+    attr_reader :key, :term, :title
 
     class << self
       def pages
-        @pages ||= Dir[PAGE_GLOB].map do |f|
-          File.basename(f, '.html.erb').slice(1..)
-        end
+        PAGE_KEYS.keys
       end
 
       def find(term)
@@ -24,8 +30,10 @@ module Pages
       end
     end
 
-    def initialize(term)
-      @term = term
+    def initialize(key)
+      @key = key
+      @term = PAGE_KEYS[key]
+      @title = PAGES[term]
     end
 
     class UnknownPage < StandardError; end

--- a/app/models/pages/glossary.rb
+++ b/app/models/pages/glossary.rb
@@ -28,10 +28,6 @@ module Pages
       @term = term
     end
 
-    def page
-      "pages/glossary/#{term}"
-    end
-
     class UnknownPage < StandardError; end
   end
 end

--- a/app/models/pages/glossary.rb
+++ b/app/models/pages/glossary.rb
@@ -23,6 +23,10 @@ module Pages
         new(term)
       end
 
+      def all
+        pages.map(&method(:find))
+      end
+
     private
 
       def templates
@@ -34,6 +38,10 @@ module Pages
       @key = key
       @term = PAGE_KEYS[key]
       @title = PAGES[term]
+    end
+
+    def term_and_title
+      "#{@term} (#{@title})"
     end
 
     class UnknownPage < StandardError; end

--- a/app/views/pages/glossary.html.erb
+++ b/app/views/pages/glossary.html.erb
@@ -1,7 +1,0 @@
-<%= back_link (request.referer || find_commodity_path), javascript: true %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render @glossary.page %>
-  </div>
-</div>

--- a/app/views/pages/glossary/_exw.html.erb
+++ b/app/views/pages/glossary/_exw.html.erb
@@ -1,5 +1,3 @@
-<h1 class="govuk-heading-xl">EXW (Ex-works price)</h1>
-
 <p>"EXW" means:</p>
 
 <ul class="govuk-list govuk-list--bullet">

--- a/app/views/pages/glossary/_fob.html.erb
+++ b/app/views/pages/glossary/_fob.html.erb
@@ -1,5 +1,3 @@
-<h1 class="govuk-heading-xl">FOB (Free on board price)</h1>
-
 <p>"FOB" means:</p>
 
 <ul class="govuk-list govuk-list--bullet">

--- a/app/views/pages/glossary/_max_nom.html.erb
+++ b/app/views/pages/glossary/_max_nom.html.erb
@@ -1,7 +1,3 @@
-<h1 class="govuk-heading-xl">
-  MaxNOM (Maximum value of non-originating materials)
-</h1>
-
 <p>
   "MaxNOM" means the maximum value of non-originating materials expressed as a
   percentage.

--- a/app/views/pages/glossary/_rvc.html.erb
+++ b/app/views/pages/glossary/_rvc.html.erb
@@ -1,5 +1,3 @@
-<h1 class="govuk-heading-xl">RVC (minimum regional value content)</h1>
-
 <p>
   "RVC" means the minimum regional value content of a product, expressed as a
   percentage.

--- a/app/views/pages/glossary/_vnm.html.erb
+++ b/app/views/pages/glossary/_vnm.html.erb
@@ -1,7 +1,3 @@
-<h1 class="govuk-heading-xl">
-  VNM (Value of non-originating materials)
-</h1>
-
 <p>
   "VNM" means the value of non-originating materials used in the manufacture of
   the product which is its customs value at the time of importation including

--- a/app/views/pages/glossary/index.html.erb
+++ b/app/views/pages/glossary/index.html.erb
@@ -1,0 +1,54 @@
+<% content_for :top_breadcrumbs do %>
+  <%= generate_breadcrumbs 'Rules of origin glossary',
+                           [ [t('breadcrumb.home'), home_path],
+                             [t('breadcrumb.help'), help_path],
+                             ['Rules of origin', help_path(anchor: 'rules-of-origin')] ] %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl">Guide to rules of origin</span>
+    <h1 class="govuk-heading-l">Rules of origin glossary</h1>
+
+    <div id="contents">
+      <h2 class="gem-c-contents-list__title">Contents</h2>
+
+      <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
+        <% for term in @terms %>
+          <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+            <%= link_to term.term_and_title,
+                        { anchor: "glossary-#{term.key.dasherize}" },
+                        class: 'gem-c-contents-list__link govuk-link--no-underline' %>
+          </li>
+        <% end %>
+      </ol>
+    </div>
+
+    <% for term in @terms %>
+      <h3 class="govuk-heading-m" id="glossary-<%= term.key.dasherize %>">
+        <%= term.term_and_title %>
+      </h3>
+
+      <%= render term.key %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <div class="gem-c-related-navigation">
+      <h2 class="gem-c-related-navigation__main-heading">
+        Understanding rules of origin
+      </h2>
+
+      <nav class="gem-c-related-navigation__nav-section">
+        <ul class="gem-c-related-navigation__link-list">
+          <li class="gem-c-related-navigation__link">
+            <%= link_to 'Rules of origin glossary', glossary_terms_path %>
+          </li>
+          <li class="gem-c-related-navigation__link">
+            <%= link_to 'Duty drawback', '#' %>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/glossary/show.html.erb
+++ b/app/views/pages/glossary/show.html.erb
@@ -1,0 +1,7 @@
+<%= back_link (request.referer || help_path), javascript: true %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render @glossary.term %>
+  </div>
+</div>

--- a/app/views/pages/glossary/show.html.erb
+++ b/app/views/pages/glossary/show.html.erb
@@ -3,8 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= @glossary.term %>
-      (<%= @glossary.title %>)
+      <%= @glossary.term_and_title %>
     </h1>
 
     <%= render @glossary.key %>

--- a/app/views/pages/glossary/show.html.erb
+++ b/app/views/pages/glossary/show.html.erb
@@ -2,6 +2,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render @glossary.term %>
+    <h1 class="govuk-heading-xl">
+      <%= @glossary.term %>
+      (<%= @glossary.title %>)
+    </h1>
+
+    <%= render @glossary.key %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
   get 'privacy', to: 'pages#privacy', as: 'privacy'
   get 'terms', to: 'pages#terms'
 
-  resources :glossary, only: %i[show], as: :glossary_terms, module: :pages
+  resources :glossary, only: %i[index show], as: :glossary_terms, module: :pages
 
   get 'geographical_areas/:id', to: 'geographical_areas#show', as: :geographical_area
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,8 @@ Rails.application.routes.draw do
   get 'opensearch', to: 'pages#opensearch', constraints: { format: :xml }
   get 'privacy', to: 'pages#privacy', as: 'privacy'
   get 'terms', to: 'pages#terms'
-  get 'glossary/:id', to: 'pages#glossary', as: :glossary
+
+  resources :glossary, only: %i[show], as: :glossary_terms, module: :pages
 
   get 'geographical_areas/:id', to: 'geographical_areas#show', as: :geographical_area
 

--- a/spec/models/pages/glossary_spec.rb
+++ b/spec/models/pages/glossary_spec.rb
@@ -29,12 +29,4 @@ RSpec.describe Pages::Glossary do
       it { expect { unknown }.to raise_exception described_class::UnknownPage }
     end
   end
-
-  describe '#page' do
-    context 'with known page' do
-      subject { described_class.new('something').page }
-
-      it { is_expected.to eql 'pages/glossary/something' }
-    end
-  end
 end

--- a/spec/models/pages/glossary_spec.rb
+++ b/spec/models/pages/glossary_spec.rb
@@ -2,19 +2,21 @@ require 'spec_helper'
 
 RSpec.describe Pages::Glossary do
   describe '.new' do
-    subject { described_class.new 'test' }
+    subject { described_class.new 'max_nom' }
 
-    it { is_expected.to have_attributes term: 'test' }
+    it { is_expected.to have_attributes key: 'max_nom' }
+    it { is_expected.to have_attributes term: 'MaxNOM' }
+    it { is_expected.to have_attributes title: /maximum value/i }
   end
 
   describe '#find' do
-    before { allow(described_class).to receive(:pages).and_return %w[some_term] }
-
     context 'with safe page term' do
-      subject { described_class.find 'some_term' }
+      subject { described_class.find 'max_nom' }
 
       it { is_expected.to be_instance_of described_class }
-      it { is_expected.to have_attributes term: 'some_term' }
+      it { is_expected.to have_attributes key: 'max_nom' }
+      it { is_expected.to have_attributes term: 'MaxNOM' }
+      it { is_expected.to have_attributes title: /maximum value/i }
     end
 
     context 'with unsafe page term' do

--- a/spec/models/pages/glossary_spec.rb
+++ b/spec/models/pages/glossary_spec.rb
@@ -1,15 +1,14 @@
 require 'spec_helper'
 
 RSpec.describe Pages::Glossary do
-  describe '.new' do
-    subject { described_class.new 'max_nom' }
+  subject { described_class.new 'max_nom' }
 
-    it { is_expected.to have_attributes key: 'max_nom' }
-    it { is_expected.to have_attributes term: 'MaxNOM' }
-    it { is_expected.to have_attributes title: /maximum value/i }
-  end
+  it { is_expected.to have_attributes key: 'max_nom' }
+  it { is_expected.to have_attributes term: 'MaxNOM' }
+  it { is_expected.to have_attributes title: /maximum value/i }
+  it { is_expected.to have_attributes term_and_title: /MaxNOM \(.*maximum value.*\)/i }
 
-  describe '#find' do
+  describe '.find' do
     context 'with safe page term' do
       subject { described_class.find 'max_nom' }
 
@@ -30,5 +29,12 @@ RSpec.describe Pages::Glossary do
 
       it { expect { unknown }.to raise_exception described_class::UnknownPage }
     end
+  end
+
+  describe '.all' do
+    subject { described_class.all }
+
+    it { is_expected.to have_attributes length: described_class::PAGES.length }
+    it { is_expected.to all be_instance_of described_class }
   end
 end

--- a/spec/requests/pages/glossary_controller_spec.rb
+++ b/spec/requests/pages/glossary_controller_spec.rb
@@ -3,6 +3,12 @@ require 'spec_helper'
 RSpec.describe Pages::GlossaryController, type: :request do
   subject { response }
 
+  describe 'GET #index' do
+    before { get glossary_terms_path }
+
+    it { is_expected.to have_http_status :ok }
+  end
+
   describe 'GET #show' do
     context 'with known page' do
       before { get glossary_term_path('vnm') }

--- a/spec/requests/pages/glossary_controller_spec.rb
+++ b/spec/requests/pages/glossary_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe Pages::GlossaryController, type: :request do
+  subject { response }
+
+  describe 'GET #show' do
+    context 'with known page' do
+      before { get glossary_term_path('vnm') }
+
+      it { is_expected.to have_http_status :ok }
+      it { is_expected.to render_template 'pages/glossary/_vnm' }
+    end
+
+    context 'with unknown page' do
+      let(:fetch_page) { get glossary_term_path('unknown_page') }
+
+      it { expect { fetch_page }.to raise_exception Pages::Glossary::UnknownPage }
+    end
+  end
+end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -37,19 +37,4 @@ RSpec.describe PagesController, type: :request do
       expect(assigns[:chapters]).to be_many
     end
   end
-
-  describe 'GET #glossary' do
-    context 'with known page' do
-      before { get glossary_path('vnm') }
-
-      it { is_expected.to have_http_status :ok }
-      it { is_expected.to render_template 'pages/glossary/_vnm' }
-    end
-
-    context 'with unknown page' do
-      let(:fetch_page) { get glossary_path('unknown_page') }
-
-      it { expect { fetch_page }.to raise_exception Pages::Glossary::UnknownPage }
-    end
-  end
 end

--- a/spec/views/pages/glossary/index.html.erb_spec.rb
+++ b/spec/views/pages/glossary/index.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe 'pages/glossary/index', type: :view do
+  subject { render && rendered }
+
+  before { assign :terms, Pages::Glossary.all }
+
+  it { is_expected.to have_css '.govuk-caption-xl', text: /guide/i }
+  it { is_expected.to have_css 'h1', text: /glossary/i }
+
+  it { is_expected.to have_css '#contents h2', text: /contents/i }
+  it { is_expected.to have_css '#contents ol li a', count: Pages::Glossary.all.length }
+
+  it { is_expected.to have_css '.govuk-grid-column-two-thirds h3', text: Pages::Glossary::PAGES.values.first }
+  it { is_expected.to have_css '.govuk-grid-column-two-thirds h3', text: Pages::Glossary::PAGES.values.last }
+
+  it { is_expected.to have_css '.govuk-grid-column-one-third a' }
+end

--- a/spec/views/pages/glossary/show.html.erb_spec.rb
+++ b/spec/views/pages/glossary/show.html.erb_spec.rb
@@ -3,14 +3,11 @@ require 'spec_helper'
 RSpec.describe 'pages/glossary/show', type: :view do
   subject { render && rendered }
 
-  before do
-    assign :glossary, glossary
-    stub_template "pages/glossary/_#{page}.html.erb" => '<p>Test page</p>'
-  end
+  before { assign :glossary, glossary }
 
-  let(:page) { 'test-page' }
-  let(:glossary) { instance_double Pages::Glossary, term: page }
+  let(:glossary) { Pages::Glossary.new term }
+  let(:term) { 'max_nom' }
 
   it { is_expected.to have_link 'Back' }
-  it { is_expected.to have_css '.govuk-grid-column-two-thirds p', text: 'Test page' }
+  it { is_expected.to have_css '.govuk-grid-column-two-thirds p', text: /NOM/i }
 end

--- a/spec/views/pages/glossary/show.html.erb_spec.rb
+++ b/spec/views/pages/glossary/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'pages/glossary', type: :view do
+RSpec.describe 'pages/glossary/show', type: :view do
   subject { render && rendered }
 
   before do
@@ -9,7 +9,7 @@ RSpec.describe 'pages/glossary', type: :view do
   end
 
   let(:page) { 'test-page' }
-  let(:glossary) { instance_double Pages::Glossary, page: "pages/glossary/#{page}" }
+  let(:glossary) { instance_double Pages::Glossary, term: page }
 
   it { is_expected.to have_link 'Back' }
   it { is_expected.to have_css '.govuk-grid-column-two-thirds p', text: 'Test page' }


### PR DESCRIPTION
### Jira link

HOTT-2221

### What?

I have added/removed/altered:

- [x] Moved the glossary pages to their own controller
- [x] Added an 'index' glossary page

### Why?

I am doing this because:

- We require a glossary page for rules of origin

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, not directly linked
