### PR TITLE
HOTT-2600: Removes meursing from helper details component

### DIFF
--- a/app/forms/additional_code_search_form.rb
+++ b/app/forms/additional_code_search_form.rb
@@ -3,9 +3,7 @@ class AdditionalCodeSearchForm
   include ActiveModel::Attributes
 
   OPTIONAL_PARAMS = [:@page].freeze
-  DEFAULT_EXCLUDED_TYPES = %w[6 9 D F P].freeze
-  UK_EXCLUDED_TYPES = (DEFAULT_EXCLUDED_TYPES.dup << '7').freeze
-  XI_EXCLUDED_TYPES = DEFAULT_EXCLUDED_TYPES.dup.freeze
+  EXCLUDED_TYPES = %w[6 7 9 D F P].freeze
 
   attribute :code, :string
   attribute :description, :string
@@ -46,11 +44,7 @@ class AdditionalCodeSearchForm
     def possible_types
       additional_code_type_ids
         .reject do |additional_code_type_id|
-          if TradeTariffFrontend::ServiceChooser.uk?
-            UK_EXCLUDED_TYPES
-          else
-            XI_EXCLUDED_TYPES
-          end.include?(additional_code_type_id)
+          EXCLUDED_TYPES.include?(additional_code_type_id)
         end
     end
 

--- a/app/views/search/additional_codes/_helper.html.erb
+++ b/app/views/search/additional_codes/_helper.html.erb
@@ -29,10 +29,6 @@
           <td class="govuk-table__cell">These codes impact whether or not a restrictive measure is to be applied</td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">7</td>
-          <td class="govuk-table__cell">Meursing codes (Northern Ireland tariff only)</td>
-        </tr>
-        <tr class="govuk-table__row">
           <td class="govuk-table__cell">8, A, B or C</td>
           <td class="govuk-table__cell">These codes relate to exporting company for determining applicable anti-dumping or anti-subsidy duty.</td>
         </tr>

--- a/spec/forms/additional_code_search_form_spec.rb
+++ b/spec/forms/additional_code_search_form_spec.rb
@@ -4,17 +4,7 @@ RSpec.describe AdditionalCodeSearchForm, type: :model, vcr: { cassette_name: 'se
   describe '.possible_types' do
     subject(:possible_types) { described_class.possible_types }
 
-    context 'when on the XI service' do
-      include_context 'with XI service'
-
-      it { is_expected.to eq(%w[2 3 4 7 8 A B C V X]) }
-    end
-
-    context 'when on the UK service' do
-      include_context 'with UK service'
-
-      it { is_expected.to eq(%w[2 3 4 8 A B C V X]) }
-    end
+    it { is_expected.to eq(%w[2 3 4 8 A B C V X]) }
   end
 
   describe 'validations' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2600

### What?

I have added/removed/altered:

- [x] Removed meursing from the additional code helper details component
- [x] Removed meursing by exclusion in the types validation

### Why?

I am doing this because:

- This additional code type is not searchable/attached in a non-convoluted way to goods nomenclature
