### PR TITLE
HOTT-3166 Remove global session gc

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,6 @@ class ApplicationController < ActionController::Base
   before_action :set_path_info
   before_action :set_search
   before_action :bots_no_index_if_historical
-  after_action :gc_session_data
 
   layout :set_layout
 
@@ -152,9 +151,5 @@ class ApplicationController < ActionController::Base
 
   def beta_search_enabled?
     !!session[:beta_search_enabled]
-  end
-
-  def gc_session_data
-    RulesOfOrigin::WizardStore.gc_store_data(session)
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,7 +4,6 @@ class ErrorsController < ApplicationController
   skip_before_action :set_path_info
   skip_before_action :set_search
   skip_before_action :bots_no_index_if_historical
-  skip_after_action :gc_session_data
 
   before_action :disable_search_form, :disable_switch_service_banner
 


### PR DESCRIPTION
### Jira link

HOTT-3166

### What?

I have added/removed/altered:

- [x] Remove the global GCing of Rules of Origin wizard session data

### Why?

I am doing this because:

- This was a temporary fix for allowing sessions to have accumulated to many journeys, and shouldn't be needed going forward

### Deployment risks (optional)

- Low
