### PR TITLE
HOTT-2572 Show proofs content on wizard proofs page

### DIFF
--- a/app/models/rules_of_origin/steps/proofs_of_origin.rb
+++ b/app/models/rules_of_origin/steps/proofs_of_origin.rb
@@ -3,6 +3,8 @@ module RulesOfOrigin
     class ProofsOfOrigin < Base
       self.section = 'proofs'
 
+      delegate :proofs, to: :chosen_scheme
+
       def skipped?
         true
       end

--- a/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
+++ b/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
@@ -19,24 +19,16 @@
   </h3>
 
   <p>
-    <%= t '.overview.body' %>
+    <%= t '.overview.body', count: current_step.proofs.length %>
   </p>
 
-  <ul class="govuk-list" id="body-links">
-    <li>
-      <%= link_to t('.links.statement'),
-                  'https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#origin-declaration',
-                  target: '_blank',
-                  rel: 'noreferrer noopener' %>
-    </li>
-
-    <li>
-      <%= link_to t('.links.knowledge'),
-                  'https://www.gov.uk/guidance/get-proof-of-origin-for-your-goods#importers-knowledge',
-                  target: '_blank',
-                  rel: 'noreferrer noopener' %>
-    </li>
-  </ul>
+  <div class="stacked-govuk-details tariff-markdown">
+    <% current_step.proofs.each do |proof| %>
+      <%= render 'shared/details', summary: proof.summary,
+                                   content: govspeak(proof.content) \
+          if proof.content.present? %>
+    <% end %>
+  </div>
 </div>
 
 <h3 class="govuk-heading-s">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -514,11 +514,13 @@ en:
         overview:
           subtitle: Proof of origin - overview
           body:
-             There are 2 way to provide proofs of origin. Click on an option to
-             see an overview of that proof.
+            one:
+              There is 1 way to provide proofs of origin. Click on an option to
+              see an overview of that proof.
+            other:
+              There are %{count} ways to provide proofs of origin. Click on an option to
+              see an overview of that proof.
         links:
-          statement: Statement on origin (opens in new tab)
-          knowledge: Importer's knowledge (opens in new tab)
           requirements: See detailed processes and requirements for proving the origin for goods
           verification: How proofs of origin are verified
           duty_drawback: Find out about duty drawback

--- a/spec/views/rules_of_origin/steps/_proofs_of_origin.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_proofs_of_origin.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'rules_of_origin/steps/_origin_requirements_met', type: :view do
   it { is_expected.to have_css 'p', text: /preferential tariff/ }
   it { is_expected.to have_css '#proofs-overview h3', text: /overview/ }
   it { is_expected.to have_css '#proofs-overview p', text: /provide proof/ }
-  it { is_expected.to have_css '#proofs-overview a', count: 2 }
+  it { is_expected.to have_css '#proofs-overview details', count: 1 }
   it { is_expected.to have_css 'h3', text: /Next/i }
   it { is_expected.to have_css '#next-steps a', count: 2 }
 


### PR DESCRIPTION
### Jira link

HOTT-2572

### What?

I have added/removed/altered:

- [x] Show proofs content on proofs of origin step in Rules of Origin wizard

### Why?

I am doing this because:

- We now have the relevant content available in the API

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Depends on availability of backend API changes (otherwise the change will prevent proofs from showing)

### Screenshot

![image](https://user-images.githubusercontent.com/10818/215739120-86f69136-b0c5-4815-afce-27d6ae8e29b9.png)
 
