### PR TITLE
HOTT-3371 Pass cache headers through from Backend

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   around_action :set_locale
 
-  before_action :set_cache
+  before_action :no_store # Rails method to prevent caching
   before_action :set_last_updated
   before_action :set_path_info
   before_action :set_search
@@ -95,12 +95,6 @@ class ApplicationController < ActionController::Base
 
   def query_params
     { as_of: @search.date }
-  end
-
-  def set_cache
-    response.headers['Cache-Control'] = 'public, must-revalidate, proxy-revalidate, max-age=0'
-    response.headers['Pragma'] = 'no-cache'
-    response.headers['Expires'] = '-1'
   end
 
   def meursing_lookup_result

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -156,6 +156,10 @@ module TradeTariffFrontend
     ENV['BETA_SEARCH_FACET_FILTER_DISPLAY_PERCENTAGE_THRESHOLD'].to_i
   end
 
+  def cdn_supports_etag?
+    ENV['FEATURE_CDN_SUPPORTS_ETAG'].to_s == 'true'
+  end
+
   class FilterBadURLEncoding
     def initialize(app)
       @app = app

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -8,19 +8,10 @@ RSpec.describe ApplicationController, type: :controller do
   end
 
   describe 'GET #index' do
-    subject(:response) { get :index }
+    subject { response.headers.to_h }
 
-    let(:expected_cache_control) do
-      %w[
-        max-age=0
-        public
-        must-revalidate
-        proxy-revalidate
-      ].join(', ')
-    end
+    before { get :index }
 
-    it { expect(response.headers['Cache-Control']).to eq(expected_cache_control) }
-    it { expect(response.headers['Pragma']).to eq('no-cache') }
-    it { expect(response.headers['Expires']).to eq('-1') }
+    it { is_expected.to include 'Cache-Control' => 'no-store' }
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-3371

### What?

I have added/removed/altered:

- [x] Pass the cache headers from the backend through to the client
- [x] Set the rest of the frontend to `no-store`

### Why?

I am doing this because:

- We don't want the frontend pages cached by the CDN
- We do want the API requests to be cached

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Makes changes to our complex routing setup that may affect apis to proxying to backend
