### PR TITLE
HOTT-3165 Redefine max size of cookies to be lower

### DIFF
--- a/config/initializers/patch_max_cookie_size.rb
+++ b/config/initializers/patch_max_cookie_size.rb
@@ -1,0 +1,12 @@
+# As best as I can tell there is a Rails bug - it calculates size of the
+# encrypted cookie jar pre-encoding, and without cookie name + flags
+#
+# Both firefox and chrome are rejecting cookies in the ~4000 bytes range as
+# as being over 4096 which I think is an artifact of encrypted cookies having
+# lots of slashes, and each gets encode as %2F taking up more bytes then are
+# included in Rails' calculation
+
+ActionDispatch::Cookies.class_eval do
+  remove_const 'MAX_COOKIE_SIZE' if const_defined?('MAX_COOKIE_SIZE')
+  const_set 'MAX_COOKIE_SIZE', 3850
+end


### PR DESCRIPTION
### Jira link

HOTT-3165

### What?

I have added/removed/altered:

- [x] Redefine the max size of cookies to be a lower value

### Why?

I am doing this because:

- This works around a rails bug. Rails is computing the cookie size lower than browsers. This means rails thinks the cookie is valid but browsers are still rejecting them as being over 4kb
- I _think_ this is caused by rails computing the cookie size pre-encoding but browsers computing the size post encoding. This probably wasn't much of a problem with signed cookies because there weren't many non ASCII characters but with encrypted cookies the prevalance of characters requiring encoding greatly increases - and the greater the occurrance of these, the greater the skew in size calculation between server and client

### Notes

This isn't a 'correct' fix - it attempts to offset for skew between server and client size calculations whilst also not wasting too much of the available cookie size _but_ ultimately the level of skew is a result of the content being encoded, which itself is a product of how the original data is encrypted. So just offsetting may well be insufficient in some cases. 

The correct fix is to improve rails' calculation but because the information require is not available with `ActionDispatch::Cookies` this isn't particularly easy to resolve.

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Patches the max size rails allows for cookies
