### PR TITLE
HOTT-3513: Add build job for new AWS environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,6 +372,25 @@ jobs:
             docker tag $IMAGE_NAME:$DOCKER_TAG $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
             docker push $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
 
+  # new aws env
+  build_and_push:
+    environment:
+      IMAGE_NAME: tariff-frontend
+    parameters:
+      environment:
+        type: string
+    docker:
+      - image: cimg/ruby:3.2.2-node
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.11
+          docker_layer_caching: false
+      - aws-cli/install
+      - run:
+          name: Build and push image
+          command: ./.circleci/ecr.sh << parameters.environment >>
+
   smoketest_dev:
     docker:
       - image: "cypress/base:16.5.0"
@@ -540,6 +559,18 @@ workflows:
           name: build_dev
           context: trade-tariff
           dev-build: true
+          filters:
+            branches:
+              ignore:
+                - main
+                - /^hotfix\/.+/
+                - /^dependabot/(?!docker/).*/
+
+      # new aws env
+      - build_and_push:
+          name: build_and_push_dev
+          context: trade-tariff-terraform-aws-development
+          environment: development
           filters:
             branches:
               ignore:

--- a/.circleci/ecr.sh
+++ b/.circleci/ecr.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+environment=$1
+docker_tag=$(git rev-parse --short HEAD)
+container="${IMAGE_NAME}:${docker_tag}"
+
+function fetch_ecr_url {
+  json=$(aws ssm get-parameter     \
+  --name "/${environment}/ECR_URL" \
+  --with-decryption                \
+  --output json                    \
+  --color off)
+
+  output=$(jq -r .Parameter.Value <<< "${json}")
+
+  if [ -n "${output}" ]; then
+    echo "${output}"
+  else
+    exit 1
+  fi
+}
+
+ecr_url=$(fetch_ecr_url)
+
+docker build -t "$container" .
+docker tag "$container" "${ecr_url}/${container}"
+
+aws ecr get-login-password --region "$AWS_DEFAULT_REGION" |
+  docker login --username AWS --password-stdin "$ecr_url"
+
+docker push "${ecr_url}/${container}"

--- a/.circleci/ecr.sh
+++ b/.circleci/ecr.sh
@@ -2,11 +2,11 @@
 
 environment=$1
 docker_tag=$(git rev-parse --short HEAD)
-container="${IMAGE_NAME}:${docker_tag}"
+container="${IMAGE_NAME}-$environment"
 
 function fetch_ecr_url {
   json=$(aws ssm get-parameter     \
-  --name "/${environment}/ECR_URL" \
+  --name "/${environment}/FRONTEND_ECR_URL" \
   --with-decryption                \
   --output json                    \
   --color off)
@@ -23,9 +23,9 @@ function fetch_ecr_url {
 ecr_url=$(fetch_ecr_url)
 
 docker build -t "$container" .
-docker tag "$container" "${ecr_url}/${container}"
+docker tag "${container}:${docker_tag}" "${ecr_url}/${container}:${docker_tag}"
 
-aws ecr get-login-password --region "$AWS_DEFAULT_REGION" |
-  docker login --username AWS --password-stdin "$ecr_url"
+aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" |
+  docker login --username AWS --password-stdin "${ecr_url}"
 
 docker push "${ecr_url}/${container}"

--- a/.circleci/ecr.sh
+++ b/.circleci/ecr.sh
@@ -27,7 +27,7 @@ function fetch_ecr_url {
 ecr_url=$(fetch_ecr_url)
 
 docker build -t "$container" .
-docker tag "${container}" "${ecr_url}/${docker_tag}"
+docker tag "${container}" "${ecr_url}:${docker_tag}"
 
 aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" |
   docker login --username AWS --password-stdin "${ecr_url}"

--- a/.circleci/ecr.sh
+++ b/.circleci/ecr.sh
@@ -2,7 +2,7 @@
 
 environment=$1
 docker_tag=$(git rev-parse --short HEAD)
-container="${IMAGE_NAME}-$environment"
+container="${IMAGE_NAME}-$environment:${docker_tag}"
 
 function fetch_ecr_url {
   json=$(aws ssm get-parameter     \
@@ -23,7 +23,7 @@ function fetch_ecr_url {
 ecr_url=$(fetch_ecr_url)
 
 docker build -t "$container" .
-docker tag "${container}:${docker_tag}" "${ecr_url}/${container}:${docker_tag}"
+docker tag "${container}" "${ecr_url}/${container}"
 
 aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" |
   docker login --username AWS --password-stdin "${ecr_url}"

--- a/.circleci/ecr.sh
+++ b/.circleci/ecr.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# let's debug
+set -x
+set -e
+
 environment=$1
 docker_tag=$(git rev-parse --short HEAD)
 container="${IMAGE_NAME}-$environment:${docker_tag}"

--- a/.circleci/ecr.sh
+++ b/.circleci/ecr.sh
@@ -27,9 +27,9 @@ function fetch_ecr_url {
 ecr_url=$(fetch_ecr_url)
 
 docker build -t "$container" .
-docker tag "${container}" "${ecr_url}/${container}"
+docker tag "${container}" "${ecr_url}/${docker_tag}"
 
 aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" |
   docker login --username AWS --password-stdin "${ecr_url}"
 
-docker push "${ecr_url}/${container}"
+docker push "${ecr_url}:${docker_tag}"


### PR DESCRIPTION
### Jira link

[HOTT-3513](https://transformuk.atlassian.net/browse/HOTT-3513)

### What?

I have added/removed/altered:

- Added a new CircleCI job to build and push images to the new AWS ECR repository.
- Broken this out into a shell script, which I've checked against `shellcheck`.

### Why?

- Multiple things needed to change here:
  - moving away from using the `dev-build` parameter (i.e. just using the short SHA for the tag), and
  - having to use a different context for the new AWS ECR repository (as it's on a different account).

### Other notes

I would have liked to add a `.pre-commit-config.yml` to this repository, but even running the basic things like end-of-file-fixer made changes to a staggering number of files across the repository. That resulted in a _giant_ diff that would take a significant amount of effort to review.

I think we should make an ADR (and, ostensibly, a new ticket on the backlog) to get this implemented at some stage for consistency across the repo. We could break it up per subdirectory in several smaller PRs, or do it all at once in a co-ordinated strike.