### PR TITLE
HOTT-3673: Update backend URLs to use private DNS

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -22,7 +22,7 @@ data "aws_security_group" "this" {
 }
 
 data "aws_secretsmanager_secret" "redis_connection_string" {
-  name = "redis-connection-string"
+  name = "redis-frontend-connection-string"
 }
 
 data "aws_secretsmanager_secret" "frontend_secret_key_base" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,7 +1,7 @@
 locals {
   api_service_backend_url_options = {
-    uk = "https://${var.base_domain}/uk/"
-    xi = "https://${var.base_domain}/xi"
+    uk = "http://backend-uk.tariff.internal:8080"
+    xi = "http://backend-xi.tariff.internal:8080"
   }
 
   govuk_app_domain = var.environment != "production" ? var.environment == "development" ? "tariff-frontend-dev" : "tariff-frontend-staging" : "tariff-frontend"


### PR DESCRIPTION
### Jira link

[HOTT-3673](https://transformuk.atlassian.net/browse/HOTT-3673)

### What?

I have added/removed/altered:

- Switched backend URLs to new private routes.

### Why?

I am doing this because:

- These will actually work now 😇 