### PR TITLE
HOTT-2317: Added commas to definition.balance on quota search page

### DIFF
--- a/app/views/search/quotas/_definition.html.erb
+++ b/app/views/search/quotas/_definition.html.erb
@@ -29,6 +29,6 @@
   </td>
 
   <td class="govuk-table__cell numerical" data-label="Balance">
-    <%= definition.balance %> <%= definition.measurement_unit %>
+    <%= number_with_precision(definition.balance, precision: 3, delimiter: ',') %> <%= definition.measurement_unit %>
   </td>
 </tr>


### PR DESCRIPTION
### Jira link

[HOTT-<2317>
](https://transformuk.atlassian.net/browse/HOTT-2317)

### What?

I have added/removed/altered:

- [ ] Added commas to definition.balance on quota search page

### Why?

I am doing this because:

- It will make the definition.balance easier to read

<img width="1143" alt="Screenshot 2022-12-07 at 14 16 22" src="https://user-images.githubusercontent.com/12201130/206202376-0f347d3a-92d5-4cf5-bf63-93adc38c474c.png">

