### PR TITLE
HOTT-2407 Don't show news banner on error pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -16,6 +16,8 @@ class ErrorsController < ApplicationController
   end
 
   def internal_server_error
+    @skip_news_banner = true
+
     respond_to do |format|
       format.html { render status: :internal_server_error }
       format.json { render json: { error: 'Internal server error' }, status: :internal_server_error }
@@ -24,6 +26,8 @@ class ErrorsController < ApplicationController
   end
 
   def maintenance
+    @skip_news_banner = true
+
     respond_to do |format|
       format.html { render status: :service_unavailable }
       format.json { render json: { error: 'Maintenance mode' }, status: :service_unavailable }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,7 +64,7 @@
       <%= yield :proposition_header %>
     </div>
     <%= render 'shared/search_banner' if TradeTariffFrontend.search_banner? && @search %>
-    <%= render 'news_items/header_banner', news_item: News::Item.cached_latest_banner %>
+    <%= render 'news_items/header_banner', news_item: News::Item.cached_latest_banner unless @skip_news_banner %>
   </header>
 
   <div class="tariff service govuk-width-container">

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Error handling' do
       it_behaves_like 'not found'
     end
 
-    context 'with non existant resource' do
+    context 'with non existent resource' do
       before do
         stub_api_request('/news/items/9999', backend: 'uk')
           .and_return jsonapi_error_response(404)
@@ -115,6 +115,17 @@ RSpec.describe 'Error handling' do
       before do
         allow(News::Item).to \
           receive(:find).and_raise(StandardError, 'Something went wrong')
+
+        visit '/news/9999'
+      end
+
+      it_behaves_like 'internal server error'
+    end
+
+    context 'with broken news banner' do
+      before do
+        allow(News::Item).to \
+          receive(:latest_banner).and_raise(StandardError, 'Something went wrong')
 
         visit '/news/9999'
       end

--- a/spec/features/maintenance_mode_spec.rb
+++ b/spec/features/maintenance_mode_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe 'Maintenance mode' do
 
       it_behaves_like 'service unavailable'
     end
+
+    context 'with broken news banner' do
+      before do
+        allow(News::Item).to \
+          receive(:latest_banner).and_raise(StandardError, 'Something went wrong')
+
+        visit '/503'
+      end
+
+      it_behaves_like 'service unavailable'
+    end
   end
 
   describe 'visiting a page whilst maintenance mode is enabled' do


### PR DESCRIPTION
### Jira link

HOTT-2407

### What?

I have added/removed/altered:

- [x] Prevent display of news banner on 500 and 503 pages

### Why?

I am doing this because:

- If there is any problem with displaying the news banner it will prevent the 'There is a problem' and 'Maintenance'  pages from being displayed and will result in all users seeing a plain white failsafe page

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Makes changes to our error handling code, but should improve their resilience
