### PR TITLE
HOTT-3264: Handle missing uk declarable in supplementary units

### DIFF
--- a/app/services/declarable_unit_service.rb
+++ b/app/services/declarable_unit_service.rb
@@ -28,7 +28,11 @@ class DeclarableUnitService
 
   def xi_units
     xi_import_measures = xi_declarable.import_measures.excluding_channel_islands
-    uk_excise_measures = uk_declarable.import_measures.excluding_channel_islands.excise.erga_omnes
+    uk_excise_measures = if uk_declarable.present?
+                           uk_declarable.import_measures.excluding_channel_islands.excise.erga_omnes
+                         else
+                           []
+                         end
 
     return xi_import_measures.supplementary.first&.measure_components&.first&.unit_for_classification if xi_import_measures.supplementary.any?
 

--- a/spec/services/declarable_unit_service_spec.rb
+++ b/spec/services/declarable_unit_service_spec.rb
@@ -141,6 +141,13 @@ RSpec.describe DeclarableUnitService do
 
         it { is_expected.to eq('There are no supplementary unit measures assigned to this commodity') }
       end
+
+      context 'when the uk declarable is nil and there are no excise or unit measures' do
+        let(:uk_declarable) { nil }
+        let(:xi_import_measures) { [] }
+
+        it { is_expected.to eq('There are no supplementary unit measures assigned to this commodity') }
+      end
     end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3274

### What?

I have added/removed/altered:

- [x] Added handling for missing uk declarable when pulling units for the supplementary classification

### Why?

I am doing this because:

- This is required to resolve an issue with expired uk declarables that are current on the xi service

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (low)

- This will fix an edge case loading xi declarables with missing uk declarables
