### PR TITLE
HOTT-2282: Fix heading/subheading overview measure alignment

### DIFF
--- a/app/webpacker/src/stylesheets/_commodity-tree.scss
+++ b/app/webpacker/src/stylesheets/_commodity-tree.scss
@@ -242,11 +242,6 @@ article.tariff {
         @media (min-width: 641px) {
           float: right;
           width: 514px;
-
-          @supports(display: flex) {
-            display: flex;
-            align-items: flex-end;
-          }
         }
 
         .lte-ie8 & {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2282

![image](https://user-images.githubusercontent.com/8156884/205687041-29256714-f4ec-4862-8d6e-98bdeff86b97.png)

### What?

I have added/removed/altered:

- [x] Removed broken flex display configuration

### Why?

I am doing this because:

- This only seems to negatively affect the alignment of the overview measure cells in a desktop browser and seems to add no value/prevents us from aligning properly
