### PR TITLE
HOTT-3305 Show CDS rules on Rules of Origin tab

### DIFF
--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -50,4 +50,8 @@ class RulesOfOrigin::Scheme
   def proof_codes
     @proof_codes ||= {}
   end
+
+  def cds_proof_info?
+    proof_intro.present? || proof_codes&.any?
+  end
 end

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -6,7 +6,10 @@ class RulesOfOrigin::Scheme
   collection_path '/rules_of_origin_schemes'
 
   attr_accessor :scheme_code, :title, :countries, :footnote, :fta_intro,
-                :introductory_notes, :unilateral, :cumulation_methods
+                :introductory_notes, :unilateral, :cumulation_methods,
+                :proof_intro
+
+  attr_writer :proof_codes
 
   has_many :rules, class_name: 'RulesOfOrigin::Rule'
   has_many :links, class_name: 'RulesOfOrigin::Link'
@@ -42,5 +45,9 @@ class RulesOfOrigin::Scheme
 
   def agreement_link
     links.find { |link| link.source == 'scheme' }&.url
+  end
+
+  def proof_codes
+    @proof_codes ||= {}
   end
 end

--- a/app/views/rules_of_origin/_cds_proof_info.html.erb
+++ b/app/views/rules_of_origin/_cds_proof_info.html.erb
@@ -1,0 +1,39 @@
+<div class="cds-proof-info">
+  <h3 class="govuk-heading-s">
+    Declaring your proof of origin
+  </h3>
+
+  <div class="tariff-markdown scheme-proof-intro">
+    <%= govspeak scheme.proof_intro if scheme.proof_intro.present? %>
+  </div>
+
+  <% if scheme.proof_codes&.any? %>
+    <table class="govuk-table govuk-table--responsive scheme-proof-codes">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">
+            CDS Data Element (DE)
+          </th>
+
+          <th class="govuk-table__header" scope="col">
+            What you must include
+          </th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        <% scheme.proof_codes.each do |code, description| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell" data-label="CDS Data Element">
+            <%= code %>
+          </td>
+
+          <td class="govuk-table__cell tariff-markdown responsive-full-width" data-label="What you must include">
+            <%= govspeak description %>
+          </td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</div>

--- a/app/views/rules_of_origin/_proofs.html.erb
+++ b/app/views/rules_of_origin/_proofs.html.erb
@@ -18,6 +18,8 @@
                                      content: govspeak(proof.content) %>
       <% end %>
     </div>
+
+    <%= render 'rules_of_origin/cds_proof_info', scheme: scheme if scheme.cds_proof_info? %>
   <% end %>
 
   <% if schemes.many? || schemes.none? %>

--- a/spec/factories/rules_of_origin/scheme_factory.rb
+++ b/spec/factories/rules_of_origin/scheme_factory.rb
@@ -65,5 +65,16 @@ FactoryBot.define do
           rules: attributes_for_list(:rules_of_origin_v2_rule, 1, :wholly_obtained)
       end
     end
+
+    trait :with_cds_proof_info do
+      proof_intro { 'Some intro text' }
+
+      proof_codes do
+        {
+          'abc' => 'Description **with markdown**',
+          'def' => 'Second description',
+        }
+      end
+    end
   end
 end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -126,6 +126,8 @@ RSpec.describe RulesOfOrigin::Scheme do
   it { is_expected.to respond_to :rule_sets }
   it { is_expected.to respond_to :origin_reference_document }
   it { is_expected.to respond_to :cumulation_methods }
+  it { is_expected.to respond_to :proof_intro }
+  it { is_expected.to respond_to :proof_codes }
 
   describe '.for_heading_and_country' do
     shared_context 'with mocked response' do
@@ -393,5 +395,11 @@ RSpec.describe RulesOfOrigin::Scheme do
 
       it { is_expected.to eql scheme.rule_sets[1].rules[0].rule }
     end
