### PR TITLE
BAU: Strip code of any whitespace

### DIFF
--- a/app/forms/footnote_search_form.rb
+++ b/app/forms/footnote_search_form.rb
@@ -10,6 +10,8 @@ class FootnoteSearchForm
 
   def validate_code
     if code.present?
+      code.strip!
+
       errors.add(:code, :invalid) unless code =~ /\A([A-Z]|[0-9]){5}\z/
       errors.add(:code, :wrong_type) unless type.in?(self.class.footnote_types)
     elsif description.blank?


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Removes any whitespace from footnote codes

### Why?

I am doing this because:

- Increases robustness of search functionality
