### PR TITLE
HOTT-2849: Show accumulated excise units when no supplementary unit

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -108,13 +108,13 @@ module Declarable
   end
 
   def supplementary_excise_measures?
-    import_measures.excise.erga_omnes.any? && import_measures.excise.erga_omnes.any?(&:measurement_units?)
+    import_measures.excise.erga_omnes.any?(&:measurement_units?)
   end
 
   def excise_unit_for_classification
     excise_units = import_measures.excise.erga_omnes.each_with_object({}) do |measure, acc|
       measure.measure_components.each do |component|
-        acc[component.measurement_unit.resource_id] = component.measurement_unit.description.downcase
+        acc[component.measurement_unit.resource_id] = component.measurement_unit&.description.to_s.downcase
       end
     end
 

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -197,6 +197,10 @@ class Measure
     measure_type.prohibitive? && additional_code.residual? && measure_conditions.none?
   end
 
+  def measurement_units?
+    measure_components.any?(&:measurement_unit)
+  end
+
   private
 
   def excluded_country_ids

--- a/app/models/measure_collection.rb
+++ b/app/models/measure_collection.rb
@@ -49,6 +49,10 @@ class MeasureCollection < SimpleDelegator
     new(select(&:third_country_duties?))
   end
 
+  def erga_omnes
+    new(select(&:erga_omnes?))
+  end
+
   def vat
     new(select(&:vat?).sort_by(&:amount).reverse)
   end

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -3,4 +3,8 @@ class MeasureComponent
 
   has_one :duty_expression
   has_one :measurement_unit
+
+  def unit_for_classification
+    "#{measurement_unit&.description} (#{casted_by.duty_expression&.base})"
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,11 @@ en:
       <p>
         The import of commodity %{code} from %{trading_partner_description} is prohibited.
       </p>
+  declarable:
+    supplementary_unit_classifications:
+      excise: >-
+        There are no supplementary unit measures assigned to this commodity, however you will need to declare the unit of import (%{units}) for excise purposes.
+      none: "There are no supplementary unit measures assigned to this commodity"
   import_destination:
     uk: United Kingdom
     xi: Northern Ireland

--- a/spec/factories/duty_expression_factory.rb
+++ b/spec/factories/duty_expression_factory.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
 
     trait :supplementary do
       description { 'Number of items' }
+      base { 'p/st' }
     end
 
     trait :vat do

--- a/spec/models/measure_collection_spec.rb
+++ b/spec/models/measure_collection_spec.rb
@@ -172,4 +172,13 @@ RSpec.describe MeasureCollection do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '#erga_omnes' do
+    subject(:collection) { described_class.new([erga_omnes_measure, measure]) }
+
+    let(:erga_omnes_measure) { build(:measure, :erga_omnes) }
+    let(:measure) { build(:measure) }
+
+    it { expect(collection.erga_omnes.measures).to eq([erga_omnes_measure]) }
+  end
 end

--- a/spec/models/measure_component_spec.rb
+++ b/spec/models/measure_component_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe MeasureComponent do
+  describe '#unit_for_classification' do
+    subject(:component) do
+      build(
+        :measure,
+        :with_supplementary_measure_components,
+        duty_expression: attributes_for(:duty_expression, :supplementary),
+      ).measure_components.first
+    end
+
+    it { expect(component.unit_for_classification).to eq('Number of items (p/st)') }
+  end
+end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -337,4 +337,18 @@ RSpec.describe Measure do
       it { is_expected.not_to be_safeguard }
     end
   end
+
+  describe '#measurement_units?' do
+    context 'with measurement units' do
+      subject(:measure) { build(:measure, :with_supplementary_measure_components) }
+
+      it { is_expected.to be_measurement_units }
+    end
+
+    context 'without measurement units' do
+      subject(:measure) { build(:measure) }
+
+      it { is_expected.not_to be_measurement_units }
+    end
+  end
 end

