### PR TITLE
HOTT-2767: CSS improvements to chapter codes on search pages

### DIFF
--- a/app/webpacker/src/stylesheets/_commodity-codes.scss
+++ b/app/webpacker/src/stylesheets/_commodity-codes.scss
@@ -32,11 +32,17 @@
   @extend .govuk-tag--grey;
   font-weight: 400;
   width: 2.6em;
+  padding: 0.125em 0.25em;
+  text-align: center;
+  font-size: 16px;
 }
 .chapter-chapter-code {
   @extend .govuk-tag--grey;
   font-weight: 400;
   width: 1.4em;
+  padding: 0.125em 0.25em;
+  text-align: center;
+  font-size: 16px;
 }
 .commodity-code {
   width: 101px;


### PR DESCRIPTION
### Jira link

[HOTT-<TODO>](https://transformuk.atlassian.net/browse/HOTT-2767)

### What?

I have added/removed/altered:

- [ ] CSS improvements to chapter codes on search pages

### Why?

I am doing this because:

- previous design was using defaults that we didn't need

<img width="1023" alt="Screenshot 2023-03-07 at 17 13 30" src="https://user-images.githubusercontent.com/12201130/223497639-a384a061-bc99-43bc-a641-08c282e49518.png">
