### PR TITLE
HOTT-2297: Adds presentation of quota closed and transferred event

### DIFF
--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -35,6 +35,8 @@ class OrderNumber
     has_one :order_number
     has_many :measures
 
+    has_one :incoming_quota_closed_and_transferred_event, class_name: 'QuotaClosedAndTransferredEvent'
+
     delegate :present?, to: :status
     delegate :warning_text, :show_warning?, to: :order_number, allow_nil: true
 

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -63,10 +63,6 @@ class OrderNumber
       blocking_period_start_date.present? && blocking_period_end_date.present?
     end
 
-    def within_first_twenty_days?
-      Time.zone.now.between? validity_start_date, validity_start_date + 20.days
-    end
-
     def first_goods_nomenclature_short_code
       all_goods_nomenclatures.select { |gn| gn.respond_to?(:short_code) }
                              .first

--- a/app/models/quota_closed_and_transferred_event.rb
+++ b/app/models/quota_closed_and_transferred_event.rb
@@ -3,15 +3,38 @@ require 'api_entity'
 class QuotaClosedAndTransferredEvent
   include ApiEntity
 
-  attr_accessor :transferred_amount, :closing_date
-
-  has_one :quota_definition, class_name: 'OrderNumber::Definition'
+  attr_accessor :transferred_amount,
+                :closing_date,
+                :quota_definition_validity_start_date,
+                :quota_definition_validity_end_date,
+                :quota_definition_measurement_unit,
+                :target_quota_definition_validity_start_date,
+                :target_quota_definition_validity_end_date,
+                :target_quota_definition_measurement_unit
 
   def presented_balance_text
-    "#{definition.measurement_unit}, transferred from the previous quota period (#{definition.validity_start_date.to_date.to_formatted_s(:long)} to #{definition.validity_end_date.to_date.to_formatted_s(:long)}) on #{closing_date.to_date.to_formatted_s(:long)}."
+    "#{quota_definition_measurement_unit}, transferred from the previous quota period (#{presented_quota_definition_validity_start_date} to #{presented_quota_definition_validity_end_date}) on #{presented_closing_date}."
   end
 
-  def definition
-    quota_definition.presence || casted_by
+  private
+
+  def presented_closing_date
+    closing_date.to_date.to_formatted_s(:long)
+  end
+
+  def presented_quota_definition_validity_start_date
+    quota_definition_validity_start_date.to_date.to_formatted_s(:long)
+  end
+
+  def presented_quota_definition_validity_end_date
+    quota_definition_validity_end_date.to_date.to_formatted_s(:long)
+  end
+
+  def presented_target_quota_definition_validity_start_date
+    target_quota_definition_validity_start_date.to_date.to_formatted_s(:long)
+  end
+
+  def presented_target_quota_definition_validity_end_date
+    target_quota_definition_validity_end_date.to_date.to_formatted_s(:long)
   end
 end

--- a/app/models/quota_closed_and_transferred_event.rb
+++ b/app/models/quota_closed_and_transferred_event.rb
@@ -1,0 +1,17 @@
+require 'api_entity'
+
+class QuotaClosedAndTransferredEvent
+  include ApiEntity
+
+  attr_accessor :transferred_amount, :closing_date
+
+  has_one :quota_definition, class_name: 'OrderNumber::Definition'
+
+  def presented_balance_text
+    "#{quota_definition.measurement_unit}, transferred from the previous quota period (#{quota_definition.validity_start_date.to_date.to_formatted_s(:long)} to #{quota_definition.validity_end_date.to_date.to_formatted_s(:long)}) on #{closing_date.to_date.to_formatted_s(:long)}."
+  end
+
+  def presented_transferred_amount
+    transferred_amount
+  end
+end

--- a/app/models/quota_closed_and_transferred_event.rb
+++ b/app/models/quota_closed_and_transferred_event.rb
@@ -23,18 +23,18 @@ class QuotaClosedAndTransferredEvent
   end
 
   def presented_quota_definition_validity_start_date
-    quota_definition_validity_start_date.to_date.to_formatted_s(:long)
+    quota_definition_validity_start_date&.to_date&.to_formatted_s(:long)
   end
 
   def presented_quota_definition_validity_end_date
-    quota_definition_validity_end_date.to_date.to_formatted_s(:long)
+    quota_definition_validity_end_date&.to_date&.to_formatted_s(:long)
   end
 
   def presented_target_quota_definition_validity_start_date
