### PR TITLE
HOTT-3581 Replace GSP specific text with unilateral scheme text

### DIFF
--- a/app/views/rules_of_origin/steps/_import_only.html.erb
+++ b/app/views/rules_of_origin/steps/_import_only.html.erb
@@ -9,7 +9,8 @@
   </h1>
 
   <p class="govuk-body-l">
-    <%= t '.lead_para_html', trade_country_name: form.object.trade_country_name %>
+    <%= t '.lead_para_html', trade_country_name: form.object.trade_country_name,
+                             scheme_title: form.object.scheme_title %>
   </p>
 
   <h3 class="govuk-heading-s">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -426,13 +426,10 @@ en:
       import_only:
         caption: Trading commodity %{commodity_code} with %{trade_country_name}
         title: |
-          Importing goods into %{service_country_name} from countries which belong to
-          the GSP scheme
+          Importing goods into %{service_country_name} from countries which
+          belong to unilateral preference schemes
         lead_para_html: |
-          %{trade_country_name} is a member of the unilateral
-          <a href="https://www.gov.uk/government/publications/trading-with-developing-nations">
-            Generalised System of Preferences (GSP)
-          </a>
+          %{trade_country_name} is a member of the unilateral %{scheme_title}
           scheme. The rules of origin apply only to the import of goods from the
           overseas country.
         importing_from: Importing goods from %{trade_country_name}

--- a/spec/features/rules_of_origin_wizard_spec.rb
+++ b/spec/features/rules_of_origin_wizard_spec.rb
@@ -175,7 +175,7 @@ RSpec.feature 'Rules of Origin wizard', type: :feature do
       expect(page).to have_css 'h2', text: 'Preferential rules of origin for trading with Japan'
       click_on 'Check rules of origin'
 
-      expect(page).to have_css 'h1', text: /Importing goods.*from countries which belong to the GSP scheme/
+      expect(page).to have_css 'h1', text: /Importing goods.*from countries which belong to unilateral preference schemes/
       click_on 'Continue'
 
       expect(page).to have_css 'h1', text: /are classed as 'originating'/
@@ -250,7 +250,7 @@ RSpec.feature 'Rules of Origin wizard', type: :feature do
       choose unilateral.title
       click_on 'Continue'
 
-      expect(page).to have_css 'h1', text: /Importing goods.*from countries which belong to the GSP scheme/
+      expect(page).to have_css 'h1', text: /Importing goods.*from countries which belong to unilateral preference schemes/
       click_on 'Continue'
 
       expect(page).to have_css 'h1', text: /are classed as 'originating'/

--- a/spec/views/rules_of_origin/steps/_import_only_html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_import_only_html.erb_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 RSpec.describe 'rules_of_origin/steps/_import_only', type: :view do
   include_context 'with rules of origin form step', 'import_only'
 
-  it { is_expected.to have_css 'h1', text: /importing .* the United Kingdom .* GSP scheme/im }
+  it { is_expected.to have_css 'h1', text: /importing .* the United Kingdom .* unilateral/im }
   it { is_expected.to have_css '.govuk-caption-xl', text: /trading .* \d{10} with Japan/i }
   it { is_expected.to have_css 'p', text: /Japan .* unilateral/m }
-  it { is_expected.to have_link 'Generalised System of Preferences (GSP)' }
+  it { is_expected.to have_css '.govuk-body-l', text: /unilateral #{schemes.first.title}/ }
 
   it { is_expected.to have_css 'p', text: /export goods to Japan/ }
   it { is_expected.to have_css 'p a[href]', text: /Find out about the product-specific rules/ }


### PR DESCRIPTION
### Jira link

HOTT-3581

### What?

I have added/removed/altered:

- [x] Replaced the GSP specific text on the Import Only step in the Rules of Origin Wizard

### Why?

I am doing this because:

- Previously the content was specific to GSP, now it references unilateral schemes instead

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, text change
