### PR TITLE
HOTT-2971: Fixed wrapping around the duty calculator image

### DIFF
--- a/app/views/measures/grouped/_tariff_duty_calculator_link.html.erb
+++ b/app/views/measures/grouped/_tariff_duty_calculator_link.html.erb
@@ -1,17 +1,19 @@
 <div class="measure-inset">
   <%= image_tag('calculator.png') %>
-  <p>
-    The table below lists the import duties that apply to the import of
-    commodity <%= segmented_commodity_code declarable_code %>.
-  </p>
+  <div>
+    <p>
+      The table below lists the import duties that apply to the import of
+      commodity <%= segmented_commodity_code declarable_code %>.
+    </p>
 
-  <p>
-    Use our <strong>tariff duty calculator</strong> to
-    <%= link_to duty_calculator_url "/#{service_choice}/#{declarable_code}/import-date" do %>
-      work out the duties and taxes applicable to the import of commodity
-      <%= divide_commodity_code(declarable_code).join ' ' %>.
-    <% end %>
-  </p>
+    <p>
+      Use our <strong>tariff duty calculator</strong> to
+      <%= link_to duty_calculator_url "/#{service_choice}/#{declarable_code}/import-date" do %>
+        work out the duties and taxes applicable to the import of commodity
+        <%= divide_commodity_code(declarable_code).join ' ' %>.
+      <% end %>
+    </p>
 
-  <p><%= I18n.t("measure_type_message")%></p>
+    <p><%= I18n.t("measure_type_message")%></p>
+  </div>
 </div>

--- a/app/webpacker/src/stylesheets/_measure-inset.scss
+++ b/app/webpacker/src/stylesheets/_measure-inset.scss
@@ -19,6 +19,10 @@
       font-size: 16px;
       margin-bottom: 0.5em;
     }
+
+    div {
+      margin-left: 60px;
+    }
   }
 
   .vat-excise-panel {

--- a/app/webpacker/src/stylesheets/_measure-inset.scss
+++ b/app/webpacker/src/stylesheets/_measure-inset.scss
@@ -20,7 +20,7 @@
       margin-bottom: 0.5em;
     }
 
-    div {
+    & > img + div {
       margin-left: 60px;
     }
   }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2971

### What?

I have added/removed/altered:

- [ ] Fixed wrapping around the duty calculator image

### Why?

I am doing this because:

- The layout was broken and needed to be fixed

### Have you? (optional)

- [ ] Validated mobile responsive behaviour of view changes

<img width="780" alt="Screenshot 2023-04-11 at 11 55 19" src="https://user-images.githubusercontent.com/12201130/231140856-83b315ad-4e31-4ea3-acd8-c2231e37b2a4.png">

