### PR TITLE
HOTT-2647 add missing links

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -29,10 +29,23 @@ class PagesController < ApplicationController
   def rules_of_origin_proof_requirements
     disable_switch_service_banner
 
-    @commodity_code, @country_code, @scheme_code = params[:id].split('-', 3)
+    load_rules_of_origin_scheme(params[:id])
+    @article = @chosen_scheme.article('origin_processes')
+  end
+
+  def rules_of_origin_proof_verification
+    disable_switch_service_banner
+
+    load_rules_of_origin_scheme(params[:id])
+    @article = @chosen_scheme.article('verification')
+  end
+
+private
+
+  def load_rules_of_origin_scheme(id)
+    @commodity_code, @country_code, @scheme_code = id.split('-', 3)
     @country = GeographicalArea.find(@country_code)
     @all_schemes = RulesOfOrigin::Scheme.for_heading_and_country(@commodity_code, @country_code)
     @chosen_scheme = @all_schemes.find { |scheme| scheme.scheme_code == @scheme_code }
-    @article = @chosen_scheme.article('origin_processes')
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -25,4 +25,14 @@ class PagesController < ApplicationController
   def rules_of_origin_duty_drawback
     @schemes = RulesOfOrigin::Scheme.with_duty_drawback_articles
   end
+
+  def rules_of_origin_proof_requirements
+    disable_switch_service_banner
+
+    @commodity_code, @country_code, @scheme_code = params[:id].split('-', 3)
+    @country = GeographicalArea.find(@country_code)
+    @all_schemes = RulesOfOrigin::Scheme.for_heading_and_country(@commodity_code, @country_code)
+    @chosen_scheme = @all_schemes.find { |scheme| scheme.scheme_code == @scheme_code }
+    @article = @chosen_scheme.article('origin_processes')
+  end
 end

--- a/app/helpers/govuk_frontend_helper.rb
+++ b/app/helpers/govuk_frontend_helper.rb
@@ -1,19 +1,47 @@
 module GovukFrontendHelper
-  def contents_list_item(text, href, classes = [])
+  def contents_list_item(text, target, classes = [], &_block)
     list_item_classes = %w[
       gem-c-contents-list__list-item
       gem-c-contents-list__list-item--dashed
     ]
 
+    target = yield(target) if block_given?
+
     link_classes = Array.wrap(classes)
     link_classes.unshift('gem-c-contents-list__link')
 
     tag.li class: list_item_classes do
-      link_to text, href, class: link_classes
+      link_to text, target, class: link_classes
     end
   end
 
   def back_to_top_link
     link_to t('navigation.back_to_top'), '#content', class: 'govuk-!-display-none-print'
+  end
+
+  def contents_list(list_items,
+                    title: I18n.t('generic.contents'),
+                    classes: [],
+                    item_classes: [],
+                    **options,
+                    &block)
+    items_html = list_items.map do |link_text, target|
+      contents_list_item(link_text, target, item_classes, &block)
+    end
+
+    nav_options = options.reverse_merge(
+      class: %w[gem-c-contents-list] + Array.wrap(classes),
+      role: 'navigation',
+    )
+
+    list_html = tag.ol(class: 'gem-c-contents-list__list') do
+      safe_join items_html, "\n"
+    end
+
+    heading = title ? tag.h2(title, class: 'gem-c-contents-list__title') : ''
+
+    tag.nav(**nav_options) do
+      heading + list_html
+    end
   end
 end

--- a/app/models/rules_of_origin/article.rb
+++ b/app/models/rules_of_origin/article.rb
@@ -16,4 +16,28 @@ class RulesOfOrigin::Article
   def ord_reference?
     !ord_reference.nil?
   end
