### PR TITLE
HOTT-2245: Hide import trade summary if basic_third_country_duty is nil

### DIFF
--- a/app/views/rules_of_origin/_import_trade_summary.html.erb
+++ b/app/views/rules_of_origin/_import_trade_summary.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-inset-text">
+<div class="govuk-inset-text import-trade-summary">
     <h3 class="govuk-heading-s">How rules of origin could affect the import duty payable</h3>
 
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -17,9 +17,11 @@
 
     <% if rules_of_origin_schemes.any? %>
       <%= rules_of_origin_schemes_intro country_name, rules_of_origin_schemes %>
-
-      <%= render 'rules_of_origin/import_trade_summary',
-                 import_trade_summary: declarable.import_trade_summary unless rules_of_origin_schemes.many? %>
+      
+      <% if declarable.import_trade_summary.basic_third_country_duty.present? %>
+        <%= render 'rules_of_origin/import_trade_summary',
+                   import_trade_summary: declarable.import_trade_summary unless rules_of_origin_schemes.many? %>
+      <% end %>
 
       <%= render 'rules_of_origin/wizard_link',
                  country_code: country_code,

--- a/spec/views/rules_of_origin/_tab.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_tab.html.erb_spec.rb
@@ -96,5 +96,11 @@ RSpec.describe 'rules_of_origin/_tab', type: :view do
 
       it { expect(rendered_page).to have_css '.no-preferential-duties' }
     end
+
+    context 'when basic_third_country_duty is missing' do
+      let(:import_trade_summary) { attributes_for(:import_trade_summary, basic_third_country_duty: nil) }
+
+      it { expect(rendered_page).not_to have_css '.import-trade-summary' }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-<2245>](https://transformuk.atlassian.net/browse/HOTT-2245)

### What?

I have added/removed/altered:

- [ ] Hidden import trade summary box if basic_third_country_duty is nil

### Why?

I am doing this because:

- There was a bug when rendering the import trade summary partial


<img width="1336" alt="Screenshot 2022-11-21 at 10 49 35" src="https://user-images.githubusercontent.com/12201130/203036551-e9123d86-583e-42ce-84dc-f17fb5ebc662.png">

<img width="1416" alt="Screenshot 2022-11-21 at 10 40 59" src="https://user-images.githubusercontent.com/12201130/203036625-a5e9ec33-6f72-4697-984c-e3cb2343de15.png">
