### PR TITLE
HOTT-2592: Fixes bug in display of additional codes

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,10 @@
+---
+EnableDefaultLinters: true
+linters:
+  ErbSafety:
+    enabled: true
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -16,29 +16,22 @@
 
   <td class="measure-type-col govuk-table__cell <%= measure.measure_type.id %>">
     <span class='table-line'><%= measure_type_description_or_link(measure) %></span>
+
     <% if measure.order_number.present? %>
       <span class='table-line'>
         <%= render 'shared/quota_definition',
-                   order_number: measure.order_number,
-                   quota_definition: measure.order_number&.definition,
-                   declarable_id: declarable.short_code %>
+          order_number: measure.order_number,
+          quota_definition: measure.order_number&.definition,
+          declarable_id: declarable.short_code %>
       </span>
     <% end %>
-    <% if measure.additional_code.present? %>
-      <div class="govuk-inset-text tariff-inset-information residual-inset">
-        <p class="govuk-!-font-size-16">
-          <% if measure.residual? %>
-            <%= measure.measure_type.abbreviation %> does not apply to goods covered under additional code:
-          <% else %>
-            <%= measure.measure_type.abbreviation %> applies to goods covered under additional code:
-          <% end %>
-          <strong><%= measure.additional_code.code %></strong>
-        </p>
 
-        <% if measure.additional_code.formatted_description.present? %>
-          <p class="govuk-!-font-size-16"><%= sanitize measure.additional_code.formatted_description %></p>
-        <% end %>
-      </div>
+    <% if measure.additional_code.present? %>
+      <% if measure.measure_type.prohibitive? %>
+        <%= render 'measures/additional_codes/prohibitive', measure: measure %>
+      <% else %>
+        <%= render 'measures/additional_codes/regular', measure: measure %>
+      <% end %>
     <% end %>
   </td>
 

--- a/app/views/measures/additional_codes/_prohibitive.html.erb
+++ b/app/views/measures/additional_codes/_prohibitive.html.erb
@@ -1,0 +1,16 @@
+<% if measure.additional_code.formatted_description.present? %>
+  <div class="govuk-inset-text tariff-inset-information residual-inset">
+    <p class="govuk-!-font-size-16">
+      <% if measure.residual? %>
+        <%= measure.measure_type.abbreviation %> does not apply to goods covered under additional code:
+      <% else %>
+        <%= measure.measure_type.abbreviation %> applies to goods covered under additional code:
+      <% end %>
+      <strong><%= measure.additional_code.code %></strong>
+    </p>
+
+    <% if measure.additional_code.formatted_description.present? %>
+      <p class="govuk-!-font-size-16"><%= sanitize measure.additional_code.formatted_description %></p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/measures/additional_codes/_regular.html.erb
+++ b/app/views/measures/additional_codes/_regular.html.erb
@@ -1,0 +1,7 @@
+<span class='table-line'>
+  Additional code: <strong><%= measure.additional_code.code %></strong>
+</span>
+
+<span class='table-line'>
+  <%= sanitize measure.additional_code.formatted_description %>
+</span>

