### PR TITLE
HOTT-2471 Autolink intercept messages

### DIFF
--- a/app/models/beta/search/intercept_message.rb
+++ b/app/models/beta/search/intercept_message.rb
@@ -10,7 +10,9 @@ module Beta
                     :formatted_message
 
       def html_message
-        Govspeak::Document.new(formatted_message, sanitize: false).to_html.html_safe
+        Rinku.auto_link(
+          Govspeak::Document.new(formatted_message, sanitize: false).to_html,
+        ).html_safe
       end
     end
   end

--- a/spec/models/beta/search/intercept_message_spec.rb
+++ b/spec/models/beta/search/intercept_message_spec.rb
@@ -1,14 +1,22 @@
 require 'spec_helper'
 
 RSpec.describe Beta::Search::InterceptMessage do
-  describe '#html_message' do
-    subject(:intercept_message) do
-      formatted_message = '[chapter 85](/chapters/85)'
+  subject(:intercept_message) { build :intercept_message, formatted_message: }
 
-      build(:intercept_message, formatted_message:).html_message
-    end
+  let(:formatted_message) { '[chapter 85](/chapters/85)' }
+
+  describe '#html_message' do
+    subject { intercept_message.html_message }
 
     it { is_expected.to be_html_safe }
     it { is_expected.to include('<a href="/chapters/85">chapter 85</a>') }
+
+    context 'with unmarkuped hyperlink' do
+      let(:formatted_message) { 'this is a *link* to https://www.gov.uk/' }
+
+      it { is_expected.to be_html_safe }
+      it { is_expected.to include '<em>link</em>' }
+      it { is_expected.to include '<a href="https://www.gov.uk/">https://www.gov.uk/</a>' }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-2471

### What?

I have added/removed/altered:

- [x] Autolink intercept messages

### Why?

I am doing this because:

- We want links which are just dropped into intercept messages without markdown formatting to still show as html links

### Deployment risks (optional)

- None
