### PR TITLE
BAU: Fix environment variable name

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,8 +34,8 @@ module "service" {
       name  = "PORT"
       value = "8080"
     },
-    { # TODO: discuss this internally via HOTT-3555
-      name  = "API_SERVICE_BACKEND_OPTIONS"
+    {
+      name  = "API_SERVICE_BACKEND_URL_OPTIONS"
       value = jsonencode(local.api_service_backend_url_options)
     },
     {


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Updated the name of the `API_SERVICE_BACKEND_URL_OPTIONS` variable to be correct.

### Why?

I am doing this because:

- It was wrong and was silently being a problem without anything to tell me