### PR TITLE
HOTT-3717: Add file links, publication_date and file_size to period list frontend

### DIFF
--- a/app/models/exchange_rates/file.rb
+++ b/app/models/exchange_rates/file.rb
@@ -7,4 +7,8 @@ class ExchangeRates::File
                 :file_size,
                 :publication_date,
                 :format
+
+  def file_size_in_kb
+    sprintf('%.1f', file_size.to_f / 1024)
+  end
 end

--- a/app/models/exchange_rates/file.rb
+++ b/app/models/exchange_rates/file.rb
@@ -1,0 +1,10 @@
+require 'api_entity'
+
+class ExchangeRates::File
+  include ApiEntity
+
+  attr_accessor :file_path,
+                :file_size,
+                :publication_date,
+                :format
+end

--- a/app/models/exchange_rates/period.rb
+++ b/app/models/exchange_rates/period.rb
@@ -4,4 +4,6 @@ class ExchangeRates::Period
   include ApiEntity
 
   attr_accessor :year, :month
+
+  has_many :files, class_name: 'ExchangeRates::File'
 end

--- a/app/models/exchange_rates/period_list.rb
+++ b/app/models/exchange_rates/period_list.rb
@@ -16,6 +16,6 @@ class ExchangeRates::PeriodList
   def publication_date
     date_str = exchange_rate_periods.first.files.first&.publication_date
     date = Date.parse(date_str) if date_str
-    date&.strftime('%d %B %Y')
+    date&.to_formatted_s(:long)
   end
 end

--- a/app/models/exchange_rates/period_list.rb
+++ b/app/models/exchange_rates/period_list.rb
@@ -12,4 +12,10 @@ class ExchangeRates::PeriodList
     opts[:year] = year
     super(nil, opts)
   end
+
+  def publication_date
+    date_str = exchange_rate_periods.first.files.first&.publication_date
+    date = Date.parse(date_str) if date_str
+    date&.strftime('%d %B %Y')
+  end
 end

--- a/app/views/exchange_rates/_document_detail.html.erb
+++ b/app/views/exchange_rates/_document_detail.html.erb
@@ -3,14 +3,18 @@
   <section class="attachment exchange-rates-attachment">
     <div class="attachment-thumb">
         <%= link_to(image_pack_tag("spreadsheet.png", alt: ""), asset_path('todo')) %>
-    
     </div>
     <div class="attachment-details">
         <h3 class="govuk-heading-s govuk-!-font-size-27 govuk-!-font-weight-regular exchange-rates-period-heading">
           <%= Date::MONTHNAMES[period.month] %> <%= period.year %> monthly exchange rates
         </h3>
 
-        <p><strong><a class="govuk-link" href="/todo">View online</a></strong></p>
+        <p><strong><a class="govuk-link" href="/todo">View online</a></strong> | 
+        <% period.files.each_with_index do |file, index| %>
+          <strong><a href="<%= file.file_path %>"><%= file.format.upcase %></strong> <%= file.file_size %> KB</a>
+          <% unless index == period.files.size - 1 %>|<% end %>
+        <% end %>
+        </p>
 
         <p>This file may not be suitable for users of assistive technology</p>
 

--- a/app/views/exchange_rates/_document_detail.html.erb
+++ b/app/views/exchange_rates/_document_detail.html.erb
@@ -12,7 +12,7 @@
         <p><strong><a class="govuk-link" href="/todo">View online</a></strong> | 
         <% period.files.each_with_index do |file, index| %>
           <strong><a href="<%= file.file_path %>"><%= file.format.upcase %></strong> <%= file.file_size_in_kb %> KB</a>
-          <% unless index == period.files.size - 1 %>|<% end %>
+          <%= '|' unless index == period.files.size - 1 %>
         <% end %>
         </p>
 

--- a/app/views/exchange_rates/_document_detail.html.erb
+++ b/app/views/exchange_rates/_document_detail.html.erb
@@ -11,7 +11,7 @@
 
         <p><strong><a class="govuk-link" href="/todo">View online</a></strong> | 
         <% period.files.each_with_index do |file, index| %>
-          <strong><a href="<%= file.file_path %>"><%= file.format.upcase %></strong> <%= file.file_size %> KB</a>
+          <strong><a href="<%= file.file_path %>"><%= file.format.upcase %></strong> <%= file.file_size_in_kb %> KB</a>
           <% unless index == period.files.size - 1 %>|<% end %>
         <% end %>
         </p>

--- a/app/views/exchange_rates/index.html.erb
+++ b/app/views/exchange_rates/index.html.erb
@@ -16,12 +16,18 @@
     <dd class="gem-c-metadata__definition">
       <strong><a href="https://www.gov.uk/government/organisations/hm-revenue-customs">HM Revenue &amp; Customs</a></strong>
     </dd>
+    <dt class="gem-c-metadata__term">Published:</dt>
+    <dd class="gem-c-metadata__definition">
+      <%= @period_list.publication_date %>
+    </dd>
 
     <h2>Documents</h2>
 
     <% @period_list.exchange_rate_periods.each do |period| %>
       <%= render partial: 'exchange_rates/document_detail', locals: { period: period } %>
     <% end %>
