### PR TITLE
HOTT-2566 Add all PSRs page

### DIFF
--- a/app/controllers/rules_of_origin/product_specific_rules_controller.rb
+++ b/app/controllers/rules_of_origin/product_specific_rules_controller.rb
@@ -1,0 +1,10 @@
+module RulesOfOrigin
+  class ProductSpecificRulesController < ApplicationController
+    before_action :disable_switch_service_banner, :disable_search_form
+
+    def index
+      @commodity = Commodity.find(params[:commodity])
+      @schemes = RulesOfOrigin::Scheme.with_rules_for_commodity(@commodity)
+    end
+  end
+end

--- a/app/controllers/rules_of_origin/product_specific_rules_controller.rb
+++ b/app/controllers/rules_of_origin/product_specific_rules_controller.rb
@@ -5,6 +5,9 @@ module RulesOfOrigin
     def index
       @commodity = Commodity.find(params[:commodity])
       @schemes = RulesOfOrigin::Scheme.with_rules_for_commodity(@commodity)
+      @countries = GeographicalArea.all(filter: { exclude_none: true })
+                                   .index_by(&:id)
+                                   .transform_values(&:description)
     end
   end
 end

--- a/app/helpers/govuk_frontend_helper.rb
+++ b/app/helpers/govuk_frontend_helper.rb
@@ -12,4 +12,8 @@ module GovukFrontendHelper
       link_to text, href, class: link_classes
     end
   end
+
+  def back_to_top_link
+    link_to t('navigation.back_to_top'), '#content', class: 'govuk-!-display-none-print'
+  end
 end

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -23,6 +23,10 @@ class RulesOfOrigin::Scheme
       )
     end
 
+    def with_rules_for_commodity(commodity, opts = {})
+      collection "#{collection_path}/#{commodity.to_param}", opts
+    end
+
     def with_duty_drawback_articles(opts = {})
       all opts.merge(filter: { has_article: 'duty-drawback' })
     end

--- a/app/views/rules_of_origin/_product_specific_rules.html.erb
+++ b/app/views/rules_of_origin/_product_specific_rules.html.erb
@@ -1,0 +1,46 @@
+<%- if rule_sets.empty? -%>
+  <p>
+    There are no product-specific rules for commodity <%= commodity_code %>
+  </p>
+<%- else -%>
+  <table class="govuk-table govuk-table--responsive commodity-rules-of-origin">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">
+          Heading
+        </th>
+
+        <% if rule_sets.many? %>
+        <th class="govuk-table__header" scope="col">
+          Description
+        </th>
+        <% end %>
+
+        <th class="govuk-table__header" scope="col">
+          Rule
+        </th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% rule_sets.each do |rule_set| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell" data-label="Heading">
+          <%= restrict_wrapping replace_non_breaking_space(rule_set.heading) %>
+        </td>
+
+        <% if rule_sets.many? %>
+        <td class="govuk-table__cell" data-label="Description">
+          <%= rule_set.subdivision %>
+        </td>
+        <% end %>
+
+        <td class="govuk-table__cell tariff-markdown responsive-full-width" data-label="Rule">
+          <% rule_set.rules.each do |rule| %>
+            <%= govspeak link_glossary_terms(rule.rule) %>
+          <% end %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+<%- end -%>

--- a/app/views/rules_of_origin/_scheme.html.erb
+++ b/app/views/rules_of_origin/_scheme.html.erb
@@ -2,49 +2,5 @@
   Rules under the <%= scheme.title %>
 </h3>
 
