### PR TITLE
HOTT-2589 Handle when unknown quota definition requested

### DIFF
--- a/app/services/pending_quota_balance_service.rb
+++ b/app/services/pending_quota_balance_service.rb
@@ -61,8 +61,13 @@ private
   def show_pending_balances?
     declarable.import_measures.any? &&
       declarable.has_safeguard_measure? &&
+      has_current_definition? &&
       not_current_definition_first_quarter? &&
       definition.shows_balance_transfers?
+  end
+
+  def has_current_definition?
+    !definition.nil?
   end
 
   def not_current_definition_first_quarter?

--- a/spec/services/pending_quota_balance_service_spec.rb
+++ b/spec/services/pending_quota_balance_service_spec.rb
@@ -128,7 +128,13 @@ RSpec.describe PendingQuotaBalanceService do
                                             .and_raise(Faraday::ResourceNotFound, 'unknown')
         end
 
-        it { is_expected.to be nil }
+        it { is_expected.to be_nil }
+      end
+
+      context 'without current definition' do
+        let(:current_definition) { nil }
+
+        it { is_expected.to be_nil }
       end
     end
 


### PR DESCRIPTION
### Jira link

HOTT-2589

### What?

I have added/removed/altered:

- [x] Fixed assumption that quota requested on a commodity is valid for that commodity

### Why?

I am doing this because:

- Because a scraper is trying to access invalid data and it creates noise which will hide 'real' errors

### Deployment risks (optional)

- Low