+  end
+
+  describe '#proof_codes' do
+    subject { described_class.new }
+
+    it { is_expected.to have_attributes proof_codes: {} }
   end
 end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -402,4 +402,18 @@ RSpec.describe RulesOfOrigin::Scheme do
 
     it { is_expected.to have_attributes proof_codes: {} }
   end
+
+  describe 'cds_proof_info?' do
+    context 'with info' do
+      subject { build(:rules_of_origin_scheme, :with_cds_proof_info).cds_proof_info? }
+
+      it { is_expected.to be true }
+    end
+
+    context 'without info' do
+      subject { build(:rules_of_origin_scheme).cds_proof_info? }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/views/rules_of_origin/_cds_proof_info.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_cds_proof_info.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe 'rules_of_origin/_cds_proof_info', type: :view do
+  subject(:rendered_page) { render_page && rendered }
+
+  let :render_page do
+    render 'rules_of_origin/cds_proof_info', scheme:
+  end
+
+  let(:scheme) { build :rules_of_origin_scheme, :with_cds_proof_info }
+
+  it { is_expected.to have_css '.scheme-proof-intro.tariff-markdown > *' }
+  it { is_expected.to have_css '.govuk-table thead th', count: 2 }
+  it { is_expected.to have_css '.govuk-table tbody td', count: 4 }
+  it { is_expected.to have_css '.govuk-table tbody td.tariff-markdown > *', count: 2 }
+
+  context 'without cds proof info' do
+    let(:scheme) { build :rules_of_origin_scheme }
+
+    it { is_expected.not_to have_css '.scheme-proof-intro *' }
+    it { is_expected.not_to have_css '.govuk-table' }
+  end
+end

--- a/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/_proofs.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'rules_of_origin/_proofs', type: :view do
                                      country_code: 'FR'
   end
 
-  let(:schemes) { build_list :rules_of_origin_scheme, 1, proof_count: 1 }
+  let(:schemes) { build_list :rules_of_origin_scheme, 1, :with_cds_proof_info, proof_count: 1 }
 
   it { is_expected.to have_css '#proofs-of-origin' }
   it { is_expected.to have_css '.govuk-list--bullet li a', count: 3 }
@@ -18,6 +18,7 @@ RSpec.describe 'rules_of_origin/_proofs', type: :view do
   it { is_expected.to have_css 'p', text: /origin is valid/ }
   it { is_expected.to have_css 'details.govuk-details', count: 1 }
   it { is_expected.to have_css 'details .govuk-details__text *' }
+  it { is_expected.to have_css '.cds-proof-info', count: 1 }
 
   context 'with multiple proofs' do
     let(:schemes) { build_list :rules_of_origin_scheme, 1, proof_count: 2 }
@@ -28,11 +29,18 @@ RSpec.describe 'rules_of_origin/_proofs', type: :view do
   end
 
   context 'with multiple schemes' do
-    let(:schemes) { build_list :rules_of_origin_scheme, 3, proof_count: 2 }
+    let(:schemes) { build_list :rules_of_origin_scheme, 3, :with_cds_proof_info, proof_count: 2 }
 
     it { is_expected.not_to have_css '.govuk-list--bullet li a' }
     it { is_expected.to have_link 'See valid proofs of origin' }
     it { is_expected.to have_css '.stacked-govuk-details', count: 3 }
     it { is_expected.to have_css '.govuk-details', count: 6 }
+    it { is_expected.to have_css '.cds-proof-info', count: 3 }
+  end
+
+  context 'without cds proof info' do
+    let(:schemes) { build_list :rules_of_origin_scheme, 1 }
+
+    it { is_expected.not_to have_css '.cds-proof-info' }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-3305

### What?

I have added/removed/altered:

- [x] Parse and show the CDS Proofs of Origin information if it is available

### Why?

I am doing this because:

- We want to share this with our users

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Makes changes to our complex routing setup that may affect apis to proxying to backend

### Screenshots

![Screenshot from 2023-06-08 12-02-19](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/811778a7-4358-443f-9303-d3268aaa273d)
![Screenshot from 2023-06-08 11-55-29](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/153c6c7f-fd9d-4af3-9f9b-72d3c4bf75e5)

