### PR TITLE
HOTT-2664: Disable switching on news items pages

### DIFF
--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -1,6 +1,7 @@
 class NewsItemsController < ApplicationController
   before_action :disable_search_form,
-                :disable_last_updated_footnote
+                :disable_last_updated_footnote,
+                :disable_switch_service_banner
 
   def index
     @news_collections = News::Collection.all


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2664

### What?

I have added/removed/altered:

- [x] Disable service switching on the news items page

### Why?

I am doing this because:

- This is a change requested by Matt