-    target_quota_definition_validity_start_date.to_date.to_formatted_s(:long)
+    target_quota_definition_validity_start_date&.to_date&.to_formatted_s(:long)
   end
 
   def presented_target_quota_definition_validity_end_date
-    target_quota_definition_validity_end_date.to_date.to_formatted_s(:long)
+    target_quota_definition_validity_end_date&.to_date&.to_formatted_s(:long)
   end
 end

--- a/app/models/quota_closed_and_transferred_event.rb
+++ b/app/models/quota_closed_and_transferred_event.rb
@@ -8,10 +8,10 @@ class QuotaClosedAndTransferredEvent
   has_one :quota_definition, class_name: 'OrderNumber::Definition'
 
   def presented_balance_text
-    "#{quota_definition.measurement_unit}, transferred from the previous quota period (#{quota_definition.validity_start_date.to_date.to_formatted_s(:long)} to #{quota_definition.validity_end_date.to_date.to_formatted_s(:long)}) on #{closing_date.to_date.to_formatted_s(:long)}."
+    "#{definition.measurement_unit}, transferred from the previous quota period (#{definition.validity_start_date.to_date.to_formatted_s(:long)} to #{definition.validity_end_date.to_date.to_formatted_s(:long)}) on #{closing_date.to_date.to_formatted_s(:long)}."
   end
 
-  def presented_transferred_amount
-    transferred_amount
+  def definition
+    quota_definition.presence || casted_by
   end
 end

--- a/app/services/pending_quota_balance_service.rb
+++ b/app/services/pending_quota_balance_service.rb
@@ -42,7 +42,7 @@ private
   end
 
   def pending_balance
-    if declarable.import_measures.any? && definition.within_first_twenty_days? && declarable.has_safeguard_measure?
+    if declarable.import_measures.any? && declarable.has_safeguard_measure?
       begin
         previous_period_definition&.balance
       rescue Faraday::ResourceNotFound

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -46,26 +46,25 @@
             </td>
           </tr>
           <% if quota_definition.incoming_quota_closed_and_transferred_event.present? %>
-          <tr class="govuk-table__row">
-            <th scope="col" class='govuk-table__header'>Transferred balance</th>
-            <td class="numerical govuk-table__cell numerical">
-              <span data-pending-balance-target="balance"></span>
-              This balance includes <%= number_with_precision quota_definition.incoming_quota_closed_and_transferred_event.presented_transferred_amount, precision: 3, delimiter: ',' %> <%= quota_definition.incoming_quota_closed_and_transferred_event.presented_balance_text %>
-            </td>
-          </tr>
+            <tr class="govuk-table__row" id="transferred-balance">
+              <th scope="col" class='govuk-table__header'>Transferred balance</th>
+              <td class="numerical govuk-table__cell numerical">
+                This balance includes <%= number_with_precision quota_definition.incoming_quota_closed_and_transferred_event.transferred_amount, precision: 3, delimiter: ',' %> <%= quota_definition.incoming_quota_closed_and_transferred_event.presented_balance_text %>
+              </td>
+            </tr>
           <% elsif declarable_id %>
-          <tr class="govuk-table__row hidden-pending-balance"
-              data-controller="pending-balance"
-              data-pending-balance-url-value="<%= pending_quota_balance_path(declarable_id, quota_definition.order_number.number) %>">
-            <th scope="col" class='govuk-table__header'>Pending balance</th>
-            <td class="numerical govuk-table__cell numerical">
-              <span data-pending-balance-target="balance"></span>
-              <%= quota_definition.measurement_unit %>
-              remains available from the previous quota period.
-              This will be transferred to the current quota period c. 20 working
-              days after the end of the previous quota period.
-            </td>
-          </tr>
+            <tr class="govuk-table__row hidden-pending-balance"
+                data-controller="pending-balance"
+                data-pending-balance-url-value="<%= pending_quota_balance_path(declarable_id, quota_definition.order_number.number) %>">
+              <th scope="col" class='govuk-table__header'>Pending balance</th>
+              <td class="numerical govuk-table__cell numerical">
+                <span data-pending-balance-target="balance"></span>
+                <%= quota_definition.measurement_unit %>
+                remains available from the previous quota period.
+                This will be transferred to the current quota period c. 20 working
+                days after the end of the previous quota period.
+              </td>
+            </tr>
           <% end %>
           <tr class="govuk-table__row">
             <th scope="col" class='govuk-table__header'>Status</th>

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -45,7 +45,15 @@
               <%= quota_definition.measurement_unit %>
             </td>
           </tr>
