### PR TITLE
HOTT-2774: Stop filtering out filtered facets

### DIFF
--- a/app/models/beta/search/facet_filter_statistic_collection.rb
+++ b/app/models/beta/search/facet_filter_statistic_collection.rb
@@ -29,8 +29,7 @@ module Beta
           facet_filter_statistic.facet_count,
         )
 
-        facet_filter_statistic.facet_classification_statistics.many? &&
-          facet_percentage_of_total > beta_search_facet_filter_display_percentage_threshold
+        facet_percentage_of_total > beta_search_facet_filter_display_percentage_threshold
       end
 
       def calculate_percentage_of(total, value)

--- a/spec/factories/facet_filter_statistic_factory.rb
+++ b/spec/factories/facet_filter_statistic_factory.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     facet_classification_statistics do
       [
         attributes_for(:facet_classification_statistic, :material),
-        attributes_for(:facet_classification_statistic, :garment_type),
       ]
     end
   end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2774

### What?

I have added/removed/altered:

- [x] Fixed issue with overzealous filtering of facets with a single classification

### Why?

I am doing this because:

- We use these facets to display any applied classifications
