### PR TITLE
HOTT-3034: Adjusts suggestion label

### DIFF
--- a/app/models/search_suggestion.rb
+++ b/app/models/search_suggestion.rb
@@ -27,7 +27,7 @@ class SearchSuggestion
     when CHEMICAL_TYPE
       PRESENTED_CHEMICAL_TYPE
     when REFERENCE_TYPE
-      PRESENTED_REFERENCE_TYPE
+      ''
     else
       suggestion_type.to_s.humanize
     end

--- a/app/views/beta/search_results/_sidebar.html.erb
+++ b/app/views/beta/search_results/_sidebar.html.erb
@@ -1,11 +1,11 @@
-<div id="search-filter-navigation"
+<div id="search-filter-navigation">
   <nav>
     <% if applied_filter_classifications.any? %>
       <strong>
         Results are filtered by:
       </strong>
       <div class="facet-classifications-tag-container">
-        <% applied_filter_classifications.each do |facet_classification_statistic|  %>
+        <% applied_filter_classifications.each do |facet_classification_statistic| %>
           <%= disapply_filter_link_for(facet_classification_statistic) %>
         <% end %>
       </div>

--- a/spec/models/search_suggestion_spec.rb
+++ b/spec/models/search_suggestion_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SearchSuggestion do
       it { is_expected.to eq(formatted_suggestion_type) }
     end
 
-    it_behaves_like 'a formatted suggestion type', 'search_reference', nil, 'Reference'
+    it_behaves_like 'a formatted suggestion type', 'search_reference', nil, ''
     it_behaves_like 'a formatted suggestion type', 'goods_nomenclature', '12', 'Chapter'
     it_behaves_like 'a formatted suggestion type', 'goods_nomenclature', '1234', 'Heading'
     it_behaves_like 'a formatted suggestion type', 'goods_nomenclature', '1234567890', 'Commodity'


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3034


![image](https://user-images.githubusercontent.com/8156884/233079597-2245b07a-efe9-435a-ab83-ba0dd4c69357.png)


### What?

I have added/removed/altered:

- [x] Removed label for search_reference suggestions

### Why?

I am doing this because:

- This is internal detail that isn't that helpful to traders
