### PR TITLE
HOTT-2849: Handle missing measurement unit for excise supplementary units

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -114,7 +114,9 @@ module Declarable
   def excise_unit_for_classification
     excise_units = import_measures.excise.erga_omnes.each_with_object({}) do |measure, acc|
       measure.measure_components.each do |component|
-        acc[component.measurement_unit.resource_id] = component.measurement_unit&.description.to_s.downcase
+        if component.measurement_unit.present?
+          acc[component.measurement_unit.resource_id] = component.measurement_unit&.description.to_s.downcase
+        end
       end
     end
 

--- a/spec/factories/measure_component_factory.rb
+++ b/spec/factories/measure_component_factory.rb
@@ -9,5 +9,11 @@ FactoryBot.define do
         attributes_for(:measurement_unit, :supplementary)
       end
     end
+
+    trait :with_monetary_unit_measure_components do
+      duty_expression do
+        attributes_for(:duty_expression, base: 'EUR')
+      end
+    end
   end
 end

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -163,6 +163,11 @@ FactoryBot.define do
       end
     end
 
+    trait :with_monetary_unit_measure_components do
+      measure_components do
+        [attributes_for(:measure_component, :with_monetary_unit_measure_components)]
+      end
+    end
     trait :with_eu_member_exclusions do
       excluded_countries do
         [

--- a/spec/support/shared_examples/a_declarable.rb
+++ b/spec/support/shared_examples/a_declarable.rb
@@ -31,6 +31,12 @@ RSpec.shared_examples 'a declarable' do
             :erga_omnes,
             :with_supplementary_measure_components,
           ),
+          attributes_for(
+            :measure,
+            :excise,
+            :erga_omnes,
+            :with_monetary_unit_measure_components,
+          ),
         ]
       end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2849

### What?

I have added/removed/altered:

- [x] Added handling for missing measurement unit on excise measures
- [x] Added tests for this case

### Why?

I am doing this because:

- This is a live issue that was missed