-<%- if scheme.rule_sets.empty? -%>
-  <p>
-    There are no product-specific rules for commodity <%= commodity_code %>
-  </p>
-<%- else -%>
-  <table class="govuk-table govuk-table--responsive commodity-rules-of-origin">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">
-          Heading
-        </th>
-
-        <% if scheme.rule_sets.many? %>
-        <th class="govuk-table__header" scope="col">
-          Description
-        </th>
-        <% end %>
-
-        <th class="govuk-table__header" scope="col">
-          Rule
-        </th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <% scheme.rule_sets.each do |rule_set| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell" data-label="Heading">
-          <%= restrict_wrapping replace_non_breaking_space(rule_set.heading) %>
-        </td>
-
-        <% if scheme.rule_sets.many? %>
-        <td class="govuk-table__cell" data-label="Description">
-          <%= rule_set.subdivision %>
-        </td>
-        <% end %>
-
-        <td class="govuk-table__cell tariff-markdown responsive-full-width" data-label="Rule">
-          <% rule_set.rules.each do |rule| %>
-            <%= govspeak link_glossary_terms(rule.rule) %>
-          <% end %>
-        </td>
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
-<%- end -%>
+<%= render 'rules_of_origin/product_specific_rules', rule_sets: scheme.rule_sets,
+                                                     commodity_code: %>

--- a/app/views/rules_of_origin/_scheme.html.erb
+++ b/app/views/rules_of_origin/_scheme.html.erb
@@ -4,3 +4,8 @@
 
 <%= render 'rules_of_origin/product_specific_rules', rule_sets: scheme.rule_sets,
                                                      commodity_code: %>
+
+<p>
+  <%= link_to 'View product-specific rules for other countries',
+              rules_of_origin_product_specific_rules_path(commodity_code) %>
+</p>

--- a/app/views/rules_of_origin/product_specific_rules/index.html.erb
+++ b/app/views/rules_of_origin/product_specific_rules/index.html.erb
@@ -1,0 +1,23 @@
+<%= back_link request.referer || find_commodity_path, javascript: true %>
+
+<%= page_header "Commodity #{@commodity.goods_nomenclature_item_id}", false %>
+
+<nav id="contents">
+  <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
+    <h2 class="gem-c-contents-list__title">Contents</h2>
+
+    <% @schemes.each do |scheme| %>
+      <%= contents_list_item scheme.title, "#rules-for-#{scheme.scheme_code}" %>
+    <% end %>
+  </ol>
+</nav>
+
+<% @schemes.each do |scheme| %>
+  <h2 class="govuk-heading-m" id="rules-for-<%= scheme.scheme_code %>">
+    <%= scheme.title %>
+  </h2>
+
+  <%= render 'rules_of_origin/product_specific_rules',
+             rule_sets: scheme.rule_sets,
+             commodity_code: @commodity.goods_nomenclature_item_id %>
+<% end %>

--- a/app/views/rules_of_origin/product_specific_rules/index.html.erb
+++ b/app/views/rules_of_origin/product_specific_rules/index.html.erb
@@ -2,6 +2,16 @@
 
 <%= page_header "Commodity #{@commodity.goods_nomenclature_item_id}", false %>
 
+<p>
+  <%= @commodity.description %>
+</p>
+
+<p>
+  This page lists the product-specific rules of origin in place for all
+  <%= TradeTariffFrontend::ServiceChooser.uk? ? 'UK' : 'Northern Ireland' %>
+  trade agreements for commodity <%= @commodity.goods_nomenclature_item_id %>.
+</p>
+
 <nav id="contents">
   <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
     <h2 class="gem-c-contents-list__title">Contents</h2>
@@ -13,11 +23,19 @@
 </nav>
 
 <% @schemes.each do |scheme| %>
-  <h2 class="govuk-heading-m" id="rules-for-<%= scheme.scheme_code %>">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-0" id="rules-for-<%= scheme.scheme_code %>">
     <%= scheme.title %>
   </h2>
+
+  <p class="govuk-caption-m">
+    <%= safe_join scheme.countries.map(&@countries.method(:[])).compact.sort, ', ' %>
+  </p>
 
   <%= render 'rules_of_origin/product_specific_rules',
              rule_sets: scheme.rule_sets,
              commodity_code: @commodity.goods_nomenclature_item_id %>
+
+  <p>
+    <%= back_to_top_link %>
+  </p>
 <% end %>

--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -1,11 +1,13 @@
 <header>
+  <% unless caption_text === false %>
   <span class="govuk-caption-xl">
     <span class="switch-service-control__caption">
