### PR TITLE
HOTT-3336 Show cds proofs info on measures overlay

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -21,6 +21,8 @@ class CommoditiesController < GoodsNomenclaturesController
 
     if params[:country].present? && @search.geographical_area
       @rules_of_origin_schemes = declarable.rules_of_origin(params[:country])
+    else
+      @roo_all_schemes = RulesOfOrigin::Scheme.all
     end
   end
 

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -34,7 +34,7 @@ class Measure
   delegate :erga_omnes?, :channel_islands?, to: :geographical_area
   delegate :mfn_no_authorized_use?, :provides_unit_context?, to: :measure_type
   delegate :amount, to: :duty_expression
-  delegate :supplementary?, :safeguard?, :cds_proofs_of_origin?, to: :measure_type
+  delegate :supplementary?, :safeguard?, to: :measure_type
 
   def pharma_additional_code?
     additional_code && additional_code.pharma?
@@ -204,6 +204,13 @@ class Measure
 
   def measurement_units?
     measure_components.any?(&:measurement_unit)
+  end
+
+  def cds_proofs_of_origin(schemes)
+    return [] unless measure_type.cds_proofs_of_origin?
+
+    schemes.select(&:cds_proof_info?)
+           .select { |s| s.applies_to_geographical_area? geographical_area }
   end
 
   private

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -34,7 +34,7 @@ class Measure
   delegate :erga_omnes?, :channel_islands?, to: :geographical_area
   delegate :mfn_no_authorized_use?, :provides_unit_context?, to: :measure_type
   delegate :amount, to: :duty_expression
-  delegate :supplementary?, :safeguard?, to: :measure_type
+  delegate :supplementary?, :safeguard?, :cds_proofs_of_origin?, to: :measure_type
 
   def pharma_additional_code?
     additional_code && additional_code.pharma?

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -2,6 +2,7 @@ require 'api_entity'
 
 class MeasureType
   RENDERED_MEASURE_TYPE_DETAILS = { 'xi' => {}, 'uk' => {} }.freeze
+  CDS_PROOFS_OF_ORIGIN = %w[141 142 143 145 146 147].freeze
 
   delegate :service_name, to: TradeTariffFrontend::ServiceChooser
 
@@ -46,6 +47,10 @@ class MeasureType
     return 'Restriction' if description.scan(/Restriction/i).present?
 
     'Control'
+  end
+
+  def cds_proofs_of_origin?
+    CDS_PROOFS_OF_ORIGIN.include? id
   end
 
   private

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -56,8 +56,6 @@ class RulesOfOrigin::Scheme
   end
 
   def applies_to_geographical_area?(area)
-    area_code = area.is_a?(GeographicalArea) ? area.geographical_area_id : area
-
-    countries.include? area_code
+    countries.include? area.geographical_area_id
   end
 end

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -54,4 +54,10 @@ class RulesOfOrigin::Scheme
   def cds_proof_info?
     proof_intro.present? || proof_codes&.any?
   end
+
+  def applies_to_geographical_area?(area)
+    area_code = area.is_a?(GeographicalArea) ? area.geographical_area_id : area
+
+    countries.include? area_code
+  end
 end

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -19,6 +19,7 @@
            declarable: declarable,
            xi_declarable: xi_declarable,
            uk_declarable: uk_declarable,
-           rules_of_origin_schemes: @rules_of_origin_schemes %>
+           rules_of_origin_schemes: @rules_of_origin_schemes,
+           roo_all_schemes: @roo_all_schemes %>
 
 <%= render 'commodities/help_popup' %>

--- a/app/views/declarables/_declarable.html.erb
+++ b/app/views/declarables/_declarable.html.erb
@@ -6,5 +6,6 @@
              declarable: declarable,
              uk_declarable: uk_declarable,
              xi_declarable: xi_declarable,
-             rules_of_origin_schemes: rules_of_origin_schemes %>
+             rules_of_origin_schemes: rules_of_origin_schemes,
+             roo_all_schemes: roo_all_schemes %>
 </article>

