### PR TITLE
HOTT-2296 use slugs for collections

### DIFF
--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -8,11 +8,16 @@ module News
 
     attr_writer   :id
     attr_accessor :name,
+                  :slug,
                   :description,
                   :priority
 
     def id
       @id ||= resource_id.presence&.to_i
+    end
+
+    def to_param
+      slug.presence || id
     end
   end
 end

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -42,7 +42,7 @@
         <% if @filter_collection == collection.id %>
           <%= collection.name %>
         <% else %>
-          <%= link_to collection.name, news_index_params.merge(collection_id: collection.id, page: nil) %>
+          <%= link_to collection.name, news_index_params.merge(collection_id: collection, page: nil) %>
         <% end %>
       </li>
       <% end %>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -93,7 +93,7 @@
 
     <p>
       <%= link_to @news_collection.name,
-                  news_items_path(collection_id: @news_collection.id) %>
+                  news_collection_path(collection_id: @news_collection) %>
     <p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,8 @@ Rails.application.routes.draw do
   resolve('Cookies::Policy') { %i[cookies policy] }
   get 'cookies', to: redirect(path: '/cookies/policy')
 
+  get '/news/collections/:collection_id', to: 'news_items#index', as: :news_collection
+  get '/news/stories/:id', to: 'news_items#show', as: :news_item
   resources :news_items, only: %i[index show], path: '/news'
 
   namespace :rules_of_origin, path: nil do

--- a/spec/factories/news/collection_factory.rb
+++ b/spec/factories/news/collection_factory.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :news_collection, class: 'News::Collection' do
     sequence(:resource_id, &:to_s)
     sequence(:name) { |n| "Collection #{n}" }
+    sequence(:slug) { |n| "collection_#{n}" }
     priority { 0 }
     description { 'This is a description' }
   end

--- a/spec/models/news/collection_spec.rb
+++ b/spec/models/news/collection_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe News::Collection do
-  it { is_expected.to respond_to :name }
   it { is_expected.to respond_to :id }
+  it { is_expected.to respond_to :name }
+  it { is_expected.to respond_to :slug }
+  it { is_expected.to respond_to :description }
+  it { is_expected.to respond_to :priority }
 
   describe '#attributes' do
     subject { described_class.new resource_id: '1', name: 'test' }
@@ -30,6 +33,20 @@ RSpec.describe News::Collection do
       include_context 'with XI service'
 
       it { is_expected.to have_attributes length: 2 }
+    end
+  end
+
+  describe '#to_param' do
+    context 'with slug' do
+      subject { build(:news_collection, slug: 'testing123').to_param }
+
+      it { is_expected.to eq 'testing123' }
+    end
+
+    context 'without slug' do
+      subject { build(:news_collection, id: 3, slug: nil).to_param }
+
+      it { is_expected.to be 3 }
     end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Added a slug field to the collections api client
- [x] Implement `News::Collection#to_param` - defaults to slug but falls back to id
- [x] Use to_param to form nice urls

### Why?

I am doing this because:

- We want to use nice urls for the stop press area

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, maintains compatibility with legacy url structure
