### PR TITLE
HOTT-3414: Exposes bulk searches api

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -59,6 +59,7 @@ module TradeTariffFrontend
       chemical_substances
       healthcheck
       simplified_procedural_code_measures
+      bulk_searches
     ]
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3414

### What?

I have added/removed/altered:

- [x] Expose bulk-searches api

### Why?

I am doing this because:

- This enables people to use bulk searches on dev and staging. This requires that the bulk search api feature flag is enabled on the backend so production is not affected by this change
