### PR TITLE
HOTT-3380 Link commodities in search tools to today

### DIFF
--- a/app/views/search/certificate_search.html.erb
+++ b/app/views/search/certificate_search.html.erb
@@ -84,7 +84,8 @@
                 <% certificate.all_goods_nomenclatures.each do |goods_nomenclature| %>
                   <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">
-                      <%= link_to(segmented_commodity_code(goods_nomenclature.goods_nomenclature_item_id), polymorphic_path(goods_nomenclature)) %>
+                      <%= link_to segmented_commodity_code(goods_nomenclature.goods_nomenclature_item_id),
+                                  polymorphic_path(goods_nomenclature, day: nil, month: nil, year: nil) %>
                     </th>
 
                     <td class="govuk-table__cell">

--- a/app/views/search/common/_goods_nomenclature.html.erb
+++ b/app/views/search/common/_goods_nomenclature.html.erb
@@ -1,9 +1,9 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
     <% if goods_nomenclature.instance_of?(GoodsNomenclature) %>
-      <a href="<%= commodity_path(goods_nomenclature) %>" aria-describedby="code-for-commodity-<%= goods_nomenclature.id %>">
+      <a href="<%= commodity_path(goods_nomenclature, day: nil, month: nil, year: nil) %>" aria-describedby="code-for-commodity-<%= goods_nomenclature.id %>">
     <% else %>
-      <a href="<%= polymorphic_path(goods_nomenclature) %>" aria-describedby="code-for-commodity-<%= goods_nomenclature.id %>">
+      <a href="<%= polymorphic_path(goods_nomenclature, day: nil, month: nil, year: nil) %>" aria-describedby="code-for-commodity-<%= goods_nomenclature.id %>">
     <% end  %>
 
     <%= goods_nomenclature.description.html_safe %>


### PR DESCRIPTION
### Jira link

HOTT-3380

I have added/removed/altered:

- [x] Links to commodities in the search tools should link to todays commodity, not the date the user was previously looking at

### Why?

I am doing this because:

- Their results are for today, so linking to the dates the user is looking at will probably confuse matters

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low
