### PR TITLE
HOTT-2388: Hide first quarter pending balances

### DIFF
--- a/app/services/pending_quota_balance_service.rb
+++ b/app/services/pending_quota_balance_service.rb
@@ -1,4 +1,7 @@
 class PendingQuotaBalanceService
+  QUOTA_FIRST_QUARTER_DAY = 1
+  QUOTA_FIRST_QUARTER_MONTH = 7
+
   attr_reader :declarable_id,
               :quota_order_number_id,
               :chosen_period,
@@ -42,7 +45,7 @@ private
   end
 
   def pending_balance
-    if declarable.import_measures.any? && declarable.has_safeguard_measure?
+    if show_pending_balances?
       begin
         previous_period_definition&.balance
       rescue Faraday::ResourceNotFound
@@ -53,5 +56,26 @@ private
 
   def previous_period
     (definition.validity_start_date - 1.day).to_date
+  end
+
+  def show_pending_balances?
+    declarable.import_measures.any? && declarable.has_safeguard_measure? && not_current_definition_first_quarter?
+  end
+
+  def not_current_definition_first_quarter?
+    !current_definition_first_quarter?
+  end
+
+  def current_definition_first_quarter?
+    current_definition_start_day == QUOTA_FIRST_QUARTER_DAY &&
+      current_definition_start_month == QUOTA_FIRST_QUARTER_MONTH
+  end
+
+  def current_definition_start_day
+    definition.validity_start_date.to_date.day
+  end
+
+  def current_definition_start_month
+    definition.validity_start_date.to_date.month
   end
 end

--- a/spec/services/pending_quota_balance_service_spec.rb
+++ b/spec/services/pending_quota_balance_service_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe PendingQuotaBalanceService do
       described_class.new(commodity.short_code, '1010', Time.zone.today).call
     end
 
-    let(:start_date) { 5.days.ago }
-
     let :current_definition do
       attributes_for :definition,
                      balance: '1000.0',
@@ -58,7 +56,27 @@ RSpec.describe PendingQuotaBalanceService do
               ]
       end
 
-      context 'with safeguard measure and inside first twenty days' do
+      context 'with the definition in the quotas first quarter' do
+        let(:start_date) { Date.current.change(day: 1, month: 7) }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'with the definition in the quotas second quarter' do
+        let(:start_date) { Date.current.change(day: 1, month: 9) }
+
+        it { is_expected.to eq previous_definition[:balance] }
+      end
+
+      context 'with the definition in the quotas third quarter' do
+        let(:start_date) { Date.current.change(day: 1, month: 1) }
+
+        it { is_expected.to eq previous_definition[:balance] }
+      end
+
+      context 'with the definition in the quotas fourth quarter' do
+        let(:start_date) { Date.current.change(day: 1, month: 4) }
+
         it { is_expected.to eq previous_definition[:balance] }
       end
 
@@ -144,19 +162,40 @@ RSpec.describe PendingQuotaBalanceService do
               ]
       end
 
-      it { is_expected.to eq previous_definition[:balance] }
+      context 'with the definition in the quotas first quarter' do
+        let(:start_date) { Date.current.change(day: 1, month: 7) }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'with the definition in the quotas second quarter' do
+        let(:start_date) { Date.current.change(day: 1, month: 9) }
+
+        it { is_expected.to eq previous_definition[:balance] }
+      end
+
+      context 'with the definition in the quotas third quarter' do
+        let(:start_date) { Date.current.change(day: 1, month: 1) }
+
+        it { is_expected.to eq previous_definition[:balance] }
+      end
+
+      context 'with the definition in the quotas fourth quarter' do
+        let(:start_date) { Date.current.change(day: 1, month: 4) }
+
+        it { is_expected.to eq previous_definition[:balance] }
+      end
     end
 
     context 'with no import measures' do
       subject { described_class.new(heading.short_code, '1010', Time.zone.today).call }
 
+      let(:start_date) { Date.current }
+      let(:heading) { build :heading }
+
       before do
         allow(Heading).to receive(:find).with(heading.short_code, as_of: Time.zone.today)
                                         .and_return heading
-      end
-
-      let :heading do
-        build :heading
       end
 
       it { is_expected.to be nil }

--- a/spec/services/pending_quota_balance_service_spec.rb
+++ b/spec/services/pending_quota_balance_service_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe PendingQuotaBalanceService do
       described_class.new(commodity.short_code, '1010', Time.zone.today).call
     end
 
+    let(:start_date) { 5.days.ago }
+
     let :current_definition do
       attributes_for :definition,
                      balance: '1000.0',
@@ -190,7 +192,6 @@ RSpec.describe PendingQuotaBalanceService do
     context 'with no import measures' do
       subject { described_class.new(heading.short_code, '1010', Time.zone.today).call }
 
-      let(:start_date) { Date.current }
       let(:heading) { build :heading }
 
       before do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2388

### What?

I have added/removed/altered:

- [x] Alter logic of when to show pending balances to hide them during the first quarter

### Why?

I am doing this because:

- Balances can only be transferred for a given quota year and not between quota years
