### PR TITLE
Fix failing frontend search specs

### DIFF
--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe SearchController, type: :controller do
 
       before do
         controller.session[:beta_search_enabled] = false
-        get :search, params: { q: query }, format: :atom
+        get :search, params: { q: query, day: '11', month: '5', year: '2023' }, format: :atom
       end
 
       specify 'includes link to current page (self link)' do


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Use specific date for search specs

### Why?

I am doing this because:

- VCR responses were tied to a specific date

