### PR TITLE
HOTT-2984:  Sanitise stop press titles and content titles

### DIFF
--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -59,7 +59,7 @@
     <% @news_items.each do |news_item| %>
       <article class="news-item" data-news-item-id="<%= news_item.id %>">
         <h2 class="govuk-heading-s">
-          <%= link_to news_item.title, news_item %>
+          <%= link_to sanitize(news_item.title), news_item %>
         </h2>
 
         <div class="tariff-markdown tariff-markdown--reduced-trailing-margin">

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -53,7 +53,7 @@
 
         <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
           <% @news_item.subheadings.each do |subheading| %>
-            <%= contents_list_item subheading,
+            <%= contents_list_item sanitize(subheading),
                                    "##{markdown_heading_id subheading}",
                                    'govuk-link--no-underline' %>
           <% end %>

--- a/spec/factories/news/item_factory.rb
+++ b/spec/factories/news/item_factory.rb
@@ -76,13 +76,11 @@ FactoryBot.define do
     end
 
     trait :with_unsafe_html do
-      unsafe_html = "<script>alert('Hello, world!')</script>"
-
-      title { "Title #{unsafe_html}" }
+      title { "Title <script>alert('Hello, world!')</script>" }
 
       content do
         <<~CONTENT
-          ## Second heading #{unsafe_html}
+          ## Second heading <script>alert('Hello, world!')</script>
 
           This is a paragraph
         CONTENT
@@ -90,13 +88,11 @@ FactoryBot.define do
     end
 
     trait :with_safe_html do
-      safe_html = '<abbr>MFN</abbr>'
-
-      title { "Title #{safe_html}" }
+      title { "Title <abbr>MFN</abbr>" }
 
       content do
         <<~CONTENT
-          ## Second heading #{safe_html}
+          ## Second heading <abbr>MFN</abbr>
 
           This is a paragraph
         CONTENT

--- a/spec/factories/news/item_factory.rb
+++ b/spec/factories/news/item_factory.rb
@@ -88,7 +88,7 @@ FactoryBot.define do
     end
 
     trait :with_safe_html do
-      title { "Title <abbr>MFN</abbr>" }
+      title { 'Title <abbr>MFN</abbr>' }
 
       content do
         <<~CONTENT

--- a/spec/factories/news/item_factory.rb
+++ b/spec/factories/news/item_factory.rb
@@ -74,5 +74,33 @@ FactoryBot.define do
         CONTENT
       end
     end
+
+    trait :with_unsafe_html do
+      unsafe_html = "<script>alert('Hello, world!')</script>"
+
+      title { "Title #{unsafe_html}" }
+
+      content do
+        <<~CONTENT
+          ## Second heading #{unsafe_html}
+
+          This is a paragraph
+        CONTENT
+      end
+    end
+
+    trait :with_safe_html do
+      safe_html = "<abbr>MFN</abbr>"
+
+      title { "Title #{safe_html}" }
+
+      content do
+        <<~CONTENT
+          ## Second heading #{safe_html}
+
+          This is a paragraph
+        CONTENT
+      end
+    end
   end
 end

--- a/spec/factories/news/item_factory.rb
+++ b/spec/factories/news/item_factory.rb
@@ -90,7 +90,7 @@ FactoryBot.define do
     end
 
     trait :with_safe_html do
-      safe_html = "<abbr>MFN</abbr>"
+      safe_html = '<abbr>MFN</abbr>'
 
       title { "Title #{safe_html}" }
 

--- a/spec/views/news_items/index.html.erb_spec.rb
+++ b/spec/views/news_items/index.html.erb_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe 'news_items/index', type: :view do
     it { is_expected.not_to have_link 'Show more ...' }
   end
 
+  context 'with safe html in title' do
+    let(:news_items) { build_list :news_item, 2, :with_safe_html }
+
+    it { is_expected.to have_css 'article h2 a abbr' }
+  end
+
+  context 'with unsafe html in title' do
+    let(:news_items) { build_list :news_item, 2, :with_unsafe_html }
+
+    it { is_expected.not_to have_css 'article h2 a script' }
+  end
+
   context 'with no news items' do
     let(:news_items) { [] }
 

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe 'news_items/show', type: :view do
 
     context 'with safe html in content' do
       let(:news_item) { build :news_item, :with_safe_html }
-  
+
       it { is_expected.to have_css '#contents li a abbr' }
-      end
+    end
   end
 end

--- a/spec/views/news_items/show.html.erb_spec.rb
+++ b/spec/views/news_items/show.html.erb_spec.rb
@@ -50,5 +50,17 @@ RSpec.describe 'news_items/show', type: :view do
     it { is_expected.to have_css '#contents ol.gem-c-contents-list__list' }
     it { is_expected.to have_css '#contents li a', count: news_item.subheadings.length }
     it { is_expected.to have_link news_item.subheadings.first, href: '#second-heading' }
+
+    context 'with unsafe html in content' do
+      let(:news_item) { build :news_item, :with_unsafe_html }
+
+      it { is_expected.not_to have_css '#contents li a script' }
+    end
+
+    context 'with safe html in content' do
+      let(:news_item) { build :news_item, :with_safe_html }
+  
+      it { is_expected.to have_css '#contents li a abbr' }
+      end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2984

### What?

I have added/removed/altered:

- [x] Sanitised stop press titles and content titles

### Why?

I am doing this because:

- We want to escape dangerous html and allow safe html

### Have you? (optional)


<img width="962" alt="Screenshot 2023-04-04 at 14 31 13" src="https://user-images.githubusercontent.com/12201130/229809151-244fb576-c37f-41ea-879f-efea58618a77.png">