--- a/spec/views/measures/_measure.html.erb_spec.rb
+++ b/spec/views/measures/_measure.html.erb_spec.rb
@@ -31,25 +31,15 @@ RSpec.describe 'measures/_measure', type: :view, vcr: { cassette_name: 'geograph
     it { expect(rendered).to match(/Hectokilogram/) }
   end
 
-  context 'with residual measure' do
-    context 'when residual returns true' do
-      let(:measure) { build(:measure, :residual) }
+  context 'with a prohibitive measure that has an additional code' do
+    let(:measure) { build(:measure, :prohibitive, :with_additional_code) }
 
-      it { expect(rendered).to match(/Control does not apply to goods/) }
+    it { expect(rendered).to render_template('measures/additional_codes/_prohibitive') }
+  end
 
-      it { expect(rendered).to match(measure.additional_code.code) }
+  context 'with a non-prohibitive measure that has an additional code' do
+    let(:measure) { build(:measure, :with_additional_code) }
 
-      it { expect(rendered).to match(measure.additional_code.formatted_description) }
-    end
-
-    context 'when residual returns false' do
-      let(:measure) { build(:measure, :with_additional_code) }
-
-      it { expect(rendered).to match(/Control applies to goods/) }
-
-      it { expect(rendered).to match(measure.additional_code.code) }
-
-      it { expect(rendered).to match(measure.additional_code.formatted_description) }
-    end
+    it { expect(rendered).to render_template('measures/additional_codes/_regular') }
   end
 end

--- a/spec/views/measures/additional_codes/_prohibitive.html.erb_spec.rb
+++ b/spec/views/measures/additional_codes/_prohibitive.html.erb_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe 'measures/additional_codes/_prohibitive', type: :view do
+  let(:measure) do
+    build(:measure, :prohibitive, :with_additional_code)
+  end
+
+  before do
+    render 'measures/additional_codes/prohibitive', measure: MeasurePresenter.new(measure)
+  end
+
+    context 'when residual returns true' do
+      let(:measure) { build(:measure, :residual) }
+
+      it { expect(rendered).to match(/Control does not apply to goods/) }
+
+      it { expect(rendered).to match(measure.additional_code.code) }
+
+      it { expect(rendered).to match(measure.additional_code.formatted_description) }
+    end
+
+    context 'when residual returns false' do
+      let(:measure) { build(:measure, :with_additional_code) }
+
+      it { expect(rendered).to match(/Control applies to goods/) }
+
+      it { expect(rendered).to match(measure.additional_code.code) }
+
+      it { expect(rendered).to match(measure.additional_code.formatted_description) }
+    end
+end

--- a/spec/views/measures/additional_codes/_prohibitive.html.erb_spec.rb
+++ b/spec/views/measures/additional_codes/_prohibitive.html.erb_spec.rb
@@ -9,23 +9,23 @@ RSpec.describe 'measures/additional_codes/_prohibitive', type: :view do
     render 'measures/additional_codes/prohibitive', measure: MeasurePresenter.new(measure)
   end
 
-    context 'when residual returns true' do
-      let(:measure) { build(:measure, :residual) }
+  context 'when residual returns true' do
+    let(:measure) { build(:measure, :residual) }
 
-      it { expect(rendered).to match(/Control does not apply to goods/) }
+    it { expect(rendered).to match(/Control does not apply to goods/) }
 
-      it { expect(rendered).to match(measure.additional_code.code) }
+    it { expect(rendered).to match(measure.additional_code.code) }
 
-      it { expect(rendered).to match(measure.additional_code.formatted_description) }
-    end
+    it { expect(rendered).to match(measure.additional_code.formatted_description) }
+  end
 
-    context 'when residual returns false' do
-      let(:measure) { build(:measure, :with_additional_code) }
+  context 'when residual returns false' do
+    let(:measure) { build(:measure, :with_additional_code) }
 
-      it { expect(rendered).to match(/Control applies to goods/) }
+    it { expect(rendered).to match(/Control applies to goods/) }
 
-      it { expect(rendered).to match(measure.additional_code.code) }
+    it { expect(rendered).to match(measure.additional_code.code) }
 
-      it { expect(rendered).to match(measure.additional_code.formatted_description) }
-    end
+    it { expect(rendered).to match(measure.additional_code.formatted_description) }
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2592

![image](https://user-images.githubusercontent.com/8156884/218469165-71ae99bd-315e-4962-8cbb-575a194f2167.png)


![image](https://user-images.githubusercontent.com/8156884/218469176-6e8d82db-7d23-436f-b5f3-eed594982987.png)


### What?

I have added/removed/altered:

- [x] Added conditional display of measure additional codes when the measure type is prohibitive
- [x] Extracted the variations into partials and added dedicated tests

### Why?

I am doing this because:

- This is required to make sure that we're only showing the insets for the prohibitive measures and preserving the UI that came before for the non-prohibitive ones