--- a/spec/support/shared_examples/a_declarable.rb
+++ b/spec/support/shared_examples/a_declarable.rb
@@ -8,7 +8,12 @@ RSpec.shared_examples 'a declarable' do
     context 'when there is a supplementary measure' do
       let(:measures) do
         [
-          attributes_for(:measure, :import_export_supplementary, :erga_omnes, :with_supplementary_measure_components),
+          attributes_for(
+            :measure,
+            :import_export_supplementary,
+            :erga_omnes,
+            :with_supplementary_measure_components,
+          ),
         ]
       end
 
@@ -17,11 +22,28 @@ RSpec.shared_examples 'a declarable' do
       end
     end
 
+    context 'when there is no official supplementary measure but there are excise units' do
+      let(:measures) do
+        [
+          attributes_for(
+            :measure,
+            :excise,
+            :erga_omnes,
+            :with_supplementary_measure_components,
+          ),
+        ]
+      end
+
+      it 'returns the appropriate supplementary unit classification' do
+        expect(declarable.supplementary_unit).to eq('There are no supplementary unit measures assigned to this commodity, however you will need to declare the unit of import (number of items) for excise purposes.')
+      end
+    end
+
     context 'when there are no supplementary measures' do
       let(:measures) { [attributes_for(:measure)] }
 
-      it 'returns the appropriate supplementary unit' do
-        expect(declarable.supplementary_unit).to eq('No supplementary unit required.')
+      it 'returns the appropriate supplementary unit classification' do
+        expect(declarable.supplementary_unit).to eq('There are no supplementary unit measures assigned to this commodity')
       end
     end
   end
@@ -30,7 +52,12 @@ RSpec.shared_examples 'a declarable' do
     context 'when there is a supplementary measure and the measure is an import measure' do
       let(:measures) do
         [
-          attributes_for(:measure, :import_only_supplementary, :erga_omnes, :with_supplementary_measure_components),
+          attributes_for(
+            :measure,
+            :import_only_supplementary,
+            :erga_omnes,
+            :with_supplementary_measure_components,
+          ),
         ]
       end
 
@@ -42,7 +69,12 @@ RSpec.shared_examples 'a declarable' do
     context 'when there is a supplementary measure and the measure is an export measure' do
       let(:measures) do
         [
-          attributes_for(:measure, :import_export_supplementary, :erga_omnes, :with_supplementary_measure_components),
+          attributes_for(
+            :measure,
+            :import_export_supplementary,
+            :erga_omnes,
+            :with_supplementary_measure_components,
+          ),
         ]
       end
 

--- a/spec/views/context_tables/commodity.html.erb_spec.rb
+++ b/spec/views/context_tables/commodity.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'shared/context_tables/_commodity', type: :view, vcr: { cassette_
 
   describe 'supplementary unit row' do
     it { is_expected.to have_css 'dl div dt', text: 'Supplementary unit' }
-    it { is_expected.to have_css 'dl div dd', text: 'No supplementary unit required.' }
+    it { is_expected.to have_css 'dl div dd', text: 'There are no supplementary unit measures assigned to this commodity' }
   end
 
   describe 'date of trade row' do

--- a/spec/views/context_tables/heading.html.erb_spec.rb
+++ b/spec/views/context_tables/heading.html.erb_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'shared/context_tables/_heading', type: :view, vcr: { cassette_na
 
     describe 'supplementary unit row' do
       it { is_expected.to have_css 'dl div dt', text: 'Supplementary unit' }
-      it { is_expected.to have_css 'dl div dd', text: 'No supplementary unit required.' }
+      it { is_expected.to have_css 'dl div dd', text: 'There are no supplementary unit measures assigned to this commodity' }
     end
 
     describe 'trading partner row' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2853

![image](https://user-images.githubusercontent.com/8156884/225308888-71b14ade-25da-46f8-826b-b289c00d961a.png)

### What?

I have added/removed/altered:

- [x] Added support for showing excise measurement units in supplementary unit row

### Why?

I am doing this because:

- This is required to better flag to traders that they need to input excise measurement units
