### PR TITLE
HOTT-2930: Show only descendants of a subheading

### DIFF
--- a/app/controllers/subheadings_controller.rb
+++ b/app/controllers/subheadings_controller.rb
@@ -5,7 +5,7 @@ class SubheadingsController < GoodsNomenclaturesController
 
   def show
     @commodities = HeadingCommodityPresenter.new(subheading.commodities)
-    @subheading_commodities = Array.wrap(@subheading.find_self_in_commodities_list.children)
+    @subheading_commodities = @subheading.descendants
     @section = subheading.section
     @chapter = subheading.chapter
     @heading = subheading.heading

--- a/app/controllers/subheadings_controller.rb
+++ b/app/controllers/subheadings_controller.rb
@@ -5,7 +5,7 @@ class SubheadingsController < GoodsNomenclaturesController
 
   def show
     @commodities = HeadingCommodityPresenter.new(subheading.commodities)
-    @subheading_commodities = Array.wrap(@subheading.find_self_in_commodities_list)
+    @subheading_commodities = Array.wrap(@subheading.find_self_in_commodities_list.children)
     @section = subheading.section
     @chapter = subheading.chapter
     @heading = subheading.heading

--- a/app/models/subheading.rb
+++ b/app/models/subheading.rb
@@ -21,6 +21,16 @@ class Subheading < GoodsNomenclature
                 :formatted_description,
                 :declarable
 
+  def descendants
+    included_subheading = commodities.find { |c| c.goods_nomenclature_sid == goods_nomenclature_sid }
+
+    if included_subheading.present?
+      included_subheading.children
+    else
+      []
+    end
+  end
+
   def page_heading
     "Subheading #{code} - #{self}"
   end
@@ -39,12 +49,6 @@ class Subheading < GoodsNomenclature
 
   def to_s
     formatted_description || description
-  end
-
-  def find_self_in_commodities_list
-    @find_self_in_commodities_list ||= commodities.find do |c|
-      c.goods_nomenclature_sid == goods_nomenclature_sid
-    end
   end
 
   private

--- a/app/models/subheading.rb
+++ b/app/models/subheading.rb
@@ -24,11 +24,7 @@ class Subheading < GoodsNomenclature
   def descendants
     included_subheading = commodities.find { |c| c.goods_nomenclature_sid == goods_nomenclature_sid }
 
-    if included_subheading.present?
-      included_subheading.children
-    else
-      []
-    end
+    included_subheading&.children || []
   end
 
   def page_heading

--- a/spec/factories/subheading_factory.rb
+++ b/spec/factories/subheading_factory.rb
@@ -47,5 +47,32 @@ FactoryBot.define do
     trait :taric_code do
       goods_nomenclature_item_id { '0101121210' }
     end
+
+    trait :with_descendants do
+      commodities_count { 2 }
+
+      commodities do
+        [
+          attributes_for(:commodity, goods_nomenclature_sid:),
+          attributes_for(:commodity, parent_sid: goods_nomenclature_sid),
+        ]
+      end
+    end
+
+    trait :without_descendants do
+      commodities_count { 2 }
+
+      commodities do
+        [
+          attributes_for(:commodity, goods_nomenclature_sid:),
+        ]
+      end
+    end
+
+    trait :without_commodities do
+      commodities_count { 0 }
+
+      commodities { [] }
+    end
   end
 end

--- a/spec/models/subheading_spec.rb
+++ b/spec/models/subheading_spec.rb
@@ -24,6 +24,26 @@ RSpec.describe Subheading do
   it { is_expected.to have_attributes(description: 'Horses') }
   it { is_expected.to have_attributes(formatted_description: '<strong>Horses</strong>') }
 
+  describe '#descendants' do
+    context 'when the subheading has descendants' do
+      subject(:descendants) { build(:subheading, :with_descendants).descendants }
+
+      it { is_expected.to be_present }
+    end
+
+    context 'when the subheading has no descendants' do
+      subject(:descendants) { build(:subheading, :without_descendants).descendants }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the subheading has no commodities' do
+      subject(:descendants) { build(:subheading, :without_commodities).descendants }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe '#page_heading' do
     subject(:page_heading) { build(:subheading).page_heading }
 

--- a/spec/views/subheading/show.html.erb_spec.rb
+++ b/spec/views/subheading/show.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'subheadings/show', type: :view do
   before do
     assign :subheading, subheading
     assign :commodities, HeadingCommodityPresenter.new(subheading.commodities)
-    assign :subheading_commodities, [subheading.find_self_in_commodities_list]
+    assign :subheading_commodities, subheading.descendants
     assign :search, Search.new
   end
 
@@ -28,5 +28,5 @@ RSpec.describe 'subheadings/show', type: :view do
   it { is_expected.to have_css 'dl.govuk-summary-list' }
   it { is_expected.to have_css 'strong', text: '1 commodity' }
   it { is_expected.to have_css 'nav.commodity-ancestors ol li', count: 7 }
-  it { is_expected.to have_css '.commodity-tree ul li', count: 4 }
+  it { is_expected.to have_css '.commodity-tree ul li', count: 3 }
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2930

**Before**

![image](https://user-images.githubusercontent.com/8156884/229493577-a38eff24-7d80-48e5-b7c2-e150f44450d7.png)


**After**

![image](https://user-images.githubusercontent.com/8156884/229493522-1a6a4d61-044a-435e-aadc-40d6e411dac8.png)


### What?

I have added/removed/altered:

- [x] Altered the commodities we pass to the commodity tree to exclude the subheading itself

### Why?

I am doing this because:

- This was noted as a bit confusing for users and the subheading is clearly visible in the classification
