### PR TITLE
HOTT-2136 update news story page

### DIFF
--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -14,6 +14,7 @@ class NewsItemsController < ApplicationController
 
   def show
     @news_item = News::Item.find(params[:id])
+    @news_collection = @news_item.collections.first || News::Collection.new
   end
 
 private

--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -15,6 +15,8 @@ class NewsItemsController < ApplicationController
   def show
     @news_item = News::Item.find(params[:id])
     @news_collection = @news_item.collections.first || News::Collection.new
+    @collection_items = News::Item.updates_page(collection_id: @news_collection.id)
+                                  .slice(0, 3)
   end
 
 private

--- a/app/helpers/news_item_helper.rb
+++ b/app/helpers/news_item_helper.rb
@@ -2,4 +2,12 @@ module NewsItemHelper
   def format_news_item_content(content)
     govspeak replace_service_tags content
   end
+
+  # Copied from Kramdown source code, see Kramdown::Convertors::Base#basic_generate_id
+  def markdown_heading_id(heading)
+    heading.gsub(/^[^a-zA-Z]+/, '')
+           .tr('^a-zA-Z0-9 -', '')
+           .tr(' ', '-')
+           .downcase
+  end
 end

--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -6,8 +6,10 @@ module News
 
     collection_path '/news/collections'
 
-    attr_accessor :name
     attr_writer   :id
+    attr_accessor :name,
+                  :description,
+                  :priority
 
     def id
       @id ||= resource_id.presence&.to_i

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -17,6 +17,7 @@ module News
     attr_accessor :id,
                   :slug,
                   :title,
+                  :precis,
                   :content,
                   :display_style,
                   :show_on_xi,
@@ -26,7 +27,6 @@ module News
                   :show_on_banner
 
     attr_reader :start_date, :end_date
-    attr_writer :precis
 
     has_many :collections, class_name: 'News::Collection'
 
@@ -107,7 +107,7 @@ module News
       @paragraphs ||= content.to_s.split(/(\r?\n)+/).map(&:presence).compact
     end
 
-    def precis
+    def precis_with_fallback
       @precis.presence || paragraphs.first
     end
 

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -114,5 +114,10 @@ module News
     def content_after_precis?
       @precis.present? ? content.present? : paragraphs.many?
     end
