### PR TITLE
HOTT-3686: Show supplementary units of type 109 in import/export tables.

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -43,6 +43,11 @@ module Declarable
     delegate :code, :short_code, to: :chapter, prefix: true
   end
 
+  def export_measures_without_supplementary_unit_for_import
+    export_measures.without_supplementary_unit_for_import
+                   .sort_by(&:key)
+  end
+
   def has_pharma_suspsension_measures?
     import_measures.third_country_duties.any?(&:pharma_additional_code?)
   end

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -43,9 +43,8 @@ module Declarable
     delegate :code, :short_code, to: :chapter, prefix: true
   end
 
-  def export_measures_without_supplementary_unit_for_import
-    export_measures.without_supplementary_unit_for_import
-                   .sort_by(&:key)
+  def has_export_measures?
+    export_measures&.any?
   end
 
   def has_pharma_suspsension_measures?

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -34,9 +34,7 @@ class Measure
   delegate :erga_omnes?, :channel_islands?, to: :geographical_area
   delegate :mfn_no_authorized_use?, :provides_unit_context?, to: :measure_type
   delegate :amount, to: :duty_expression
-  delegate :supplementary?,
-           :supplementary_unit_import_only?,
-           :safeguard?, to: :measure_type
+  delegate :supplementary?, :safeguard?, to: :measure_type
 
   def pharma_additional_code?
     additional_code && additional_code.pharma?

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -34,7 +34,9 @@ class Measure
   delegate :erga_omnes?, :channel_islands?, to: :geographical_area
   delegate :mfn_no_authorized_use?, :provides_unit_context?, to: :measure_type
   delegate :amount, to: :duty_expression
-  delegate :supplementary?, :safeguard?, to: :measure_type
+  delegate :supplementary?,
+           :supplementary_unit_import_only?,
+           :safeguard?, to: :measure_type
 
   def pharma_additional_code?
     additional_code && additional_code.pharma?

--- a/app/models/measure_collection.rb
+++ b/app/models/measure_collection.rb
@@ -109,6 +109,10 @@ class MeasureCollection < SimpleDelegator
     quotas.find { |m| m.order_number.number == number }
   end
 
+  def has_no_duties?
+    none?(&:duty_expression)
+  end
+
   private
 
   def tariff_preferences

--- a/app/models/measure_collection.rb
+++ b/app/models/measure_collection.rb
@@ -13,6 +13,10 @@ class MeasureCollection < SimpleDelegator
     new(reject(&:supplementary?))
   end
 
+  def without_supplementary_unit_for_import
+    new(reject(&:supplementary_unit_import_only?))
+  end
+
   def without_excluded
     new(reject(&:excluded?))
   end

--- a/app/models/measure_collection.rb
+++ b/app/models/measure_collection.rb
@@ -13,10 +13,6 @@ class MeasureCollection < SimpleDelegator
     new(reject(&:supplementary?))
   end
 
-  def without_supplementary_unit_for_import
-    new(reject(&:supplementary_unit_import_only?))
-  end
-
   def without_excluded
     new(reject(&:excluded?))
   end

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -63,9 +63,10 @@
         <!-- Export Measures are present in EU or UK (or both) -->
         <h3 class="govuk-heading-m" id="uk-export-controls">UK export controls</h3>
         <% if uk_declarable&.has_export_measures? %>
+
           <%= render partial: 'measures/grouped/table', locals: {
                      collection: uk_declarable.export_measures.sort_by(&:key),
-                     hide_duty_rate: true } %>
+                     hide_duty_rate: uk_declarable.export_measures.has_no_duties? } %>
           <% else %>
             <%= render 'measures/no_export_measures_warning', header: 'UK export controls' %>
         <% end %>
@@ -74,7 +75,7 @@
         <% if xi_declarable&.has_export_measures? %>
           <%= render partial: 'measures/grouped/table', locals: {
                      collection: xi_declarable.export_measures.sort_by(&:key),
-                     hide_duty_rate: true } %>
+                     hide_duty_rate: xi_declarable.export_measures.has_no_duties? } %>
         <% else %>
           <%= render 'measures/no_export_measures_warning', header: 'EU export controls' %>
         <% end %>
@@ -87,7 +88,7 @@
         <h3 class="govuk-heading-m" id="uk-export-controls">UK export controls</h3>
         <%= render partial: 'measures/grouped/table', locals: {
                    collection: uk_declarable.export_measures.sort_by(&:key),
-                   hide_duty_rate: true } %>
+                   hide_duty_rate: uk_declarable.export_measures.has_no_duties? } %>
       <% else %>
         <%= render 'measures/no_export_measures_warning' %>
       <% end %>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -25,21 +25,24 @@
   <div class="govuk-tabs__panel" id="import">
     <h2 class="govuk-heading-l"><%= measures_heading(anchor: 'import') %></h2>
 
