### PR TITLE
HOTT-2903: Handle no additional code measures

### DIFF
--- a/app/views/commodities/_additional_code_table.html.erb
+++ b/app/views/commodities/_additional_code_table.html.erb
@@ -9,7 +9,7 @@
   <tbody class="govuk-table__body">
   <% measures.each do |m| %>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell" id="additional-code"><%= m.additional_code&.code %></td>
+      <td class="govuk-table__cell" id="additional-code"><%= m.additional_code&.code.presence || 'No code' %></td>
       <td class="govuk-table__cell"><%= m.duty_expression.formatted_base.html_safe %></td>
     </tr>
   <% end %>


### PR DESCRIPTION
### Jira link

![image](https://user-images.githubusercontent.com/8156884/226375621-0c2f03ed-a49f-44a2-81e0-51c2107d65af.png)


https://transformuk.atlassian.net/browse/HOTT-2903

### What?

I have added/removed/altered:

- [x] Added display handling for no additional code measures on multi-additional code measure variants

### Why?

I am doing this because:

- This was requested for clarity
