### PR TITLE
HOTT-2323: Integrate alpine updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,7 +516,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - /^dependabot\/.*/
+                - /^dependabot/(?!docker/).*/
                 - /^hotfix\/.+/
 
       - checks:
@@ -545,7 +545,7 @@ workflows:
               ignore:
                 - main
                 - /^hotfix\/.+/
-                - /^dependabot\/.*/
+                - /^dependabot/(?!docker/).*/
 
       - deploy_dev:
           context: trade-tariff
@@ -556,7 +556,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - /^dependabot\/.*/
+                - /^dependabot/(?!docker/).*/
                 - /^hotfix\/.+/
 
       - deploy_review:
@@ -568,7 +568,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - /^dependabot\/.*/
+                - /^dependabot/(?!docker/).*/
                 - /^hotfix\/.+/
 
       - smoketest_dev:
@@ -579,7 +579,7 @@ workflows:
               ignore:
                 - main
                 - /^hotfix\/.+/
-                - /^dependabot\/.*/
+                - /^dependabot/(?!docker/).*/
           requires:
             - deploy_dev
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2323
https://github.com/trade-tariff/trade-tariff-backend/pull/1060 - fully integrating docker dependabot branch
https://github.com/trade-tariff/trade-tariff-backend/pull/1062 - partially integrating ruby dependabot branch
https://github.com/trade-tariff/trade-tariff-backend/pull/1061 - partially integrating npm_and_yarn dependabot branch

### What?

I have added/removed/altered:

- [x] Excluded the dependabot/docker updates from the ignore filter when doing a build/deploy/release/smoke test to dev environment

### Why?

I am doing this because:

- This enables us to save time debugging docker os updates as part of our standard process
