### PR TITLE
HOTT-2933: Expose chemical substances api

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -22,6 +22,7 @@ module TradeTariffFrontend
       goods_nomenclatures
       search_references
       geographical_areas
+      chemical_substances
     ]
   end
 
@@ -54,6 +55,7 @@ module TradeTariffFrontend
       measure_actions
       quota_order_numbers
       preference_codes
+      chemical_substances
       healthcheck
     ]
   end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2933

### What?

I have added/removed/altered:

- [x] Added /chemical_substances to whitelists

### Why?

I am doing this because:

- This is required to make this api public/consumable by the frontend
