### PR TITLE
HOTT-1355 Reduce request retries to Backend

### DIFF
--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -4,8 +4,8 @@ class ClientBuilder
 
   RETRY_DEFAULTS = {
     methods: %i[get head],
-    max: 3,
-    interval: 0.2,
+    max: 1,
+    interval: 0.5,
     interval_randomness: 0.5,
     backoff_factor: 2,
     exceptions: (

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -197,19 +197,35 @@ RSpec.describe ApiEntity do
     end
 
     context 'with flaky connection' do
-      before do
-        stub_request(:get, "#{api_endpoint}/mock_entities")
-          .to_timeout
-          .then.to_timeout
-          .then.to_return status:,
-                          headers:,
-                          body:
-      end
-
       let(:body) { file_fixture('jsonapi/multiple_no_relationship.json').read }
 
-      it 'retries' do
-        expect(request).to have_attributes length: 1
+      context 'with one failure' do
+        before do
+          stub_request(:get, "#{api_endpoint}/mock_entities")
+            .to_timeout
+            .then.to_return status:,
+                            headers:,
+                            body:
+        end
+
+        it 'retries' do
+          expect(request).to have_attributes length: 1
+        end
+      end
+
+      context 'with multiple failures' do
+        before do
+          stub_request(:get, "#{api_endpoint}/mock_entities")
+            .to_timeout
+            .then.to_timeout
+            .then.to_return status:,
+                            headers:,
+                            body:
+        end
+
+        it 'raises an exception' do
+          expect { request }.to raise_exception Faraday::TimeoutError
+        end
       end
     end
   end


### PR DESCRIPTION
### Jira link

HOTT-1355

### What?

I have added/removed/altered:

- [x] Increased initial time between attempts
- [x] Reduced the retries from 3 to 1 (ie 4 attempts down to only 2 attempts)

### Why?

I am doing this because:

- To continue to ride out flaky network connections
- To reduce the total time before accepting failure on slower endpoints

### Deployment risks (optional)

- Should only impact endpoints which timeout
