### PR TITLE
HOTT-2291: Updated text on cookies page

### DIFF
--- a/app/views/cookies/policies/show.html.erb
+++ b/app/views/cookies/policies/show.html.erb
@@ -178,6 +178,11 @@
               <td class="govuk-table__cell" data-label="Purpose">Saves your cookie consent settings</td>
               <td class="govuk-table__cell" data-label="Expires">1 year</td>
             </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell" data-label="Name">show_digital_assistant_popup</td>
+              <td class="govuk-table__cell" data-label="Purpose">Determines if the Digital Assistant popup on the commodity code page will be shown until the cookie expires.</td>
+              <td class="govuk-table__cell" data-label="Expires">28 days</td>
+            </tr>
           </tbody>
         </table>
         <%= submit_tag "Save Changes", class: "govuk-button


### PR DESCRIPTION
### Jira link

[HOTT-<2291>](https://transformuk.atlassian.net/browse/HOTT-2291)

### What?

I have added/removed/altered:

- [ ] Updated the text on cookies page

### Why?

I am doing this because:

- We need to update our cookie policy 

<img width="1567" alt="Screenshot 2022-12-01 at 15 17 18" src="https://user-images.githubusercontent.com/12201130/205089941-b23522f0-15c2-4739-9210-fbc191f0d125.png">
