### PR TITLE
HOTT-3166 Garbage collect wizard sessions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ class ApplicationController < ActionController::Base
   before_action :set_path_info
   before_action :set_search
   before_action :bots_no_index_if_historical
+  after_action :gc_session_data
 
   layout :set_layout
 
@@ -151,5 +152,9 @@ class ApplicationController < ActionController::Base
 
   def beta_search_enabled?
     !!session[:beta_search_enabled]
+  end
+
+  def gc_session_data
+    RulesOfOrigin::WizardStore.gc_store_data(session)
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,6 +4,7 @@ class ErrorsController < ApplicationController
   skip_before_action :set_path_info
   skip_before_action :set_search
   skip_before_action :bots_no_index_if_historical
+  skip_after_action :gc_session_data
 
   before_action :disable_search_form, :disable_switch_service_banner
 

--- a/app/controllers/rules_of_origin/steps_controller.rb
+++ b/app/controllers/rules_of_origin/steps_controller.rb
@@ -26,7 +26,11 @@ module RulesOfOrigin
     private
 
     def wizard_store_key
-      "rules_of_origin-#{params['commodity']}-#{params['country']}"
+      "#{params['commodity']}-#{params['country']}"
+    end
+
+    def wizard_store
+      RulesOfOrigin::WizardStore.new(session, wizard_store_key)
     end
 
     def step_path(step_id = params[:id], ...)

--- a/app/models/rules_of_origin/wizard_store.rb
+++ b/app/models/rules_of_origin/wizard_store.rb
@@ -3,6 +3,17 @@ module RulesOfOrigin
     PREFIX = 'rules_of_origin-'.freeze
     MAX_JOURNEYS = 5
 
+    class << self
+      def gc_store_data(backing_store)
+        backing_store.keys
+                     .select { |k| k.start_with? PREFIX }
+                     .sort_by { |k| backing_store[k]['modified'] || '2022-01-01T00:00:00Z' }
+                     .reverse
+                     .slice(MAX_JOURNEYS..)
+                     &.each { |k| backing_store.delete k }
+      end
+    end
+
     def initialize(backing_store, key)
       @backing_store = backing_store
       @backing_store["#{PREFIX}#{key}"] ||= {}
@@ -12,19 +23,8 @@ module RulesOfOrigin
 
     def persist(attributes)
       super(attributes.merge('modified' => Time.zone.now.iso8601)).tap do
-        gc_old_data
+        self.class.gc_store_data(@backing_store)
       end
-    end
-
-  private
-
-    def gc_old_data
-      @backing_store.keys
-                    .select { |k| k.start_with? PREFIX }
-                    .sort_by { |k| @backing_store[k]['modified'] || '2022-01-01T00:00:00Z' }
-                    .reverse
-                    .slice(MAX_JOURNEYS..)
-                    &.each { |k| @backing_store.delete k }
     end
   end
 end

--- a/app/models/rules_of_origin/wizard_store.rb
+++ b/app/models/rules_of_origin/wizard_store.rb
@@ -1,0 +1,30 @@
+module RulesOfOrigin
+  class WizardStore < ::WizardSteps::Store
+    PREFIX = 'rules_of_origin-'.freeze
+    MAX_JOURNEYS = 5
+
+    def initialize(backing_store, key)
+      @backing_store = backing_store
+      @backing_store["#{PREFIX}#{key}"] ||= {}
+
+      super @backing_store["#{PREFIX}#{key}"]
+    end
+
+    def persist(attributes)
+      super(attributes.merge('modified' => Time.zone.now.iso8601)).tap do
+        gc_old_data
+      end
+    end
+
+  private
+
+    def gc_old_data
+      @backing_store.keys
+                    .select { |k| k.start_with? PREFIX }
+                    .sort_by { |k| @backing_store[k]['modified'] || '2022-01-01T00:00:00Z' }
+                    .reverse
+                    .slice(MAX_JOURNEYS..)
+                    &.each { |k| @backing_store.delete k }
+    end
+  end
+end

--- a/spec/models/rules_of_origin/wizard_store_spec.rb
+++ b/spec/models/rules_of_origin/wizard_store_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe RulesOfOrigin::WizardStore do
+  subject(:store) { described_class.new backing_store, 'testkey' }
+
+  let(:backing_store) { {} }
+
+  describe '#initialize' do
+    it { is_expected.to be_instance_of described_class }
+  end
+
+  describe '#persist' do
+    subject { backing_store['rules_of_origin-testkey'] }
+
+    before do
+      freeze_time
+      store.persist 'foo' => 'bar'
+    end
+
+    it { is_expected.to include 'foo' => 'bar' }
+    it { is_expected.to include 'modified' => Time.zone.now.utc.iso8601 }
+  end
+
+  describe 'garbage collection' do
+    subject { backing_store.keys }
+
+    before { store.persist 'c' => 'd' }
+
+    context 'with nothing to collect' do
+      let :backing_store do
+        {
+          'rules_of_origin-older' => {
+            'a' => 'b',
+            'modified' => 1.minute.ago.utc.iso8601,
+          },
+        }
+      end
+
+      it { is_expected.to include 'rules_of_origin-testkey' }
+      it { is_expected.to include 'rules_of_origin-older' }
+    end
+
+    context 'with old records to collect' do
+      let :backing_store do
+        {}.tap do |store|
+          1.upto(8) do |i|
+            store["rules_of_origin-old#{i}"] = {
+              'a' => 'b',
+              'modified' => i.minutes.ago.utc.iso8601,
+            }
+          end
+        end
+      end
+
+      it { is_expected.to have_attributes length: 5 }
+      it { is_expected.to include 'rules_of_origin-testkey' }
+      it { is_expected.to include 'rules_of_origin-old1' }
+      it { is_expected.to include 'rules_of_origin-old4' }
+      it { is_expected.not_to include 'rules_of_origin-old5' }
+      it { is_expected.not_to include 'rules_of_origin-old8' }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,6 +56,7 @@ RSpec.configure do |config|
   config.include Capybara::DSL
   config.include ApiResponsesHelper
   config.include Shoulda::Matchers::ActiveModel
+  config.include ActiveSupport::Testing::TimeHelpers
 
   config.include_context 'with switch service banner', type: :view
 


### PR DESCRIPTION
### Jira link

HOTT-3166

### What?

I have added/removed/altered:

- [x] Added a custom wizard store which garbage collects old journeys

### Why?

I am doing this because:

- We are overflowing the cookie size because our sessions are long lived

### Deployment risks (optional)

- Removes user session data