+
+    def subheadings
+      @subheadings ||= paragraphs.select { |p| p.start_with? '## ' }
+                                 .map { |heading| heading.sub(/^\#\# /, '') }
+    end
   end
 end

--- a/app/views/news_items/_latest_news.html.erb
+++ b/app/views/news_items/_latest_news.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="govuk-notification-banner__content">
     <div class="tariff-markdown">
-      <%= format_news_item_content news_item.precis %>
+      <%= format_news_item_content news_item.precis_with_fallback %>
 
       <%- if news_item.content_after_precis? -%>
         <%= link_to 'Show more ...', news_item,

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -61,7 +61,7 @@
         </h2>
 
         <div class="tariff-markdown tariff-markdown--reduced-trailing-margin">
-          <%= format_news_item_content news_item.precis %>
+          <%= format_news_item_content news_item.precis_with_fallback %>
         </div>
 
         <p class="tariff-body-subtext">

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -19,9 +19,20 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <article class="news-item">
-      <h3 class="govuk-heading-s">
-        Published on <%= @news_item.start_date.to_formatted_s :long %>
-      </h3>
+      <div class="gem-c-metadata">
+        <dl>
+          <dt class="gem-c-metadata__term">From:</dt>
+          <dd class="gem-c-metadata__definition">
+            <%= link_to 'HM Revenue & Customs',
+                        'https://www.gov.uk/government/organisations/hm-revenue-customs' %>
+          </dd>
+
+          <dt class="gem-c-metadata__term">Published</dt>
+          <dd class="gem-c-metadata__definition">
+            <%= @news_item.start_date.to_formatted_s :long %>
+          </dd>
+        </dl>
+      </div>
 
       <div class="tariff-markdown">
         <%= format_news_item_content @news_item.content %>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -59,5 +59,29 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
+    <div class="gem-c-related-navigation">
+      <h3 class="gem-c-related-navigation__main-heading">
+        Latest content from this collection
+      </h3>
+
+      <ul class="govuk-list govuk-!-margin-bottom-6">
+        <% @collection_items.each do |collection_item| %>
+          <li class="govuk-!-padding-top-2">
+            <%= link_to collection_item.title, collection_item %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+
+    <h3 class="govuk-heading-s">
+      Collection
+    </h3>
+
+    <p>
+      <%= link_to @news_collection.name,
+                  news_items_path(collection_id: @news_collection.id) %>
+    <p>
   </div>
 </div>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -56,6 +56,10 @@
         <%= format_news_item_content @news_item.content %>
       </div>
 
+      <p>
+        <%= link_to t('navigation.back_to_top'), '#content' %>
+      </p>
+
       <% if @news_collection.description.present? %>
         <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-2" />
 

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -1,22 +1,34 @@
-<%= page_header t('breadcrumb.news') %>
-
 <% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs truncate(@news_item.title),
                            [ [t('breadcrumb.home'), home_path],
-                             [t('breadcrumb.news'), news_items_path] ] %>
+                             [t('breadcrumb.news'), news_items_path],
+                             [@news_collection.name,
+                              news_items_path(collections_id: @news_collection.id)], ] %>
 <% end %>
 
-<article class="news-item">
-  <h2 class="govuk-heading-m">
-    <%= @news_item.title %>
-  </h2>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= page_header @news_item.title %>
 
-  <h3 class="govuk-heading-s">
-    Published on <%= @news_item.start_date.to_formatted_s :long %>
-  </h3>
-
-  <div class="tariff-markdown">
-    <%= format_news_item_content @news_item.content %>
+    <div class="tariff-markdown tariff-markdown--with-all-lead-paragraph">
+      <%= format_news_item_content @news_item.precis %>
+    </div>
   </div>
-</article>
+</div>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <article class="news-item">
+      <h3 class="govuk-heading-s">
+        Published on <%= @news_item.start_date.to_formatted_s :long %>
+      </h3>
+
+      <div class="tariff-markdown">
+        <%= format_news_item_content @news_item.content %>
+      </div>
+    </article>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+  </div>
+</div>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -10,9 +10,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= page_header @news_item.title %>
 
+    <% if @news_item.precis.present? %>
     <div class="tariff-markdown tariff-markdown--with-all-lead-paragraph">
       <%= format_news_item_content @news_item.precis %>
     </div>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -36,6 +36,22 @@
         </dl>
       </div>
 
+      <% if @news_item.subheadings.any? %>
+      <div id="contents">
+        <h2 class="gem-c-contents-list__title">Contents</h2>
+
+        <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
+          <% @news_item.subheadings.each do |subheading| %>
+            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <%= link_to subheading,
+                          "##{markdown_heading_id subheading}",
+                          class: 'gem-c-contents-list__link govuk-link--no-underline' %>
+            </li>
+          <% end %>
+        </ol>
+      </div>
+      <% end %>
+
       <div class="tariff-markdown">
         <%= format_news_item_content @news_item.content %>
       </div>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -70,7 +70,7 @@
     </article>
   </div>
 
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-third news-item__sidebar">
     <div class="gem-c-related-navigation">
       <h3 class="gem-c-related-navigation__main-heading">
         Latest content from this collection

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -55,6 +55,14 @@
       <div class="tariff-markdown">
         <%= format_news_item_content @news_item.content %>
       </div>
+
+      <% if @news_collection.description.present? %>
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-2" />
+
+        <div class="tariff-markdown">
+          <%= format_news_item_content @news_collection.description %>
+        </div>
+      <% end %>
     </article>
   </div>
 

--- a/app/webpacker/src/stylesheets/_markdown.scss
+++ b/app/webpacker/src/stylesheets/_markdown.scss
@@ -38,6 +38,10 @@
     @extend .govuk-body-l;
   }
 
