### PR TITLE
HOTT-2332 Show first paragraph as precis when no precis

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -100,6 +100,10 @@ module News
       precis.present? ? content.present? : paragraphs.many?
     end
 
+    def content_without_precis
+      precis.present? ? content : paragraphs.slice(1..).join("\n\n")
+    end
+
     def subheadings
       @subheadings ||= paragraphs.select { |p| p.start_with? '## ' }
                                  .map { |heading| heading.sub(/^\#\# /, '') }

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -10,9 +10,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= page_header @news_item.title %>
 
-    <% if @news_item.precis.present? %>
+    <% if @news_item.precis_with_fallback.present? %>
     <div class="tariff-markdown tariff-markdown--with-all-lead-paragraph">
-      <%= format_news_item_content @news_item.precis %>
+      <%= format_news_item_content @news_item.precis_with_fallback %>
     </div>
     <% end %>
   </div>
@@ -52,8 +52,8 @@
       </div>
       <% end %>
 
-      <div class="tariff-markdown">
-        <%= format_news_item_content @news_item.content %>
+      <div class="news-item__content tariff-markdown">
+        <%= format_news_item_content @news_item.content_without_precis %>
       </div>
 
       <p>

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -303,6 +303,38 @@ RSpec.describe News::Item do
     end
   end
 
+  describe '#content_without_precis' do
+    subject { news.content_without_precis }
+
+    context 'with precis' do
+      context 'with content' do
+        let(:news) { build :news_item, :with_precis, content: 'something' }
+
+        it { is_expected.to eq 'something' }
+      end
+
+      context 'without content' do
+        let(:news) { build :news_item, :with_precis, content: '' }
+
+        it { is_expected.to be_blank }
+      end
+    end
+
+    context 'without precis' do
+      context 'with single paragraph content' do
+        let(:news) { build :news_item, content: 'first paragraph' }
+
+        it { is_expected.to be_blank }
+      end
+
+      context 'with multiple paragraph content' do
+        let(:news) { build :news_item, content: "first\n\nsecond\n\nthird" }
+
+        it { is_expected.to eq "second\n\nthird" }
+      end
+    end
+  end
+
   describe '#subheadings' do
     subject { news_item.subheadings }
 

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe 'news_items/show', type: :view do
   it { is_expected.to have_css '.govuk-grid-column-one-third p a', text: news_collection.name }
 
   context 'without precis' do
-    let(:news_item) { build :news_item, content: "First\n\nSecond" }
+    let(:news_item) { build :news_item, content: "First\n\nSecond", precis: '' }
 
-    it { is_expected.not_to have_css '.tariff-markdown--with-all-lead-paragraph p' }
-    it { is_expected.to have_css '.tariff-markdown p', text: 'First' }
-    it { is_expected.to have_css '.tariff-markdown p', text: 'Second' }
+    it { is_expected.to have_css '.tariff-markdown--with-all-lead-paragraph p', text: 'First' }
+    it { is_expected.not_to have_css '.news-item__content.tariff-markdown p', text: 'First' }
+    it { is_expected.to have_css '.news-item__content.tariff-markdown p', text: 'Second' }
   end
 
   context 'with subheadings' do


### PR DESCRIPTION
### Jira link

HOTT-2332

### What?

I have added/removed/altered:

- [x] Show the first paragraph as the precis when the precis is blank

### Why?

I am doing this because:

- Old stories are missing a precis

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low

### Before

![Screenshot from 2022-12-07 14-59-14](https://user-images.githubusercontent.com/10818/206218015-2b4069bc-3b2d-43c0-99aa-fa11bd7f5b68.png)

### After

![Screenshot from 2022-12-07 15-00-02](https://user-images.githubusercontent.com/10818/206218075-22a30b73-dcb4-4c25-a3ed-40f281466d54.png)
