### PR TITLE
HOTT-2244: Temporarily hide prohibited message

### DIFF
--- a/app/views/measures/grouped/_table.html.erb
+++ b/app/views/measures/grouped/_table.html.erb
@@ -8,7 +8,7 @@
   </div>
 <% end %>
 
-<%= render 'shared/stw_link', declarable: declarable, search: search, anchor: anchor if local_assigns[:show_stw_text]  %>
+<%= render 'shared/stw_link', declarable: declarable, search: search, anchor: anchor if local_assigns[:show_stw_text] && !declarable.one_or_more_prohibitive_measures?  %>
 
 <%= render 'measures/grouped/tariff_duty_calculator_link', declarable_code: declarable.code if local_assigns[:show_duty_calculator] %>
 

--- a/app/views/rules_of_origin/_import_trade_summary.html.erb
+++ b/app/views/rules_of_origin/_import_trade_summary.html.erb
@@ -5,7 +5,7 @@
         <li class="basic-third-country-duty">
           Basic third country duty =
           <strong>
-            <%= import_trade_summary.basic_third_country_duty.html_safe %>
+            <%= import_trade_summary.basic_third_country_duty&.html_safe %>
           </strong>
         </li>
 


### PR DESCRIPTION
### Jira link

[HOTT-<2244>](https://transformuk.atlassian.net/browse/HOTT-2244)

### What?

I have added/removed/altered:

- [ ] Temporarily hidden prohibited message

### Why?

I am doing this because:

- We are waiting for DIT to fix the data

Hide when prohibited
<img width="1242" alt="Screenshot 2022-11-18 at 13 41 12" src="https://user-images.githubusercontent.com/12201130/202718313-e69a3baf-3eab-4ccb-9f60-f6260d627744.png">

Display when not prohibited
<img width="1176" alt="Screenshot 2022-11-18 at 13 41 16" src="https://user-images.githubusercontent.com/12201130/202718297-ab6e7cab-1a0e-4d7b-8a3a-f8a047e9b753.png">