--- a/app/views/measures/_cds_proofs_modal.html.erb
+++ b/app/views/measures/_cds_proofs_modal.html.erb
@@ -1,0 +1,11 @@
+<div data-popup='<%= measure.destination %>-<%= measure.id %>-cds-proofs'>
+  <% measure.cds_proofs_of_origin(rules_of_origin_schemes).each do |scheme| %>
+    <article>
+      <h2 class="govuk-heading-m">
+        <%= scheme.title %>
+      </h2>
+
+      <%= render 'rules_of_origin/cds_proof_info', scheme: %>
+    </article>
+  <% end %>
+</div>

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -53,10 +53,8 @@
   <td class="conditions-col govuk-table__cell">
     <% if measure.has_measure_conditions? %>
       <%= link_to "Conditions",  "#", class: 'reference', 'data-popup-ref' => "#{measure.destination}-#{measure.id}-conditions", "aria-label": "Click to open a dialog with the conditions for this measure", role: "button" %>
-    <% elsif measure.cds_proofs_of_origin? && roo_schemes.select(&:cds_proof_info?).any? { |scheme|
-        scheme.applies_to_geographical_area? measure.geographical_area
-      } %>
-      <strong><%= 'goes here' %></strong>
+    <% elsif measure.cds_proofs_of_origin(roo_schemes).any? %>
+      <%= link_to "Conditions",  "#", class: 'reference', 'data-popup-ref' => "#{measure.destination}-#{measure.id}-cds-proofs", "aria-label": "Click to open a dialog with the conditions for this measure", role: "button" %>
     <% end %>
   </td>
 

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -53,6 +53,8 @@
   <td class="conditions-col govuk-table__cell">
     <% if measure.has_measure_conditions? %>
       <%= link_to "Conditions",  "#", class: 'reference', 'data-popup-ref' => "#{measure.destination}-#{measure.id}-conditions", "aria-label": "Click to open a dialog with the conditions for this measure", role: "button" %>
+    <% elsif measure.cds_proofs_of_origin? && roo_schemes&.any?(&:cds_proof_info?) %>
+      <strong><%= 'goes here' %></strong>
     <% end %>
   </td>
 

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -53,7 +53,9 @@
   <td class="conditions-col govuk-table__cell">
     <% if measure.has_measure_conditions? %>
       <%= link_to "Conditions",  "#", class: 'reference', 'data-popup-ref' => "#{measure.destination}-#{measure.id}-conditions", "aria-label": "Click to open a dialog with the conditions for this measure", role: "button" %>
-    <% elsif measure.cds_proofs_of_origin? && roo_schemes&.any?(&:cds_proof_info?) %>
+    <% elsif measure.cds_proofs_of_origin? && roo_schemes.select(&:cds_proof_info?).any? { |scheme|
+        scheme.applies_to_geographical_area? measure.geographical_area
+      } %>
       <strong><%= 'goes here' %></strong>
     <% end %>
   </td>

--- a/app/views/measures/_measure_references.html.erb
+++ b/app/views/measures/_measure_references.html.erb
@@ -1,5 +1,7 @@
 <% if measure.has_measure_conditions? %>
   <%= render partial: 'measures/measure_condition_modal', locals: { declarable: declarable, measure:, anchor: } %>
+<% elsif measure.cds_proofs_of_origin(rules_of_origin_schemes).any? %>
+  <%= render 'measures/cds_proofs_modal', measure:, rules_of_origin_schemes: %>
 <% end %>
 
 <% if measure.has_measure_footnotes? %>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -31,7 +31,10 @@
       <%= render partial: 'measures/grouped/navigation', locals: { uk_declarable: uk_declarable, xi_declarable: xi_declarable } %>
 
       <% if TradeTariffFrontend::ServiceChooser.xi? %>
-        <%= render partial: 'measures/grouped/xi', locals: { uk_declarable: uk_declarable, xi_declarable: xi_declarable } %>
+        <%= render partial: 'measures/grouped/xi',
+                   locals: { uk_declarable: uk_declarable,
+                             xi_declarable: xi_declarable,
+                             rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes } %>
       <% else %>
         <%= render partial: 'measures/grouped/uk',
                    locals: { uk_declarable: uk_declarable,

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -31,15 +31,12 @@
       <%= render partial: 'measures/grouped/navigation', locals: { uk_declarable: uk_declarable, xi_declarable: xi_declarable } %>
 
       <% if TradeTariffFrontend::ServiceChooser.xi? %>
-        <%= render partial: 'measures/grouped/xi',
-                   locals: { uk_declarable: uk_declarable,
-                             xi_declarable: xi_declarable,
-                             rules_of_origin_schemes: rules_of_origin_schemes } %>
+        <%= render partial: 'measures/grouped/xi', locals: { uk_declarable: uk_declarable, xi_declarable: xi_declarable } %>
       <% else %>
         <%= render partial: 'measures/grouped/uk',
                    locals: { uk_declarable: uk_declarable,
                              xi_declarable: xi_declarable,
-                             rules_of_origin_schemes: rules_of_origin_schemes } %>
+                             rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes } %>
       <% end %>
 
     <% else %>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -109,13 +109,44 @@
   </div>
 
   <div id="import-measure-references">