-    <%= render partial: 'declarables/consigned', locals: { declarable: declarable } %>
+    <%= render 'declarables/consigned', declarable: declarable %>
 
     <% if declarable.import_measures.any? %>
-      <%= render partial: 'measures/grouped/navigation', locals: { uk_declarable: uk_declarable, xi_declarable: xi_declarable } %>
+      <%= render 'measures/grouped/navigation',
+                 uk_declarable: uk_declarable,
+                 xi_declarable: xi_declarable
+      %>
 
       <% if TradeTariffFrontend::ServiceChooser.xi? %>
-        <%= render partial: 'measures/grouped/xi',
-                   locals: { uk_declarable: uk_declarable,
-                             xi_declarable: xi_declarable,
-                             rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes } %>
+        <%= render 'measures/grouped/xi',
+                   uk_declarable: uk_declarable,
+                   xi_declarable: xi_declarable,
+                   rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes %>
       <% else %>
-        <%= render partial: 'measures/grouped/uk',
-                   locals: { uk_declarable: uk_declarable,
-                             xi_declarable: xi_declarable,
-                             rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes } %>
+        <%= render 'measures/grouped/uk',
+                   uk_declarable: uk_declarable,
+                   xi_declarable: xi_declarable,
+                   rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes %>
       <% end %>
 
     <% else %>
@@ -52,7 +55,7 @@
     <h2 class="govuk-heading-l"><%= measures_heading(anchor: 'export') %></h2>
     <p>The commodity code for exporting and <%= link_to 'Intrastat reporting', 'https://www.gov.uk/intrastat', target: "_blank" %> is <%= declarable.display_export_code %>.</p>
 
-    <%= render partial: 'declarables/consigned', locals: { declarable: declarable } %>
+    <%= render 'declarables/consigned', declarable: declarable %>
 
     <!-- EU Service -->
     <%= render "measures/measures_export_eu",

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -54,25 +54,22 @@
 
     <%= render partial: 'declarables/consigned', locals: { declarable: declarable } %>
 
-    <% if uk_declarable&.export_measures&.any? %>
+    <% if uk_declarable&.export_measures_without_supplementary_unit_for_import&.any? %>
       <h3 class="govuk-heading-m" id="uk-export-controls">
         UK export controls
       </h3>
       <%= render partial: 'measures/grouped/table', locals: {
-        collection: uk_declarable.export_measures
-                              .without_supplementary_unit
-                              .sort_by(&:key),
+        collection: uk_declarable.export_measures_without_supplementary_unit_for_import,
         hide_duty_rate: true } %>
     <% end %>
 
-    <% if TradeTariffFrontend::ServiceChooser.xi? && xi_declarable&.export_measures&.any? %>
+    <% if TradeTariffFrontend::ServiceChooser.xi? &&
+          xi_declarable&.export_measures_without_supplementary_unit_for_import&.any? %>
       <h3 class="govuk-heading-m govuk-!-margin-top-9" id="eu-export-controls">
         EU export controls
       </h3>
       <%= render partial: 'measures/grouped/table', locals: {
-        collection: xi_declarable.export_measures
-                                 .without_supplementary_unit
-                                 .sort_by(&:key),
+        collection: xi_declarable.export_measures_without_supplementary_unit_for_import,
         hide_duty_rate: true } %>
     <% else %>
       <p>There are no export measures for this commodity on this date.</p>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -55,44 +55,15 @@
     <%= render partial: 'declarables/consigned', locals: { declarable: declarable } %>
 
     <!-- EU Service -->
-    <% if TradeTariffFrontend::ServiceChooser.xi? %>
-       <!-- With no export measures in EU and UK -->
-      <% if !uk_declarable&.has_export_measures? && !xi_declarable&.has_export_measures? %>
-        <%= render 'measures/no_export_measures_warning', header: 'Export controls', no_uk_eu_measures: true %>
-      <% else %>
-        <!-- Export Measures are present in EU or UK (or both) -->
-        <h3 class="govuk-heading-m" id="uk-export-controls">UK export controls</h3>
-        <% if uk_declarable&.has_export_measures? %>
-
-          <%= render partial: 'measures/grouped/table', locals: {
-                     collection: uk_declarable.export_measures.sort_by(&:key),
-                     hide_duty_rate: uk_declarable.export_measures.has_no_duties? } %>
-          <% else %>
-            <%= render 'measures/no_export_measures_warning', header: 'UK export controls' %>
-        <% end %>
-
-        <h3 class="govuk-heading-m govuk-!-margin-top-9" id="eu-export-controls">EU export controls</h3>
-        <% if xi_declarable&.has_export_measures? %>
-          <%= render partial: 'measures/grouped/table', locals: {
-                     collection: xi_declarable.export_measures.sort_by(&:key),
-                     hide_duty_rate: xi_declarable.export_measures.has_no_duties? } %>
-        <% else %>
-          <%= render 'measures/no_export_measures_warning', header: 'EU export controls' %>
-        <% end %>
-      <% end %>
-    <% end %>
-
+    <%= render "measures/measures_export_eu",
+                xi_declarable: xi_declarable,
+                uk_declarable: uk_declarable
+    %>
+    
     <!-- UK service -->
