### PR TITLE
HOTT-3278 Hide uk only link

### DIFF
--- a/app/views/measures/_export_tab_check_duties.html.erb
+++ b/app/views/measures/_export_tab_check_duties.html.erb
@@ -1,24 +1,30 @@
-<div class="govuk-inset-text govuk-inset-text--s feature-panel--shaded explainer">
-    <h3>Check duties and customs procedures for exporting goods</h3>
+<div class="govuk-inset-text govuk-inset-text--s feature-panel--shaded explainer" data-controller="uk-only">
+  <h3>Check duties and customs procedures for exporting goods</h3>
 
+  <p>
     <% if eu_member %>
-      <p>Find information about how to move goods from the UK to <%= country_name %>.</p>
+      Find information about how to move goods from the UK to <%= country_name %>.
     <% else %>
-      <p>Find information about how to move goods from the UK to the rest of the world.</p>
+      Find information about how to move goods from the UK to the rest of the world.
     <% end %>
+  </p>
 
-    <p>Use this service to check:</p>
+  <p>Use this service to check:</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-        <li>rules and restrictions</li>
-        <li>tax and duty rates</li>
-        <li>what exporting documents you need</li>
-    </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>rules and restrictions</li>
+    <li>tax and duty rates</li>
+    <li>what exporting documents you need</li>
+  </ul>
 
-    <p>
-      <%= check_how_to_export_goods_link(declarable: declarable,
-                                         country_code: country_code,
-                                         country_name: country_name,
-                                         eu_member: eu_member ) %>
-    </p>
+  <p>
+    This service is only available in the UK due to licencing restrictions;
+  </p>
+
+  <p>
+    <%= check_how_to_export_goods_link(declarable: declarable,
+                                       country_code: country_code,
+                                       country_name: country_name,
+                                       eu_member: eu_member ) %>
+  </p>
 </div>

--- a/app/webpacker/controllers/tree_controller.js
+++ b/app/webpacker/controllers/tree_controller.js
@@ -26,8 +26,6 @@ export default class extends Controller {
     const commodityNode = event.currentTarget;
     const childList = commodityNode.parentElement.querySelector('ul');
 
-    console.log('running toggle node with childList aria-hidden', childList.getAttribute('aria-hidden'));
-
     if (childList.getAttribute('aria-hidden') == 'true') {
       this.#openBranch(commodityNode, childList);
     } else {

--- a/app/webpacker/controllers/uk_only_controller.js
+++ b/app/webpacker/controllers/uk_only_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    if (!this.userInUk())
+      this.removeUkOnlyContent()
+  }
+
+  removeUkOnlyContent() {
+    this.element.remove()
+  }
+
+  userInUk() {
+    return this.timeZone() == 'Europe/London'
+  }
+
+  timeZone() {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone
+  }
+}

--- a/spec/javascript/controllers/uk_only_controller_spec.js
+++ b/spec/javascript/controllers/uk_only_controller_spec.js
@@ -1,0 +1,51 @@
+import { Application } from '@hotwired/stimulus' ;
+import UkOnlyController from 'uk_only_controller.js' ;
+
+describe('UkOnlyController', () => {
+  const template = `
+    <div>
+      <p class="pre">Some Content</p>
+
+      <div data-controller="uk-only">
+        <p class="to-hide">Hidden Content</p>
+      </div>
+    </div>
+  `
+
+  const application = Application.start()
+  application.register('uk-only', UkOnlyController)
+
+  beforeEach(() => document.body.innerHTML = template)
+
+  describe('visibility', () => {
+    describe('when in UK', () => {
+      beforeEach(() => {
+        jest.spyOn(UkOnlyController.prototype, 'timeZone')
+            .mockImplementationOnce(() => 'Europe/London')
+      })
+
+      it('shows pre content', () => {
+        expect(document.querySelector('p.pre').textContent).toBe('Some Content')
+      })
+
+      it('shows content to hide', () => {
+        expect(document.querySelector('p.to-hide').textContent).toBe('Hidden Content')
+      })
+    })
+
+    describe('when outside UK', () => {
+      beforeEach(() => {
+        jest.spyOn(UkOnlyController.prototype, 'timeZone')
+            .mockImplementationOnce(() => 'Europe/Paris')
+      })
+
+      it('shows pre content', () => {
+        expect(document.querySelector('p.pre').textContent).toBe('Some Content')
+      })
+
+      it('hides content to hide', () => {
+        expect(document.querySelector('p.to-hide')).toBeNull()
+      })
+    })
+  })
+})


### PR DESCRIPTION
### Jira link

HOTT-3278

### What?

I have added/removed/altered:

- [x] Added a UkOnly stimulus controller to remove content from the page which isn't valid for other regions
- [x] Use it to hide the link to the CHEG service

### Why?

I am doing this because:

- That service is georestricted so linking to it for users outside the UK is not useful

### Deployment risks (optional)

- Limited: if users timezones are not 'Europe/London' then they will lose access to the link

### Screenshots

In UK

![Screenshot from 2023-06-01 16-43-28](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/81344db7-7424-48d4-b160-d325de575304)

Outside UK

![Screenshot from 2023-06-01 15-57-30](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/43e5b88d-44c7-4648-8366-08278b549d92)

