### PR TITLE
HOTT-2393: Use direct hit relationship to redirect to a polymorphic path

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -191,7 +191,7 @@ class SearchController < ApplicationController
     @query = params[:q]
     @filters = beta_filters
 
-    return redirect_to beta_redirect_path if @search_result.redirect?
+    return redirect_to polymorphic_path(@search_result.direct_hit) if @search_result.direct_hit.present?
 
     render 'beta/search_results/show'
   end
@@ -239,9 +239,5 @@ class SearchController < ApplicationController
 
   def beta_search_params
     params.permit(:q, :filters, :spell)
-  end
-
-  def beta_redirect_path
-    "#{@search_result.redirect_to}?#{url_options.slice(:year, :month, :day, :country).to_query}"
   end
 end

--- a/app/models/beta/search/search_result.rb
+++ b/app/models/beta/search/search_result.rb
@@ -11,16 +11,12 @@ module Beta
                     :total_results,
                     :meta
 
-      meta_attribute :redirect
-      meta_attribute :redirect_to
-
-      alias_method :redirect?, :redirect
-
       delegate :spelling_corrected?, :original_search_query, :corrected_search_query, to: :search_query_parser_result
 
       has_many :chapter_statistics, class_name: 'Beta::Search::ChapterStatistic'
       has_many :heading_statistics, class_name: 'Beta::Search::HeadingStatistic', wrapper: Beta::Search::HeadingStatisticCollection
       has_many :hits, polymorphic: true, wrapper: Beta::Search::HitsCollection
+      has_one :direct_hit, polymorphic: true
       has_many :facet_filter_statistics, class_name: 'Beta::Search::FacetFilterStatistic'
       has_one :guide, class_name: 'Beta::Search::Guide'
       has_one :search_query_parser_result, class_name: 'Beta::Search::SearchQueryParserResult'

--- a/spec/factories/search_result_factory.rb
+++ b/spec/factories/search_result_factory.rb
@@ -24,21 +24,11 @@ FactoryBot.define do
     end
 
     trait :no_redirect do
-      meta do
-        {
-          'redirect' => false,
-          'redirect_to' => '',
-        }
-      end
+      direct_hit { nil }
     end
 
     trait :redirect do
-      meta do
-        {
-          'redirect' => true,
-          'redirect_to' => '/headings/0101',
-        }
-      end
+      direct_hit { attributes_for(:heading, goods_nomenclature_item_id: '0101000000', producline_suffix: '80') }
     end
 
     trait :multiple_headings_view do

--- a/spec/models/beta/search/search_result_spec.rb
+++ b/spec/models/beta/search/search_result_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Beta::Search::SearchResult do
       chapter_statistics
       heading_statistics
       hits
+      direct_hit
       facet_filter_statistics
       guide
       search_query_parser_result
@@ -19,8 +20,7 @@ RSpec.describe Beta::Search::SearchResult do
     expect(search_result).to have_attributes(took: 2,
                                              timed_out: false,
                                              max_score: 76.975296,
-                                             total_results: 1097,
-                                             meta: { redirect: false, redirect_to: '' })
+                                             total_results: 1097)
   end
 
   it { expect(described_class.relationships).to eq(expected_relationships) }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2393

### What?

I have added/removed/altered:

- [x] Added direct hit implementation to replace redirect to
- [x] Updated factories and broken specs

### Why?

I am doing this because:

- This is a better idiom for redirecting to goods nomenclatures
