### PR TITLE
HOTT-2261 Add GovUK Pub Components to webpacker path

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,4 +1,5 @@
 const { environment } = require('@rails/webpacker');
+const { execSync } = require('child_process')
 const webpack = require('webpack');
 
 environment.plugins.append('Provide', new webpack.ProvidePlugin({
@@ -6,5 +7,20 @@ environment.plugins.append('Provide', new webpack.ProvidePlugin({
   jQuery: 'jquery',
   BetaPopup: 'popup'
 }));
+
+let gpcGemPath = null
+try {
+  gpcGemPath = execSync('bundle show govuk_publishing_components')
+    .toString()
+    .replace(/\n$/, '')
+} catch (err) {
+  console.error("Expected govuk_publishing_components gem to be installed")
+  process.exit()
+}
+
+const config = environment.toWebpackConfig()
+config.resolve.modules.push(`${gpcGemPath}/app/assets/images/govuk_publishing_components`)
+config.resolve.modules.push(`${gpcGemPath}/app/assets/stylesheets/govuk_publishing_components`)
+config.resolve.modules.push(`${gpcGemPath}/app/assets/javascripts/govuk_publishing_components`)
 
 module.exports = environment;


### PR DESCRIPTION
### Jira link

HOTT-2261

### What?

I have added/removed/altered:

- [x] Added the GovUK Publishing Components assets folder to the load paths for webpacker

### Why?

I am doing this because:

- we are currently vendoring various css files from GPC and this is fiddly and error prone
- we are increasingly incorporating design elements from the main GovUK site and this makes it much easier

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Medium - drops several css assets and relies on GPC to provide them
