### PR TITLE
HOTT-3229 fixed over wide tables in markdown

### DIFF
--- a/app/webpacker/src/stylesheets/_markdown.scss
+++ b/app/webpacker/src/stylesheets/_markdown.scss
@@ -45,4 +45,9 @@
   &--reduced-trailing-margin > p:last-of-type {
     @include govuk-responsive-margin(2, "bottom");
   }
+
+  .scroll-x {
+    max-width: 100%;
+    overflow-x: scroll;
+  }
 }

--- a/config/initializers/govspeak_extensions.rb
+++ b/config/initializers/govspeak_extensions.rb
@@ -1,0 +1,4 @@
+Govspeak::PostProcessor.extension 'wrap tables in divs' do |document|
+  document.css('table')
+          .wrap('<div class="scroll-x">')
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe ApplicationHelper, type: :helper do
         EOSOURCE
       end
 
-      it { is_expected.to have_css 'table thead tr th', count: 2 }
-      it { is_expected.to have_css 'table tbody tr td', count: 2 }
+      it { is_expected.to have_css 'div.scroll-x table thead tr th', count: 2 }
+      it { is_expected.to have_css 'div.scroll-x table tbody tr td', count: 2 }
     end
   end
 


### PR DESCRIPTION
### Jira link

HOTT-3229

### What?

I have added/removed/altered:

- [x] Refactored the specs for `govspeak` helper
- [x] Added Govspeak extension to wrap tables in a `<div>`
- [x] Added CSS to horizontally scroll that `<div>`

### Why?

I am doing this because:

- If tables are wider then their container they overflow the container instead of scrolling

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Mid, changes all govspeak rendered tables to be wrapped in a `<div`>
