### PR TITLE
HOTT-2280 Always allow access to Roo wizard

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,12 +88,10 @@ Rails.application.routes.draw do
 
   resources :news_items, only: %i[index show], path: '/news'
 
-  if TradeTariffFrontend.roo_wizard?
-    namespace :rules_of_origin, path: nil do
-      get '/rules_of_origin/:commodity/:country', to: 'steps#index', as: :steps
-      get '/rules_of_origin/:commodity/:country/:id', to: 'steps#show', as: :step
-      patch '/rules_of_origin/:commodity/:country/:id', to: 'steps#update', as: nil
-    end
+  namespace :rules_of_origin, path: nil do
+    get '/rules_of_origin/:commodity/:country', to: 'steps#index', as: :steps
+    get '/rules_of_origin/:commodity/:country/:id', to: 'steps#show', as: :step
+    patch '/rules_of_origin/:commodity/:country/:id', to: 'steps#update', as: nil
   end
 
   if TradeTariffFrontend.beta_search_enabled?


### PR DESCRIPTION
### Jira link

HOTT-2280

### What?

I have added/removed/altered:

- [x] Remove the feature flag on the rules of origin routes

### Why?

I am doing this because:

- This means if we later disable disable the RoO wizard after enabling it, users can continue with their existing journey rather then suddenly getting 404s

### Deployment risks (optional)

- Allows access to RoO wizard irrespective of feature flag if the correct url is known
