### PR TITLE
HOTT-2249 Display filter lists with prefix hyphens

### DIFF
--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -14,7 +14,7 @@
       Filter by year
     </h3>
 
-    <ul class="govuk-list govuk-list--disc" id="news-year-filter">
+    <ul class="govuk-list tariff-list--hyphen" id="news-year-filter">
       <li>
         <%= @filter_year ? link_to('All years', year: nil, page: nil) : 'All years' %>
       </li>
@@ -33,7 +33,7 @@
       Filter by collection
     </h3>
 
-    <ul class="govuk-list govuk-list--disc" id="news-collection-filter">
+    <ul class="govuk-list tariff-list--hyphen" id="news-collection-filter">
       <li>
         <%= @filter_collection ? link_to('All collections', collection_id: nil, page: nil) : 'All collections' %>
       </li>

--- a/app/webpacker/src/stylesheets/_lists.scss
+++ b/app/webpacker/src/stylesheets/_lists.scss
@@ -45,3 +45,12 @@ ol.numbered-then-lettered-list {
     padding-left: 2em;
   }
 }
+
+.tariff-list--hyphen {
+  padding-left: govuk-spacing(2);
+
+  li {
+    list-style-type: "-";
+    padding-left: govuk-spacing(3);
+  }
+}


### PR DESCRIPTION
### Jira link

HOTT-2249

### What?

I have added/removed/altered:

- [x] Display hypens on news story filter lists

### Why?

I am doing this because:

- It makes it clearer that the filters are lists of filters

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None

### Screenshots
![Screenshot from 2022-12-07 16-11-12](https://user-images.githubusercontent.com/10818/206231883-4f557520-dd73-4d9d-aa71-7963271118cc.png)
![image](https://user-images.githubusercontent.com/10818/206232019-5adc755a-2d9e-4099-97a9-8af68a065ea1.png)

