### PR TITLE
HOTT-2250 Use GovUK pagination component

### DIFF
--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,13 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="govuk-pagination__item">
+  <%= link_to t('views.pagination.first').html_safe,
+              remote: remote,
+              class: "govuk-pagination__link" %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,13 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="govuk-pagination__item">
+  <%= link_to t('views.pagination.last').html_safe,
+              remote: remote,
+              class: "govuk-pagination__link" %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,23 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<div class="govuk-pagination__next">
+  <%= link_to url, rel: 'next', remote: remote do %>
+    <span class="govuk-pagination__link-title">Next</span>
+
+    <svg class="govuk-pagination__icon govuk-pagination__icon--next"
+         xmlns="http://www.w3.org/2000/svg"
+         height="13"
+         width="15"
+         aria-hidden="true"
+         focusable="false"
+         viewBox="0 0 15 13">
+      <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+    </svg>
+  <% end %>
+</div>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,14 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="govuk-pagination__item <%= 'govuk-pagination__item--current' if page.current? %>">
+  <%= link_to page, url, { rel: page.rel,
+                           class: "govuk-pagination__link",
+                           aria: { label: "Page #{page.number}" } } %>
+</li>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="govuk-pagination" role="navigation" aria-label="results">
+    <%= prev_page_tag unless current_page.first? %>
+    <ul class="govuk-pagination__list">
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    </ul>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,23 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<div class="govuk-pagination__prev">
+  <%= link_to url, rel: 'prev', remote: remote do %>
+    <svg class="govuk-pagination__icon govuk-pagination__icon--prev"
+         xmlns="http://www.w3.org/2000/svg"
+         height="13"
+         width="15"
+         aria-hidden="true"
+         focusable="false"
+         viewBox="0 0 15 13">
+      <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+    </svg>
+
+    <span class="govuk-pagination__link-title">Previous</span></a>
+  <% end %>
+</div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  config.window = 2
+  config.outer_window = 1
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/spec/views/news_items/index.html.erb_spec.rb
+++ b/spec/views/news_items/index.html.erb_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'news_items/index', type: :view do
       Kaminari.paginate_array(news_items, total_count: 200).page(1).per(10)
     end
 
-    it { is_expected.to have_css '.pagination' }
+    it { is_expected.to have_css '.govuk-pagination' }
   end
 
   context 'with single paragraph news items' do


### PR DESCRIPTION
### Jira link

HOTT-2250

### What?

I have added/removed/altered:

- [x] Implemented the pagination pattern from the GovUK design system across the site

### Why?

I am doing this because:

- We want to follow GovUK recommendations wherever possible

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, does update pagination on other unrelated pages like Quotas

### Screenshots

![Screenshot from 2022-12-06 11-58-03](https://user-images.githubusercontent.com/10818/205906121-d506399c-0611-45c7-9cfd-4aa688e7f778.png)
![Screenshot from 2022-12-06 11-57-41](https://user-images.githubusercontent.com/10818/205906155-f8e7afee-5953-4ae9-a64f-29e051f45cb1.png)
![Screenshot from 2022-12-06 11-59-41](https://user-images.githubusercontent.com/10818/205906166-c546ffb4-471e-43a6-b7dc-8bea8e4c2f12.png)