+
+    <p>HMRC currency exchange rates for Customs and VAT are sourced from data provided by ft.com and xe.com.</p>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,7 +110,7 @@ Rails.application.routes.draw do
 
   get '/search/toggle_beta_search', as: :toggle_beta_search, to: 'search#toggle_beta_search'
 
-  get 'exchange_rates(/:year)', to: 'exchange_rates#index', as: 'exchange_rates'
+  # get 'exchange_rates(/:year)', to: 'exchange_rates#index', as: 'exchange_rates'
   get 'search_suggestions', to: 'search#suggestions', as: :search_suggestions
   get 'quota_search', to: 'search#quota_search', as: :quota_search
   get 'simplified_procedure_value', to: 'simplified_procedural_values#index', as: :simplified_procedural_values

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,7 +110,7 @@ Rails.application.routes.draw do
 
   get '/search/toggle_beta_search', as: :toggle_beta_search, to: 'search#toggle_beta_search'
 
-  # get 'exchange_rates(/:year)', to: 'exchange_rates#index', as: 'exchange_rates'
+  get 'exchange_rates(/:year)', to: 'exchange_rates#index', as: 'exchange_rates'
   get 'search_suggestions', to: 'search#suggestions', as: :search_suggestions
   get 'quota_search', to: 'search#quota_search', as: :quota_search
   get 'simplified_procedure_value', to: 'simplified_procedural_values#index', as: :simplified_procedural_values

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -24,6 +24,7 @@ module TradeTariffFrontend
       geographical_areas
       chemical_substances
       simplified_procedural_code_measures
+      exchange_rates
     ]
   end
 
@@ -60,6 +61,7 @@ module TradeTariffFrontend
       healthcheck
       simplified_procedural_code_measures
       bulk_searches
+      exchange_rates
     ]
   end
 

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -24,7 +24,6 @@ module TradeTariffFrontend
       geographical_areas
       chemical_substances
       simplified_procedural_code_measures
-      exchange_rates
     ]
   end
 

--- a/spec/factories/exchange_rates/file_factory.rb
+++ b/spec/factories/exchange_rates/file_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :exchange_rate_file, class: 'ExchangeRates::File' do
+    file_path { '/exchange_rates/csv/exrates-monthly-0623.csv' }
+    format { 'csv' }
+    file_size { 123 }
+    publication_date { Date.new(2023, 7, 25) }
+  end
+end

--- a/spec/factories/exchange_rates/file_factory.rb
+++ b/spec/factories/exchange_rates/file_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :exchange_rate_file, class: 'ExchangeRates::File' do
     file_path { '/exchange_rates/csv/exrates-monthly-0623.csv' }
     format { 'csv' }
-    file_size { 123 }
-    publication_date { Date.new(2023, 7, 25) }
+    file_size { 2048 }
+    publication_date { '2023-07-25' }
   end
 end

--- a/spec/factories/exchange_rates/period_factory.rb
+++ b/spec/factories/exchange_rates/period_factory.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :exchange_rate_period, class: 'ExchangeRates::Period' do
     sequence(:year) { |n| 2022 - n + 1 }
     month { 6 }
+
+    files { attributes_for_list :exchange_rate_file, 2 }
   end
 end

--- a/spec/models/exchange_rates/file_spec.rb
+++ b/spec/models/exchange_rates/file_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe ExchangeRates::File do
-  let(:file) { build(:exchange_rate_file)}
+  let(:file) { build(:exchange_rate_file) }
 
   it { is_expected.to respond_to :file_path }
   it { is_expected.to respond_to :file_size }

--- a/spec/models/exchange_rates/file_spec.rb
+++ b/spec/models/exchange_rates/file_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+RSpec.describe ExchangeRates::File do
+  it { is_expected.to respond_to :file_path }
+  it { is_expected.to respond_to :file_size }
+  it { is_expected.to respond_to :publication_date }
+  it { is_expected.to respond_to :format }
+end

--- a/spec/models/exchange_rates/file_spec.rb
+++ b/spec/models/exchange_rates/file_spec.rb
@@ -1,8 +1,16 @@
 require 'spec_helper'
 
 RSpec.describe ExchangeRates::File do
+  let(:file) { build(:exchange_rate_file)}
+
   it { is_expected.to respond_to :file_path }
   it { is_expected.to respond_to :file_size }
   it { is_expected.to respond_to :publication_date }
   it { is_expected.to respond_to :format }
+
+  describe '#file_size_in_kb' do
+    it 'converts bytes to kilobytes with one decimal place' do
+      expect(file.file_size_in_kb).to eq('2.0')
+    end
+  end
 end

--- a/spec/models/exchange_rates/period_list_spec.rb
+++ b/spec/models/exchange_rates/period_list_spec.rb
@@ -92,4 +92,12 @@ RSpec.describe ExchangeRates::PeriodList do
       it { is_expected.to have_attributes year: }
     end
   end