+  & &--with-all-lead-paragraph, &.tariff-markdown--with-all-lead-paragraph {
+    p { @extend .govuk-body-l }
+  }
+
   &--reduced-trailing-margin > p:last-of-type {
     @include govuk-responsive-margin(2, "bottom");
   }

--- a/app/webpacker/src/stylesheets/_news_items.scss
+++ b/app/webpacker/src/stylesheets/_news_items.scss
@@ -10,3 +10,53 @@
     }
   }
 }
+
+/* Metadata section for news page */
+/* Copied from https://github.com/alphagov/govuk_publishing_components/blob/v32.1.0/app/assets/stylesheets/govuk_publishing_components/components/_metadata.scss */
+.gem-c-metadata {
+  @include govuk-text-colour;
+  @include govuk-font(16);
+  @include govuk-clearfix;
+
+  margin-bottom: govuk-spacing(3);
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(7);
+  }
+
+  a {
+    @include govuk-link-common;
+    @include govuk-link-style-default;
+    font-weight: bold;
+  }
+
+  .gem-c-metadata__definition-link {
+    font-weight: normal;
+  }
+}
+
+.gem-c-metadata__term,
+.gem-c-metadata__definition {
+  line-height: 1.4;
+}
+
+.gem-c-metadata__term {
+  margin-top: .5em;
+
+  @include govuk-media-query($from: tablet) {
+    box-sizing: border-box;
+    float: left;
+    clear: left;
+    padding-right: govuk-spacing(1);
+    margin-top: 0;
+  }
+}
+
+.gem-c-metadata__definition {
+  margin: 0;
+
+  @include govuk-media-query($from: tablet) {
+    &:not(:last-of-type) {
+      margin-bottom: govuk-spacing(1);
+    }
+  }
+}

--- a/app/webpacker/src/stylesheets/_news_items.scss
+++ b/app/webpacker/src/stylesheets/_news_items.scss
@@ -60,3 +60,9 @@
     }
   }
 }
+
+/* Fix for headings in sidebar on mobile */
+.news-item__sidebar .gem-c-related-navigation__main-heading {
+  @include govuk-font($size: 19, $weight: bold);
+  @include govuk-responsive-margin(2, "bottom");
+}

--- a/spec/factories/news/collection_factory.rb
+++ b/spec/factories/news/collection_factory.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :news_collection, class: 'News::Collection' do
     sequence(:resource_id, &:to_s)
     sequence(:name) { |n| "Collection #{n}" }
+    priority { 0 }
+    description { 'This is a description' }
   end
 end

--- a/spec/factories/news/item_factory.rb
+++ b/spec/factories/news/item_factory.rb
@@ -52,5 +52,27 @@ FactoryBot.define do
     trait :with_precis do
       precis { "first paragraph\n\nsecond paragraph" }
     end
+
+    trait :with_subheadings do
+      content do
+        <<~CONTENT
+          ## Second heading
+
+          This is a paragraph
+
+          And Another
+
+          ## Additional second heading
+
+          Paragraph
+
+          ### Third level heading
+
+          * One
+          * Two
+          * Three
+        CONTENT
+      end
+    end
   end
 end

--- a/spec/helpers/news_item_helper_spec.rb
+++ b/spec/helpers/news_item_helper_spec.rb
@@ -23,4 +23,10 @@ RSpec.describe NewsItemHelper, type: :helper do
       expect(formatted).to have_content 'Heading for UK'
     end
   end
+
+  describe '#markdown_heading_id' do
+    subject { markdown_heading_id 'This is a Heading with punctuation!' }
+
+    it { is_expected.to eq 'this-is-a-heading-with-punctuation' }
+  end
 end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -372,4 +372,12 @@ RSpec.describe News::Item do
       end
     end
   end
+
+  describe '#subheadings' do
+    subject { news_item.subheadings }
+
+    let(:news_item) { build :news_item, :with_subheadings }
+
+    it { is_expected.to eql ['Second heading', 'Additional second heading'] }
+  end
 end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -325,8 +325,8 @@ RSpec.describe News::Item do
     it { is_expected.to all be_instance_of News::Collection }
   end
 
