### PR TITLE
HOTT-2259 Move the critical footnotes after the header.

### DIFF
--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -1,19 +1,21 @@
 <% content_for :title, goods_nomenclature_title(@heading) %>
 
-
 <% content_for :head do %>
   <meta name="description" content="<%= @heading %>">
   <link rel='alternate' type='application/json' href='<%= heading_url(@heading, format: :json) %>' title='Heading information page in JSON format' />
 <% end %>
-
+  
 <% if @heading.declarable? %>
   <%= render 'commodities/header', commodity_code: (@heading.page_heading + '000000') %>
-<% else %>
-  <%= page_header @heading.page_heading %>
 <% end %>
 
-<% @heading.critical_footnotes.each do |footnote| %>
-  <%= render 'footnotes/critical_warning', footnote: footnote %>
+<%= page_header do %>
+  <% @heading.critical_footnotes.each do |footnote| %>
+    <%= render 'footnotes/critical_warning', footnote: footnote %>
+  <% end %>
+  <h1 class="<%= css_heading_size(@heading.page_heading) %>">
+    <%= sanitize @heading.page_heading %>
+  </h1>
 <% end %>
 
 <%= render 'shared/context_tables/heading' %>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -5,10 +5,6 @@
   <link rel='alternate' type='application/json' href='<%= heading_url(@heading, format: :json) %>' title='Heading information page in JSON format' />
 <% end %>
   
-<% if @heading.declarable? %>
-  <%= render 'commodities/header', commodity_code: (@heading.page_heading + '000000') %>
-<% end %>
-
 <%= page_header do %>
   <% @heading.critical_footnotes.each do |footnote| %>
     <%= render 'footnotes/critical_warning', footnote: footnote %>
@@ -20,16 +16,11 @@
 
 <%= render 'shared/context_tables/heading' %>
 <%= render 'shared/callouts/heading', leaf_commodity_count: @commodities.leaf_commodities_count,
-                                      section_note: @heading.section.section_note, chapter_note: @heading.chapter.chapter_note %>
+                                      section_note: @heading.section.section_note,
+                                      chapter_note: @heading.chapter.chapter_note %>
+
 <%= render 'shared/commodity_tree', commodities: @commodities.root_commodities %>
 <%= render 'shared/footnote', footnotes: @heading.footnotes %>
 
-<% if @heading.declarable? %>
-  <%= render 'declarables/declarable',
-    declarable: @heading,
-    uk_declarable: uk_heading,
-    xi_declarable: xi_heading,
-    rules_of_origin_schemes: @rules_of_origin_schemes %>
-<% else %>
-  <%= render 'shared/notes', section_note: @heading.section.section_note, chapter_note: @heading.chapter.chapter_note %>
-<% end %>
+<%= render 'shared/notes', section_note: @heading.section.section_note,
+                           chapter_note: @heading.chapter.chapter_note %>


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-2259

### What?
Move the critical footnotes after the header to make it more evident.
