### PR TITLE
HOTT-2472: Fix issue with checkout on test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,9 +335,6 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      #- ruby/rubocop-check:
-      #   format: progress
-      #   label: Inspecting with Rubocop
       - run:
           name: Rubocop changed files
           when: always
@@ -424,8 +421,9 @@ jobs:
           NODE_OPTIONS: --openssl-legacy-provider
     resource_class: medium
     steps:
-      - browser-tools/install-browser-tools
       - checkout
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - ruby/install-deps
       - node/install-packages:
           pkg-manager: yarn


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2478

### What?

I have added/removed/altered:

- [x] Removed firefox and gecko installation
- [x] Checkout code before chrome/chromium driver installation

### Why?

I am doing this because:

- Capybara is configued with chrome not firefox and this is wasted job time
- The chrome install litters the root directory with a license file that's stopping us from checking out