-  describe '#precis' do
-    subject { news.precis }
+  describe '#precis_with_fallback' do
+    subject { news.precis_with_fallback }
 
     context 'with precis' do
       let(:news) { build :news_item, precis: "first para\n\nsecond para" }

--- a/spec/requests/news_items_controller_spec.rb
+++ b/spec/requests/news_items_controller_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe NewsItemsController, type: :request do
       allow(News::Item).to receive(:find)
                          .with(news_item.id.to_s)
                          .and_return news_item
+
+      allow(News::Item).to receive(:updates_page)
+                           .with(collection_id: news_item.collections.first&.id)
+                           .and_return([])
     end
 
     let(:make_request) { get news_item_path news_item.id }

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -5,10 +5,12 @@ RSpec.describe 'news_items/show', type: :view do
 
   before do
     assign :news_item, news_item
-    assign :news_collection, news_item.collections.first
+    assign :news_collection, news_collection
+    assign :collection_items, build_list(:news_item, 3)
   end
 
   let(:news_item) { build :news_item, :with_precis, content: 'Welcome to [[SERVICE_NAME]]' }
+  let(:news_collection) { news_item.collections.first }
   let(:expected_date) { news_item.start_date.to_formatted_s :long }
 
   it { is_expected.to have_css '.govuk-grid-row .govuk-grid-column-two-thirds', count: 2 }