-          <% if quota_definition.within_first_twenty_days? && declarable_id %>
+          <% if quota_definition.incoming_quota_closed_and_transferred_event.present? %>
+          <tr class="govuk-table__row">
+            <th scope="col" class='govuk-table__header'>Transferred balance</th>
+            <td class="numerical govuk-table__cell numerical">
+              <span data-pending-balance-target="balance"></span>
+              This balance includes <%= number_with_precision quota_definition.incoming_quota_closed_and_transferred_event.presented_transferred_amount, precision: 3, delimiter: ',' %> <%= quota_definition.incoming_quota_closed_and_transferred_event.presented_balance_text %>
+            </td>
+          </tr>
+          <% elsif declarable_id %>
           <tr class="govuk-table__row hidden-pending-balance"
               data-controller="pending-balance"
               data-pending-balance-url-value="<%= pending_quota_balance_path(declarable_id, quota_definition.order_number.number) %>">

--- a/spec/factories/order_number_definition_factory.rb
+++ b/spec/factories/order_number_definition_factory.rb
@@ -35,5 +35,13 @@ FactoryBot.define do
       validity_start_date { 1.month.ago.iso8601 }
       validity_end_date { 2.months.from_now.iso8601 }
     end
+
+    trait :with_incoming_quota_closed_and_transferred_event do
+      incoming_quota_closed_and_transferred_event { attributes_for(:quota_closed_and_transferred_event) }
+    end
+
+    trait :without_incoming_quota_closed_and_transferred_event do
+      incoming_quota_closed_and_transferred_event {}
+    end
   end
 end

--- a/spec/factories/quota_closed_and_transferred_event_factory.rb
+++ b/spec/factories/quota_closed_and_transferred_event_factory.rb
@@ -1,8 +1,13 @@
 FactoryBot.define do
   factory :quota_closed_and_transferred_event, class: 'QuotaClosedAndTransferredEvent' do
-    quota_definition { attributes_for(:definition) }
+    id { '1-2012-01-01' }
     transferred_amount { Forgery(:basic).number }
     closing_date { Date.current.iso8601 }
-    id { '1-2012-01-01' }
+    quota_definition_validity_start_date { Date.current.iso8601 }
+    quota_definition_validity_end_date { Date.current.iso8601 }
+    quota_definition_measurement_unit { 'Kilogram (kg)' }
+    target_quota_definition_validity_start_date { Date.current.iso8601 }
+    target_quota_definition_validity_end_date {}
+    target_quota_definition_measurement_unit { 'Kilogram (kg)' }
   end
 end

--- a/spec/factories/quota_closed_and_transferred_event_factory.rb
+++ b/spec/factories/quota_closed_and_transferred_event_factory.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :quota_closed_and_transferred_event, class: 'QuotaClosedAndTransferredEvent' do
-    transferred_amount { '54000.0' }
-    closing_date { '2021-12-31T00:00:00.000Z' }
-    id { '1' }
+    quota_definition { attributes_for(:definition) }
+    transferred_amount { Forgery(:basic).number }
+    closing_date { Date.current.iso8601 }
+    id { '1-2012-01-01' }
   end
 end

--- a/spec/factories/quota_closed_and_transferred_event_factory.rb
+++ b/spec/factories/quota_closed_and_transferred_event_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :quota_closed_and_transferred_event, class: 'QuotaClosedAndTransferredEvent' do
+    transferred_amount { '54000.0' }
+    closing_date { '2021-12-31T00:00:00.000Z' }
+    id { '1' }
+  end
+end

--- a/spec/models/order_number/definition_spec.rb
+++ b/spec/models/order_number/definition_spec.rb
@@ -119,32 +119,6 @@ RSpec.describe OrderNumber::Definition do
     end
   end
 
-  describe '#within_first_twenty_days?' do
-    context 'with future definition' do
-      subject { build :definition, :future }
-
-      it { is_expected.not_to be_within_first_twenty_days }
-    end
-
-    context 'with historical definition' do
-      subject { build :definition, :historical }
-
-      it { is_expected.not_to be_within_first_twenty_days }
-    end
-
-    context 'with current definition within first twenty days' do
-      subject { build :definition, :current, validity_start_date: 10.days.ago.iso8601 }
-
-      it { is_expected.to be_within_first_twenty_days }
-    end
-
-    context 'with current definition started more than twenty days ago' do
-      subject { build :definition, :current, validity_start_date: 21.days.ago.iso8601 }
-
-      it { is_expected.not_to be_within_first_twenty_days }
-    end
-  end
-
   describe '#first_goods_nomenclature_short_code' do
     subject { definition.first_goods_nomenclature_short_code }
 

