### PR TITLE
HOTT-2381: Simplify search references

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,10 +1,2 @@
 ---
 EnableDefaultLinters: true
-linters:
-  ErbSafety:
-    enabled: true
-  Rubocop:
-    enabled: true
-    rubocop_config:
-      inherit_from:
-        - .rubocop.yml

--- a/app/presenters/search_reference_presenter.rb
+++ b/app/presenters/search_reference_presenter.rb
@@ -4,21 +4,6 @@ class SearchReferencePresenter < SimpleDelegator
   end
 
   def link
-    "/#{referenced_class.tableize}/#{composite_id}"
-  end
-
-  def composite_id
-    case referenced_class
-    when 'Subheading'
-      "#{referenced_id}-#{productline_suffix}"
-    else
-      referenced_id
-    end
-  end
-
-  private
-
-  def append_product_line_suffix(link)
-    link + (referenced_class == 'Subheading' ? "-#{productline_suffix}" : '')
+    "/#{referenced_class.tableize}/#{referenced_id}"
   end
 end

--- a/spec/factories/search_reference_factory.rb
+++ b/spec/factories/search_reference_factory.rb
@@ -6,9 +6,28 @@ FactoryBot.define do
 
     referenced_id { '1234567890' }
 
+    trait :with_chapter do
+      referenced_id { '20' }
+      referenced_class { 'Chapter' }
+      productline_suffix { '80' }
+    end
+
+    trait :with_heading do
+      referenced_id { '2001' }
+      referenced_class { 'Heading' }
+      productline_suffix { '80' }
+    end
+
     trait :with_subheading do
+      referenced_id { '8418690000-10' }
       referenced_class { 'Subheading' }
-      productline_suffix { '12' }
+      productline_suffix { '10' }
+    end
+
+    trait :with_commodity do
+      referenced_id { '8418690000' }
+      referenced_class { 'Commodity' }
+      productline_suffix { '80' }
     end
   end
 end

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe SearchReference do
   it 'has correct attributes' do
     expect(search_reference).to have_attributes(id: '1',
                                                 title: 'tomatoes',
-                                                referenced_id: '1234567890',
+                                                referenced_id: '8418690000-10',
                                                 referenced_class: 'Subheading',
-                                                productline_suffix: '12')
+                                                productline_suffix: '10')
   end
 end

--- a/spec/presenters/search_reference_presenter_spec.rb
+++ b/spec/presenters/search_reference_presenter_spec.rb
@@ -1,15 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe SearchReferencePresenter do
-  subject(:presenter) { described_class.new(declarable) }
+  subject(:presented) { described_class.new(search_reference) }
 
-  let(:declarable) { build :search_reference, :with_subheading }
+  let(:search_reference) { build :search_reference, :with_subheading }
 
   describe '#link' do
-    it { expect(presenter.link).to eq('/subheadings/1234567890-12') }
+    shared_examples 'a search reference link' do |trait, expected_link|
+      let(:search_reference) { build :search_reference, trait }
+
+      it { expect(presented.link).to eq(expected_link) }
+    end
+
+    it_behaves_like 'a search reference link', :with_chapter, '/chapters/20'
+    it_behaves_like 'a search reference link', :with_heading, '/headings/2001'
+    it_behaves_like 'a search reference link', :with_subheading, '/subheadings/8418690000-10'
+    it_behaves_like 'a search reference link', :with_commodity, '/commodities/8418690000'
   end
 
   describe '#to_s' do
-    it { expect(presenter.to_s).to eq('Tomatoes') }
+    it { expect(presented.to_s).to eq('Tomatoes') }
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2381

### What?

I have added/removed/altered:

- [x] The referenced_id now returns something compatible for the az without any real adjustments

### Why?

I am doing this because:

- This is required since we've simplified the search references in the backend