-    <%= render partial: 'measures/measure_references', collection: declarable.import_measures, as: 'measure', locals: { declarable: declarable, anchor: 'import' } %>
+    <%= render partial: 'measures/measure_references',
+               collection: declarable.import_measures,
+               as: 'measure',
+               locals: {
+                 declarable: declarable,
+                 anchor: 'import',
+                 rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes
+               } %>
+
     <% if TradeTariffFrontend::ServiceChooser.xi? && uk_declarable.present? %>
-      <%= render partial: 'measures/measure_references', collection: uk_declarable.import_measures.import_controls, as: 'measure', locals: { declarable: declarable, anchor: 'import' } %>
-      <%= render partial: 'measures/measure_references', collection: uk_declarable.import_measures.vat_excise, as: 'measure', locals: { declarable: declarable, anchor: 'import' } %>
+      <%= render partial: 'measures/measure_references',
+                 collection: uk_declarable.import_measures.import_controls,
+                 as: 'measure',
+                 locals: {
+                   declarable: declarable,
+                   anchor: 'import',
+                   rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes
+                 } %>
+
+      <%= render partial: 'measures/measure_references',
+                 collection: uk_declarable.import_measures.vat_excise,
+                 as: 'measure',
+                 locals: {
+                   declarable: declarable,
+                   anchor: 'import',
+                   rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes
+                 } %>
     <% end %>
   </div>
+
   <div id="export-measure-references">
-    <%= render partial: 'measures/measure_references', collection: declarable.export_measures, as: 'measure', locals: { declarable: declarable, anchor: 'export' } %>
+    <%= render partial: 'measures/measure_references',
+               collection: declarable.export_measures,
+               as: 'measure',
+               locals: {
+                 declarable: declarable,
+                 anchor: 'export',
+                 rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes
+               } %>
   </div>
 </div>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -31,9 +31,15 @@
       <%= render partial: 'measures/grouped/navigation', locals: { uk_declarable: uk_declarable, xi_declarable: xi_declarable } %>
 
       <% if TradeTariffFrontend::ServiceChooser.xi? %>
-        <%= render partial: 'measures/grouped/xi', locals: { uk_declarable: uk_declarable, xi_declarable: xi_declarable } %>
+        <%= render partial: 'measures/grouped/xi',
+                   locals: { uk_declarable: uk_declarable,
+                             xi_declarable: xi_declarable,
+                             rules_of_origin_schemes: rules_of_origin_schemes } %>
       <% else %>
-        <%= render partial: 'measures/grouped/uk', locals: { uk_declarable: uk_declarable, xi_declarable: xi_declarable } %>
+        <%= render partial: 'measures/grouped/uk',
+                   locals: { uk_declarable: uk_declarable,
+                             xi_declarable: xi_declarable,
+                             rules_of_origin_schemes: rules_of_origin_schemes } %>
       <% end %>
 
     <% else %>

--- a/app/views/measures/grouped/_table.html.erb
+++ b/app/views/measures/grouped/_table.html.erb
@@ -35,6 +35,11 @@
   </thead>
 
   <tbody class="govuk-table__body">
-    <%= render partial: 'measures/measure', collection: collection, locals: { hide_duty_rate: local_assigns[:hide_duty_rate] } %>
+    <%= render partial: 'measures/measure',
+               collection: collection,
+               locals: {
+                 hide_duty_rate: local_assigns[:hide_duty_rate],
+                 roo_schemes: local_assigns[:roo_schemes],
+               } %>
   </tbody>
 </table>

--- a/app/views/measures/grouped/_uk.html.erb
+++ b/app/views/measures/grouped/_uk.html.erb
@@ -9,7 +9,8 @@
     hide_duty_rate: true,
     search: @search,
     show_stw_text: true,
