### PR TITLE
HOTT-3185 Show RoO footnotes

### DIFF
--- a/app/models/rules_of_origin/steps/product_specific_rules.rb
+++ b/app/models/rules_of_origin/steps/product_specific_rules.rb
@@ -25,7 +25,8 @@ module RulesOfOrigin
     private
 
       def none_option
-        Struct.new(:resource_id, :rule).new('none', none_option_text)
+        Struct.new(:resource_id, :rule, :footnotes)
+              .new('none', none_option_text, [])
       end
 
       def none_option_text

--- a/app/models/rules_of_origin/v2_rule.rb
+++ b/app/models/rules_of_origin/v2_rule.rb
@@ -6,10 +6,18 @@ class RulesOfOrigin::V2Rule
   WHOLLY_OBTAINED_CLASS = 'WO'.freeze
 
   attr_accessor :rule, :operator
-  attr_writer :rule_class
+  attr_writer :rule_class, :footnotes
 
   def rule_class
     @rule_class ||= []
+  end
+
+  def footnotes
+    @footnotes ||= []
+  end
+
+  def all_footnotes
+    footnotes.join("\n\n").presence
   end
 
   def only_wholly_obtained_class?

--- a/app/views/rules_of_origin/_product_specific_rules.html.erb
+++ b/app/views/rules_of_origin/_product_specific_rules.html.erb
@@ -21,6 +21,7 @@
         </th>
       </tr>
     </thead>
+
     <tbody class="govuk-table__body">
       <% rule_sets.each do |rule_set| %>
       <tr class="govuk-table__row">
@@ -36,7 +37,13 @@
 
         <td class="govuk-table__cell tariff-markdown responsive-full-width" data-label="Rule">
           <% rule_set.rules.each do |rule| %>
-            <%= govspeak link_glossary_terms(rule.rule) %>
+            <% if rule.footnotes.any? %>
+              <%= render 'shared/details',
+                         summary: rule.rule,
+                         content: govspeak(rule.all_footnotes) %>
+            <% else %>
+              <%= govspeak link_glossary_terms(rule.rule) %>
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
+++ b/app/views/rules_of_origin/steps/_product_specific_rules.html.erb
@@ -3,7 +3,15 @@
         :rule,
         form.object.options,
         :resource_id,
-        ->(option) { govspeak link_glossary_terms option.rule } %>
+        ->(option) do
+          if option.footnotes.any?
+            render 'shared/details',
+                   summary: option.rule,
+                   content: govspeak(option.all_footnotes)
+          else
+            govspeak link_glossary_terms option.rule
+          end
+        end %>
 
   <div class="tariff-markdown">
     <%= govspeak t '.body', scheme_title: form.object.scheme_title %>

--- a/spec/factories/rules_of_origin/rule_factory.rb
+++ b/spec/factories/rules_of_origin/rule_factory.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
     sequence(:heading) { |n| "Chapter #{n}" }
     description { 'Description' }
     rule { 'Rule' }
+    footnotes { [] }
+
+    trait :with_footnote do
+      footnotes { ['This is a footnote'] }
+    end
   end
 end

--- a/spec/factories/rules_of_origin/v2_rule_factory.rb
+++ b/spec/factories/rules_of_origin/v2_rule_factory.rb
@@ -7,5 +7,13 @@ FactoryBot.define do
     trait :wholly_obtained do
       rule_class { %w[WO] }
     end
+
+    trait :with_markdown do
+      rule { '[Chapter&nbsp;1](/some/where)' }
+    end
+
+    trait :with_footnote do
+      footnotes { ['This is a **footnote**'] }
+    end
   end
 end

--- a/spec/models/rules_of_origin/v2_rule_spec.rb
+++ b/spec/models/rules_of_origin/v2_rule_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe RulesOfOrigin::V2Rule do
   it { is_expected.to respond_to :rule }
   it { is_expected.to respond_to :rule_class }
   it { is_expected.to respond_to :operator }
+  it { is_expected.to respond_to :footnotes }
 
   describe '#only_wholly_obtained_class?' do
     subject { described_class.new(rule_class:).only_wholly_obtained_class? }
@@ -30,6 +31,22 @@ RSpec.describe RulesOfOrigin::V2Rule do
       let(:rule_class) { %w[WO] }
 
       it { is_expected.to be true }
