### PR TITLE
HOTT-2936: Adjust display of tab when chemicals not available

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -79,28 +79,30 @@
     <%- end -%>
   </div>
 
-  <!-- Chemicals tab -->
-  <div class="govuk-tabs__panel" id="chemicals">
-    <h2 class="govuk-heading-m">
-      Chemicals included within commodity code <%= segmented_commodity_code declarable.code %>
-    </h2>
-    <table class="govuk-table govuk-table--responsive govuk-!-margin-top-8">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">
-            <abbr title="Chemical Abstracts Service Registry Number">CAS RN</abbr>
-          </th>
-          <th scope="col" class="govuk-table__header">
-            <abbr title="European Union unique chemical identifier">CUS number</abbr>
-          </th>
-          <th scope="col" class="govuk-table__header">Name</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <%= render partial: 'chemicals/chemical', collection: @chemicals %>
-      </tbody>
-    </table>
-  </div>
+  <% if declarable.has_chemicals? %>
+    <!-- Chemicals tab -->
+    <div class="govuk-tabs__panel" id="chemicals">
+      <h2 class="govuk-heading-m">
+        Chemicals included within commodity code <%= segmented_commodity_code declarable.code %>
+      </h2>
+      <table class="govuk-table govuk-table--responsive govuk-!-margin-top-8">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">
+              <abbr title="Chemical Abstracts Service Registry Number">CAS RN</abbr>
+            </th>
+            <th scope="col" class="govuk-table__header">
+              <abbr title="European Union unique chemical identifier">CUS number</abbr>
+            </th>
+            <th scope="col" class="govuk-table__header">Name</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <%= render partial: 'chemicals/chemical', collection: @chemicals %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
 
   <!-- Footnotes tab -->
   <div class="govuk-tabs__panel" id="footnotes">


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2936

**Before**

![image](https://user-images.githubusercontent.com/8156884/233426890-be0fe6e4-aaca-46d6-b15a-040985bf1d92.png)

**After**

![image](https://user-images.githubusercontent.com/8156884/233426933-cf7c4d7e-10ad-4e0e-8caa-45df84c0e0bc.png)

### What?

I have added/removed/altered:

- [x] Render the chemicals tab only when the declarable has chemicals

### Why?

I am doing this because:

- Fixes weird issue with display of chemicals tab on non chem commodities
