### PR TITLE
HOTT-2814: Only display VAT rates with geographical area ID of 1011

### DIFF
--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -113,36 +113,37 @@ module MeasuresHelper
 
   def vat_messages(measure_collection)
     messages = []
+    measure_collection = measure_collection.vat_erga_omnes
     return messages if measure_collection.blank?
 
-    count = measure_collection.vat.count
+    count = measure_collection.count
     vat_info_message = I18n.t('measure_collection.message_overrides.vat.info_message_html')
 
     case count
     when 1
       messages.push I18n.t(
         "measure_collection.message_overrides.vat.message_#{count}_html",
-        vat: filter_duty_expression(measure_collection.vat.first),
+        vat: filter_duty_expression(measure_collection.first),
       )
     when 2
       messages.push I18n.t(
         "measure_collection.message_overrides.vat.message_#{count}_html",
-        vat: filter_duty_expression(measure_collection.vat.first),
-        vat_2: filter_duty_expression(measure_collection.vat.last),
+        vat: filter_duty_expression(measure_collection.first),
+        vat_2: filter_duty_expression(measure_collection.last),
       ).html_safe
       messages.push vat_info_message
     when 3
       messages.push I18n.t(
         "measure_collection.message_overrides.vat.message_#{count}_html",
-        vat: filter_duty_expression(measure_collection.vat[0]),
-        vat_2: filter_duty_expression(measure_collection.vat[1]),
-        vat_3: filter_duty_expression(measure_collection.vat[2]),
+        vat: filter_duty_expression(measure_collection[0]),
+        vat_2: filter_duty_expression(measure_collection[1]),
+        vat_3: filter_duty_expression(measure_collection[2]),
       ).html_safe
       messages.push vat_info_message
     else
       messages.push I18n.t(
         'measure_collection.message_overrides.vat.message_1_html',
-        vat: filter_duty_expression(measure_collection.measure_with_highest_vat_rate),
+        vat: filter_duty_expression(measure_collection.measure_with_highest_vat_rate_erga_omnes),
       )
     end
 

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -3,6 +3,7 @@ require 'api_entity'
 class GeographicalArea
   EUROPEAN_UNION_ID = '1013'.freeze
   REFERENCING_EUROPEAN_UNION_ID = 'EU'.freeze
+  ERGA_OMNES_ID = '1011'.freeze
 
   include ApiEntity
 

--- a/app/models/measure_collection.rb
+++ b/app/models/measure_collection.rb
@@ -57,6 +57,14 @@ class MeasureCollection < SimpleDelegator
     new(select(&:vat?).sort_by(&:amount).reverse)
   end
 
+  def vat_erga_omnes
+    new(vat.select { |measure_collection| measure_collection.geographical_area.id == GeographicalArea::ERGA_OMNES_ID })
+  end
+
+  def measure_with_highest_vat_rate_erga_omnes
+    vat_erga_omnes.max_by(&:amount)
+  end
+
   def measure_with_highest_vat_rate
     vat.max_by(&:amount)
   end

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -284,7 +284,6 @@ RSpec.describe MeasuresHelper, type: :helper do
 
   describe '#vat_message' do
     let(:vat_measure) { build(:measure, :vat, :erga_omnes) }
-    let(:vat_measure_not_erga_omnes) { build(:measure, :vat) }
     let(:vat_info_message) { 'Read more about <a href="https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services">VAT rates on different goods and services</a> and the conditions that apply to these rates.' }
     let(:vat_message_1) { "Goods are subject to an import <abbr title='Value-added tax'>VAT</abbr> rate of <strong><span class=\"duty-expression\"><span>20.0%</span></span></strong>" }
     let(:vat_message_3) { "An import <abbr title='Value-added tax'>VAT</abbr> rate of <strong><span class=\"duty-expression\"><span>20.0%</span></span></strong>, <strong><span class=\"duty-expression\"><span>20.0%</span></span></strong> or <strong><span class=\"duty-expression\"><span>20.0%</span></span></strong> may apply if certain conditions are met." }
@@ -297,7 +296,7 @@ RSpec.describe MeasuresHelper, type: :helper do
     end
 
     context 'with 1 VAT record in measure collection that is not erga omnes' do