+
+  def sections
+    return [] unless content
+
+    @sections ||= content.split(/^(## )/m)
+                         .map(&:presence)
+                         .compact
+                         .slice_before('## ')
+                         .select { |marker, _| marker == '## ' }
+                         .map(&:join)
+  end
+
+  def section(section_number)
+    section_number = section_number.to_i - 1
+    sections[section_number.positive? ? section_number : 0]
+  end
+
+  def subheadings
+    sections.map do |content|
+      content.lines(chomp: true)
+             .first
+             .sub(/^## /, '')
+    end
+  end
 end

--- a/app/models/rules_of_origin/article.rb
+++ b/app/models/rules_of_origin/article.rb
@@ -40,4 +40,9 @@ class RulesOfOrigin::Article
              .sub(/^## /, '')
     end
   end
+
+  def sections_contents_list
+    subheadings.map
+               .with_index { |title, index| [title, index + 1] }
+  end
 end

--- a/app/models/rules_of_origin/steps/proof_requirements.rb
+++ b/app/models/rules_of_origin/steps/proof_requirements.rb
@@ -8,30 +8,25 @@ module RulesOfOrigin
       end
 
       def processes_text
-        chosen_scheme.article('origin_processes')&.content
+        origin_processes&.content
       end
 
       def processes_sections
-        return [] if processes_text.nil?
-
-        @processes_sections ||= \
-          processes_text.split(/^(## )/m)
-                        .map(&:presence)
-                        .compact
-                        .slice_before('## ')
-                        .select { |marker, _| marker == '## ' }
-                        .map(&:join)
+        origin_processes&.sections || []
       end
 
       def processes_section(section_number)
-        section_number = section_number.to_i - 1
-        processes_sections[section_number.positive? ? section_number : 0]
+        origin_processes&.section(section_number)
       end
 
       def processes_section_titles
-        processes_sections.map do |content|
-          content.lines(chomp: true).first.sub(/^## /, '')
-        end
+        origin_processes&.subheadings || []
+      end
+
+    private
+
+      def origin_processes
+        chosen_scheme.article('origin_processes')
       end
     end
   end

--- a/app/models/rules_of_origin/steps/proof_requirements.rb
+++ b/app/models/rules_of_origin/steps/proof_requirements.rb
@@ -11,16 +11,12 @@ module RulesOfOrigin
         origin_processes&.content
       end
 
-      def processes_sections
-        origin_processes&.sections || []
-      end
-
       def processes_section(section_number)
         origin_processes&.section(section_number)
       end
 
-      def processes_section_titles
-        origin_processes&.subheadings || []
+      def processes_contents_list
+        origin_processes&.sections_contents_list || {}
       end
 
     private

--- a/app/views/pages/rules_of_origin_proof_requirements.html.erb
+++ b/app/views/pages/rules_of_origin_proof_requirements.html.erb
@@ -1,0 +1,24 @@
+<%= back_link request.referer || find_commodity_path, javascript: true %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= page_header t('rules_of_origin.steps.proof_requirements.title',
+                      trade_country_name: @country.description),
+                    t('rules_of_origin.steps.proof_requirements.caption') %>
+
+    <p>
+      <%= t 'rules_of_origin.steps.proof_requirements.body',
+            scheme_title: @chosen_scheme.title %>
+    </p>
+
+    <aside role="complementary" id="article-section-list">
+      <%= contents_list(@article.sections_contents_list) { |section| url_for(section:) } %>
+    </aside>
+
+    <div class="tariff-markdown numbered-then-lettered-list" id="article-section">
+      <%= govspeak @article.section(params[:section]) %>
+    </div>
+
+    <%= link_to t('navigation.back_to_top'), '#content' %>
+  </div>
+</div>

--- a/app/views/pages/rules_of_origin_proof_verification.html.erb
+++ b/app/views/pages/rules_of_origin_proof_verification.html.erb
@@ -1,0 +1,20 @@
+<%= back_link request.referer || find_commodity_path, javascript: true %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= page_header t('rules_of_origin.steps.proof_verification.title',
+                      trade_country_name: @country.description),
+                    t('rules_of_origin.steps.proof_verification.caption') %>
+
+    <div class="tariff-markdown">
+      <div class="numbered-then-lettered-list">
+        <%= govspeak remove_article_reference(@article.content) %>
+      </div>
+    </div>
+
+    <%= render 'shared/origin_reference_document',
+          origin_reference_document: @chosen_scheme.origin_reference_document,
+          article_match: find_article_reference(@article.content) \
+          if find_article_reference(@article.content) %>
+  <div>
+</div>

--- a/app/views/rules_of_origin/_proofs.html.erb
+++ b/app/views/rules_of_origin/_proofs.html.erb
@@ -20,7 +20,7 @@
     </div>
   <% end %>
 
-  <% if schemes.many? %>
+  <% if schemes.many? || schemes.none? %>
     <p>
       <%= link_to 'See valid proofs of origin for all trade agreements',
                   rules_of_origin_proofs_path %>
@@ -29,16 +29,19 @@
     <p>Find out more about proofs of origin:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <% if false %>
       <li>
-        <%= link_to 'How proofs are verified', '#tbd' %>
+        <%= link_to 'How proofs are verified',
+                    rules_of_origin_proof_verification_path(
+                      "#{commodity_code}-#{country_code}-#{schemes.first.scheme_code}"
+                    ) %>
       </li>
 
       <li>
         <%= link_to 'Detailed processes and requirements for proving the origin for goods',
-                    '#tbd' %>
+                    rules_of_origin_proof_requirements_path(
+                      "#{commodity_code}-#{country_code}-#{schemes.first.scheme_code}"
+                    ) %>
       </li>
-      <% end %>
 
       <li>
         <%= link_to 'See valid proofs of origin for all trade agreements',

--- a/app/views/rules_of_origin/_tab.html.erb
+++ b/app/views/rules_of_origin/_tab.html.erb
@@ -52,7 +52,8 @@
                locals: { commodity_code: } %>
 
     <%= render 'rules_of_origin/proofs', schemes: rules_of_origin_schemes,
-                                         commodity_code: %>
+                                         commodity_code:,
+                                         country_code: %>
   </div>
 <% else %>
   <p class="govuk-inset-text">

--- a/app/views/rules_of_origin/steps/_proof_requirements.html.erb
+++ b/app/views/rules_of_origin/steps/_proof_requirements.html.erb
@@ -11,20 +11,10 @@
 </p>
 
 <aside role="complementary" id="article-section-list">
-  <nav class="gem-c-contents-list" aria-label="<%= t '.article_list' %>" role="navigation">
-    <h2 class="gem-c-contents-list__title">
-      <%= t 'generic.contents' %>
-    </h2>
-
-    <ol class="gem-c-contents-list__list">
-      <% current_step.processes_section_titles.each.with_index do |title, index| %>
-      <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <%= link_to title, step_path(:proof_requirements, section: index + 1),
-                    class: 'gem-c-contents-list__link' %>
-      </li>
-      <% end %>
-    </ol>
-  </nav>
+  <%= contents_list current_step.processes_contents_list,
+                    aria: { label: t('.article_list') } do |section|
+        step_path(:proof_requirements, section: )
+      end %>
 </aside>
 
 <div class="tariff-markdown numbered-then-lettered-list" id="article-section">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,8 @@ Rails.application.routes.draw do
   get 'help/cn2021_cn2022', to: 'pages#cn2021_cn2022', as: 'cn2021_cn2022'
   get 'help/help_find_commodity', to: 'pages#help_find_commodity', as: 'help_find_commodity'
   get 'help/rules_of_origin/duty_drawback', to: 'pages#rules_of_origin_duty_drawback', as: 'rules_of_origin_duty_drawback'
+  get 'help/rules_of_origin/proof_requirements/:id', to: 'pages#rules_of_origin_proof_requirements',
+                                                     as: 'rules_of_origin_proof_requirements'
   get 'opensearch', to: 'pages#opensearch', constraints: { format: :xml }
   get 'privacy', to: 'pages#privacy', as: 'privacy'
   get 'terms', to: 'pages#terms'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,8 @@ Rails.application.routes.draw do
   get 'help/rules_of_origin/duty_drawback', to: 'pages#rules_of_origin_duty_drawback', as: 'rules_of_origin_duty_drawback'
   get 'help/rules_of_origin/proof_requirements/:id', to: 'pages#rules_of_origin_proof_requirements',
                                                      as: 'rules_of_origin_proof_requirements'
+  get 'help/rules_of_origin/proof_verification/:id', to: 'pages#rules_of_origin_proof_verification',
+                                                     as: 'rules_of_origin_proof_verification'
   get 'opensearch', to: 'pages#opensearch', constraints: { format: :xml }
   get 'privacy', to: 'pages#privacy', as: 'privacy'
   get 'terms', to: 'pages#terms'

--- a/spec/helpers/govuk_frontend_helper_spec.rb
+++ b/spec/helpers/govuk_frontend_helper_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe GovukFrontendHelper, type: :helper do
 
       it { is_expected.to have_css 'li a.gem-c-contents-list__link.some-custom-class' }
     end
+
+    context 'with custom url generation' do
+      subject do
+        contents_list_item('Some link', { id: 10 }) { |item| "/page/#{item[:id]}" }
+      end
+
+      it { is_expected.to have_link 'Some link', href: '/page/10' }
+    end
   end
 
   describe '#back_to_top_link' do
@@ -21,5 +29,58 @@ RSpec.describe GovukFrontendHelper, type: :helper do
 
     it { is_expected.to have_link 'Back to top', href: '#content' }
     it { is_expected.to have_css 'a.govuk-\!-display-none-print' }
+  end
+
+  describe '#contents_list' do
+    subject { contents_list list }
+
+    let :list do
+      [
+        ['First section', '#section1'],
+        ['Second section', '#section2'],
+        ['Third section', '#section3'],
+      ]
+    end
+
+    it { is_expected.to have_css 'nav.gem-c-contents-list' }
+    it { is_expected.to have_css 'nav h2.gem-c-contents-list__title', text: 'Contents' }
+    it { is_expected.to have_css 'nav ol.gem-c-contents-list__list li a', count: 3 }
+    it { is_expected.to have_link 'Second section', href: '#section2' }
+
+    context 'without title' do
+      subject { contents_list list, title: false }
+
+      it { is_expected.not_to have_css 'h2' }
+    end
+
+    context 'with custom title' do
+      subject { contents_list list, title: 'List title' }
+
+      it { is_expected.to have_css 'h2', text: 'List title' }
+    end
+
+    context 'with extra nav classes' do
+      subject { contents_list list, classes: 'another' }
+
+      it { is_expected.to have_css 'nav.gem-c-contents-list.another' }
+    end
+
+    context 'with extra nav params' do
+      subject { contents_list list, role: 'testing' }
+
+      it { is_expected.to have_css 'nav[role="testing"]' }
+    end
+
+    context 'with extra list item classes' do
+      subject { contents_list list, item_classes: 'listitem' }
+
+      it { is_expected.to have_css 'nav ol li a.listitem' }
+    end
+
+    context 'with custom link generation' do
+      subject { contents_list(list) { |item| item.gsub '#', '/page/' } }
+
+      it { is_expected.to have_link 'First section', href: '/page/section1' }
+    end
   end
 end

--- a/spec/models/rules_of_origin/article_spec.rb
+++ b/spec/models/rules_of_origin/article_spec.rb
@@ -128,5 +128,13 @@ RSpec.describe RulesOfOrigin::Article do
         it { is_expected.to include '## First section' }
       end
     end
+
+    describe '#sections_contents_list' do
+      subject { instance.sections_contents_list }
+
+      it { is_expected.to have_attributes length: 2 }
+      it { is_expected.to include ['First section', 1] }
+      it { is_expected.to include ['Second section', 2] }
+    end
   end
 end

--- a/spec/models/rules_of_origin/steps/proof_requirements_spec.rb
+++ b/spec/models/rules_of_origin/steps/proof_requirements_spec.rb
@@ -37,24 +37,11 @@ RSpec.describe RulesOfOrigin::Steps::ProofRequirements do
       EOCONTENT
     end
 
-    describe '#processes_sections' do
-      subject(:sections) { instance.processes_sections }
+    describe '#processes_contents_list' do
+      subject { instance.processes_contents_list }
 
-      it { is_expected.to have_attributes length: 2 }
-
-      context 'with first section' do
-        subject { sections.first }
-
-        it { is_expected.to include '## First section' }
-        it { is_expected.to include '### sub sub heading' }
-        it { is_expected.to include 'sub content' }
-      end
-    end
-
-    describe '#processes_section_titles' do
-      subject { instance.processes_section_titles }
-
-      it { is_expected.to eql ['First section', 'Second section'] }
+      it { is_expected.to include ['First section', 1] }
+      it { is_expected.to include ['Second section', 2] }
     end
 
     describe '#processes_section' do

--- a/spec/models/rules_of_origin/steps/proof_requirements_spec.rb
+++ b/spec/models/rules_of_origin/steps/proof_requirements_spec.rb
@@ -49,22 +49,6 @@ RSpec.describe RulesOfOrigin::Steps::ProofRequirements do
         it { is_expected.to include '### sub sub heading' }
         it { is_expected.to include 'sub content' }
       end
-
-      context 'with second section' do
-        subject { sections.second }
-
-        it { is_expected.to eql %(## Second section\n\nSection 2 content\n) }
-      end
-
-      context 'with no content' do
-        subject(:sections) { instance.processes_sections }
-
-        let(:articles) { [] }
-
-        it 'returns an empty array' do
-          expect(sections).to be_empty
-        end
-      end
     end
 
     describe '#processes_section_titles' do
@@ -74,23 +58,9 @@ RSpec.describe RulesOfOrigin::Steps::ProofRequirements do
     end
 
     describe '#processes_section' do
-      context 'without section' do
-        subject { instance.processes_section(nil) }
+      subject { instance.processes_section(2) }
 
-        it { is_expected.to include '## First section' }
-      end
-
-      context 'with valid section' do
-        subject { instance.processes_section(2) }
-
-        it { is_expected.to include '## Second section' }
-      end
-
-      context 'with invalid section' do
-        subject { instance.processes_section('foobar') }
-
-        it { is_expected.to include '## First section' }
-      end
+      it { is_expected.to include '## Second section' }
     end
   end
 end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -69,4 +69,20 @@ RSpec.describe PagesController, type: :request do
     it { is_expected.to have_http_status(:ok) }
     it { is_expected.to render_template('pages/rules_of_origin_proof_requirements') }
   end
+
+  describe 'GET #proof_verification' do
+    before do
+      allow(RulesOfOrigin::Scheme).to receive(:for_heading_and_country).and_return schemes
+      allow(GeographicalArea).to receive(:find).and_return country
+
+      get rules_of_origin_proof_verification_path('123457890-FR-eu')
+    end
+
+    let(:schemes) { build_list :rules_of_origin_scheme, 1, scheme_code: 'eu', articles: }
+    let(:country) { build :geographical_area }
+    let(:articles) { attributes_for_list :rules_of_origin_article, 1, article: 'verification' }
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template('pages/rules_of_origin_proof_verification') }
+  end
 end

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -53,4 +53,20 @@ RSpec.describe PagesController, type: :request do
       expect(assigns[:schemes]).to be_many
     end
   end
+
+  describe 'GET #proof_requirements' do
+    before do
+      allow(RulesOfOrigin::Scheme).to receive(:for_heading_and_country).and_return schemes
+      allow(GeographicalArea).to receive(:find).and_return country
+
+      get rules_of_origin_proof_requirements_path('123457890-FR-eu')
+    end
+
+    let(:schemes) { build_list :rules_of_origin_scheme, 1, scheme_code: 'eu', articles: }
+    let(:country) { build :geographical_area }
+    let(:articles) { attributes_for_list :rules_of_origin_article, 1, article: 'origin_processes' }
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template('pages/rules_of_origin_proof_requirements') }
+  end
 end

--- a/spec/views/pages/rules_of_origin_proof_requirements.html.erb_spec.rb
+++ b/spec/views/pages/rules_of_origin_proof_requirements.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe 'pages/rules_of_origin_proof_requirements', type: :view do
+  subject { render && rendered }
+
+  before do
+    allow(view).to receive(:url_for).and_return 'stubbed'
+    assign :country, country
+    assign :chosen_scheme, scheme
+    assign :article, article
+  end
+
+  let(:country) { build :geographical_area, description: 'Japan' }
+  let(:scheme) { build :rules_of_origin_scheme }
+  let(:article) { build :rules_of_origin_article, article: 'origin_processes', content: }
+  let(:content) { "## First section\n\nfirst\n\n## Second section\n\nsecond\n" }
+
+  it { is_expected.to have_css 'span.govuk-caption-xl', text: /obtaining and verifying/i }
+  it { is_expected.to have_css 'h1', text: /Requirements.*Japan/ }
+  it { is_expected.to have_css 'p', text: %r{processes.*#{scheme.title}} }
+  it { is_expected.to have_css '.tariff-markdown *' }
+  it { is_expected.to have_css '#article-section-list li a', count: 2 }
+  it { is_expected.to have_link 'First section' }
+  it { is_expected.to have_link 'Second section' }
+  it { is_expected.to have_css '#article-section h2', count: 1, text: 'First section' }
+  it { is_expected.to have_link 'Back to top' }
+end

--- a/spec/views/pages/rules_of_origin_proof_verification.html.erb_spec.rb
+++ b/spec/views/pages/rules_of_origin_proof_verification.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe 'pages/rules_of_origin_proof_verification', type: :view do
+  subject { render && rendered }
+
+  before do
+    assign :country, country
+    assign :chosen_scheme, scheme
+    assign :article, article
+  end
+
+  let(:country) { build :geographical_area, description: 'Japan' }
+  let(:scheme) { build :rules_of_origin_scheme }
+  let(:article) { build :rules_of_origin_article, article: 'verification' }
+
+  it { is_expected.to have_css 'span.govuk-caption-xl', text: /obtaining and verifying/i }
+  it { is_expected.to have_css 'h1', text: /Verification.*Japan/ }
+  it { is_expected.to have_css '.tariff-markdown *' }
+
+  context 'with article reference' do
+    let :article do
+      build :rules_of_origin_article,
+            article: 'verification',
+            content: "Some content\n\n{{ article 123 }}"
+    end
+
+    it { is_expected.to have_link 'Download rules of origin reference document' }
+  end
+end

--- a/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
@@ -4,14 +4,15 @@ RSpec.describe 'rules_of_origin/_proofs', type: :view do
   subject(:rendered_page) { render_page && rendered }
 
   let :render_page do
-    render 'rules_of_origin/proofs', schemes:, commodity_code: '2203000100'
+    render 'rules_of_origin/proofs', schemes:,
+                                     commodity_code: '2203000100',
+                                     country_code: 'FR'
   end
 
   let(:schemes) { build_list :rules_of_origin_scheme, 1, proof_count: 1 }
 
   it { is_expected.to have_css '#proofs-of-origin' }
-  xit { is_expected.to have_css '.govuk-list--bullet li a', count: 3 }
-  it { is_expected.to have_css '.govuk-list--bullet li a', count: 1 } # FIXME: determine best option for other links
+  it { is_expected.to have_css '.govuk-list--bullet li a', count: 3 }
 
   it { is_expected.to have_css '.stacked-govuk-details', count: 1 }
   it { is_expected.to have_css 'p', text: /origin is valid/ }


### PR DESCRIPTION
### Jira link

HOTT-2647

### What?

I have added/removed/altered:

- [x] Generalised splitting articles into sections
- [x] Generalised contents-list generation
- [x] Added Rules of Origin Proof Requirements help page
- [x] Added Rules of Origin Proof Verification help page
- [x] Linked these pages from the Rules of Origin tab

### Why?

I am doing this because:

- This content is already in the wizard but is inaccessible without setting up the state for the wizard then inserting the user to the end of the wizard
- Its easier to just add new pages loading the same content
- The links on the RoO tab were originally disable because it was clear how to link the content

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low
