### PR TITLE
HOTT-3345: Footnotes bug fix

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -106,7 +106,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <%= render partial: 'footnotes/footnote', collection: declarable.all_footnotes %>
+        <%= render partial: 'footnotes/footnote', collection: declarable.footnotes %>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3345

### What?

I have added/removed/altered:

- [ ] Footnotes bug fix

### Why?

I am doing this because:

-  We were displaying footnotes for measures when we should only be showing ones that belong to a commodity

<img width="1380" alt="Screenshot 2023-06-08 at 17 02 13" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/a8de873e-f0fb-4496-85e8-9dbd25e92742">

