### PR TITLE
HOTT-2492 Escape typed search entry

### DIFF
--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -10,6 +10,7 @@
 (function() {
   const IMask = require('imask');
   const debounce = require('./debounce');
+  const htmlEscaper = require('html-escaper');
 
   global.GOVUK = global.GOVUK || {};
   /**
@@ -823,8 +824,10 @@
                   }
                 },
                 source: debounce(function(query, populateResults) {
+                  const escapedQuery = htmlEscaper.escape(query) ;
+
                   let opts = {
-                    term: query
+                    term: escapedQuery
                   };
 
                   $.ajax({
@@ -842,16 +845,16 @@
                         newSource.push(result.text);
                         options.push(result);
 
-                        if (result.text.toLowerCase() == query.toLowerCase()) {
+                        if (result.text.toLowerCase() == escapedQuery.toLowerCase()) {
                           exactMatch = true;
                         }
                       });
 
-                      if ($.inArray(query.toLowerCase(), newSource) < 0) {
-                        newSource.unshift(query.toLowerCase());
+                      if ($.inArray(escapedQuery.toLowerCase(), newSource) < 0) {
+                        newSource.unshift(escapedQuery.toLowerCase());
                         options.unshift({
-                          id: query.toLowerCase(),
-                          text: query.toLowerCase(),
+                          id: escapedQuery.toLowerCase(),
+                          text: escapedQuery.toLowerCase(),
                           newOption: true
                         });
                       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "accessible-autocomplete": "^2.0.4",
     "alphagov-static": "github:alphagov/static.git#release_3463",
     "govuk-frontend": "^4.4.1",
+    "html-escaper": "^2.0.2",
     "imask": "^6.4.3",
     "jquery": "3.6.3",
     "jquery-common-keydown": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3872,7 +3872,7 @@ html-encoding-sniffer@^3.0.0:
   dependencies:
     whatwg-encoding "^2.0.0"
 
-html-escaper@^2.0.0:
+html-escaper@^2.0.0, html-escaper@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==


### PR DESCRIPTION
### Jira link

HOTT-2492

### What?

I have added/removed/altered:

- [x] Added `html-escaper` npm library
- [x] Escaped query from commodity search box

### Why?

I am doing this because:

- It was being reflected back into the autocomplete drop down without being escaped

### Deployment risks (optional)

- None
