### PR TITLE
HOTT-2341 Fix linking selected collection filter

### DIFF
--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -3,14 +3,12 @@ class NewsItemsController < ApplicationController
                 :disable_last_updated_footnote
 
   def index
-    @filter_collection = params[:collection_id].presence&.to_i
-    @filter_year = params[:year].presence&.to_i
-
     @news_collections = News::Collection.all
     @news_years = News::Year.all
 
+    @filter_year = params[:year].presence&.to_i
     if params[:collection_id]
-      @current_collection = @news_collections.find do |collection|
+      @filter_collection = @news_collections.find do |collection|
         collection.matches_param? params[:collection_id]
       end
     end

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -39,7 +39,7 @@
       </li>
       <% @news_collections.each do |collection| %>
       <li>
-        <% if @filter_collection == collection.id %>
+        <% if collection.id == @filter_collection&.id %>
           <%= collection.name %>
         <% else %>
           <%= link_to collection.name, news_index_params.merge(collection_id: collection, page: nil) %>
@@ -51,7 +51,7 @@
 
   <div class="govuk-grid-column-three-quarters news-items">
     <h2 class="govuk-heading-l">
-      <%= @current_collection&.name || 'All collections' %>
+      <%= @filter_collection&.name || 'All collections' %>
     </h2>
 
     <% @news_items.each do |news_item| %>

--- a/spec/views/news_items/index.html.erb_spec.rb
+++ b/spec/views/news_items/index.html.erb_spec.rb
@@ -70,10 +70,7 @@ RSpec.describe 'news_items/index', type: :view do
   end
 
   context 'when filtering by collection' do
-    before do
-      assign :filter_collection, news_collections.first.id
-      assign :current_collection, news_collections.first
-    end
+    before { assign :filter_collection, news_collections.first }
 
     it { is_expected.to have_css 'ul#news-collection-filter li', count: 3 }
     it { is_expected.to have_css 'ul#news-collection-filter li a', count: 2 }


### PR DESCRIPTION
### Jira link

HOTT-2341

### What?

I have added/removed/altered:

- [x] Fixed linking currently selected collection fliter

### Why?

I am doing this because:

- It makes it clear to the user that they are already filtering by the chosen collection

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, minor bugfix
