### PR TITLE
HOTT-2274 Upgraded NewRelic version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
       digest
       net-protocol
       timeout
-    newrelic_rpm (8.12.0)
+    newrelic_rpm (8.13.1)
     nio4r (2.5.8)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
@@ -311,7 +311,7 @@ GEM
     rake (13.0.6)
     redis (5.0.5)
       redis-client (>= 0.9.0)
-    redis-client (0.9.0)
+    redis-client (0.11.2)
       connection_pool
     regexp_parser (2.6.1)
     request_store (1.5.1)


### PR DESCRIPTION
### Jira link

HOTT-2274

### What?

I have added/removed/altered:

- [x] Upgraded NewRelic to 8.13.1
- [x] Upgraded redis-client to 0.11

### Why?

I am doing this because:

- NewRelic 8.13.x is incompatible with versions of redis-client < 0.11
- This is fixed in 8.14 but better to get the redis-client version upgraded as well

### Deployment risks (optional)

- None, if the app wont render the homepage we now stop the deploy
