### PR TITLE
HOTT-2279 Use slugs for news item links

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -119,5 +119,9 @@ module News
       @subheadings ||= paragraphs.select { |p| p.start_with? '## ' }
                                  .map { |heading| heading.sub(/^\#\# /, '') }
     end
+
+    def to_param
+      slug.presence || id
+    end
   end
 end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -380,4 +380,20 @@ RSpec.describe News::Item do
 
     it { is_expected.to eql ['Second heading', 'Additional second heading'] }
   end
+
+  describe '#to_param' do
+    subject { news_item.to_param }
+
+    context 'with slug' do
+      let(:news_item) { build :news_item, slug: 'test-slug' }
+
+      it { is_expected.to eql 'test-slug' }
+    end
+
+    context 'with blank slug' do
+      let(:news_item) { build :news_item, slug: '' }
+
+      it { is_expected.to eql news_item.id }
+    end
+  end
 end

--- a/spec/requests/news_items_controller_spec.rb
+++ b/spec/requests/news_items_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe NewsItemsController, type: :request do
   describe 'GET #show' do
     before do
       allow(News::Item).to receive(:find)
-                         .with(news_item.id.to_s)
+                         .with(news_item.slug)
                          .and_return news_item
 
       allow(News::Item).to receive(:updates_page)
@@ -52,7 +52,7 @@ RSpec.describe NewsItemsController, type: :request do
                            .and_return([])
     end
 
-    let(:make_request) { get news_item_path news_item.id }
+    let(:make_request) { get news_item_path news_item }
 
     it { is_expected.to have_http_status :ok }
     it { is_expected.to have_attributes content_type: %r{text/html} }

--- a/spec/views/news_items/index.html.erb_spec.rb
+++ b/spec/views/news_items/index.html.erb_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'news_items/index', type: :view do
   it { is_expected.to have_css 'article .tariff-body-subtext', text: date_format }
   it { is_expected.to have_css 'article .tariff-body-subtext', text: news_items.first.collections.first.name }
   it { is_expected.to have_css 'article h2', count: 3 }
-  it { is_expected.to have_link news_items.first.title, href: %r{/news/\d+} }
+  it { is_expected.to have_link news_items.first.title, href: news_item_path(news_items.first) }
   it { is_expected.to have_css 'article .tariff-markdown p', count: 3 }
   it { is_expected.to have_css '.news-item p', text: /#{I18n.t('title.service_name.uk')}/ }
   it { is_expected.not_to have_css '.pagination' }


### PR DESCRIPTION
### Jira link

HOTT-2081

### What?

I have added/removed/altered:

- [x] Use slugs for the news item urls

### Why?

I am doing this because:

- we want friendlier urls for our users

### Deployment risks (optional)

- None

![Screenshot from 2022-12-01 16-38-39](https://user-images.githubusercontent.com/10818/205109301-a31f1fd1-3c93-4200-a24e-019c6534fb07.png)
![Screenshot from 2022-12-01 16-37-45](https://user-images.githubusercontent.com/10818/205109320-98a7bdde-a391-4e06-a4f5-c766a9b55a47.png)
