### PR TITLE
Removes basic auth from review apps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ commands:
           command: |
             sed -i "s/instances: [0-9]\+/instances\: 1/" deploy_manifest.yml
             sed -i "s|CORS_HOST: dev\.trade-tariff\.service\.gov\.uk|CORS_HOST: ${CF_APP}-${REVIEW_URL_ID}.london.cloudapps.digital|" deploy_manifest.yml
+            sed -i "/BASIC_/d" deploy_manifest.yml
             sed -i "s|HOST: dev\.trade-tariff\.service\.gov\.uk|HOST: ${CF_APP}-${REVIEW_URL_ID}.london.cloudapps.digital|" deploy_manifest.yml
       - run:
           name: Push review app


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removed basic authentication from the review apps

### Why?

I am doing this because:

- These are ephemeral/cycle anyway so this is no longer necessary