@@ -25,6 +27,11 @@ RSpec.describe 'news_items/show', type: :view do
 
   it { is_expected.to have_css 'article .tariff-markdown p' }
   it { is_expected.to have_css 'p', text: /Welcome to #{I18n.t('title.service_name.uk')}/ }
+
+  it { is_expected.to have_css '.govuk-grid-column-one-third h3', text: /latest content/i }
+  it { is_expected.to have_css '.govuk-grid-column-one-third li a', count: 3 }
+  it { is_expected.to have_css '.govuk-grid-column-one-third h3', text: 'Collection' }
+  it { is_expected.to have_css '.govuk-grid-column-one-third p a', text: news_collection.name }
 
   context 'without precis' do
     let(:news_item) { build :news_item, content: "First\n\nSecond" }

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -23,4 +23,12 @@ RSpec.describe 'news_items/show', type: :view do
 
   it { is_expected.to have_css 'article .tariff-markdown p' }
   it { is_expected.to have_css 'p', text: /Welcome to #{I18n.t('title.service_name.uk')}/ }
+
+  context 'without precis' do
+    let(:news_item) { build :news_item, content: "First\n\nSecond" }
+
+    it { is_expected.not_to have_css '.tariff-markdown--with-all-lead-paragraph p' }
+    it { is_expected.to have_css '.tariff-markdown p', text: 'First' }
+    it { is_expected.to have_css '.tariff-markdown p', text: 'Second' }
+  end
 end

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe 'news_items/show', type: :view do
   it { is_expected.to have_css '.govuk-grid-column-one-third h3', text: /latest content/i }
   it { is_expected.to have_css '.govuk-grid-column-one-third li a', count: 3 }
   it { is_expected.to have_css '.govuk-grid-column-one-third h3', text: 'Collection' }
+  it { is_expected.to have_link 'Back to top' }
   it { is_expected.to have_css '.govuk-grid-column-one-third p a', text: news_collection.name }
 
   context 'without precis' do

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -3,13 +3,19 @@ require 'spec_helper'
 RSpec.describe 'news_items/show', type: :view do
   subject { render }
 
-  before { assign :news_item, news_item }
+  before do
+    assign :news_item, news_item
+    assign :news_collection, news_item.collections.first
+  end
 
-  let(:news_item) { build :news_item, content: 'Welcome to [[SERVICE_NAME]]' }
+  let(:news_item) { build :news_item, :with_precis, content: 'Welcome to [[SERVICE_NAME]]' }
   let(:expected_date) { news_item.start_date.to_formatted_s :long }
 
+  it { is_expected.to have_css '.govuk-grid-row .govuk-grid-column-two-thirds', count: 2 }
+  it { is_expected.to have_css '.govuk-grid-row .govuk-grid-column-one-third', count: 1 }
   it { is_expected.to have_css 'article.news-item' }
-  it { is_expected.to have_css 'article h2', text: news_item.title }
+  it { is_expected.to have_css 'h1', text: news_item.title }
+  it { is_expected.to have_css '.tariff-markdown--with-all-lead-paragraph p' }
   it { is_expected.to have_css 'article h3', text: /published.*#{expected_date}/i }
   it { is_expected.to have_css 'article .tariff-markdown p' }
   it { is_expected.to have_css 'p', text: /Welcome to #{I18n.t('title.service_name.uk')}/ }

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'news_items/show', type: :view do
 
   it { is_expected.to have_css 'article .tariff-markdown p' }
   it { is_expected.to have_css 'p', text: /Welcome to #{I18n.t('title.service_name.uk')}/ }
+  it { is_expected.to have_css 'p', text: news_collection.description }
 
   it { is_expected.to have_css '.govuk-grid-column-one-third h3', text: /latest content/i }
   it { is_expected.to have_css '.govuk-grid-column-one-third li a', count: 3 }

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'news_items/show', type: :view do
   it { is_expected.to have_css '.gem-c-metadata dl dt', text: /published/i }
   it { is_expected.to have_css '.gem-c-metadata dl dd', count: 2 }
 
+  it { is_expected.not_to have_css '#contents' }
+
   it { is_expected.to have_css 'article .tariff-markdown p' }
   it { is_expected.to have_css 'p', text: /Welcome to #{I18n.t('title.service_name.uk')}/ }
 
@@ -30,5 +32,13 @@ RSpec.describe 'news_items/show', type: :view do
     it { is_expected.not_to have_css '.tariff-markdown--with-all-lead-paragraph p' }
     it { is_expected.to have_css '.tariff-markdown p', text: 'First' }
     it { is_expected.to have_css '.tariff-markdown p', text: 'Second' }
+  end
+
+  context 'with subheadings' do
+    let(:news_item) { build :news_item, :with_subheadings }
+
+    it { is_expected.to have_css '#contents ol.gem-c-contents-list__list' }
+    it { is_expected.to have_css '#contents li a', count: news_item.subheadings.length }
+    it { is_expected.to have_link news_item.subheadings.first, href: '#second-heading' }
   end
 end

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -16,7 +16,11 @@ RSpec.describe 'news_items/show', type: :view do
   it { is_expected.to have_css 'article.news-item' }
   it { is_expected.to have_css 'h1', text: news_item.title }
   it { is_expected.to have_css '.tariff-markdown--with-all-lead-paragraph p' }
-  it { is_expected.to have_css 'article h3', text: /published.*#{expected_date}/i }
+
+  it { is_expected.to have_css '.gem-c-metadata dl dt', text: /from/i }
+  it { is_expected.to have_css '.gem-c-metadata dl dt', text: /published/i }
+  it { is_expected.to have_css '.gem-c-metadata dl dd', count: 2 }
+
   it { is_expected.to have_css 'article .tariff-markdown p' }
   it { is_expected.to have_css 'p', text: /Welcome to #{I18n.t('title.service_name.uk')}/ }
 end


### PR DESCRIPTION
### Jira link

HOTT-2136

### What?

I have added/removed/altered:

- [x] Updated the display of the news story page to match the prototype

### Why?

I am doing this because:

- We wish to ship an updated News story interface

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, merges into standalone epic branch

### Screenshots

![Screenshot from 2022-11-28 12-12-04](https://user-images.githubusercontent.com/10818/204278224-1e14fdf6-8ce5-45f2-95bc-620f70df52c8.png)
![Screen Shot 2022-11-28 at 12 30 11](https://user-images.githubusercontent.com/10818/204278329-7bb72d4a-61b6-4810-9364-e53d5cf465e0.png)

