### PR TITLE
HOTT-2770:  CSS tweaks on search page

### DIFF
--- a/app/webpacker/src/stylesheets/_search.scss
+++ b/app/webpacker/src/stylesheets/_search.scss
@@ -40,3 +40,19 @@ div.facet-classifications-tag-container {
     display: inline;
   }
 }
+
+.govuk-accordion__show-all-text {
+  font-size: 16px;
+}
+
+.govuk-accordion__section-heading-text {
+  font-size: 19px;
+}
+
+.govuk-accordion__section-toggle-text {
+  font-size: 16px;
+}
+
+.govuk-accordion__section-content {
+  padding-bottom:1.5em !important;
+}


### PR DESCRIPTION
### Jira link

[HOTT-<TODO>](https://transformuk.atlassian.net/browse/HOTT-2770)

### What?

I have added/removed/altered:

- [ ] Updated the search page CSS

### Why?

I am doing this because:

- The font size and padding needed to be updated


<img width="1014" alt="Screenshot 2023-03-08 at 16 38 49" src="https://user-images.githubusercontent.com/12201130/223774671-74599536-d6c4-4ab4-9fb3-ccdd83ddd3ab.png">
