### PR TITLE
HOTT-2766: Adds contextualised descriptions for commodities

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -56,6 +56,29 @@ class Commodity < GoodsNomenclature
     formatted_description || description
   end
 
+  def descriptions_with_other_handling
+    return [] unless to_s.match(/^other$/i)
+
+    all_other = true
+    descriptions = []
+
+    ancestors.reverse.each do |ancestor|
+      if ancestor.is_other?
+        descriptions.unshift(ancestor.to_s)
+      else
+        descriptions.unshift(ancestor.to_s)
+        all_other = false
+        break
+      end
+    end
+
+    if all_other
+      descriptions.unshift(heading.to_s)
+    end
+
+    descriptions
+  end
+
   def root
     parent_sid.blank?
   end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -31,6 +31,10 @@ class GoodsNomenclature
     @attributes['validity_end_date'].presence || NullObject.new
   end
 
+  def is_other?
+    to_s.match(/^other$/i)
+  end
+
   def chapter?
     goods_nomenclature_item_id.ends_with?('00000000')
   end

--- a/app/views/shared/context_tables/_commodity.html.erb
+++ b/app/views/shared/context_tables/_commodity.html.erb
@@ -13,7 +13,17 @@
       Classification
     </dt>
     <dd class="govuk-summary-list__value">
-      <%= convert_text_to_links(sanitize declarable.formatted_description).html_safe %>
+      <% if declarable.is_other? %>
+        <% declarable.descriptions_with_other_handling.each do |description| %>
+          <%= convert_text_to_links(description).html_safe %> >
+        <% end %>
+
+        <strong>
+          <%= convert_text_to_links(declarable.to_s).html_safe %>
+        </strong>
+      <% else %>
+        <%= convert_text_to_links(declarable.to_s).html_safe %>
+    <% end %>
     </dd>
     <dd class="govuk-summary-list__actions"></dd>
   </div>
@@ -29,7 +39,7 @@
       <%= link_to('Change', import_export_dates_path, class: 'govuk-link') %>
     </dd>
   </div>
-  <div class="govuk-summary-list__row" >
+  <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       Filter by country
     </dt>

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -221,4 +221,51 @@ RSpec.describe Commodity do
       it { is_expected.not_to be_has_safeguard_measure }
     end
   end
+
+  describe '#descriptions_with_other_handling' do
+    subject(:descriptions_with_other_handling) do
+      build(:commodity, ancestors:, formatted_description:).descriptions_with_other_handling
+    end
+
+    context 'when the commodity does not have `other` as a description' do
+      let(:formatted_description) { 'Mules' }
+
+      let(:ancestors) do
+        [
+          attributes_for(:chapter, formatted_description: 'Live animals '),
+          attributes_for(:heading, formatted_description: 'Live horses, asses, mules and hinnies '),
+          attributes_for(:subheading, formatted_description: 'Horses'),
+        ]
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when the subheading has a non other description' do
+      let(:formatted_description) { 'Other' }
+      let(:ancestors) do
+        [
+          attributes_for(:chapter, formatted_description: 'Live animals '),
+          attributes_for(:heading, formatted_description: 'Live horses, asses, mules and hinnies '),
+          attributes_for(:subheading, formatted_description: 'Horses'),
+        ]
+      end
+
+      it { is_expected.to eq(%w[Horses]) }
+    end
+
+    context 'when the heading has the non other description' do
+      let(:formatted_description) { 'Other' }
+      let(:ancestors) do
+        [
+          attributes_for(:chapter, formatted_description: 'Live animals '),
+          attributes_for(:heading, formatted_description: 'Live horses, asses, mules and hinnies'),
+          attributes_for(:subheading, formatted_description: 'Other'),
+          attributes_for(:subheading, formatted_description: 'Other'),
+        ]
+      end
+
+      it { is_expected.to eq(['Live horses, asses, mules and hinnies', 'Other', 'Other']) }
+    end
+  end
 end

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -166,4 +166,28 @@ RSpec.describe GoodsNomenclature do
     it { is_expected.to have_attributes length: 6 }
     it { is_expected.to eql schemes.map(&:rules).flatten }
   end
+
+  describe '#is_other?' do
+    shared_examples 'a goods nomenclature with an `other` description' do |formatted_description|
+      subject(:goods_nomenclature) { build(:commodity, formatted_description:) }
+
+      it { is_expected.to be_is_other }
+    end
+
+    it_behaves_like 'a goods nomenclature with an `other` description', 'Other'
+    it_behaves_like 'a goods nomenclature with an `other` description', 'other'
+    it_behaves_like 'a goods nomenclature with an `other` description', 'OTHER'
+
+    context 'when the description is `nil`' do
+      subject(:goods_nomenclature) { build(:commodity, formatted_description: nil) }
+
+      it { is_expected.not_to be_is_other }
+    end
+
+    context 'when the description is anything else' do
+      subject(:goods_nomenclature) { build(:commodity, formatted_description: 'foo') }
+
+      it { is_expected.not_to be_is_other }
+    end
+  end
 end

--- a/spec/views/context_tables/commodity.html.erb_spec.rb
+++ b/spec/views/context_tables/commodity.html.erb_spec.rb
@@ -19,6 +19,19 @@ RSpec.describe 'shared/context_tables/_commodity', type: :view, vcr: { cassette_
   describe 'classification row' do
     it { is_expected.to have_css 'dl div dt', text: 'Classification' }
     it { is_expected.to have_css 'dl div dd', text: declarable.formatted_description }
+
+    context 'when the declarable description is `Other`' do
+      let(:declarable) do
+        build(
+          :commodity,
+          :with_ancestors,
+          formatted_description: 'Other',
+        )
+      end
+
+      it { is_expected.to have_css 'dl div dd', text: 'Horses' }
+      it { is_expected.to have_css 'dl div dd strong', text: 'Other' }
+    end
   end
 
   describe 'supplementary unit row' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2766

![image](https://user-images.githubusercontent.com/8156884/226361891-3dc19d4d-5d76-44d7-9a3f-6263995b0589.png)

### What?

I have added/removed/altered:

- [x] Add contextualised descriptions for commodities

### Why?

I am doing this because:

- This is required because some of these descriptions are just "Other" which can be quite unhelpful for users