-      <%= caption_text.presence || trade_tariff_heading %>
+      <%= caption_text || trade_tariff_heading %>
     </span>
 
     <%= switch_service_button if show_switch_service %>
   </span>
+  <% end %>
 
   <% if heading_text.present? %>
     <h1 class="<%= css_heading_size(heading_text) %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,9 @@ Rails.application.routes.draw do
     get '/rules_of_origin/:commodity/:country', to: 'steps#index', as: :steps
     get '/rules_of_origin/:commodity/:country/:id', to: 'steps#show', as: :step
     patch '/rules_of_origin/:commodity/:country/:id', to: 'steps#update', as: nil
+    get '/rules_of_origin/:commodity', constraints: { commodity: /\d{10}/ },
+                                       to: 'product_specific_rules#index',
+                                       as: :product_specific_rules
     get '/rules_of_origin/proofs', to: 'proofs#index', as: :proofs
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -276,6 +276,13 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { is_expected.to have_css 'header h1.govuk-heading-l', text: 'Some header' }
       it { is_expected.to have_css 'header span.govuk-caption-xl', text: 'Some caption' }
     end
+
+    context 'with false caption' do
+      subject { helper.page_header 'Some header', false }
+
+      it { is_expected.to have_css 'header h1.govuk-heading-l', text: 'Some header' }
+      it { is_expected.not_to have_css 'header span.govuk-caption-xl' }
+    end
   end
 
   describe '#css_heading_size' do

--- a/spec/helpers/govuk_frontend_helper_spec.rb
+++ b/spec/helpers/govuk_frontend_helper_spec.rb
@@ -15,4 +15,11 @@ RSpec.describe GovukFrontendHelper, type: :helper do
       it { is_expected.to have_css 'li a.gem-c-contents-list__link.some-custom-class' }
     end
   end
+
+  describe '#back_to_top_link' do
+    subject { back_to_top_link }
+
+    it { is_expected.to have_link 'Back to top', href: '#content' }
+    it { is_expected.to have_css 'a.govuk-\!-display-none-print' }
+  end
 end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe RulesOfOrigin::Scheme do
   let(:api_host) { TradeTariffFrontend::ServiceChooser.api_host }
   let(:response_headers) { { content_type: 'application/json; charset=utf-8' } }
   let(:cumulation_methods) { { 'bilateral' => %w[GB CA], 'extended' => %w[EU AD] } }