-    anchor: 'import'
+    anchor: 'import',
+    roo_schemes: rules_of_origin_schemes
   } %>
 <% end %>
 
@@ -19,7 +20,8 @@
               collection: uk_import_measures.customs_duties.sort_by(&:key),
               css_id: 'import_duties',
               declarable: uk_declarable,
-              show_duty_calculator: uk_declarable.calculate_duties? %>
+              show_duty_calculator: uk_declarable.calculate_duties?,
+              roo_schemes: rules_of_origin_schemes %>
 <% end %>
 
 <%= render 'shared/unknown_quota_definition' %>
@@ -29,7 +31,8 @@
     caption: 'Quotas',
     information: t('tabs.measures.quotas_information_html'),
     collection: uk_import_measures.quotas.sort_by(&:key),
-    css_id: 'quotas'
+    css_id: 'quotas',
+    roo_schemes: rules_of_origin_schemes
   } %>
 <% end %>
 
@@ -37,7 +40,8 @@
   <%= render partial: 'measures/grouped/table', locals: {
     caption: 'Trade remedies, safeguards and retaliatory duties',
     collection: uk_import_measures.trade_remedies.sort_by(&:key),
-    css_id: 'trade_remedies' } %>
+    css_id: 'trade_remedies',
+    roo_schemes: rules_of_origin_schemes } %>
 <% end %>
 
 <% if uk_import_measures.suspensions.present? %>
@@ -45,7 +49,8 @@
     caption: 'Suspensions',
     collection: uk_import_measures.suspensions.sort_by(&:key),
     css_id: 'suspensions',
-    uk_declarable: uk_declarable } %>
+    uk_declarable: uk_declarable,
+    roo_schemes: rules_of_origin_schemes } %>
 <% end %>
 
 <% if uk_import_measures.credibility_checks.present? %>
@@ -55,7 +60,8 @@
     css_id: 'credibility_checks',
     hide_duty_rate: true,
     credibility_checks: true,
-    uk_declarable: uk_declarable } %>
+    uk_declarable: uk_declarable,
+    roo_schemes: rules_of_origin_schemes } %>
 <% end %>
 
 <% if uk_import_measures.vat_excise.present? %>
@@ -64,5 +70,6 @@
     collection: uk_import_measures.vat_excise.sort_by(&:key),
     css_id: 'vat_excise',
     uk_declarable: uk_declarable,
-    vat_excise: true } %>
+    vat_excise: true,
+    roo_schemes: rules_of_origin_schemes } %>
 <% end %>

--- a/app/views/measures/grouped/_xi.html.erb
+++ b/app/views/measures/grouped/_xi.html.erb
@@ -8,14 +8,16 @@
               collection: xi_import_measures.customs_duties.sort_by(&:key),
               css_id: 'import_duties',
               declarable: xi_declarable,
-              show_duty_calculator: xi_declarable.calculate_duties? %>
+              show_duty_calculator: xi_declarable.calculate_duties?,
+              roo_schemes: rules_of_origin_schemes %>
 <% end %>
 
 <% if xi_import_measures.trade_remedies.present? %>
   <%= render partial: 'measures/grouped/table', locals: {
     caption: 'Trade remedies, safeguards and retaliatory duties',
     collection: xi_import_measures.trade_remedies.sort_by(&:key),
-    css_id: 'trade_remedies' } %>
+    css_id: 'trade_remedies',
+    roo_schemes: rules_of_origin_schemes } %>
 <% end %>
 
 <% if xi_import_measures.suspensions.present? %>
@@ -23,7 +25,8 @@
     caption: 'Suspensions',
     collection: xi_import_measures.suspensions.sort_by(&:key),
     css_id: 'suspensions',
-    declarable: xi_declarable } %>
+    declarable: xi_declarable,
+    roo_schemes: rules_of_origin_schemes } %>
 <% end %>
 
 <% if xi_import_measures.credibility_checks.present? %>
@@ -33,7 +36,8 @@
     css_id: 'credibility_checks',
     credibility_checks: true,
     hide_duty_rate: true,
-    xi_declarable: xi_declarable } %>
+    xi_declarable: xi_declarable,
+    roo_schemes: rules_of_origin_schemes } %>
 <% end %>
 
 <% if uk_import_measures&.vat_excise.present? %>