--- a/spec/models/quota_closed_and_transferred_event_spec.rb
+++ b/spec/models/quota_closed_and_transferred_event_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+RSpec.describe QuotaClosedAndTransferredEvent do
+  subject(:quota_closed_and_transferred_event) { build(:quota_closed_and_transferred_event) }
+
+  descride '#presented_balance_text' do
+  end
+end

--- a/spec/models/quota_closed_and_transferred_event_spec.rb
+++ b/spec/models/quota_closed_and_transferred_event_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.describe QuotaClosedAndTransferredEvent do
   subject(:quota_closed_and_transferred_event) { build(:quota_closed_and_transferred_event) }
 
-  descride '#presented_balance_text' do
+  describe '#presented_balance_text' do
+    it { expect(quota_closed_and_transferred_event.presented_balance_text).to eq("Kilogram (kg), transferred from the previous quota period (1 January 2021 to 31 December 2021) on #{Date.current.to_formatted_s(:long)}.") }
   end
 end

--- a/spec/models/quota_closed_and_transferred_event_spec.rb
+++ b/spec/models/quota_closed_and_transferred_event_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe QuotaClosedAndTransferredEvent do
   subject(:quota_closed_and_transferred_event) { build(:quota_closed_and_transferred_event) }
 
   describe '#presented_balance_text' do
-    it { expect(quota_closed_and_transferred_event.presented_balance_text).to eq("Kilogram (kg), transferred from the previous quota period (1 January 2021 to 31 December 2021) on #{Date.current.to_formatted_s(:long)}.") }
+    it { expect(quota_closed_and_transferred_event.presented_balance_text).to eq("Kilogram (kg), transferred from the previous quota period (#{Date.current.to_formatted_s(:long)} to #{Date.current.to_formatted_s(:long)}) on #{Date.current.to_formatted_s(:long)}.") }
   end
 end

--- a/spec/services/pending_quota_balance_service_spec.rb
+++ b/spec/services/pending_quota_balance_service_spec.rb
@@ -78,12 +78,6 @@ RSpec.describe PendingQuotaBalanceService do
         it { is_expected.to be_nil }
       end
 
-      context 'when outside of first twenty days' do
-        let(:start_date) { 30.days.ago }
-
-        it { is_expected.to be_nil }
-      end
-
       context 'without previous balance' do
         let :previous_commodity do
           build :commodity, goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,

--- a/spec/views/shared/_quota_definition.html.erb_spec.rb
+++ b/spec/views/shared/_quota_definition.html.erb_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 RSpec.describe 'shared/_quota_definition', type: :view do
   subject(:rendered_page) { render_page && rendered }
 
-  before { assign :search, Search.new }
+  before do
+    assign :search, Search.new
+    allow(view).to receive(:declarable_id)
+  end
 
   let :render_page do
     render 'shared/quota_definition', order_number:, quota_definition:
@@ -48,5 +51,17 @@ RSpec.describe 'shared/_quota_definition', type: :view do
 
     it { is_expected.to have_css 'th', text: 'Suspension period' }
     it { is_expected.to have_css 'th', text: 'Blocking period' }
+  end
+
+  context 'when there is a QuotaClosedAndTransferredEvent returned for the definition' do
+    let(:quota_definition) { build(:definition, :with_incoming_quota_closed_and_transferred_event) }
+
+    it { is_expected.to have_css '#transferred-balance', text: 'Transferred balance' }
+  end
+
+  context 'when there is not a QuotaClosedAndTransferredEvent returned for the definition' do
+    let(:definition) { build(:definition, :without_incoming_quota_closed_and_transferred_event) }
+
+    it { is_expected.not_to have_css '#transferred-balance', text: 'Transferred balance' }
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2297

### What?

I have added/removed/altered:

- [x] Added view for quota closed and transferred events
- [x] Removed 20 day requirement for fetching pending safeguard quota events
- [x] Adds specs for new transfer events

### Why?

I am doing this because:

- This is required to enable transfer events to present in the quota modal UI
- The requirement of showing pending balance events only within 20 days of the definition period no longer applies
