### PR TITLE
HOTT-2893: Adds special support for missing definitions on non-licensed quotas

### DIFF
--- a/app/models/order_number.rb
+++ b/app/models/order_number.rb
@@ -28,4 +28,8 @@ class OrderNumber
   def show_warning?
     definition.description && number.start_with?('05')
   end
+
+  def licenced?
+    number[2] == '4'
+  end
 end

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -27,7 +27,7 @@
               <%= number_with_precision quota_definition.balance, precision: 3, delimiter: ',' %>
               <%= quota_definition.measurement_unit %>
               <% unless @search.date.today? %>
-                <br />
+                <br>
                 <%= link_to params.permit(QuotaSearchForm::PERMITTED_PARAMS)
                                   .merge(day: Date.today.day,
                                          month: Date.today.month,
@@ -119,7 +119,17 @@
         up-to-date information that HMRC can provide at any given time.
       </p>
     <% else %>
-      <p class="govuk-!-margin-top-4">Information on the availability of this quota can be obtained from the Rural Payments Agency.</p>
+      <p class="govuk-!-margin-top-4">
+        <% if order_number.licenced? %>
+          <div id="missing-definition-licenced">
+            Information on the availability of licenced quotas can be obtained from the <%= link_to("Rural Payments Agency (opens in new browser window)", "https://www.gov.uk/government/organisations/rural-payments-agency", target: '_blank', class: 'govuk-link') %>.
+          </div>
+        <% else %>
+          <div id="missing-definition-non-licenced">
+            No further information for this quota can be found.
+          </div>
+        <% end %>
+      </p>
     <% end %>
   </article>
 </div>

--- a/spec/factories/order_number_factory.rb
+++ b/spec/factories/order_number_factory.rb
@@ -1,5 +1,21 @@
 FactoryBot.define do
   factory :order_number do
     number { Forgery(:basic).number(exactly: 6).to_s }
+
+    trait :with_definition do
+      quota_definition { attributes_for(:quota_definition) }
+    end
+
+    trait :no_definition do
+      quota_definition { nil }
+    end
+
+    trait :licenced do
+      number { '054002' }
+    end
+
+    trait :non_licenced do
+      number { '055002' }
+    end
   end
 end

--- a/spec/models/order_number_spec.rb
+++ b/spec/models/order_number_spec.rb
@@ -94,4 +94,18 @@ RSpec.describe OrderNumber do
       it { is_expected.to eq('flibble') }
     end
   end
+
+  describe '#licenced?' do
+    context 'when the order number is not licenced' do
+      subject(:order_number) { build(:order_number, :non_licenced) }
+
+      it { expect(order_number).not_to be_licenced }
+    end
+
+    context 'when the order number is licenced' do
+      subject(:order_number) { build(:order_number, :licenced) }
+
+      it { expect(order_number).to be_licenced }
+    end
+  end
 end

--- a/spec/views/shared/_quota_definition.html.erb_spec.rb
+++ b/spec/views/shared/_quota_definition.html.erb_spec.rb
@@ -64,4 +64,16 @@ RSpec.describe 'shared/_quota_definition', type: :view do
 
     it { is_expected.not_to have_css '#transferred-balance', text: 'Transferred balance' }
   end
+
+  context 'when there is no quota definition and the quota order number is not licenced' do
+    let(:order_number) { build(:order_number, :no_definition, :non_licenced) }
+
+    it { is_expected.to have_css '#missing-definition-non-licenced' }
+  end
+
+  context 'when there is no quota definition and the quota order number is licenced' do
+    let(:order_number) { build(:order_number, :no_definition, :licenced) }
+
+    it { is_expected.to have_css '#missing-definition-licenced' }
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2893

![image](https://user-images.githubusercontent.com/8156884/226406612-0b6c6d93-eaca-4505-92bc-12ddf5aced4e.png)
![image](https://user-images.githubusercontent.com/8156884/226406655-465cee3a-7b50-499b-86f3-f0a70b46852e.png)


### What?

I have added/removed/altered:

- [x] Added support for missing definitions for non-licenced quotas

### Why?

I am doing this because:

- This is required to provide more helpful feedback in broken data scenarios
