### PR TITLE
HOTT-2491 Strip country URL option on comm history pages

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -19,6 +19,10 @@ class CommoditiesController < GoodsNomenclaturesController
     end
   end
 
+  def url_options
+    @remove_country_url_option ? super.merge(country: nil) : super
+  end
+
   private
 
   def declarable
@@ -105,6 +109,7 @@ class CommoditiesController < GoodsNomenclaturesController
     @heading_code = params[:id].first(4)
     @chapter_code = params[:id].first(2)
 
+    @remove_country_url_option = true
     disable_search_form
 
     render :show_404, status: :not_found

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -20,9 +20,14 @@ class HeadingsController < GoodsNomenclaturesController
     @heading_code = params[:id]
     @chapter_code = params[:id].first(2)
 
+    @remove_country_url_option = true
     disable_search_form
 
     render :show_404, status: :not_found
+  end
+
+  def url_options
+    @remove_country_url_option ? super.merge(country: nil) : super
   end
 
   private

--- a/app/controllers/subheadings_controller.rb
+++ b/app/controllers/subheadings_controller.rb
@@ -11,6 +11,10 @@ class SubheadingsController < GoodsNomenclaturesController
     @heading = subheading.heading
   end
 
+  def url_options
+    @remove_country_url_option ? super.merge(country: nil) : super
+  end
+
   private
 
   def subheading
@@ -38,6 +42,7 @@ class SubheadingsController < GoodsNomenclaturesController
     @subheading_code = params[:id].first(10)
     @chapter_code = params[:id].first(2)
 
+    @remove_country_url_option = true
     disable_search_form
 
     render :show_404, status: :not_found


### PR DESCRIPTION
### Jira link

HOTT-2491

### What?

I have added/removed/altered:

- [x] Remove the country parameter from commodity histories pages

### Why?

I am doing this because:

- The backend api now raises a 404 when trying to access an unknown country code, this will take the user to the commodity histories page. If we don't remove the country code then we'll end up directing the user back to a page which will 404

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low