+
+  describe '.publication_date' do
+    let(:period_list) { build(:exchange_rate_period_list) }
+
+    it 'returns the first files publication_date' do
+      expect(period_list.publication_date).to eq('25 July 2023')
+    end
+  end
 end

--- a/spec/models/exchange_rates/period_spec.rb
+++ b/spec/models/exchange_rates/period_spec.rb
@@ -3,4 +3,5 @@ require 'spec_helper'
 RSpec.describe ExchangeRates::Period do
   it { is_expected.to respond_to :year }
   it { is_expected.to respond_to :month }
+  it { is_expected.to respond_to :files }
 end

--- a/spec/views/exchange_rates/_document_detail.html.erb_spec.rb
+++ b/spec/views/exchange_rates/_document_detail.html.erb_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe 'exchange_rates/_document_detail', type: :view do
   end
 
   it { is_expected.to have_css 'h3', text: "June #{period.year} monthly exchange rates" }
+
+  it { is_expected.to have_link('CSV', href: '/exchange_rates/csv/exrates-monthly-0623.csv'), count: 2 }
+
+  it { is_expected.to have_css 'p', text: 'View online | CSV 2.0 KB | CSV 2.0 KB', normalize_ws: true }
 end

--- a/spec/views/exchange_rates/index.html.erb_spec.rb
+++ b/spec/views/exchange_rates/index.html.erb_spec.rb
@@ -9,15 +9,17 @@ RSpec.describe 'exchange_rates/index', type: :view do
     assign :period_list, period_list
   end
 
-  pending 'uncomment tests when exchange rates is ready'
+  it { is_expected.to have_css 'h1', text: "#{period_list.year} HMRC currency exchange rates" }
 
-  # it { is_expected.to have_css 'h1', text: "#{period_list.year} HMRC currency exchange rates" }
+  it { is_expected.to have_css 'p', text: "Check the official #{period_list.year}" }
 
-  # it { is_expected.to have_css 'p', text: "Check the official #{period_list.year}" }
+  it { is_expected.to render_template(partial: '_document_detail') }
 
-  # it { is_expected.to render_template(partial: '_document_detail') }
+  it { is_expected.to have_css 'h3', text: "June #{period_list.exchange_rate_periods.first.year} monthly exchange rates" }
 
-  # it { is_expected.to have_css 'h3', text: "June #{period_list.exchange_rate_periods.first.year} monthly exchange rates" }
+  it { is_expected.to have_css 'a', text: "HMRC exchange rates for #{period_list.exchange_rate_years.first.year}" }
 
-  # it { is_expected.to have_css 'a', text: "HMRC exchange rates for #{period_list.exchange_rate_years.first.year}" }
+  it { is_expected.to have_css 'dt', text: 'Published:' }
+
+  it { is_expected.to have_css 'dd', text: '25 July 2023' }
 end

--- a/spec/views/exchange_rates/index.html.erb_spec.rb
+++ b/spec/views/exchange_rates/index.html.erb_spec.rb
@@ -9,17 +9,19 @@ RSpec.describe 'exchange_rates/index', type: :view do
     assign :period_list, period_list
   end
 
-  it { is_expected.to have_css 'h1', text: "#{period_list.year} HMRC currency exchange rates" }
+  pending 'uncomment routes/tests when exchange rates is ready'
 
-  it { is_expected.to have_css 'p', text: "Check the official #{period_list.year}" }
+  # it { is_expected.to have_css 'h1', text: "#{period_list.year} HMRC currency exchange rates" }
 
-  it { is_expected.to render_template(partial: '_document_detail') }
+  # it { is_expected.to have_css 'p', text: "Check the official #{period_list.year}" }
 
-  it { is_expected.to have_css 'h3', text: "June #{period_list.exchange_rate_periods.first.year} monthly exchange rates" }
+  # it { is_expected.to render_template(partial: '_document_detail') }
 
-  it { is_expected.to have_css 'a', text: "HMRC exchange rates for #{period_list.exchange_rate_years.first.year}" }
+  # it { is_expected.to have_css 'h3', text: "June #{period_list.exchange_rate_periods.first.year} monthly exchange rates" }
 
-  it { is_expected.to have_css 'dt', text: 'Published:' }
+  # it { is_expected.to have_css 'a', text: "HMRC exchange rates for #{period_list.exchange_rate_years.first.year}" }
 
-  it { is_expected.to have_css 'dd', text: '25 July 2023' }
+  # it { is_expected.to have_css 'dt', text: 'Published:' }
+
+  # it { is_expected.to have_css 'dd', text: '25 July 2023' }
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3717

### What?

I have added/removed/altered:

- [ ] Added file links, publication_date and file_size to period list frontend

### Why?

I am doing this because:

- We need access to these attributes and links on the views

### Deployment risks (optional)

- Makes changes to our complex routing setup that may affect apis to proxying to backend

<img width="1104" alt="Screenshot 2023-08-03 at 11 06 14" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/1c7b5f5f-fee6-48fb-9356-51cdc977fb8d">