@@ -42,7 +46,8 @@
     collection: uk_import_measures.vat_excise.sort_by(&:key),
     css_id: 'vat_excise',
     uk_declarable: uk_declarable,
-    vat_excise: true } %>
+    vat_excise: true,
+    roo_schemes: rules_of_origin_schemes } %>
 <% end %>
 
 <% if xi_import_measures.import_controls.present? %>
@@ -50,7 +55,8 @@
     caption: 'EU import controls',
     collection: xi_import_measures.import_controls.sort_by(&:key),
     hide_duty_rate: true,
-    css_id: 'xi_import_controls' } %>
+    css_id: 'xi_import_controls',
+    roo_schemes: rules_of_origin_schemes } %>
 <% end %>
 
 <% if uk_import_measures&.import_controls.present? %>
@@ -58,5 +64,6 @@
     caption: 'UK import controls',
     collection: uk_import_measures.import_controls.sort_by(&:key),
     hide_duty_rate: true,
-    css_id: 'uk_import_controls' } %>
+    css_id: 'uk_import_controls',
+    roo_schemes: rules_of_origin_schemes } %>
 <% end %>

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe CommoditiesController, type: :controller do
+  before do
+    allow(RulesOfOrigin::Scheme).to receive(:all).and_return \
+      build_list(:rules_of_origin_scheme, 1)
+  end
+
   describe 'GET to #show' do
     shared_examples_for 'a commodity controller response' do
       context 'with existing commodity id provided', vcr: { cassette_name: 'commodities#0101300000_xi' } do

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     end
 
     geographical_area do
-      attributes_for(:geographical_area, id: geographical_area_id)
+      attributes_for(:geographical_area, id: geographical_area_id, geographical_area_id:)
     end
 
     preference_code do

--- a/spec/features/commodities_spec.rb
+++ b/spec/features/commodities_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Commodity show page', vcr: { cassette_name: 'geographical_areas#
   before do
     stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
     allow(DeclarableUnitService).to receive(:new).and_return(instance_double(DeclarableUnitService, call: ''))
+    allow(RulesOfOrigin::Scheme).to receive(:all).and_return build_list(:rules_of_origin_scheme, 1)
 
     TradeTariffFrontend::ServiceChooser.service_choice = 'xi'
 

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Measure do
   end
 
   it { is_expected.to respond_to :universal_waiver_applies }
-  it { is_expected.to respond_to :cds_proofs_of_origin? }
 
   describe '#vat_excise?' do
     subject(:measure) { build(:measure, measure_type:) }
@@ -350,6 +349,42 @@ RSpec.describe Measure do
       subject(:measure) { build(:measure) }
 
       it { is_expected.not_to be_measurement_units }
+    end
+  end
+
+  describe '#cds_proofs_of_origin' do
+    subject { measure.cds_proofs_of_origin schemes }
+
+    let(:measure) { build :measure, geographical_area_id: 'FR', measure_type_id: '142' }
+
+    let :schemes do
+      build_list :rules_of_origin_scheme, 1, :with_cds_proof_info, countries: %w[FR]
+    end
+
+    context 'with measure of wrong type' do
+      let(:measure) { build :measure, geographical_area_id: 'FR', measure_type_id: '101' }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'with measure of right type' do
+      context 'with matching schemes with proof info present' do
+        it { is_expected.to include schemes.first }
+      end
+
+      context 'with matching schemes without proof info present' do
+        let(:schemes) { build_list :rules_of_origin_scheme, 1, countries: %w[FR] }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'without matching schemes' do
+        let :schemes do
+          build_list :rules_of_origin_scheme, 1, :with_cds_proof_info, countries: %w[DE]
+        end
+
+        it { is_expected.to be_empty }
+      end
     end
   end
 end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Measure do
   end
 
   it { is_expected.to respond_to :universal_waiver_applies }
+  it { is_expected.to respond_to :cds_proofs_of_origin? }
 
   describe '#vat_excise?' do
     subject(:measure) { build(:measure, measure_type:) }

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -263,4 +263,18 @@ RSpec.describe MeasureType do
       it { is_expected.not_to be_provides_unit_context }
     end
   end
