### PR TITLE
HOTT-3567: Fix open/close tooltip text.

### DIFF
--- a/app/webpacker/controllers/tree_controller.js
+++ b/app/webpacker/controllers/tree_controller.js
@@ -66,7 +66,7 @@ export default class extends Controller {
   #openBranch(branch, childList) {
     childList.setAttribute('aria-hidden', 'false');
     branch.classList.add('open');
-    branch.setAttribute('title', 'Click to open');
+    branch.setAttribute('title', 'Click to close');
     branch.setAttribute('aria-expanded', 'true');
 
     this.#focusChild(childList);
@@ -75,7 +75,7 @@ export default class extends Controller {
   #closeBranch(branch, childList) {
     childList.setAttribute('aria-hidden', 'true');
     branch.classList.remove('open');
-    branch.setAttribute('title', 'Click to close');
+    branch.setAttribute('title', 'Click to open');
     branch.setAttribute('aria-expanded', 'false');
 
     this.#focusChild(childList);


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-3567

### What?
Fix open/close tooltip text.

### Why?
The message is the opposite open instead of close (and vice-versa)
