### PR TITLE
HOTT-3027: Display standard rate text on VAT measures without additio…

### DIFF
--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -25,13 +25,14 @@
           declarable_id: declarable.short_code %>
       </span>
     <% end %>
-
     <% if measure.additional_code.present? %>
       <% if measure.measure_type.prohibitive? %>
         <%= render 'measures/additional_codes/prohibitive', measure: measure %>
       <% else %>
         <%= render 'measures/additional_codes/regular', measure: measure %>
       <% end %>
+    <% elsif !measure.additional_code.present? && measure.vat? %>
+      <span class="table-line">Standard rate</span>
     <% end %>
   </td>
 

--- a/spec/views/measures/_measure.html.erb_spec.rb
+++ b/spec/views/measures/_measure.html.erb_spec.rb
@@ -42,4 +42,18 @@ RSpec.describe 'measures/_measure', type: :view, vcr: { cassette_name: 'geograph
 
     it { expect(rendered).to render_template('measures/additional_codes/_regular') }
   end
+
+  context 'when standard rate' do
+    context 'with a VAT measure that has no additional code' do
+      let(:measure) { build(:measure, :vat) }
+
+      it { expect(rendered).to match(/Standard rate/) }
+    end
+
+    context 'without a VAT measure' do
+      let(:measure) { build(:measure) }
+
+      it { expect(rendered).not_to match(/Standard rate/) }
+    end
+  end
 end


### PR DESCRIPTION
…nal code

### Jira link

https://transformuk.atlassian.net/browse/HOTT-3027

### What?

I have added/removed/altered:

- [ ] Displayed standard rate text on VAT measures without additional code

### Why?

I am doing this because:

- This will make it clearer for users to understand which measures are "standard rate" measures


<img width="1388" alt="Screenshot 2023-04-20 at 13 23 34" src="https://user-images.githubusercontent.com/12201130/233366263-ac673237-0994-4148-b028-3357a12c0cef.png">
