### PR TITLE
HOTT-2909: Tweak encoding of cookies

### DIFF
--- a/app/webpacker/src/javascripts/cookie-manager.js
+++ b/app/webpacker/src/javascripts/cookie-manager.js
@@ -73,7 +73,7 @@ export default class CookieManager {
 
   #setCookie(name, value, expires) {
     const isSecureEnvironment = location.protocol === 'https:';
-    const encodedValue = encodeURIComponent(JSON.stringify(value));
+    const encodedValue = JSON.stringify(value);
     Cookies.set(name, encodedValue, {expires: expires, secure: isSecureEnvironment});
   }
 
@@ -84,10 +84,8 @@ export default class CookieManager {
       return null;
     }
 
-    const decodedJson = decodeURIComponent(candidateJson);
-
     try {
-      return JSON.parse(decodedJson);
+      return JSON.parse(candidateJson);
     } catch (e) {
       return candidateJson;
     }

--- a/spec/features/cookies_spec.rb
+++ b/spec/features/cookies_spec.rb
@@ -1,31 +1,55 @@
 require 'spec_helper'
 
 RSpec.feature 'Cookies management', js: true do
+  def cookie_for(name)
+    cookie_value = begin
+      page.driver.browser.manage.cookie_named(name)[:value]
+    rescue Selenium::WebDriver::Error::NoSuchCookieError
+      nil
+    end
+
+    JSON.parse(CGI.unescape(cookie_value)) if cookie_value.present?
+  end
+
   scenario 'accepting cookies from banner' do
     visit help_path
 
+    expect(cookie_for('cookies_policy')).to be_nil
+    expect(cookie_for('cookies_preferences_set')).to be_nil
     expect(page).to have_css 'h1', text: 'Help on using the tariff'
     expect(page).to have_css '#banner', text: /We use some essential cookies/
     find(:button, 'Accept additional cookies', visible: true).click
+    expect(cookie_for('cookies_policy')).to eq('remember_settings' => true, 'usage' => true)
+    expect(cookie_for('cookies_preferences_set')).to be_nil
     expect(page).to have_css 'h1', text: 'Help on using the tariff'
     find(:button, 'Hide this message', visible: true).click
+    expect(cookie_for('cookies_policy')).to eq('remember_settings' => true, 'usage' => true)
+    expect(cookie_for('cookies_preferences_set')).to eq('value' => true)
     expect(page).to have_css '#banner', visible: :hidden
   end
 
   scenario 'rejecting cookies from banner' do
     visit help_path
 
+    expect(cookie_for('cookies_policy')).to be_nil
+    expect(cookie_for('cookies_preferences_set')).to be_nil
     expect(page).to have_css 'h1', text: 'Help on using the tariff'
     expect(page).to have_css '#banner', text: /We use some essential cookies/
     find(:button, 'Reject additional cookies', visible: true).click
+    expect(cookie_for('cookies_policy')).to eq('remember_settings' => false, 'usage' => false)
+    expect(cookie_for('cookies_preferences_set')).to be_nil
     expect(page).to have_css 'h1', text: 'Help on using the tariff'
     find(:button, 'Hide this message', visible: true).click
+    expect(cookie_for('cookies_policy')).to eq('remember_settings' => false, 'usage' => false)
+    expect(cookie_for('cookies_preferences_set')).to eq('value' => true)
     expect(page).to have_css '#banner', visible: :hidden
   end
 
   scenario 'manually setting cookies' do
     visit help_path
 
+    expect(cookie_for('cookies_policy')).to be_nil
+    expect(cookie_for('cookies_preferences_set')).to be_nil
     expect(page).to have_css 'h1', text: 'Help on using the tariff'
     expect(page).to have_css '#banner', text: /We use some essential cookies/
     find(:link, 'View cookies', visible: true).click
@@ -36,11 +60,18 @@ RSpec.feature 'Cookies management', js: true do
     choose 'Yes, use cookies that remember my settings on the site'
     choose 'Use cookies that measure my website use'
     click_on 'Save Changes'
+    expect(cookie_for('cookies_policy')).to eq('remember_settings' => true, 'usage' => true)
+    expect(cookie_for('cookies_preferences_set')).to be_nil
     expect(page).to have_css '.govuk-notification-banner h3', text: 'Your cookie settings were saved'
     expect(page).to have_css '#cookies_accepted'
 
     find(:button, 'Accept additional cookies', visible: true).click
+    expect(cookie_for('cookies_policy')).to eq('remember_settings' => true, 'usage' => true)
+    expect(cookie_for('cookies_preferences_set')).to be_nil
+
     find(:button, 'Hide this message', visible: true).click
+    expect(cookie_for('cookies_policy')).to eq('remember_settings' => true, 'usage' => true)
+    expect(cookie_for('cookies_preferences_set')).to eq('value' => true)
 
     expect(page).to have_css 'h1', text: 'Cookies on the UK Integrated Online Tariff'
     expect(page).to have_css '#banner', visible: :hidden


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2909

### What?

I have added/removed/altered:

- [x] Removed extra handling of component encoding
- [x] Added some extra feature tests to validate cookie values

### Why?

I am doing this because:

- The js-cookie already encodes correctly