-      let(:measure_collection) { MeasureCollection.new([vat_measure_not_erga_omnes]) }
+      let(:measure_collection) { MeasureCollection.new([build(:measure, :vat)]) }
 
       it { expect(vat_messages(measure_collection).count).to eq 0 }
     end

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -283,7 +283,8 @@ RSpec.describe MeasuresHelper, type: :helper do
   end
 
   describe '#vat_message' do
-    let(:vat_measure) { build(:measure, :vat) }
+    let(:vat_measure) { build(:measure, :vat, :erga_omnes) }
+    let(:vat_measure_not_erga_omnes) { build(:measure, :vat) }
     let(:vat_info_message) { 'Read more about <a href="https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services">VAT rates on different goods and services</a> and the conditions that apply to these rates.' }
     let(:vat_message_1) { "Goods are subject to an import <abbr title='Value-added tax'>VAT</abbr> rate of <strong><span class=\"duty-expression\"><span>20.0%</span></span></strong>" }
     let(:vat_message_3) { "An import <abbr title='Value-added tax'>VAT</abbr> rate of <strong><span class=\"duty-expression\"><span>20.0%</span></span></strong>, <strong><span class=\"duty-expression\"><span>20.0%</span></span></strong> or <strong><span class=\"duty-expression\"><span>20.0%</span></span></strong> may apply if certain conditions are met." }
@@ -293,6 +294,12 @@ RSpec.describe MeasuresHelper, type: :helper do
 
       it { expect(vat_messages(measure_collection).count).to eq 1 }
       it { expect(vat_messages(measure_collection)[0]).to eq vat_message_1 }
+    end
+
+    context 'with 1 VAT record in measure collection that is not erga omnes' do
+      let(:measure_collection) { MeasureCollection.new([vat_measure_not_erga_omnes]) }
+
+      it { expect(vat_messages(measure_collection).count).to eq 0 }
     end
 
     context 'with 2 VAT records in measure collection' do

--- a/spec/models/measure_collection_spec.rb
+++ b/spec/models/measure_collection_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe MeasureCollection do
     it { expect(collection.vat.measures).to eq([vat_measure_standard, vat_measure_reduced, vat_measure_zero]) }
   end
 
+  describe '#vat_erga_omnes' do
+    subject(:collection) { described_class.new([vat_measure_reduced, measure, vat_measure_standard_erga_omnes, vat_measure_zero]) }
+
+    let(:vat_measure_standard_erga_omnes) { build(:measure, :vat_standard, :erga_omnes) }
+    let(:vat_measure_zero) { build(:measure, :vat_zero) }
+    let(:vat_measure_reduced) { build(:measure, :vat_reduced) }
+
+    let(:measure) { build(:measure) }
+
+    it { expect(collection.vat_erga_omnes.measures).to eq([vat_measure_standard_erga_omnes]) }
+  end
+
   describe '#excise' do
     subject(:collection) { described_class.new([excise_measure, measure]) }
 
@@ -68,6 +80,16 @@ RSpec.describe MeasureCollection do
     let(:vat_measure_reduced) { build(:measure, :vat_reduced) }
 
     it { expect(collection.measure_with_highest_vat_rate).to eq(vat_measure_standard) }
+  end
+
+  describe '#measure_with_highest_vat_rate_erga_omnes' do
+    subject(:collection) { described_class.new([vat_measure_zero, vat_measure_standard_erga_omnes, vat_measure_reduced]) }
+
+    let(:vat_measure_standard_erga_omnes) { build(:measure, :vat_standard, :erga_omnes) }
+    let(:vat_measure_zero) { build(:measure, :vat_zero) }
+    let(:vat_measure_reduced) { build(:measure, :vat_reduced) }
+
+    it { expect(collection.measure_with_highest_vat_rate_erga_omnes).to eq(vat_measure_standard_erga_omnes) }
   end
 
   describe '#national' do


### PR DESCRIPTION
### Jira link

[HOTT-<TODO>](https://transformuk.atlassian.net/browse/HOTT-2814)

### What?

I have added/removed/altered:

- [ ] Added condition to only display VAT rates with geographical area ID of 1011

### Why?

I am doing this because:

- We need to only display VAT rates with geographical area ID 1011


<img width="1293" alt="Screenshot 2023-03-14 at 12 00 28" src="https://user-images.githubusercontent.com/12201130/224995272-93dea717-6630-4d9c-bac3-c5d02b5ff9c9.png">