+    end
+  end
+
+  describe '#all_footnotes' do
+    subject { rule.all_footnotes }
+
+    context 'with no footnotes' do
+      let(:rule) { build :rules_of_origin_v2_rule, footnotes: [] }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with footnotes' do
+      let(:rule) { build :rules_of_origin_v2_rule, footnotes: %w[one two] }
+
+      it { is_expected.to eq "one\n\ntwo" }
     end
   end
 end

--- a/spec/views/rules_of_origin/_product_specific_rules.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_product_specific_rules.html.erb_spec.rb
@@ -31,4 +31,12 @@ RSpec.describe 'rules_of_origin/_product_specific_rules', type: :view do
     it { is_expected.to have_content 'no product-specific rules' }
     it { is_expected.not_to have_css 'table' }
   end
+
+  context 'with footnotes on the rules' do
+    let(:rule_sets) { build_list :rules_of_origin_rule_set, 1, rules: }
+    let(:rules) { attributes_for_list :rules_of_origin_v2_rule, 1, :with_footnote }
+
+    it { is_expected.to have_css 'td details summary', text: rules.first[:rule] }
+    it { is_expected.to have_css 'td details .govuk-details__text *' }
+  end
 end

--- a/spec/views/rules_of_origin/product_specific_rules/index.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/product_specific_rules/index.html.erb_spec.rb
@@ -68,5 +68,18 @@ RSpec.describe 'rules_of_origin/product_specific_rules/index', type: :view do
       it { is_expected.to have_css 'td', text: %r{#{ruleset.rules.first.rule}} }
       it { is_expected.not_to have_css 'tbody tr td:nth-of-type(3)' }
     end
+
+    context 'with footnotes on the rules' do
+      let :schemes do
+        build_list :rules_of_origin_scheme, 1, rule_sets: [
+          attributes_for(:rules_of_origin_rule_set, rules: [
+            attributes_for(:rules_of_origin_rule, :with_footnote),
+          ]),
+        ]
+      end
+
+      it { is_expected.to have_css 'td details summary', text: %r{\w+} }
+      it { is_expected.to have_css 'td details .govuk-details__text *' }
+    end
   end
 end

--- a/spec/views/rules_of_origin/steps/_product_specific_rules.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_product_specific_rules.html.erb_spec.rb
@@ -36,12 +36,23 @@ RSpec.describe 'rules_of_origin/steps/_product_specific_rules', type: :view do
     end
 
     let(:rule_sets) { attributes_for_list :rules_of_origin_rule_set, 1, rules: }
-
-    let :rules do
-      attributes_for_list :rules_of_origin_v2_rule, 1,
-                          rule: '[Chapter&nbsp;1](/some/where)'
-    end
+    let(:rules) { attributes_for_list :rules_of_origin_v2_rule, 1, :with_markdown }
 
     it { is_expected.to have_css 'fieldset label a', text: /Chapter.*1/ }
+  end
+
+  context 'with footnotes on rule' do
+    let :schemes do
+      build_list :rules_of_origin_scheme, 1,
+                 countries: [country.id],
+                 rule_sets:,
+                 articles:
+    end
+
+    let(:rule_sets) { attributes_for_list :rules_of_origin_rule_set, 1, rules: }
+    let(:rules) { attributes_for_list :rules_of_origin_v2_rule, 1, :with_footnote, rule: 'Test' }
+
+    it { is_expected.to have_css 'fieldset label details summary', text: 'Test' }
+    it { is_expected.to have_css 'fieldset label details .govuk-details__text *' }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-3185

### What?

I have added/removed/altered:

- [x] Show the RoO footnotes on the Rules of Origin rules table
- [x] Show the RoO footnotes on the Product Specific Rules step of the RoO wizard
- [x] Show the RoO footnotes on the Rules of Origin page for all schemes for a given commodity

### Why?

I am doing this because:

- We want to show the footnotes to our users to provide them with further information

### Deployment risks (optional)

- Low

### Screenshots

![Screenshot from 2023-05-15 14-08-44](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/ad445bad-04a3-498d-a4fd-fffcf7b7325e)
![Screenshot from 2023-05-15 14-08-27](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/08bcff95-02e9-44fa-996f-9ffa826e0428)
![Screenshot from 2023-05-15 14-08-13](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/e212b2db-e257-46c4-acdf-483c83f889f7)
