### PR TITLE
HOTT-2587: Update links to guides

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -8,6 +8,18 @@ module PagesHelper
     [asset, asset_size, link_text]
   end
 
+  def help_guide_links
+    content_tag(:ul, class: 'govuk-list govuk-list--bullet') do
+      safe_join(
+        Rails.application.config.guide_links.map do |link_text, url|
+          content_tag(:li) do
+            link_to link_text, url, class: 'gem-c-contents-list__link govuk-link govuk-link--no-underline', target: '_blank', rel: 'noopener'
+          end
+        end,
+      )
+    end
+  end
+
   private
 
   def chapter_for(short_code, chapters)

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -71,77 +71,7 @@
 
     <h2 class="govuk-heading-s" id="difficult-to-classify">Goods that are difficult to classify</h2>
     <p>Some goods are more difficult to classify than others. You can read more on how to classify these goods correctly:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-aircraft-parts-and-accessories">aircraft parts</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-audio-and-video-equipment">audio and video equipment for import and export</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-ceramics">ceramics</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/government/collections/classification-of-goods">classification of goods</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-computers-and-software">computers and software</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-edible-fruits-nuts-and-peel">edible fruits, nuts and peel</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-edible-vegetables-roots-and-tubers">edible vegetables, roots and tubers</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-electric-lamps">electric lamps</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-footwear">footwear</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-herbal-medicines-supplements-tonics">herbal medicines, tonics and supplements</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-iron-and-steel">iron and steel</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-leather">leather</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-monitors-for-import-and-export">monitors</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-organic-chemicals">organic chemicals</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-pharmaceutical-products">pharmaceutical products</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-placebos-and-comparators">placebos and comparators</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-plastics">plastics</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-rice">rice</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-textile-apparel">textiles and textile articles</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-tobacco">tobacco and manufactured tobacco substitutes</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-toys-games-and-sports-equipment">toys, games and sports equipment</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-vehicles">vehicles, parts and accessories</a>
-      </li>
-      <li>
-        <a href="https://www.gov.uk/guidance/classifying-wood">wood</a>
-      </li>
-    </ul>
+    <%= help_guide_links %>
 
     <h2 class="govuk-heading-s" id="rules-of-origin">Rules of origin</h2>
     <p>Find out about the key concepts involved in determining a product's origin.</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,7 @@ module TradeTariffFrontend
       #{config.root}/app/forms
     ]
 
+
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins ENV['CORS_HOST'] || '*'
@@ -58,6 +59,7 @@ module TradeTariffFrontend
 
     config.x.http.retry_options = {}
 
+    config.guide_links = config_for(:guide_links)
     # Prevent invalid queries from causing an error, e.g., `/api/v2/search_references.json?query[letter]=%`
     config.middleware.use TradeTariffFrontend::FilterBadURLEncoding
     config.middleware.use TradeTariffFrontend::BasicAuth do |username, password|

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,6 @@ module TradeTariffFrontend
       #{config.root}/app/forms
     ]
 
-
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins ENV['CORS_HOST'] || '*'

--- a/config/guide_links.yml
+++ b/config/guide_links.yml
@@ -1,0 +1,28 @@
+default: &default
+  ceramics: https://www.gov.uk/guidance/classifying-ceramics
+  computers and software: https://www.gov.uk/guidance/classifying-computers-and-software
+  drones and aircraft parts: https://www.gov.uk/guidance/classifying-aircraft-parts-and-accessories
+  edible fruit, vegetables and nuts: https://www.gov.uk/guidance/classifying-edible-fruit-vegetables-and-nuts-for-import-and-export
+  electrical equipment: https://www.gov.uk/guidance/classifying-electrical-equipment-for-import-and-export
+  electric lamps: https://www.gov.uk/guidance/classifying-electric-lamps
+  footwear: https://www.gov.uk/guidance/classifying-footwear
+  herbal medicines, supplements and tonics: https://www.gov.uk/guidance/classifying-vitamins-supplements-and-herbal-medicines-for-import-and-export
+  iron and steel: https://www.gov.uk/guidance/classifying-iron-and-steel
+  leather: https://www.gov.uk/guidance/classifying-leather
+  organic chemicals: https://www.gov.uk/guidance/classifying-organic-chemicals
+  pharmaceutical products and placebos: https://www.gov.uk/guidance/classifying-pharmaceutical-products
+  plastics: https://www.gov.uk/guidance/classifying-plastics
+  rice: https://www.gov.uk/guidance/classifying-rice
+  textile apparel: https://www.gov.uk/guidance/classifying-textile-apparel
+  tobacco: https://www.gov.uk/guidance/classifying-tobacco
+  toys, games and festive articles: https://www.gov.uk/guidance/classifying-toys-games-and-festive-articles-for-import-and-export
+  vehicles, bicycles, parts and accessories: https://www.gov.uk/guidance/classifying-vehicles
+  wood: https://www.gov.uk/guidance/classifying-wood
+
+development:
+  <<: *default
+test:
+  ceramics: https://www.gov.uk/guidance/classifying-ceramics
+  computers and software: https://www.gov.uk/guidance/classifying-computers-and-software
+production:
+  <<: *default

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PagesHelper, type: :helper do
     subject(:help_guide_links) { helper.help_guide_links }
 
     it { is_expected.to be_html_safe }
-    it { is_expected.to have_link 'computers and software', href: 'https://www.gov.uk/guidance/classifying-ceramics' }
+    it { is_expected.to have_link 'computers and software', href: 'https://www.gov.uk/guidance/classifying-computers-and-software' }
     it { is_expected.to have_link 'ceramics', href: 'https://www.gov.uk/guidance/classifying-ceramics' }
   end
 end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -14,4 +14,12 @@ RSpec.describe PagesHelper, type: :helper do
 
     it { is_expected.to eq(expected_file_info) }
   end
+
+  describe '#help_guide_links' do
+    subject(:help_guide_links) { helper.help_guide_links }
+
+    it { is_expected.to be_html_safe }
+    it { is_expected.to have_link 'computers and software', href: 'https://www.gov.uk/guidance/classifying-ceramics' }
+    it { is_expected.to have_link 'ceramics', href: 'https://www.gov.uk/guidance/classifying-ceramics' }
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2587

![image](https://user-images.githubusercontent.com/8156884/216085084-5b352c9b-beb8-46a6-aa59-f61d851aed65.png)


### What?

I have added/removed/altered:

- [x] Use a configuration file for configuring guide links

### Why?

I am doing this because:

- This makes the help page a bit more manageable going forward
- This updates guides to reflect changes from HMRC