-    <% if TradeTariffFrontend::ServiceChooser.uk? %>
-      <% if uk_declarable&.has_export_measures? %>
-        <h3 class="govuk-heading-m" id="uk-export-controls">UK export controls</h3>
-        <%= render partial: 'measures/grouped/table', locals: {
-                   collection: uk_declarable.export_measures.sort_by(&:key),
-                   hide_duty_rate: uk_declarable.export_measures.has_no_duties? } %>
-      <% else %>
-        <%= render 'measures/no_export_measures_warning' %>
-      <% end %>
-    <% end %>
+    <%= render "measures/measures_export_uk",
+               uk_declarable: uk_declarable
+    %>
 
     <%= render 'measures/export_tab_check_duties',
                 declarable: declarable,
@@ -178,20 +149,20 @@
                 collection: uk_declarable.export_measures,
                 as: 'measure',
                 locals: {
-                    declarable: uk_declarable,
-                    anchor: 'export',
-                    rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes
+                  declarable: uk_declarable,
+                  anchor: 'export',
+                  rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes
                 } %>
     <% end %>
 
     <% if xi_declarable&.export_measures&.any? %>
-        <%= render partial: 'measures/measure_references',
-                collection: xi_declarable.export_measures,
-                as: 'measure',
-                locals: {
-                    declarable: xi_declarable,
-                    anchor: 'export',
-                    rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes
+      <%= render partial: 'measures/measure_references',
+                 collection: xi_declarable.export_measures,
+                 as: 'measure',
+                 locals: {
+                   declarable: xi_declarable,
+                   anchor: 'export',
+                   rules_of_origin_schemes: rules_of_origin_schemes || roo_all_schemes
                 } %>
     <% end %>
   </div>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -54,25 +54,43 @@
 
     <%= render partial: 'declarables/consigned', locals: { declarable: declarable } %>
 
-    <% if uk_declarable&.export_measures_without_supplementary_unit_for_import&.any? %>
-      <h3 class="govuk-heading-m" id="uk-export-controls">
-        UK export controls
-      </h3>
-      <%= render partial: 'measures/grouped/table', locals: {
-        collection: uk_declarable.export_measures_without_supplementary_unit_for_import,
-        hide_duty_rate: true } %>
+    <!-- EU Service -->
+    <% if TradeTariffFrontend::ServiceChooser.xi? %>
+       <!-- With no export measures in EU and UK -->
+      <% if !uk_declarable&.has_export_measures? && !xi_declarable&.has_export_measures? %>
+        <%= render 'measures/no_export_measures_warning', header: 'Export controls', no_uk_eu_measures: true %>
+      <% else %>
+        <!-- Export Measures are present in EU or UK (or both) -->
+        <h3 class="govuk-heading-m" id="uk-export-controls">UK export controls</h3>
+        <% if uk_declarable&.has_export_measures? %>
+          <%= render partial: 'measures/grouped/table', locals: {
+                     collection: uk_declarable.export_measures.sort_by(&:key),
+                     hide_duty_rate: true } %>
+          <% else %>
+            <%= render 'measures/no_export_measures_warning', header: 'UK export controls' %>
+        <% end %>
+
+        <h3 class="govuk-heading-m govuk-!-margin-top-9" id="eu-export-controls">EU export controls</h3>
+        <% if xi_declarable&.has_export_measures? %>
+          <%= render partial: 'measures/grouped/table', locals: {
+                     collection: xi_declarable.export_measures.sort_by(&:key),
+                     hide_duty_rate: true } %>
+        <% else %>
+          <%= render 'measures/no_export_measures_warning', header: 'EU export controls' %>
+        <% end %>
+      <% end %>
     <% end %>
 
-    <% if TradeTariffFrontend::ServiceChooser.xi? &&
-          xi_declarable&.export_measures_without_supplementary_unit_for_import&.any? %>
-      <h3 class="govuk-heading-m govuk-!-margin-top-9" id="eu-export-controls">
-        EU export controls
-      </h3>
-      <%= render partial: 'measures/grouped/table', locals: {
-        collection: xi_declarable.export_measures_without_supplementary_unit_for_import,
-        hide_duty_rate: true } %>
-    <% else %>
-      <p>There are no export measures for this commodity on this date.</p>
+    <!-- UK service -->
+    <% if TradeTariffFrontend::ServiceChooser.uk? %>
+      <% if uk_declarable&.has_export_measures? %>
+        <h3 class="govuk-heading-m" id="uk-export-controls">UK export controls</h3>
+        <%= render partial: 'measures/grouped/table', locals: {
+                   collection: uk_declarable.export_measures.sort_by(&:key),
+                   hide_duty_rate: true } %>
+      <% else %>
+        <%= render 'measures/no_export_measures_warning' %>
+      <% end %>
     <% end %>
 
     <%= render 'measures/export_tab_check_duties',

--- a/app/views/measures/_measures_export_eu.html.erb
+++ b/app/views/measures/_measures_export_eu.html.erb
@@ -1,0 +1,27 @@
+<!-- EU Service -->
+
+<% if TradeTariffFrontend::ServiceChooser.xi? %>
+    <!-- With no export measures in EU and UK -->
+    <% if !uk_declarable&.has_export_measures? && !xi_declarable&.has_export_measures? %>
+      <%= render 'measures/no_export_measures_warning', header: 'Export controls', no_uk_eu_measures: true %>
+    <% else %>
+    <!-- Export Measures are present in EU or UK (or both) -->
+    <h3 class="govuk-heading-m" id="uk-export-controls">UK export controls</h3>
+    <% if uk_declarable&.has_export_measures? %>
+      <%= render partial: 'measures/grouped/table', locals: {
+                 collection: uk_declarable.export_measures.sort_by(&:key),
+                 hide_duty_rate: uk_declarable.export_measures.has_no_duties? } %>
+    <% else %>
+      <%= render 'measures/no_export_measures_warning', header: 'UK export controls' %>
+    <% end %>
+
+    <h3 class="govuk-heading-m govuk-!-margin-top-9" id="eu-export-controls">EU export controls</h3>
+    <% if xi_declarable&.has_export_measures? %>
+        <%= render partial: 'measures/grouped/table', locals: {
+                    collection: xi_declarable.export_measures.sort_by(&:key),
+                    hide_duty_rate: xi_declarable.export_measures.has_no_duties? } %>
+    <% else %>
+        <%= render 'measures/no_export_measures_warning', header: 'EU export controls' %>
+    <% end %>
+    <% end %>
+<% end %>

--- a/app/views/measures/_measures_export_eu.html.erb
+++ b/app/views/measures/_measures_export_eu.html.erb
@@ -6,22 +6,22 @@
       <%= render 'measures/no_export_measures_warning', header: 'Export controls', no_uk_eu_measures: true %>
     <% else %>
     <!-- Export Measures are present in EU or UK (or both) -->
-    <h3 class="govuk-heading-m" id="uk-export-controls">UK export controls</h3>
-    <% if uk_declarable&.has_export_measures? %>
-      <%= render partial: 'measures/grouped/table', locals: {
+      <h3 class="govuk-heading-m" id="uk-export-controls">UK export controls</h3>
+      <% if uk_declarable&.has_export_measures? %>
+        <%= render partial: 'measures/grouped/table', locals: {
                  collection: uk_declarable.export_measures.sort_by(&:key),
                  hide_duty_rate: uk_declarable.export_measures.has_no_duties? } %>
-    <% else %>
-      <%= render 'measures/no_export_measures_warning', header: 'UK export controls' %>
-    <% end %>
+      <% else %>
+        <%= render 'measures/no_export_measures_warning', header: 'UK export controls' %>
+      <% end %>
 
-    <h3 class="govuk-heading-m govuk-!-margin-top-9" id="eu-export-controls">EU export controls</h3>
-    <% if xi_declarable&.has_export_measures? %>
-        <%= render partial: 'measures/grouped/table', locals: {
+      <h3 class="govuk-heading-m govuk-!-margin-top-9" id="eu-export-controls">EU export controls</h3>
+      <% if xi_declarable&.has_export_measures? %>
+          <%= render partial: 'measures/grouped/table', locals: {
                     collection: xi_declarable.export_measures.sort_by(&:key),
                     hide_duty_rate: xi_declarable.export_measures.has_no_duties? } %>
-    <% else %>
+      <% else %>
         <%= render 'measures/no_export_measures_warning', header: 'EU export controls' %>
-    <% end %>
+      <% end %>
     <% end %>
 <% end %>

--- a/app/views/measures/_measures_export_uk.html.erb
+++ b/app/views/measures/_measures_export_uk.html.erb
@@ -1,0 +1,11 @@
+<!-- UK service -->
+<% if TradeTariffFrontend::ServiceChooser.uk? %>
+    <% if uk_declarable&.has_export_measures? %>
+    <h3 class="govuk-heading-m" id="uk-export-controls">UK export controls</h3>
+    <%= render partial: 'measures/grouped/table', locals: {
+                collection: uk_declarable.export_measures.sort_by(&:key),
+                hide_duty_rate: uk_declarable.export_measures.has_no_duties? } %>
+    <% else %>
+    <%= render 'measures/no_export_measures_warning' %>
+    <% end %>
+<% end %>

--- a/app/views/measures/_no_export_measures_warning.html.erb
+++ b/app/views/measures/_no_export_measures_warning.html.erb
@@ -1,10 +1,10 @@
 <% if defined?(header) %>
-  <h3 class="govuk-heading-m" id="uk-export-controls">
+  <h3 class="govuk-heading-m">
     <%= header %>
   </h3>
 <% end %>
 
-<div class="govuk-warning-text">
+<div class="govuk-warning-text" id='no-export-measures-warning'>
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Info</span>

--- a/app/views/measures/_no_export_measures_warning.html.erb
+++ b/app/views/measures/_no_export_measures_warning.html.erb
@@ -1,0 +1,17 @@
+<% if defined?(header) %>
+  <h3 class="govuk-heading-m" id="uk-export-controls">
+    <%= header %>
+  </h3>
+<% end %>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Info</span>
+    <% if defined?(no_uk_eu_measures) && no_uk_eu_measures %>
+      There are no UK or EU export measures for this commodity on this date.
+    <% else %>
+      There are no export measures for this commodity on this date.
+    <% end %>
+  </strong>
+</div>

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -127,6 +127,14 @@ FactoryBot.define do
       end
     end
 
+    trait :with_export_measures do
+      export_measures do
+        [
+          attributes_for(:measure),
+        ]
+      end
+    end
+
     trait :with_conditionally_prohibitive_measures do
       import_measures do
         [

--- a/spec/views/measures/_measure_export_eu_spec.rb
+++ b/spec/views/measures/_measure_export_eu_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe 'measures/_measure_export_eu', type: :view do
+  context 'when in EU service' do
+    include_context 'with XI service'
+
+    before do
+      render 'measures/measures_export_eu',
+             declarable: nil,
+             uk_declarable: uk_commodity,
+             xi_declarable: eu_commodity,
+             rules_of_origin_schemes: []
+    end
+
+    let(:eu_commodity) { build(:commodity) }
+
+    context 'when there are only EU export measures' do
+      let(:eu_commodity) { build(:commodity, :with_export_measures) }
+      let(:uk_commodity) { nil }
+
+      it { expect(rendered).to have_css('#eu-export-controls') }
+
+      it { expect(rendered).to have_css('#uk-export-controls') }
+      it { expect(rendered).to match('There are no export measures for this commodity on this date.') }
+    end
+
+    context 'when there are no export measures for both EU and UK' do
+      let(:uk_commodity) { build(:commodity) }
+      let(:eu_commodity) { build(:commodity) }
+
+      it { expect(rendered).not_to have_css('h3#uk-export-controls') }
+      it { expect(rendered).not_to have_css('h3#eu-export-controls') }
+
+      it { expect(rendered).to match('Export controls') }
+      it { expect(rendered).to match('There are no UK or EU export measures for this commodity on this date.') }
+    end
+  end
+end

--- a/spec/views/measures/_measure_export_uk_spec.rb
+++ b/spec/views/measures/_measure_export_uk_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe 'measures/_measure_export_uk', type: :view do
+  context 'when in UK service' do
+    include_context 'with UK service'
+
+    before do
+      render 'measures/measures_export_uk',
+             declarable: nil,
+             uk_declarable: commodity,
+             xi_declarable: nil,
+             rules_of_origin_schemes: []
+    end
+
+    context 'when there are UK export measures' do
+      let(:commodity) { build(:commodity, :with_export_measures) }
+
+      it { expect(rendered).to have_css('h3#uk-export-controls') }
+    end
+
+    context 'when there are no export measures' do
+      let(:commodity) { build(:commodity) }
+
+      it { expect(rendered).to match('There are no export measures for this commodity on this date.') }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-3686


### What?
Make supplementary units of type 109 appear in the export tab as well as the import tab
