### PR TITLE
HOTT-2256: Remember selected tab on commodities page when country is …

### DIFF
--- a/app/controllers/trading_partners_controller.rb
+++ b/app/controllers/trading_partners_controller.rb
@@ -15,7 +15,7 @@ class TradingPartnersController < ApplicationController
     if @trading_partner.valid?
       redirect_to goods_nomenclature_path(
         country: @trading_partner.country,
-        anchor: trading_partner_params["anchor"],
+        anchor: trading_partner_params['anchor'],
       )
     elsif should_not_render_errors?
       redirect_to goods_nomenclature_path

--- a/app/controllers/trading_partners_controller.rb
+++ b/app/controllers/trading_partners_controller.rb
@@ -15,6 +15,7 @@ class TradingPartnersController < ApplicationController
     if @trading_partner.valid?
       redirect_to goods_nomenclature_path(
         country: @trading_partner.country,
+        anchor: trading_partner_params["anchor"],
       )
     elsif should_not_render_errors?
       redirect_to goods_nomenclature_path
@@ -30,6 +31,6 @@ class TradingPartnersController < ApplicationController
   end
 
   def trading_partner_params
-    params.fetch(:trading_partner, {}).permit(:country)
+    params.fetch(:trading_partner, {}).permit(:country, :anchor)
   end
 end

--- a/app/controllers/trading_partners_controller.rb
+++ b/app/controllers/trading_partners_controller.rb
@@ -10,12 +10,12 @@ class TradingPartnersController < ApplicationController
   end
 
   def update
-    @trading_partner = TradingPartner.new(trading_partner_params)
+    @trading_partner = TradingPartner.new(country: trading_partner_params[:country])
 
     if @trading_partner.valid?
       redirect_to goods_nomenclature_path(
         country: @trading_partner.country,
-        anchor: trading_partner_params['anchor'],
+        anchor: trading_partner_params[:anchor],
       )
     elsif should_not_render_errors?
       redirect_to goods_nomenclature_path

--- a/app/models/trading_partner.rb
+++ b/app/models/trading_partner.rb
@@ -3,7 +3,6 @@ class TradingPartner
   include ActiveModel::Attributes
 
   attribute :country, :string
-  attribute :anchor, :string
 
   delegate :options, to: :class
 

--- a/app/models/trading_partner.rb
+++ b/app/models/trading_partner.rb
@@ -3,6 +3,7 @@ class TradingPartner
   include ActiveModel::Attributes
 
   attribute :country, :string
+  attribute :anchor, :string
 
   delegate :options, to: :class
 

--- a/app/views/shared/_country_picker.html.erb
+++ b/app/views/shared/_country_picker.html.erb
@@ -2,6 +2,7 @@
   <fieldset class="govuk-fieldset country-picker js-country-picker govuk-!-font-size-16">
     <div class="country-picker-container">
       <%= f.hidden_field :render_errors, value: false %>
+      <%= f.hidden_field :anchor, value: nil %>
       <%= f.label :country, country_picker_text, class: 'govuk-label' %>
       <%= f.select :country, GeographicalArea.country_options, { include_blank: 'All countries' }, class: 'custom-select js-country-picker-select', "aria-label": "Filter measures by country" %>
       <%= link_to('Reset to all countries', goods_nomenclature_path(country: nil), class: 'reset-country-picker') %>

--- a/spec/controllers/trading_partners_controller_spec.rb
+++ b/spec/controllers/trading_partners_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe TradingPartnersController, type: :controller do
         session[:goods_nomenclature_code] = goods_nomenclature_code
       end
 
-      it { is_expected.to redirect_to(public_send(path_method, country: 'IT', id: goods_nomenclature_code)) }
+      it { is_expected.to redirect_to(public_send(path_method, country: 'IT', id: goods_nomenclature_code, anchor: 'export')) }
     end
 
     shared_examples_for 'an invalid trading partner redirect' do |path_method, goods_nomenclature_code|
@@ -63,7 +63,7 @@ RSpec.describe TradingPartnersController, type: :controller do
     end
 
     context 'when passing valid trading partner params' do
-      let(:params) { { trading_partner: { country: 'IT' } } }
+      let(:params) { { trading_partner: { country: 'IT', anchor: 'export' } } }
 
       it_behaves_like 'a valid trading partner redirect', :find_commodity_path, nil
       it_behaves_like 'a valid trading partner redirect', :chapter_path, '01'


### PR DESCRIPTION
…selected

### Jira link

[HOTT-<2256>](https://transformuk.atlassian.net/browse/HOTT-2256)

### What?

I have added/removed/altered:

- [ ] Added a hidden field to remember which tab the user has selected

### Why?

I am doing this because:

- We want to remember the selected tab when switching countries to deliver a better user experience

<img width="1135" alt="Screenshot 2022-12-02 at 13 31 39" src="https://user-images.githubusercontent.com/12201130/205304050-23dafa59-b78b-41b6-aa14-44043b3e1fa3.png">

