### PR TITLE
HOTT-2294 show collection name

### DIFF
--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -9,6 +9,12 @@ class NewsItemsController < ApplicationController
     @news_collections = News::Collection.all
     @news_years = News::Year.all
 
+    if params[:collection_id]
+      @current_collection = @news_collections.find do |collection|
+        collection.matches_param? params[:collection_id]
+      end
+    end
+
     @news_items = News::Item.updates_page(**news_index_params)
   end
 

--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -19,5 +19,15 @@ module News
     def to_param
       slug.presence || id
     end
+
+    def matches_param?(collection_id)
+      if collection_id.to_s.match? %r{\A\d+\z}
+        id == collection_id.to_i
+      elsif slug.present?
+        slug == collection_id
+      else
+        false
+      end
+    end
   end
 end

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -51,7 +51,7 @@
 
   <div class="govuk-grid-column-three-quarters news-items">
     <h2 class="govuk-heading-l">
-      <%= @collection_name || 'All collections' %>
+      <%= @current_collection&.name || 'All collections' %>
     </h2>
 
     <% @news_items.each do |news_item| %>

--- a/spec/models/news/collection_spec.rb
+++ b/spec/models/news/collection_spec.rb
@@ -49,4 +49,44 @@ RSpec.describe News::Collection do
       it { is_expected.to be 3 }
     end
   end
+
+  describe '#matches_param?' do
+    subject { collection.matches_param? collection_id }
+
+    let(:collection) { build :news_collection }
+
+    context 'with slug' do
+      context 'when matching' do
+        let(:collection_id) { collection.slug }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when not matching' do
+        let(:collection_id) { "#{collection.slug}-unknown" }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'with id' do
+      context 'when matching' do
+        let(:collection_id) { collection.id }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when not matching' do
+        let(:collection_id) { collection.id.to_i + 1 }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'with nil' do
+      let(:collection_id) { nil }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/views/news_items/index.html.erb_spec.rb
+++ b/spec/views/news_items/index.html.erb_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'news_items/index', type: :view do
   it { is_expected.to have_css 'article .tariff-body-subtext', text: date_format }
   it { is_expected.to have_css 'article .tariff-body-subtext', text: news_items.first.collections.first.name }
   it { is_expected.to have_css 'article h2', count: 3 }
+  it { is_expected.to have_css '.news-items > h2', text: 'All collections' }
   it { is_expected.to have_link news_items.first.title, href: news_item_path(news_items.first) }
   it { is_expected.to have_css 'article .tariff-markdown p', count: 3 }
   it { is_expected.to have_css '.news-item p', text: /#{I18n.t('title.service_name.uk')}/ }
@@ -69,11 +70,16 @@ RSpec.describe 'news_items/index', type: :view do
   end
 
   context 'when filtering by collection' do
-    before { assign :filter_collection, news_collections.first.id }
+    before do
+      assign :filter_collection, news_collections.first.id
+      assign :current_collection, news_collections.first
+    end
 
     it { is_expected.to have_css 'ul#news-collection-filter li', count: 3 }
     it { is_expected.to have_css 'ul#news-collection-filter li a', count: 2 }
     it { is_expected.to have_css 'ul#news-collection-filter li a', text: 'All collections' }
     it { is_expected.not_to have_css 'ul#news-collection-filter li a', text: news_collections.first.name }
+
+    it { is_expected.to have_css '.news-items > h2', text: news_collections.first.name }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-2294

### What?

I have added/removed/altered:

- [x] Fixed display of collection name when filtering by collection

### Why?

I am doing this because:

- Saying 'All collections' when its not is misleading for the user

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None - epic branch
