### PR TITLE
HOTT-2328 Cache model attributes instead of instance

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -6,7 +6,7 @@ module News
 
     CACHE_KEY = 'news-item-any-updates'.freeze
     BANNER_CACHE_KEY = 'news-item-latest-banner'.freeze
-    CACHE_VERSION = 10
+    CACHE_VERSION = 11
     CACHE_LIFETIME = 5.minutes
 
     DISPLAY_STYLE_REGULAR = 0
@@ -68,15 +68,20 @@ module News
       end
 
       def cached_latest_banner
-        Rails.cache.fetch(banner_cache_key, expires_in: CACHE_LIFETIME) do
-          latest_banner
-        end
+        attrs = cached_latest_banner_attributes
+        new(attrs) if attrs
       end
 
     private
 
       def banner_cache_key
         "#{BANNER_CACHE_KEY}-#{service_name}-v#{CACHE_VERSION}"
+      end
+
+      def cached_latest_banner_attributes
+        Rails.cache.fetch(banner_cache_key, expires_in: CACHE_LIFETIME) do
+          latest_banner&.attributes
+        end
       end
     end
 


### PR DESCRIPTION
### Jira link

HOTT-2328

### What?

I have added/removed/altered:

- [x] Change banner caching to caching attributes rather then model instances

### Why?

I am doing this because:

- Internally rails cache uses `Marshal.dump` which includes internal variables which includes a lot of info which may change between code deploys.
- Storing only the attributes field on an ApiEntity instance then instantiating a new object equates to just caching the api request so should avoid any problems from outdated data structures.

### Deployment risks (optional)

- Low, should avoid need to bump CACHE_VERSION variable so much