-  let(:json_response) { response_data.to_json }
   let :response_data do
     {
       data: [
@@ -135,7 +134,7 @@ RSpec.describe RulesOfOrigin::Scheme do
       before do
         stub_request(:get, "#{api_host}/rules_of_origin_schemes")
           .with(query: { heading_code: '190531', country_code: 'FR' })
-          .to_return(body: json_response, status: 200, headers: response_headers)
+          .to_return(body: response_data.to_json, status: 200, headers: response_headers)
       end
     end
 
@@ -184,7 +183,7 @@ RSpec.describe RulesOfOrigin::Scheme do
 
         stub_request(:get, "#{api_host}/rules_of_origin_schemes")
           .with(query: { heading_code: '190531', country_code: 'FR', page: 1 })
-          .to_return(body: json_response, status: 200, headers: response_headers)
+          .to_return(body: response_data.to_json, status: 200, headers: response_headers)
       end
 
       let(:api_instance) { described_class.api }
@@ -206,7 +205,7 @@ RSpec.describe RulesOfOrigin::Scheme do
       before do
         stub_request(:get, "#{api_host}/rules_of_origin_schemes")
           .with(query: { heading_code: '190531', country_code: 'FR' })
-          .to_return(body: json_response, status: 200, headers: response_headers)
+          .to_return(body: response_data.to_json, status: 200, headers: response_headers)
       end
 
       it { is_expected.to have_attributes length: 1 }
@@ -264,7 +263,7 @@ RSpec.describe RulesOfOrigin::Scheme do
 
       before do
         stub_request(:get, "#{api_host}/rules_of_origin_schemes/#{commodity.to_param}")
-          .to_return(body: json_response, status: 200, headers: response_headers)
+          .to_return(body: response_data.to_json, status: 200, headers: response_headers)
       end
 
       let(:commodity) { build :commodity }
@@ -278,7 +277,7 @@ RSpec.describe RulesOfOrigin::Scheme do
 
       before do
         stub_request(:get, "#{api_host}/rules_of_origin_schemes?filter[has_article]=duty-drawback")
-          .to_return(body: json_response, status: 200, headers: response_headers)
+          .to_return(body: response_data.to_json, status: 200, headers: response_headers)
       end
 
       it { is_expected.to have_attributes length: 1 }

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -259,6 +259,32 @@ RSpec.describe RulesOfOrigin::Scheme do
       end
     end
 
+    describe '.with_rules_for_commodity' do
+      subject { described_class.with_rules_for_commodity commodity }
+
+      before do
+        stub_request(:get, "#{api_host}/rules_of_origin_schemes/#{commodity.to_param}")
+          .to_return(body: json_response, status: 200, headers: response_headers)
+      end
+
+      let(:commodity) { build :commodity }
+
+      it { is_expected.to have_attributes length: 1 }
+      it { is_expected.to all be_instance_of described_class }
+    end
+
+    describe '.with_duty_drawback_articles' do
+      subject { described_class.with_duty_drawback_articles }
+
+      before do
+        stub_request(:get, "#{api_host}/rules_of_origin_schemes?filter[has_article]=duty-drawback")
+          .to_return(body: json_response, status: 200, headers: response_headers)
+      end
+
+      it { is_expected.to have_attributes length: 1 }
+      it { is_expected.to all be_instance_of described_class }
+    end
+
     describe '#links' do
       include_context 'with mocked response'
 
@@ -368,17 +394,5 @@ RSpec.describe RulesOfOrigin::Scheme do
 
       it { is_expected.to eql scheme.rule_sets[1].rules[0].rule }
     end
-  end
-
-  describe '#with_duty_drawback_articles' do
-    subject { described_class.with_duty_drawback_articles }
-
-    before do
-      stub_request(:get, "#{api_host}/rules_of_origin_schemes?filter[has_article]=duty-drawback")
-        .to_return(body: json_response, status: 200, headers: response_headers)
-    end
-
-    it { is_expected.to have_attributes length: 1 }
-    it { is_expected.to all be_instance_of described_class }
   end
 end

--- a/spec/requests/rules_of_origin/product_specific_rules_controller_spec.rb
+++ b/spec/requests/rules_of_origin/product_specific_rules_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RulesOfOrigin::ProductSpecificRulesController, type: :request do
     before do
       allow(RulesOfOrigin::Scheme).to receive(:with_rules_for_commodity).and_return(schemes)
       allow(Commodity).to receive(:find).with(commodity.to_param).and_return(commodity)
+      allow(GeographicalArea).to receive(:all).and_return []
 
       get rules_of_origin_product_specific_rules_path(commodity)
     end

--- a/spec/requests/rules_of_origin/product_specific_rules_controller_spec.rb
+++ b/spec/requests/rules_of_origin/product_specific_rules_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe RulesOfOrigin::ProductSpecificRulesController, type: :request do
+  subject { response }
+
+  describe 'GET #index' do
+    before do
+      allow(RulesOfOrigin::Scheme).to receive(:with_rules_for_commodity).and_return(schemes)
+      allow(Commodity).to receive(:find).with(commodity.to_param).and_return(commodity)
+
+      get rules_of_origin_product_specific_rules_path(commodity)
+    end
+
+    let(:schemes) { build_list :rules_of_origin_scheme, 3, scheme_count: 3, rule_set_count: 2 }
+    let(:commodity) { build :commodity }
+
+    it { is_expected.to have_http_status :ok }
+    it { is_expected.to have_attributes content_type: %r{text/html} }
+  end
+end

--- a/spec/views/rules_of_origin/_product_specific_rules.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_product_specific_rules.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/_product_specific_rules', type: :view do
+  subject(:rendered_page) { render_page && rendered }
+
+  let :render_page do
+    render 'rules_of_origin/product_specific_rules',
+           rule_sets:,
+           commodity_code: '2203000100'
+  end
+
+  let(:rule_sets) { build_list :rules_of_origin_rule_set, 1 }
+
+  it { is_expected.to have_css 'table' }
+  it { is_expected.to have_css 'table th', count: 2 }
+  it { is_expected.to have_css 'table td', count: 2 }
+  it { is_expected.to have_css 'td', text: /#{rule_sets.first.rules.first.rule}/ }
+  it { is_expected.to have_css 'td.tariff-markdown *' } # check markdown being rendered
+
+  context 'with multiple rule sets' do
+    let(:rule_sets) { build_list :rules_of_origin_rule_set, 3 }
+
+    it { is_expected.to have_css 'table th', count: 3 }
+    it { is_expected.to have_css 'table tr', count: 4 }
+    it { is_expected.to have_css 'table td', count: 9 }
+  end
+
+  context 'with no rule sets' do
+    let(:rule_sets) { [] }
+
+    it { is_expected.to have_content 'no product-specific rules' }
+    it { is_expected.not_to have_css 'table' }
+  end
+end

--- a/spec/views/rules_of_origin/_scheme.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_scheme.html.erb_spec.rb
@@ -9,25 +9,8 @@ RSpec.describe 'rules_of_origin/_scheme', type: :view do
 
   let(:scheme) { build :rules_of_origin_scheme }
 
+  it { is_expected.to have_css 'h3', text: /#{scheme.title}/ }
   it { is_expected.to have_css 'table' }
   it { is_expected.to have_css 'table th', count: 2 }
   it { is_expected.to have_css 'table td', count: 2 }
-  it { is_expected.to have_css 'h3', text: /#{scheme.title}/ }
-  it { is_expected.to have_css 'td', text: /#{scheme.v2_rules.first.rule}/ }
-  it { is_expected.to have_css 'td.tariff-markdown *' } # check markdown being rendered
-
-  context 'with multiple rule sets' do
-    let(:scheme) { build :rules_of_origin_scheme, rule_set_count: 3 }
-
-    it { is_expected.to have_css 'table th', count: 3 }
-    it { is_expected.to have_css 'table tr', count: 4 }
-    it { is_expected.to have_css 'table td', count: 9 }
-  end
-
-  context 'with no rule sets' do
-    let(:scheme) { build :rules_of_origin_scheme, rule_set_count: 0 }
-
-    it { is_expected.to have_content 'no product-specific rules' }
-    it { is_expected.not_to have_css 'table' }
-  end
 end

--- a/spec/views/rules_of_origin/_scheme.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_scheme.html.erb_spec.rb
@@ -13,4 +13,5 @@ RSpec.describe 'rules_of_origin/_scheme', type: :view do
   it { is_expected.to have_css 'table' }
   it { is_expected.to have_css 'table th', count: 2 }
   it { is_expected.to have_css 'table td', count: 2 }
+  it { is_expected.to have_link 'View product-specific rules', href: %r{/2203000100} }
 end

--- a/spec/views/rules_of_origin/product_specific_rules/index.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/product_specific_rules/index.html.erb_spec.rb
@@ -6,16 +6,26 @@ RSpec.describe 'rules_of_origin/product_specific_rules/index', type: :view do
   before do
     assign :commodity, commodity
     assign :schemes, schemes
+    assign :countries, countries.transform_values(&:description)
   end
 
   let(:commodity) { build :commodity }
   let(:schemes) { build_list :rules_of_origin_scheme, 2, rule_set_count: }
   let(:rule_set_count) { 2 }
 
+  let :countries do
+    schemes.flat_map(&:countries).uniq.map { |code|
+      build :geographical_area, id: code
+    }.index_by(&:id)
+  end
+
   it { is_expected.to have_link 'Back' }
 
   it { is_expected.to have_css 'h1', text: %r{Commodity \d{10}} }
   it { is_expected.not_to have_css '.govuk-caption-xl' }
+
+  it { is_expected.to have_css 'p', text: commodity.description }
+  it { is_expected.to have_css 'p', text: %r{for commodity \d{10}} }
 
   describe 'Contents section' do
     let(:link_id) { "#rules-for-#{schemes.first.scheme_code}" }
@@ -31,6 +41,11 @@ RSpec.describe 'rules_of_origin/product_specific_rules/index', type: :view do
 
     it { is_expected.to have_css 'h2.govuk-heading-m', count: 2 }
     it { is_expected.to have_css 'h2.govuk-heading-m', text: schemes.first.title }
+
+    it { is_expected.to have_css '.govuk-caption-m', count: 2 }
+    it { is_expected.to have_css '.govuk-caption-m', text: countries[schemes.first.countries.first].description }
+
+    it { is_expected.to have_css 'a.govuk-\!-display-none-print', count: 2 }
 
     context 'with multiple rulesets' do
       it { is_expected.to have_css 'table', count: 2 }

--- a/spec/views/rules_of_origin/product_specific_rules/index.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/product_specific_rules/index.html.erb_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/product_specific_rules/index', type: :view do
+  subject { render }
+
+  before do
+    assign :commodity, commodity
+    assign :schemes, schemes
+  end
+
+  let(:commodity) { build :commodity }
+  let(:schemes) { build_list :rules_of_origin_scheme, 2, rule_set_count: }
+  let(:rule_set_count) { 2 }
+
+  it { is_expected.to have_link 'Back' }
+
+  it { is_expected.to have_css 'h1', text: %r{Commodity \d{10}} }
+  it { is_expected.not_to have_css '.govuk-caption-xl' }
+
+  describe 'Contents section' do
+    let(:link_id) { "#rules-for-#{schemes.first.scheme_code}" }
+
+    it { is_expected.to have_css 'h2', text: 'Contents' }
+    it { is_expected.to have_css '.gem-c-contents-list__list li', count: 2 }
+    it { is_expected.to have_link schemes.first.title, href: link_id }
+    it { is_expected.to have_css link_id }
+  end
+
+  describe 'Product specific rules' do
+    let(:ruleset) { schemes.first.rule_sets.first }
+
+    it { is_expected.to have_css 'h2.govuk-heading-m', count: 2 }
+    it { is_expected.to have_css 'h2.govuk-heading-m', text: schemes.first.title }
+
+    context 'with multiple rulesets' do
+      it { is_expected.to have_css 'table', count: 2 }
+      it { is_expected.to have_css 'tbody tr', count: 4 }
+      it { is_expected.to have_css 'tbody td', count: 12 }
+
+      it { is_expected.to have_css 'td', text: ruleset.heading }
+      it { is_expected.to have_css 'td', text: ruleset.subdivision }
+      it { is_expected.to have_css 'td', text: %r{#{ruleset.rules.first.rule}} }
+    end
+
+    context 'with only 1 ruleset' do
+      let(:rule_set_count) { 1 }
+
+      it { is_expected.to have_css 'table', count: 2 }
+      it { is_expected.to have_css 'tbody tr', count: 2 }
+      it { is_expected.to have_css 'tbody td', count: 4 }
+
+      it { is_expected.to have_css 'td', text: ruleset.heading }
+      it { is_expected.to have_css 'td', text: %r{#{ruleset.rules.first.rule}} }
+      it { is_expected.not_to have_css 'tbody tr td:nth-of-type(3)' }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-2566

### What?

I have added/removed/altered:

- [x] Add api client for fetching all PSRs for a given commodity
- [x] Added all PSRs page
- [x] Allow using standardised `page_header` without a caption

### Why?

I am doing this because:

- We want to show all PSRs across all schemes for a  valid commodity to allow traders to choose their supply chain based of favourable trade agreements with the United Kingdom

### Have you? (optional)

- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low

### Screenshots

![image](https://user-images.githubusercontent.com/10818/217255632-28bbb065-edf8-4a60-bf4b-3b2602b5a812.png)
![Screenshot from 2023-02-07 13-18-07](https://user-images.githubusercontent.com/10818/217255676-62112012-217f-4e66-84f9-828c47f580ec.png)

