### PR TITLE
HOTT-3197 Don't match bad urls to RoO wizard

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,12 +95,13 @@ Rails.application.routes.draw do
   resources :news_items, only: %i[index show], path: '/news'
 
   namespace :rules_of_origin, path: nil do
-    get '/rules_of_origin/:commodity/:country', to: 'steps#index', as: :steps
-    get '/rules_of_origin/:commodity/:country/:id', to: 'steps#show', as: :step
-    patch '/rules_of_origin/:commodity/:country/:id', to: 'steps#update', as: nil
-    get '/rules_of_origin/:commodity', constraints: { commodity: /\d{10}/ },
-                                       to: 'product_specific_rules#index',
-                                       as: :product_specific_rules
+    with_options constraints: { commodity: /\d{10}/ } do
+      get '/rules_of_origin/:commodity/:country', to: 'steps#index', as: :steps
+      get '/rules_of_origin/:commodity/:country/:id', to: 'steps#show', as: :step
+      patch '/rules_of_origin/:commodity/:country/:id', to: 'steps#update', as: nil
+      get '/rules_of_origin/:commodity', to: 'product_specific_rules#index',
+                                         as: :product_specific_rules
+    end
     get '/rules_of_origin/proofs', to: 'proofs#index', as: :proofs
   end
 

--- a/spec/requests/rules_of_origin/steps_controller_spec.rb
+++ b/spec/requests/rules_of_origin/steps_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RulesOfOrigin::StepsController, type: :request do
     end
 
     context 'with missing params' do
-      before { get rules_of_origin_step_path(' ', ' ', 'start') }
+      before { get rules_of_origin_step_path('1234567890', ' ', 'start') }
 
       it { is_expected.to redirect_to find_commodity_path }
     end


### PR DESCRIPTION
### Jira link

HOTT-3197

### What?

I have added/removed/altered:

- [x] Added constraints to the url mapping for the rules of origin wizard

### Why?

I am doing this because:

- Incorrect urls under `/rules_of_origin/` always got routed to the wizard, which then did an invalid redirect on the incomplete url

### Deployment risks (optional)

- Low, should only impact users following invalid urls