+
+  describe '#cds_proofs_of_origin?' do
+    context 'when expected type' do
+      subject { build(:measure_type, :tariff_preference).cds_proofs_of_origin? }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when not expected type' do
+      subject { build(:measure_type, :suspension).cds_proofs_of_origin? }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -421,24 +421,21 @@ RSpec.describe RulesOfOrigin::Scheme do
     let(:scheme) { build :rules_of_origin_scheme, countries: %w[FR] }
 
     context 'when area in countries list' do
-      subject { scheme.applies_to_geographical_area? 'FR' }
-
-      it { is_expected.to be true }
-    end
-
-    context 'when area not in countries list' do
-      subject { scheme.applies_to_geographical_area? 'DE' }
-
-      it { is_expected.to be false }
-    end
-
-    context 'with GeographicalArea model' do
       subject do
         scheme.applies_to_geographical_area? \
           build(:geographical_area, geographical_area_id: 'FR')
       end
 
       it { is_expected.to be true }
+    end
+
+    context 'when area not in countries list' do
+      subject do
+        scheme.applies_to_geographical_area? \
+          build(:geographical_area, geographical_area_id: 'DE')
+      end
+
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -403,7 +403,7 @@ RSpec.describe RulesOfOrigin::Scheme do
     it { is_expected.to have_attributes proof_codes: {} }
   end
 
-  describe 'cds_proof_info?' do
+  describe '#cds_proof_info?' do
     context 'with info' do
       subject { build(:rules_of_origin_scheme, :with_cds_proof_info).cds_proof_info? }
 
@@ -414,6 +414,31 @@ RSpec.describe RulesOfOrigin::Scheme do
       subject { build(:rules_of_origin_scheme).cds_proof_info? }
 
       it { is_expected.to be false }
+    end
+  end
+
+  describe '#applies_to_geographical_area?' do
+    let(:scheme) { build :rules_of_origin_scheme, countries: %w[FR] }
+
+    context 'when area in countries list' do
+      subject { scheme.applies_to_geographical_area? 'FR' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when area not in countries list' do
+      subject { scheme.applies_to_geographical_area? 'DE' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with GeographicalArea model' do
+      subject do
+        scheme.applies_to_geographical_area? \
+          build(:geographical_area, geographical_area_id: 'FR')
+      end
+
+      it { is_expected.to be true }
     end
   end
 end

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Commodity page', type: :request do
     allow(GeographicalArea).to receive(:find).with('AD').and_return(build(:geographical_area, id: 'AD', description: 'Andorra'))
     allow(GeographicalArea).to receive(:all).and_return([build(:geographical_area, id: 'AD', description: 'Andorra')])
     allow(RulesOfOrigin::Scheme).to receive(:for_heading_and_country).and_return([])
+    allow(RulesOfOrigin::Scheme).to receive(:all).and_return build_list(:rules_of_origin_scheme, 1)
 
     TradeTariffFrontend::ServiceChooser.service_choice = nil
   end

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Search page', type: :request do
     stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
     allow(Section).to receive(:all).and_return([])
     allow(GeographicalArea).to receive(:all).and_return([])
+    allow(RulesOfOrigin::Scheme).to receive(:all).and_return([])
   end
 
   context 'when exact match' do

--- a/spec/views/measures/_measure.html.erb_spec.rb
+++ b/spec/views/measures/_measure.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'measures/_measure', type: :view, vcr: { cassette_name: 'geograph
   before do
     stub_const('MeasureConditionDialog::CONFIG_FILE_NAME', file_fixture('measure_condition_dialog_config.yaml'))
 
-    render 'measures/measure', measure: MeasurePresenter.new(measure)
+    render 'measures/measure', measure: MeasurePresenter.new(measure), roo_schemes: []
   end
 
   context 'with verbose_duty' do


### PR DESCRIPTION
### Jira link

HOTT-3336

### What?

I have added/removed/altered:

- [x] Show CDS proof info on measures tab for relevant measures

### Why?

I am doing this because:

- If helps our users submit valid declarations

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Adds a call to the all rules of origin schemes endpoint on the commodities page

### Screenshots

![Screenshot from 2023-06-09 11-36-21](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/2491aaa5-2a9b-4a50-9528-8e3202e025b0)
![Screenshot from 2023-06-09 11-36-28](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/2b4b7e8f-8fd1-4780-aa64-024fbb756545)
![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/10818/17653e98-e6d2-4c32-ad7f-0afdfbe2a23c)
