### PR TITLE
HOTT-2768: Rename sections to filters on search page

### DIFF
--- a/app/views/beta/search_results/_sidebar.html.erb
+++ b/app/views/beta/search_results/_sidebar.html.erb
@@ -12,7 +12,7 @@
     <% end %>
 
     <% if unapplied_filter_classifications.any? %>
-      <div class="govuk-accordion tariff-facet-classifications" data-module="govuk-accordion" id="accordion-default">
+      <div class="govuk-accordion tariff-facet-classifications" data-module="govuk-accordion" id="accordion-default" data-i18n.show-all-sections="Show all filters" data-i18n.hide-all-sections="Hide all filters">
         <% unapplied_filter_classifications.each do |facet_filter_statistic| %>
           <div class="govuk-accordion__section tariff-facet-classification">
             <div class="govuk-accordion__section-header">


### PR DESCRIPTION
### Jira link

[HOTT-<TODO>](https://transformuk.atlassian.net/browse/HOTT-2768)

### What?

I have added/removed/altered:

- [ ] Renamed sections to filters on search page

### Why?

I am doing this because:

- The filters label was incorrect


<img width="1042" alt="Screenshot 2023-03-08 at 11 27 04" src="https://user-images.githubusercontent.com/12201130/223703614-cf20089a-5b8a-4561-ab75-5b644fd14757.png">
