### PR TITLE
HOTT-2338 Fixed collections link in breadcrumb

### DIFF
--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -3,7 +3,7 @@
                            [ [t('breadcrumb.home'), home_path],
                              [t('breadcrumb.news'), news_items_path],
                              [@news_collection.name,
-                              news_items_path(collections_id: @news_collection.id)], ] %>
+                              news_collection_path(@news_collection)], ] %>
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
### Jira link

HOTT-2338

### What?

I have added/removed/altered:

- [x] Fixed collections link in story breadcrumb

### Why?

I am doing this because:

- it didn't get updated when we switched to slugs for collections

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, fixes trivial bug
