### PR TITLE
HOTT-3106: Set max width in markdown images on desktop and mobile

### DIFF
--- a/app/views/rules_of_origin/steps/show.html.erb
+++ b/app/views/rules_of_origin/steps/show.html.erb
@@ -4,7 +4,7 @@
   <%= back_link step_path(wizard.previous_key) %>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds rules-of-origin__step-col">
       <%= render current_step.key, current_step: current_step, wizard: wizard %>
     </div>
 

--- a/app/webpacker/src/stylesheets/_rules_of_origin.scss
+++ b/app/webpacker/src/stylesheets/_rules_of_origin.scss
@@ -48,7 +48,7 @@
   }
 }
 
-.tariff-markdown {
+.rules-of-origin__step-col .tariff-markdown {
   img {
     max-width: 75%;
   }

--- a/app/webpacker/src/stylesheets/_rules_of_origin.scss
+++ b/app/webpacker/src/stylesheets/_rules_of_origin.scss
@@ -47,3 +47,15 @@
     margin-bottom: 0;
   }
 }
+
+.tariff-markdown {
+  img {
+    max-width: 75%;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    img {
+      max-width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3106

### What?

I have added/removed/altered:

- [x] Set max width in markdown images on desktop and mobile

### Why?

I am doing this because:

- the images were displaying incorrectly

### Screenshots

![Screenshot from 2023-05-12 14-32-13](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/0b035976-bdfd-4a6e-8f5c-97086d79dbe1)
![Screenshot from 2023-05-12 14-32-00](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/fbc3e6df-93d9-40ac-b773-278b3560fa93)
![Screenshot from 2023-05-12 14-31-41](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/a8c7f0ca-8a3f-431c-b67b-2225955e8f0c)
![Screenshot from 2023-05-12 14-30-30](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/4fe8a37b-55e9-4e4e-ae79-0540bae9394f)

