### PR TITLE
HOTT-2750: Removed simple format to fix footnotes rendering

### DIFF
--- a/app/views/footnotes/_footnote.html.erb
+++ b/app/views/footnotes/_footnote.html.erb
@@ -1,6 +1,6 @@
 <% if footnote&.code.present? %>
   <tr class="govuk-table__row" >
     <th scope="row" class="govuk-table__header"><%= footnote.code %></th>
-    <td class="govuk-table__cell footnote-list"><%= footnote.formatted_description.html_safe %></td>
+    <td class="govuk-table__cell footnote-list"><%= sanitize footnote.formatted_description, tags: %w(strong em a ul li p br b em ol sub sup u ul), attributes: %w(href) %></td>
   </tr>
 <% end %>

--- a/app/views/footnotes/_footnote.html.erb
+++ b/app/views/footnotes/_footnote.html.erb
@@ -1,6 +1,6 @@
 <% if footnote&.code.present? %>
   <tr class="govuk-table__row" >
     <th scope="row" class="govuk-table__header"><%= footnote.code %></th>
-    <td class="govuk-table__cell"><%= simple_format footnote.formatted_description %></td>
+    <td class="govuk-table__cell footnote-list"><%= footnote.formatted_description.html_safe %></td>
   </tr>
 <% end %>

--- a/app/views/footnotes/_footnote.html.erb
+++ b/app/views/footnotes/_footnote.html.erb
@@ -1,6 +1,6 @@
 <% if footnote&.code.present? %>
   <tr class="govuk-table__row" >
     <th scope="row" class="govuk-table__header"><%= footnote.code %></th>
-    <td class="govuk-table__cell footnote-list"><%= sanitize footnote.formatted_description, tags: %w(strong em a ul li p br b em ol sub sup u ul), attributes: %w(href) %></td>
+    <td class="govuk-table__cell footnote-list"><%= sanitize footnote.formatted_description, tags: %w[strong em a ul li p br b em ol sub sup u ul], attributes: %w[href target rel] %></td>
   </tr>
 <% end %>

--- a/app/webpacker/src/stylesheets/_commodity-codes.scss
+++ b/app/webpacker/src/stylesheets/_commodity-codes.scss
@@ -114,3 +114,11 @@
     }
   }
 }
+
+.footnote-list {
+  ul {
+    li {
+      margin-bottom: 0.5em;
+    }
+  }
+}


### PR DESCRIPTION
### Jira link

[HOTT-<TODO>](https://transformuk.atlassian.net/browse/HOTT-2750)

### What?

I have added/removed/altered:

- [ ] Removed simple_format and added new CSS to fix footnotes

### Why?

I am doing this because:

- simple format was causing issues when rendering footnotes
<img width="922" alt="Screenshot 2023-03-06 at 14 59 11" src="https://user-images.githubusercontent.com/12201130/223151032-89f91be5-3a90-45f3-a16f-488a97b90625.png">

<img width="923" alt="Screenshot 2023-03-06 at 14 59 20" src="https://user-images.githubusercontent.com/12201130/223150995-5aa8d1de-0e56-40f9-87e9-4d9bacd19e0e.png">

