### PR TITLE
HOTT-3050: Support excise supplementary units on XI

### DIFF
--- a/app/helpers/declarable_helper.rb
+++ b/app/helpers/declarable_helper.rb
@@ -59,4 +59,16 @@ module DeclarableHelper
       commodity_path(declarable, format: :json)
     end
   end
+
+  # Supplementary units coming from the UK declarable excise measures
+  # need to be displayed when there are no units on the XI declarable.
+  def supplementary_unit_for(declarable, uk_declarable)
+    supplementary_unit = if declarable.has_supplementary_unit? || !uk_declarable
+                           declarable.supplementary_unit
+                         else
+                           uk_declarable.supplementary_unit
+                         end
+
+    sanitize supplementary_unit
+  end
 end

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -103,6 +103,10 @@ module Declarable
     import_measures.any?(&:safeguard?)
   end
 
+  def has_supplementary_unit?
+    supplementary_component.present? || supplementary_excise_measures?
+  end
+
   private
 
   def supplementary_component

--- a/app/views/shared/context_tables/_supplementary_unit_row.html.erb
+++ b/app/views/shared/context_tables/_supplementary_unit_row.html.erb
@@ -2,7 +2,7 @@
   <dt class="govuk-summary-list__key"><%= declarable.supplementary_unit_description %></dt>
   <dd class="govuk-summary-list__value ">
     <p>
-      <%= sanitize declarable.supplementary_unit %>
+      <%= supplementary_unit_for(declarable, uk_declarable) %>
     </p>
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -43,6 +43,32 @@ FactoryBot.define do
       }
     end
 
+    trait :with_supplementary_unit do
+      import_measures do
+        [
+          attributes_for(
+            :measure,
+            :excise,
+            :erga_omnes,
+            :with_supplementary_measure_components,
+          ),
+        ]
+      end
+    end
+
+    trait :with_excise_supplementary_unit do
+      import_measures do
+        [
+          attributes_for(
+            :measure,
+            :excise,
+            :erga_omnes,
+            :with_monetary_unit_measure_components,
+          ),
+        ]
+      end
+    end
+
     trait :with_a_vat_overview_measure do
       overview_measures do
         [

--- a/spec/helpers/declarable_helper_spec.rb
+++ b/spec/helpers/declarable_helper_spec.rb
@@ -123,4 +123,41 @@ RSpec.describe DeclarableHelper, type: :helper, vcr: { cassette_name: 'geographi
       it { is_expected.to eq('All countries') }
     end
   end
+
+  describe '#supplementary_unit_for' do
+    subject(:supplementary_unit_for) { helper.supplementary_unit_for(declarable, uk_declarable) }
+
+    context 'when the declarable has a supplementary unit' do
+      let(:declarable) { build(:commodity, :with_supplementary_unit) }
+      let(:uk_declarable) { build(:commodity, :with_excise_supplementary_unit) }
+
+      it { is_expected.to eq(declarable.supplementary_unit) }
+      it { is_expected.to be_html_safe }
+    end
+
+    context 'when both the decalarable and the uk declarable have no supplementary units' do
+      let(:declarable) { build(:commodity) }
+      let(:uk_declarable) { build(:commodity) }
+
+      it { is_expected.to eq(declarable.supplementary_unit) }
+      it { is_expected.to be_html_safe }
+    end
+
+    context 'when the declarable has no supplementary unit and the uk declarable does' do
+      let(:declarable) { build(:commodity) }
+      let(:uk_declarable) { build(:commodity, :with_supplementary_unit) }
+
+      it { is_expected.to eq(uk_declarable.supplementary_unit) }
+      it { is_expected.to be_html_safe }
+    end
+
+    # Handle cases where the declarable is present on the XI but not on the UK
+    context 'when the uk declarable is nil' do
+      let(:declarable) { build(:commodity) }
+      let(:uk_declarable) { nil }
+
+      it { is_expected.to eq(declarable.supplementary_unit) }
+      it { is_expected.to be_html_safe }
+    end
+  end
 end

--- a/spec/support/shared_examples/a_declarable.rb
+++ b/spec/support/shared_examples/a_declarable.rb
@@ -114,5 +114,49 @@ RSpec.shared_examples 'a declarable' do
         end
       end
     end
+
+    describe '#has_supplementary_unit?' do
+      context 'when there is a supplementary measure' do
+        let(:measures) do
+          [
+            attributes_for(
+              :measure,
+              :import_export_supplementary,
+              :erga_omnes,
+              :with_supplementary_measure_components,
+            ),
+          ]
+        end
+
+        it { is_expected.to be_has_supplementary_unit }
+      end
+
+      context 'when there is no official supplementary measure but there are excise units' do
+        let(:measures) do
+          [
+            attributes_for(
+              :measure,
+              :excise,
+              :erga_omnes,
+              :with_supplementary_measure_components,
+            ),
+          ]
+        end
+
+        it { is_expected.to be_has_supplementary_unit }
+      end
+
+      context 'when there are no supplementary measures' do
+        let(:measures) { [attributes_for(:measure)] }
+
+        it { is_expected.not_to be_has_supplementary_unit }
+      end
+
+      context 'when there are no measures' do
+        let(:measures) { [] }
+
+        it { is_expected.not_to be_has_supplementary_unit }
+      end
+    end
   end
 end

--- a/spec/views/context_tables/commodity.html.erb_spec.rb
+++ b/spec/views/context_tables/commodity.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'shared/context_tables/_commodity', type: :view, vcr: { cassette_
 
   before do
     allow(view).to receive(:declarable).and_return(declarable)
+    allow(view).to receive(:uk_declarable).and_return(declarable)
     assign(:search, search)
   end
 

--- a/spec/views/context_tables/heading.html.erb_spec.rb
+++ b/spec/views/context_tables/heading.html.erb_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe 'shared/context_tables/_heading', type: :view, vcr: { cassette_na
   subject { render }
 
   before do
+    allow(view).to receive(:declarable).and_return(heading)
+    allow(view).to receive(:uk_declarable).and_return(heading)
     assign(:heading, heading)
     assign(:search, search)
   end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3050

**Before**

![image](https://user-images.githubusercontent.com/8156884/234314902-6a52a749-cb5e-416f-b57a-9aa28f051e93.png)

**After**

![image](https://user-images.githubusercontent.com/8156884/234315023-0e78bed3-5797-415b-9d35-476ab14a0a91.png)

### What?

I have added/removed/altered:

- [x] Added support for showing excise supplementary units on the XI service

### Why?

I am doing this because:

- This is required after customer confusion
