### PR TITLE
HOTT-2924 Bugfix for news using same param as TimeMachine

### DIFF
--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -7,7 +7,7 @@ class NewsItemsController < ApplicationController
     @news_collections = News::Collection.all
     @news_years = News::Year.all
 
-    @filter_year = params[:year].presence&.to_i
+    @filter_year = params[:story_year].presence&.to_i
     if params[:collection_id]
       @filter_collection = @news_collections.find do |collection|
         collection.matches_param? params[:collection_id]
@@ -27,7 +27,7 @@ class NewsItemsController < ApplicationController
 private
 
   def news_index_params
-    params.permit(:page, :year, :collection_id)
+    params.permit(:page, :story_year, :collection_id)
           .to_h
           .symbolize_keys
   end

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -55,6 +55,10 @@ module News
       end
 
       def updates_page(**filters)
+        if filters.key?(:story_year)
+          filters = filters.merge(year: filters.delete(:story_year))
+        end
+
         all filters.merge(service: service_name,
                           target: 'updates',
                           per_page: 10)

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -18,14 +18,14 @@
 
     <ul class="govuk-list tariff-list--hyphen" id="news-year-filter">
       <li>
-        <%= @filter_year ? link_to('All years', year: nil, page: nil) : 'All years' %>
+        <%= @filter_year ? link_to('All years', story_year: nil, page: nil) : 'All years' %>
       </li>
-      <% @news_years.each do |news_year| %>
+      <% @news_years.each do |story_year| %>
       <li>
-        <% if @filter_year == news_year.year %>
-          <%= news_year.year %>
+        <% if @filter_year == story_year.year %>
+          <%= story_year.year %>
         <% else %>
-          <%= link_to news_year.year, news_index_params.merge(year: news_year.year, page: nil) %>
+          <%= link_to story_year.year, news_index_params.merge(story_year: story_year.year, page: nil) %>
         <% end %>
       </li>
       <% end %>
@@ -44,7 +44,7 @@
         <% if collection.id == @filter_collection&.id %>
           <%= collection.name %>
         <% else %>
-          <%= link_to collection.name, news_index_params.merge(collection_id: collection, page: nil) %>
+          <%= link_to collection.name, news_index_params.merge(collection_id: collection, page: nil, story_year: @filter_year) %>
         <% end %>
       </li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,8 @@ Rails.application.routes.draw do
   resolve('Cookies::Policy') { %i[cookies policy] }
   get 'cookies', to: redirect(path: '/cookies/policy')
 
-  get '/news/collections/:collection_id', to: 'news_items#index', as: :news_collection
+  get '/news/collections/:collection_id(/:story_year)', to: 'news_items#index', as: :news_collection
+  get '/news/years/:story_year', to: 'news_items#index', as: :news_year
   get '/news/stories/:id', to: 'news_items#show', as: :news_item
   resources :news_items, only: %i[index show], path: '/news'
 

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe News::Item do
     end
 
     context 'with year filter' do
-      subject { described_class.updates_page(year: 2020) }
+      subject { described_class.updates_page(story_year: 2020) }
 
       before do
         stub_api_request('/news/items?per_page=10&service=uk&target=updates&year=2020', backend: 'uk')


### PR DESCRIPTION
### Jira link

HOTT-2924

### What?

I have added/removed/altered:

- [x] Changed the query param to select the year for news stories
- [x] Added additional url route for `/news/years/2023`
- [x] Added additional url route for `/news/collections/tariff_trade/2023`

### Why?

I am doing this because:

- It was clashing with the `year` param from time machine that was sometimes carried over from other pages
- Cleans up some of the urls

### Have you? (optional)

- [x] Reviewed view changes with stake holders

### Deployment risks (optional)

- Will swap back to showing stories from all years for any users browsing a specific year at the point of deploy