### PR TITLE
HOTT-2652: Silence sentry noise for country scrapers

### DIFF
--- a/app/helpers/country_flag_helper.rb
+++ b/app/helpers/country_flag_helper.rb
@@ -1,6 +1,4 @@
 module CountryFlagHelper
-  COUNTRY_FLAG_IGNORE = %w[xi xc xl].freeze
-
   def country_flag_tag(two_letter_country_code, **kwargs)
     two_letter_country_code = two_letter_country_code.downcase
 

--- a/app/helpers/country_flag_helper.rb
+++ b/app/helpers/country_flag_helper.rb
@@ -7,11 +7,6 @@ module CountryFlagHelper
     image_pack_tag "flags/#{two_letter_country_code}.png",
                    **kwargs.merge(class: 'country-flag')
   rescue Webpacker::Manifest::MissingEntryError
-    unless CountryFlagHelper::COUNTRY_FLAG_IGNORE.include?(two_letter_country_code)
-      Sentry.capture_message \
-        "Missing flag image file for #{two_letter_country_code}"
-    end
-
     nil
   end
 end

--- a/app/helpers/image_guides_helper.rb
+++ b/app/helpers/image_guides_helper.rb
@@ -4,8 +4,6 @@ module ImageGuidesHelper
 
     image_pack_tag "guides/#{guide_filename}", **kwargs.merge(class: 'image-guide')
   rescue Webpacker::Manifest::MissingEntryError
-    Sentry.capture_message "Missing guide image file: #{guide_filename}"
-
     nil
   end
 end

--- a/spec/helpers/country_flag_helper_spec.rb
+++ b/spec/helpers/country_flag_helper_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 
 RSpec.describe CountryFlagHelper, type: :helper do
   describe '#country_flag_tag' do
-    before { allow(Sentry).to receive(:capture_message).and_return(true) }
-
     context 'with GB' do
       subject(:rendered) { helper.country_flag_tag('GB') }
 
@@ -28,24 +26,12 @@ RSpec.describe CountryFlagHelper, type: :helper do
       subject(:rendered) { helper.country_flag_tag('A1') }
 
       it('returns nothing') { is_expected.to be_nil }
-
-      it 'notifies Sentry' do
-        rendered
-
-        expect(Sentry).to have_received(:capture_message)
-      end
     end
 
     context "with country which we don't have a flag which is in ignore list" do
       subject(:rendered) { helper.country_flag_tag('XI') }
 
       it('returns nothing') { is_expected.to be_nil }
-
-      it 'does not notify Sentry' do
-        rendered
-
-        expect(Sentry).not_to have_received(:capture_message)
-      end
     end
   end
 end

--- a/spec/helpers/image_guides_helper_spec.rb
+++ b/spec/helpers/image_guides_helper_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 
 RSpec.describe ImageGuidesHelper, type: :helper do
   describe '#image_for_guide' do
-    before { allow(Sentry).to receive(:capture_message).and_return(true) }
-
     context 'when image for the guides does exist' do
       subject(:rendered) { helper.image_for_guide('rice.png') }
 
@@ -22,15 +20,9 @@ RSpec.describe ImageGuidesHelper, type: :helper do
     end
 
     context 'when the image for the guide does NOT exist' do
-      subject(:rendered) { helper.country_flag_tag('non-existent-guide') }
+      subject(:rendered) { helper.image_for_guide('non-existent-guide') }
 
       it('returns nothing') { is_expected.to be_nil }
-
-      it 'notifies Sentry' do
-        rendered
-
-        expect(Sentry).to have_received(:capture_message)
-      end
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2652
https://engine-le.sentry.io/issues/3929079904/?project=5557002&referrer=slack

### What?

I have added/removed/altered:

- [x] Removed sentry alerts for missing country flag
- [x] Removed sentry alerts for missing guide images

### Why?

I am doing this because:

- More signal, less noise
- The guide images are controlled by us on all fronts and if someone is scraping images of guides and they put in the wrong text we don't want to be alerted to that
