### PR TITLE
HOTT-2356 Added feedback links to Rules of Origin wizard

### DIFF
--- a/app/views/rules_of_origin/_new_feature.html.erb
+++ b/app/views/rules_of_origin/_new_feature.html.erb
@@ -1,0 +1,4 @@
+<div class="govuk-inset-text tariff-inset-meursing">
+  <p>The rules of origin wizard is new functionality.</p>
+  <p>Your <%= link_to 'feedback', feedback_path %> will help us to improve it.</p>
+</div>

--- a/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
+++ b/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
@@ -51,7 +51,4 @@
   <% end %>
 </ul>
 
-<div class="govuk-inset-text tariff-inset-meursing">
-  <p>The rules of origin wizard is new functionality.</p>
-  <p>Your <%= link_to 'feedback', feedback_path %> will help us to improve it.</p>
-</div>
+<%= render 'rules_of_origin/new_feature' %>

--- a/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
+++ b/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
@@ -49,4 +49,9 @@
       <%= link_to t('.links.direct_transport'), step_path(:direct_transport_rule) %>
     </li>
   <% end %>
-<ul>
+</ul>
+
+<div class="govuk-inset-text tariff-inset-meursing">
+  <p>The rules of origin wizard is new functionality.</p>
+  <p>Your <%= link_to 'feedback', feedback_path %> will help us to improve it.</p>
+</div>

--- a/app/views/rules_of_origin/steps/_rules_not_met.html.erb
+++ b/app/views/rules_of_origin/steps/_rules_not_met.html.erb
@@ -96,7 +96,4 @@
   </div>
 </div>
 
-<div class="govuk-inset-text tariff-inset-meursing">
-  <p>The rules of origin wizard is new functionality.</p>
-  <p>Your <%= link_to 'feedback', feedback_path %> will help us to improve it.</p>
-</div>
+<%= render 'rules_of_origin/new_feature' %>

--- a/app/views/rules_of_origin/steps/_rules_not_met.html.erb
+++ b/app/views/rules_of_origin/steps/_rules_not_met.html.erb
@@ -95,3 +95,8 @@
     </div>
   </div>
 </div>
+
+<div class="govuk-inset-text tariff-inset-meursing">
+  <p>The rules of origin wizard is new functionality.</p>
+  <p>Your <%= link_to 'feedback', feedback_path %> will help us to improve it.</p>
+</div>

--- a/spec/views/rules_of_origin/steps/_origin_requirements_met.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_origin_requirements_met.html.erb_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'rules_of_origin/steps/_origin_requirements_met', type: :view do
   it { is_expected.to have_css 'span.govuk-caption-xl', text: %r{(Im|Ex)porting.* #{wizardstore['commodity_code']}.*Japan.*UK} }
   it { is_expected.to have_css 'h1', text: /Product-specific rules met/i }
   it { is_expected.to have_css '.rules-of-origin-met-message', text: %r{#{schemes.first.title}} }
+  it { is_expected.to have_link 'feedback' }
   it { is_expected.to have_css '#next-steps a', count: 3 }
 
   context 'with duty drawback available' do

--- a/spec/views/rules_of_origin/steps/_rules_not_met.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_rules_not_met.html.erb_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'rules_of_origin/steps/_rules_not_met', type: :view do
   it { is_expected.to have_css '#cumulation-section a' }
   it { is_expected.to have_css '#whats-next-section.panel--coloured strong' }
   it { is_expected.to have_css '#whats-next-section a', count: 2 }
+  it { is_expected.to have_link 'feedback' }
   it { is_expected.not_to have_css '#next-steps' }
 
   context 'without tolerances article' do


### PR DESCRIPTION
### Jira link

HOTT-2356

### What?

I have added/removed/altered:

- [x] Added a link to the feedback page from the requirements met page
- [x] Added a link to the feedback page from the requirements not met page

### Why?

I am doing this because:

- This feature is new and it makes clear to users how to provide us with feedback

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low

### Screenshots

![Screenshot from 2022-12-13 09-49-03](https://user-images.githubusercontent.com/10818/207285847-d4d30d2a-cd57-45b8-9ad4-424ced3526ca.png)
![Screenshot from 2022-12-13 09-48-42](https://user-images.githubusercontent.com/10818/207285852-8556c0f9-6ef7-479c-a85b-7fb61a6ce0bb.png)

