### PR TITLE
HOTT-2474: Fix CAS number rendering in commodity classification

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -59,8 +59,8 @@ module CommoditiesHelper
   end
 
   def convert_text_to_links(text)
-    starting_characters = /(\s|^)/
-    terminating_characters = /(\s|;|,|$|\.)/
+    starting_characters = /(\s|^|\A|<br>|<\/br>)/
+    terminating_characters = /(\s|;|,|$|\.|\z|<br>|<\/br>)/
 
     text = text.gsub( # Match subheading longer-syntax
       /#{starting_characters}(\d{4})\s(\d{2})\s(\d{2})#{terminating_characters}/,

--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -59,10 +59,25 @@ module CommoditiesHelper
   end
 
   def convert_text_to_links(text)
-    text.gsub(/\s(\d{4})\s(\d{2})\s(\d{2})/, " <a href='/search?q=\\1\\2\\3#{query}'>\\1 \\2 \\3</a>")
-        .gsub(/\s(\d{4})\s(\d{2})/, " <a href='/search?q=\\1\\2#{query}'>\\1 \\2</a>")
-        .gsub(/\s(\d{4})/, " <a href='/search?q=\\1#{query}'>\\1</a>")
-        .gsub(/(chapter)\s(\d{2})/i, "<a href='/search?q=\\2#{query}'>\\1 \\2</a>")
+    starting_characters = /(\s|^)/
+    terminating_characters = /(\s|;|,|$|\.)/
+
+    text = text.gsub( # Match subheading longer-syntax
+      /#{starting_characters}(\d{4})\s(\d{2})\s(\d{2})#{terminating_characters}/,
+      " <a href='/search?q=\\2\\3\\4#{query}'>\\2 \\3 \\4</a>\\5",
+    )
+    text = text.gsub( # Match subheading short syntax
+      /#{starting_characters}(\d{4})\s(\d{2})#{terminating_characters}/,
+      " <a href='/search?q=\\2\\3#{query}'>\\2 \\3</a>\\4",
+    )
+    text = text.gsub( # Match heading short syntax
+      /#{starting_characters}(\d{4})#{terminating_characters}/,
+      " <a href='/search?q=\\2#{query}'>\\2</a>\\3",
+    )
+    text.gsub( # Match chapter short syntax
+      /(chapter)\s(\d{2})#{terminating_characters}/i,
+      "<a href='/search?q=\\2#{query}'>\\1 \\2</a>\\3",
+    )
   end
 
   def query

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -202,13 +202,13 @@ RSpec.describe CommoditiesHelper, type: :helper do
     context 'with chemical references in formatted description' do
       let(:declarable_formatted_description) { 'CAS RN 7439-93-2' }
 
-      it { is_expected.to eql "CAS RN <a href='/search?q=7439&country=IN&day=01&month=12&year=2022'>7439</a>-93-2" }
+      it { is_expected.to eql 'CAS RN 7439-93-2' }
     end
 
     context 'with chapter in formatted description' do
-      let(:declarable_formatted_description) { ' Chapter 32 ' }
+      let(:declarable_formatted_description) { ' Chapter 32.' }
 
-      it { is_expected.to eql " <a href='/search?q=32&country=IN&day=01&month=12&year=2022'>Chapter 32</a> " }
+      it { is_expected.to eql " <a href='/search?q=32&country=IN&day=01&month=12&year=2022'>Chapter 32</a>." }
     end
 
     context 'with heading in formatted description' do
@@ -218,15 +218,15 @@ RSpec.describe CommoditiesHelper, type: :helper do
     end
 
     context 'with 8 digit subheading in formatted description' do
-      let(:declarable_formatted_description) { ' 1234 11 22 ' }
+      let(:declarable_formatted_description) { ' 1234 11 22' }
 
-      it { is_expected.to eql " <a href='/search?q=12341122&country=IN&day=01&month=12&year=2022'>1234 11 22</a> " }
+      it { is_expected.to eql " <a href='/search?q=12341122&country=IN&day=01&month=12&year=2022'>1234 11 22</a>" }
     end
 
     context 'with 6 digit subheading in formatted description' do
-      let(:declarable_formatted_description) { ' 1234 11 ' }
+      let(:declarable_formatted_description) { ' 1234 11, flibble' }
 
-      it { is_expected.to eql " <a href='/search?q=123411&country=IN&day=01&month=12&year=2022'>1234 11</a> " }
+      it { is_expected.to eql " <a href='/search?q=123411&country=IN&day=01&month=12&year=2022'>1234 11</a>, flibble" }
     end
   end
 

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -199,6 +199,12 @@ RSpec.describe CommoditiesHelper, type: :helper do
       it { is_expected.to be_empty }
     end
 
+    context 'with chemical references in formatted description' do
+      let(:declarable_formatted_description) { 'CAS RN 7439-93-2' }
+
+      it { is_expected.to eql "CAS RN <a href='/search?q=7439&country=IN&day=01&month=12&year=2022'>7439</a>-93-2" }
+    end
+
     context 'with chapter in formatted description' do
       let(:declarable_formatted_description) { ' Chapter 32 ' }
 

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -212,9 +212,9 @@ RSpec.describe CommoditiesHelper, type: :helper do
     end
 
     context 'with heading in formatted description' do
-      let(:declarable_formatted_description) { ' 1234 ' }
+      let(:declarable_formatted_description) { ' 1234<br>' }
 
-      it { is_expected.to eql " <a href='/search?q=1234&country=IN&day=01&month=12&year=2022'>1234</a> " }
+      it { is_expected.to eql " <a href='/search?q=1234&country=IN&day=01&month=12&year=2022'>1234</a><br>" }
     end
 
     context 'with 8 digit subheading in formatted description' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2474

Before:

![image](https://user-images.githubusercontent.com/8156884/212932102-724702b7-11cc-4aed-af66-c49f0659fef9.png)

After:

![image](https://user-images.githubusercontent.com/8156884/212932259-88145166-a289-42f5-8050-b2d5e28080c3.png)

### What?

I have added/removed/altered:

- [x] Fixes CAS numbers from being rendered as links

### Why?

I am doing this because:

- CAS numbers terminate with `-` and we need to make sure that these aren't being shown as links to headings
