### PR TITLE
HOTT-3228: Exclude measure components without a qualifier in supplementary unit

### DIFF
--- a/app/services/declarable_unit_service.rb
+++ b/app/services/declarable_unit_service.rb
@@ -45,7 +45,7 @@ class DeclarableUnitService
 
     units = measures.each_with_object({}) do |measure, acc|
       measure.measure_components.each do |component|
-        next if component.measurement_unit.blank?
+        next if component.measurement_unit.blank? || component.measurement_unit_qualifier.blank?
 
         id = component.measurement_unit.resource_id.to_s
         id += "-#{component.measurement_unit_qualifier.resource_id}" if component.measurement_unit_qualifier.present?

--- a/spec/factories/measure_component_factory.rb
+++ b/spec/factories/measure_component_factory.rb
@@ -29,6 +29,10 @@ FactoryBot.define do
       measurement_unit do
         attributes_for(:measurement_unit, :hectokilogram)
       end
+
+      measurement_unit_qualifier do
+        attributes_for(:measurement_unit_qualifier)
+      end
     end
   end
 end

--- a/spec/factories/measurement_unit_qualifier_factory.rb
+++ b/spec/factories/measurement_unit_qualifier_factory.rb
@@ -1,0 +1,9 @@
+require 'api_entity'
+
+FactoryBot.define do
+  factory :measurement_unit_qualifier do
+    resource_id { 'E' }
+    description { 'of drained net weight' }
+    formatted_description { 'of drained net weight' }
+  end
+end

--- a/spec/services/declarable_unit_service_spec.rb
+++ b/spec/services/declarable_unit_service_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe DeclarableUnitService do
         let(:country) { 'FR' }
         let(:uk_import_measures) { [attributes_for(:measure, :third_country, :with_measurement_unit_measure_components)] }
 
-        it { is_expected.to include('hectokilogram') }
+        it { is_expected.to include('hectokilogram of drained net weight') }
       end
 
       context 'when the country is provided and there are excise measures' do
         let(:country) { 'FR' }
         let(:uk_import_measures) { [attributes_for(:measure, :excise, :with_measurement_unit_measure_components)] }
 
-        it { is_expected.to include('hectokilogram') }
+        it { is_expected.to include('hectokilogram of drained net weight') }
       end
 
       context 'when there are no excise or unit measures' do
@@ -59,14 +59,14 @@ RSpec.describe DeclarableUnitService do
           ]
         end
 
-        it { is_expected.to include('hectokilogram') }
+        it { is_expected.to include('hectokilogram of drained net weight') }
       end
 
       context 'when the country is not provided and there are excise measures' do
         let(:country) { nil }
         let(:uk_import_measures) { [attributes_for(:measure, :excise, :with_measurement_unit_measure_components)] }
 
-        it { is_expected.to include('hectokilogram') }
+        it { is_expected.to include('hectokilogram of drained net weight') }
       end
 
       context 'when the country is not provided and there are no excise or unit measures' do
@@ -90,14 +90,14 @@ RSpec.describe DeclarableUnitService do
         let(:country) { 'FR' }
         let(:xi_import_measures) { [attributes_for(:measure, :third_country, :with_measurement_unit_measure_components)] }
 
-        it { is_expected.to include('hectokilogram') }
+        it { is_expected.to include('hectokilogram of drained net weight') }
       end
 
       context 'when the country is provided and there are excise measures' do
         let(:country) { 'FR' }
         let(:uk_import_measures) { [attributes_for(:measure, :excise, :with_measurement_unit_measure_components)] }
 
-        it { is_expected.to include('hectokilogram') }
+        it { is_expected.to include('hectokilogram of drained net weight') }
       end
 
       context 'when there are no excise or unit measures' do
@@ -125,14 +125,14 @@ RSpec.describe DeclarableUnitService do
           ]
         end
 
-        it { is_expected.to include('hectokilogram') }
+        it { is_expected.to include('hectokilogram of drained net weight') }
       end
 
       context 'when the country is not provided and there are excise measures' do
         let(:country) { nil }
         let(:uk_import_measures) { [attributes_for(:measure, :excise, :with_measurement_unit_measure_components)] }
 
-        it { is_expected.to include('hectokilogram') }
+        it { is_expected.to include('hectokilogram of drained net weight') }
       end
 
       context 'when the country is not provided and there are no excise or unit measures' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3228

### What?

I have added/removed/altered:

- [x] Added condition which excluded measure components without a qualifier in supplementary unit messaging

### Why?

I am doing this because:

- This was missed from the ticket
