### PR TITLE
HOTT-2243 Show precis on news story page

### DIFF
--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -16,6 +16,7 @@ class NewsItem
   attr_accessor :id,
                 :slug,
                 :title,
+                :precis,
                 :content,
                 :display_style,
                 :show_on_xi,
@@ -25,7 +26,6 @@ class NewsItem
                 :show_on_banner
 
   attr_reader :start_date, :end_date
-  attr_writer :precis
 
   has_many :collections, class_name: 'NewsCollection'
 
@@ -113,11 +113,11 @@ class NewsItem
     @paragraphs ||= content.to_s.split(/(\r?\n)+/).map(&:presence).compact
   end
 
-  def precis
-    @precis.presence || paragraphs.first
+  def precis_with_fallback
+    precis.presence || paragraphs.first
   end
 
   def content_after_precis?
-    @precis.present? ? content.present? : paragraphs.many?
+    precis.present? ? content.present? : paragraphs.many?
   end
 end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -5,7 +5,7 @@ class NewsItem
 
   CACHE_KEY = 'news-item-any-updates'.freeze
   BANNER_CACHE_KEY = 'news-item-latest-banner'.freeze
-  CACHE_VERSION = 3
+  CACHE_VERSION = 4
   CACHE_LIFETIME = 15.minutes
   BANNER_CACHE_LIFETIME = 5.minutes
 

--- a/app/views/news_items/_latest_news.html.erb
+++ b/app/views/news_items/_latest_news.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="govuk-notification-banner__content">
     <div class="tariff-markdown">
-      <%= format_news_item_content news_item.precis %>
+      <%= format_news_item_content news_item.precis_with_fallback %>
 
       <%- if news_item.content_after_precis? -%>
         <%= link_to 'Show more ...', news_item,

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -18,7 +18,7 @@
         </h2>
 
         <div class="tariff-markdown">
-          <%= format_news_item_content news_item.precis %>
+          <%= format_news_item_content news_item.precis_with_fallback %>
         </div>
 
         <%= link_to 'Show more ...', news_item if news_item.content_after_precis? %>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -16,6 +16,8 @@
   </h3>
 
   <div class="tariff-markdown">
+    <%= format_news_item_content @news_item.precis if @news_item.precis.present? %>
+
     <%= format_news_item_content @news_item.content %>
   </div>
 </article>

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -292,8 +292,8 @@ RSpec.describe NewsItem do
     it { is_expected.to all be_instance_of NewsCollection }
   end
 
-  describe '#precis' do
-    subject { news.precis }
+  describe '#precis_with_fallback' do
+    subject { news.precis_with_fallback }
 
     context 'with precis' do
       let(:news) { build :news_item, precis: "first para\n\nsecond para" }

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-          .with('news-item-any-updates-uk-v3', expires_in: 15.minutes)
+          .with('news-item-any-updates-uk-v4', expires_in: 15.minutes)
       end
 
       context 'with no news items' do
@@ -171,7 +171,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-          .with('news-item-any-updates-xi-v3', expires_in: 15.minutes)
+          .with('news-item-any-updates-xi-v4', expires_in: 15.minutes)
       end
 
       context 'with no news items' do
@@ -209,7 +209,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-            .with('news-item-latest-banner-uk-v3', expires_in: 5.minutes)
+            .with('news-item-latest-banner-uk-v4', expires_in: 5.minutes)
       end
     end
 
@@ -226,7 +226,7 @@ RSpec.describe NewsItem do
 
         expect(Rails.cache).to \
           have_received(:fetch)
-            .with('news-item-latest-banner-xi-v3', expires_in: 5.minutes)
+            .with('news-item-latest-banner-xi-v4', expires_in: 5.minutes)
       end
     end
   end

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe 'news_items/show', type: :view do
   it { is_expected.to have_css 'article.news-item' }
   it { is_expected.to have_css 'article h2', text: news_item.title }
   it { is_expected.to have_css 'article h3', text: /published.*#{expected_date}/i }
-  it { is_expected.to have_css 'article .tariff-markdown p' }
+  it { is_expected.to have_css 'article .tariff-markdown p', text: /Welcome to/, count: 1 }
   it { is_expected.to have_css 'p', text: /Welcome to #{I18n.t('title.service_name.uk')}/ }
+
+  context 'with precis' do
+    let :news_item do
+      build :news_item, precis: 'precis para', content: 'content para'
+    end
+
+    it { is_expected.to have_css 'article .tariff-markdown p', text: 'precis para' }
+    it { is_expected.to have_css 'article .tariff-markdown p', text: 'content para' }
+  end
 end


### PR DESCRIPTION
### Jira link

HOTT-2243

### What?

I have added/removed/altered:

- [x] Render the precis if present on the full News story page

### Why?

I am doing this because:

- Previously we were only showing body content - this worked fine when the `precis` was a duplicate of the first paragraph but that is no longer the case if the dedicated `precis` attribute is populated

### Deployment risks (optional)

- Low, resolves issue which occurs if the new precis field is populated in the admin

### Screenshots

![Screenshot from 2022-11-23 11-06-47](https://user-images.githubusercontent.com/10818/203531907-f61babe3-220c-46f0-869c-9e59e8e40700.png)

![image](https://user-images.githubusercontent.com/10818/203531860-95268715-8b9c-4f0a-80af-ab2bec6c1bd5.png)

