### PR TITLE
HOTT-2292 remove conditionality from news nav item

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -7,8 +7,7 @@ module News
     CACHE_KEY = 'news-item-any-updates'.freeze
     BANNER_CACHE_KEY = 'news-item-latest-banner'.freeze
     CACHE_VERSION = 10
-    CACHE_LIFETIME = 15.minutes
-    BANNER_CACHE_LIFETIME = 5.minutes
+    CACHE_LIFETIME = 5.minutes
 
     DISPLAY_STYLE_REGULAR = 0
 
@@ -68,27 +67,13 @@ module News
         )
       end
 
-      def any_updates?
-        Rails.cache.fetch(updates_cache_key, expires_in: CACHE_LIFETIME) do
-          updates_page.any?
-        rescue Faraday::Error
-          # This method is used by all pages in the main template so backend
-          # failures should not prevent rendering of the frontend
-          false
-        end
-      end
-
       def cached_latest_banner
-        Rails.cache.fetch(banner_cache_key, expires_in: BANNER_CACHE_LIFETIME) do
+        Rails.cache.fetch(banner_cache_key, expires_in: CACHE_LIFETIME) do
           latest_banner
         end
       end
 
     private
-
-      def updates_cache_key
-        "#{CACHE_KEY}-#{service_name}-v#{CACHE_VERSION}"
-      end
 
       def banner_cache_key
         "#{BANNER_CACHE_KEY}-#{service_name}-v#{CACHE_VERSION}"

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -37,7 +37,7 @@
         <% end %>
         <%= govuk_header_navigation_item(active_class: updates_active_class) do %>
           <%= link_to "News", news_items_path, class: "govuk-header__link" %>
-        <% end if News::Item.any_updates? %>
+        <% end %>
         <%= govuk_header_navigation_item(active_class: help_active_class) do %>
           <%= link_to "Help", help_path, class: "govuk-header__link" %>
         <% end %>

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe News::Item do
   # This is stubbed for _every_ spec because its in the header menu
   # Reverting it to real implementation for this spec
   before do
-    allow(described_class).to receive(:any_updates?).and_call_original
     allow(described_class).to receive(:latest_banner).and_call_original
   end
 
@@ -153,75 +152,6 @@ RSpec.describe News::Item do
     end
 
     it { is_expected.to have_attributes length: 2 }
-  end
-
-  describe '.any_updates?' do
-    subject(:any_updates) { described_class.any_updates? }
-
-    before { allow(Rails.cache).to receive(:fetch).and_call_original }
-
-    context 'with UK service' do
-      include_context 'with UK service'
-
-      before do
-        stub_api_request('/news/items?&per_page=10&service=uk&target=updates', backend: 'uk')
-          .to_return jsonapi_response :news_item, updates
-      end
-
-      let(:updates) { attributes_for_list(:news_item, 2) }
-
-      it { is_expected.to be true }
-
-      it 'is caches the answer' do
-        any_updates
-
-        expect(Rails.cache).to \
-          have_received(:fetch)
-          .with('news-item-any-updates-uk-v10', expires_in: 15.minutes)
-      end
-
-      context 'with no news items' do
-        let(:updates) { [] }
-
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'with XI service' do
-      include_context 'with XI service'
-
-      before do
-        stub_api_request('/news/items?&per_page=10&service=xi&target=updates', backend: 'uk')
-          .to_return jsonapi_response :news_item, updates
-      end
-
-      let(:updates) { attributes_for_list(:news_item, 2) }
-
-      it { is_expected.to be true }
-
-      it 'is caches the answer' do
-        any_updates
-
-        expect(Rails.cache).to \
-          have_received(:fetch)
-          .with('news-item-any-updates-xi-v10', expires_in: 15.minutes)
-      end
-
-      context 'with no news items' do
-        let(:updates) { [] }
-
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'with failed connection to backend' do
-      before do
-        stub_api_request('/news/items?per_page=10&service=uk&target=updates', backend: 'uk')
-          .to_timeout
-      end
-
-      it { is_expected.to be false }
-    end
   end
 
   describe '.cached_latest_banner' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,7 +61,6 @@ RSpec.configure do |config|
 
   config.before do
     allow(TariffUpdate).to receive(:all).and_return([OpenStruct.new(applied_at: Time.zone.today)])
-    allow(News::Item).to receive(:any_updates?).and_return true
     allow(News::Item).to receive(:latest_banner).and_return build(:news_item, :banner)
     Thread.current[:service_choice] = nil
   end


### PR DESCRIPTION
### Jira link

HOTT-2292

### What?

I have added/removed/altered:

- [x] Always show the news nav bar item

### Why?

I am doing this because:

- Querying for whether to show the news menu is unnecessary since we are importing a lot of historical stories from GovUK and it will always be true

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low
