### PR TITLE
HOTT-3566 Revised rules for where to show CDS Roo info

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -210,7 +210,7 @@ class Measure
     return [] unless measure_type.cds_proofs_of_origin?
 
     schemes.select(&:cds_proof_info?)
-           .select { |s| s.applies_to_geographical_area? geographical_area }
+           .select { |s| s.applies_to_geographical_area_or_its_children? geographical_area }
   end
 
   private

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -58,4 +58,9 @@ class RulesOfOrigin::Scheme
   def applies_to_geographical_area?(area)
     countries.include? area.geographical_area_id
   end
+
+  def applies_to_geographical_area_or_its_children?(area)
+    applies_to_geographical_area?(area) ||
+      area.children_geographical_areas.any?(&method(:applies_to_geographical_area?))
+  end
 end

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -53,7 +53,8 @@
   <td class="conditions-col govuk-table__cell">
     <% if measure.has_measure_conditions? %>
       <%= link_to "Conditions",  "#", class: 'reference', 'data-popup-ref' => "#{measure.destination}-#{measure.id}-conditions", "aria-label": "Click to open a dialog with the conditions for this measure", role: "button" %>
-    <% elsif measure.cds_proofs_of_origin(roo_schemes).any? %>
+    <% elsif !roo_schemes&.many? { |s| s.applies_to_geographical_area? measure.geographical_area } &&
+        measure.cds_proofs_of_origin(roo_schemes).any? %>
       <%= link_to "Conditions",  "#", class: 'reference', 'data-popup-ref' => "#{measure.destination}-#{measure.id}-cds-proofs", "aria-label": "Click to open a dialog with the conditions for this measure", role: "button" %>
     <% end %>
   </td>

--- a/spec/factories/geographical_area_factory.rb
+++ b/spec/factories/geographical_area_factory.rb
@@ -1,7 +1,18 @@
 FactoryBot.define do
   factory :geographical_area do
+    transient do
+      child_area_ids { [] }
+    end
+
     id { Forgery(:basic).text(exactly: 2).upcase }
     description { Forgery(:basic).text }
+    geographical_area_id { id }
+
+    children_geographical_areas do
+      child_area_ids.map do |child_id|
+        attributes_for :geographical_area, id: child_id
+      end
+    end
 
     trait :specific_country do
       description { Forgery(:basic).text }

--- a/spec/support/api_responses_helper.rb
+++ b/spec/support/api_responses_helper.rb
@@ -1,6 +1,10 @@
 module ApiResponsesHelper
   # Wrapper around WebMock's stub_request with defaults that apply to all our api requests
   def stub_api_request(endpoint, method = :get, backend: nil)
+    unless %i[head get post patch put delete].include?(method)
+      raise "Stubbing unknown HTTP method, '#{method}'"
+    end
+
     backend_url = if backend
                     TradeTariffFrontend::ServiceChooser.service_choices[backend]
                   else


### PR DESCRIPTION
### Jira link

HOTT-3566

### What?

I have added/removed/altered:

- [x] Revised the logic around when to show the Proof info from CDS on the measures page

### Why?

I am doing this because:

- Currently we are showing the proof info for Solomon Islands and should not be
- Currently we are not showing proof info for the various DCTS schemes

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low
