### PR TITLE
HOTT-3611: Support controlling showing proofs for specific area

### DIFF
--- a/app/helpers/rules_of_origin_helper.rb
+++ b/app/helpers/rules_of_origin_helper.rb
@@ -9,7 +9,7 @@ module RulesOfOriginHelper
   def show_proofs_for_geographical_areas?(roo_schemes, measure)
     schemes_that_apply_to_geographical_area = roo_schemes&.select do |s|
       s.applies_to_geographical_area?(measure.geographical_area)
-    end
+    end || []
 
     (schemes_that_apply_to_geographical_area.count <= 1) && measure.cds_proofs_of_origin(roo_schemes).any?
   end

--- a/app/helpers/rules_of_origin_helper.rb
+++ b/app/helpers/rules_of_origin_helper.rb
@@ -6,6 +6,15 @@ module RulesOfOriginHelper
     TradeTariffFrontend::ServiceChooser.uk? ? 'UK' : 'EU'
   end
 
+  def show_proofs_for_geographical_areas?(roo_schemes, measure)
+    zero_or_one_schemes_that_apply_to_geographical_area = !roo_schemes&.many? { |s|
+      s.applies_to_geographical_area?(measure.geographical_area)
+    }
+
+    zero_or_one_schemes_that_apply_to_geographical_area &&
+      measure.cds_proofs_of_origin(roo_schemes).any?
+  end
+
   def rules_of_origin_schemes_intro(country_name, schemes)
     if schemes.empty?
       render 'rules_of_origin/intros/no_scheme',

--- a/app/helpers/rules_of_origin_helper.rb
+++ b/app/helpers/rules_of_origin_helper.rb
@@ -7,12 +7,11 @@ module RulesOfOriginHelper
   end
 
   def show_proofs_for_geographical_areas?(roo_schemes, measure)
-    zero_or_one_schemes_that_apply_to_geographical_area = !roo_schemes&.many? { |s|
+    schemes_that_apply_to_geographical_area = roo_schemes&.select do |s|
       s.applies_to_geographical_area?(measure.geographical_area)
-    }
+    end
 
-    zero_or_one_schemes_that_apply_to_geographical_area &&
-      measure.cds_proofs_of_origin(roo_schemes).any?
+    (schemes_that_apply_to_geographical_area.count <= 1) && measure.cds_proofs_of_origin(roo_schemes).any?
   end
 
   def rules_of_origin_schemes_intro(country_name, schemes)

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -2,7 +2,6 @@ require 'api_entity'
 
 class MeasureType
   RENDERED_MEASURE_TYPE_DETAILS = { 'xi' => {}, 'uk' => {} }.freeze
-  CDS_PROOFS_OF_ORIGIN = %w[141 142 143 145 146 147].freeze
 
   delegate :service_name, to: TradeTariffFrontend::ServiceChooser
 
@@ -15,6 +14,7 @@ class MeasureType
     safeguard: %w[696],
     supplementary: %w[109 110 111],
     supplementary_unit_import_only: %w[110],
+    cds_proofs_of_origin: %w[141 142 143 145 146 147],
   }
 
   enum :measure_component_applicable_code, {
@@ -47,10 +47,6 @@ class MeasureType
     return 'Restriction' if description.scan(/Restriction/i).present?
 
     'Control'
-  end
-
-  def cds_proofs_of_origin?
-    CDS_PROOFS_OF_ORIGIN.include? id
   end
 
   private

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -5,9 +5,16 @@ class RulesOfOrigin::Scheme
 
   collection_path '/rules_of_origin_schemes'
 
-  attr_accessor :scheme_code, :title, :countries, :footnote, :fta_intro,
-                :introductory_notes, :unilateral, :cumulation_methods,
-                :proof_intro
+  attr_accessor :scheme_code,
+                :title,
+                :countries,
+                :footnote,
+                :fta_intro,
+                :introductory_notes,
+                :unilateral,
+                :cumulation_methods,
+                :proof_intro,
+                :show_proofs_for_geographical_areas
 
   attr_writer :proof_codes
 
@@ -56,6 +63,10 @@ class RulesOfOrigin::Scheme
   end
 
   def applies_to_geographical_area?(area)
+    if show_proofs_for_geographical_areas.present?
+      return show_proofs_for_geographical_areas.include?(area.geographical_area_id)
+    end
+
     countries.include? area.geographical_area_id
   end
 

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -67,7 +67,7 @@ class RulesOfOrigin::Scheme
       return show_proofs_for_geographical_areas.include?(area.geographical_area_id)
     end
 
-    countries.include? area.geographical_area_id
+    countries.include?(area.geographical_area_id)
   end
 
   def applies_to_geographical_area_or_its_children?(area)

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -53,8 +53,7 @@
   <td class="conditions-col govuk-table__cell">
     <% if measure.has_measure_conditions? %>
       <%= link_to "Conditions",  "#", class: 'reference', 'data-popup-ref' => "#{measure.destination}-#{measure.id}-conditions", "aria-label": "Click to open a dialog with the conditions for this measure", role: "button" %>
-    <% elsif !roo_schemes&.many? { |s| s.applies_to_geographical_area? measure.geographical_area } &&
-        measure.cds_proofs_of_origin(roo_schemes).any? %>
+    <% elsif show_proofs_for_geographical_areas?(roo_schemes, measure) %>
       <%= link_to "Conditions",  "#", class: 'reference', 'data-popup-ref' => "#{measure.destination}-#{measure.id}-cds-proofs", "aria-label": "Click to open a dialog with the conditions for this measure", role: "button" %>
     <% end %>
   </td>

--- a/app/views/measures/grouped/_table.html.erb
+++ b/app/views/measures/grouped/_table.html.erb
@@ -14,9 +14,9 @@
 
 <%= render 'measures/grouped/tariff_duty_calculator_link', declarable_code: declarable.code if local_assigns[:show_duty_calculator] %>
 
-<%= render 'measures/grouped/vat_excise', uk_declarable: uk_declarable, declarable_code: uk_declarable.code if local_assigns[:vat_excise] && local_assigns[:uk_declarable] %> 
+<%= render 'measures/grouped/vat_excise', uk_declarable: uk_declarable, declarable_code: uk_declarable.code if local_assigns[:vat_excise] && local_assigns[:uk_declarable] %>
 
-<%= render 'measures/grouped/credibility_checks' if local_assigns[:credibility_checks] %> 
+<%= render 'measures/grouped/credibility_checks' if local_assigns[:credibility_checks] %>
 
 <table class="small-table measures govuk-table"  >
   <thead class="govuk-table__head">

--- a/app/views/measures/grouped/_table.html.erb
+++ b/app/views/measures/grouped/_table.html.erb
@@ -1,4 +1,4 @@
-<h3 class="govuk-heading-m govuk-!-margin-top-5 govuk-!-margin-bottom-3", id=<%= local_assigns[:css_id]%>>
+<h3 class="govuk-heading-m govuk-!-margin-top-5 govuk-!-margin-bottom-3" <%= local_assigns[:css_id] %>>
   <%= local_assigns[:caption] %>
 </h3>
 
@@ -18,7 +18,7 @@
 
 <%= render 'measures/grouped/credibility_checks' if local_assigns[:credibility_checks] %>
 
-<table class="small-table measures govuk-table"  >
+<table class="small-table measures govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Country</th>

--- a/app/views/measures/grouped/_table.html.erb
+++ b/app/views/measures/grouped/_table.html.erb
@@ -28,7 +28,7 @@
         <th class="govuk-table__header">Duty rate</th>
       <% end %>
 
-      <th class="govuk-table__header">tantanConditions</th>
+      <th class="govuk-table__header">Conditions</th>
       <th class="govuk-table__header legal-base-col" title="Opens in a new window">Legal base</th>
       <th class="govuk-table__header">Footnotes</th>
     </tr>

--- a/app/views/measures/grouped/_table.html.erb
+++ b/app/views/measures/grouped/_table.html.erb
@@ -28,7 +28,7 @@
         <th class="govuk-table__header">Duty rate</th>
       <% end %>
 
-      <th class="govuk-table__header">Conditions</th>
+      <th class="govuk-table__header">tantanConditions</th>
       <th class="govuk-table__header legal-base-col" title="Opens in a new window">Legal base</th>
       <th class="govuk-table__header">Footnotes</th>
     </tr>

--- a/spec/factories/rules_of_origin/scheme_factory.rb
+++ b/spec/factories/rules_of_origin/scheme_factory.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     links { attributes_for_list :rules_of_origin_link, link_count }
     articles { attributes_for_list :rules_of_origin_article, article_count }
     proofs { attributes_for_list :rules_of_origin_proof, proof_count }
+    show_proofs_for_geographical_areas { [] } # if emtpy it is ignored
     origin_reference_document { attributes_for :rules_of_origin_origin_reference_document }
 
     rule_sets do

--- a/spec/factories/rules_of_origin/scheme_factory.rb
+++ b/spec/factories/rules_of_origin/scheme_factory.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     links { attributes_for_list :rules_of_origin_link, link_count }
     articles { attributes_for_list :rules_of_origin_article, article_count }
     proofs { attributes_for_list :rules_of_origin_proof, proof_count }
-    show_proofs_for_geographical_areas { [] } # if emtpy it is ignored
+    show_proofs_for_geographical_areas { [] } # if empty it is ignored
     origin_reference_document { attributes_for :rules_of_origin_origin_reference_document }
 
     rule_sets do

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -223,7 +223,6 @@ RSpec.describe RulesOfOrigin::Scheme do
 
     context 'with show_proofs_for_geographical_areas' do
       include_context 'with mocked response'
-      
     end
 
     context 'with response with no rules or links' do

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -221,6 +221,11 @@ RSpec.describe RulesOfOrigin::Scheme do
       it { is_expected.to eql [] }
     end
 
+    context 'with show_proofs_for_geographical_areas' do
+      include_context 'with mocked response'
+      
+    end
+
     context 'with response with no rules or links' do
       include_context 'with mocked response'
 

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -221,10 +221,6 @@ RSpec.describe RulesOfOrigin::Scheme do
       it { is_expected.to eql [] }
     end
 
-    context 'with show_proofs_for_geographical_areas' do
-      include_context 'with mocked response'
-    end
-
     context 'with response with no rules or links' do
       include_context 'with mocked response'
 
@@ -433,6 +429,20 @@ RSpec.describe RulesOfOrigin::Scheme do
 
     context 'when area not in countries list' do
       let(:area) { build :geographical_area, geographical_area_id: 'DE' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when area is specified in show_proofs_for_geographical_areas' do
+      let(:area) { build :geographical_area, geographical_area_id: 'AU' }
+      let(:scheme) { build :rules_of_origin_scheme, show_proofs_for_geographical_areas: %w[AU] }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when show_proofs_for_geographical_areas is not specified' do
+      let(:area) { build :geographical_area, geographical_area_id: 'AU' }
+      let(:scheme) { build :rules_of_origin_scheme }
 
       it { is_expected.to be false }
     end

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -421,13 +421,13 @@ RSpec.describe RulesOfOrigin::Scheme do
 
     let(:scheme) { build :rules_of_origin_scheme, countries: %w[FR] }
 
-    context 'when area in countries list' do
+    context 'when area in countries list and there is no show_proofs_for_geographical_areas list' do
       let(:area) { build :geographical_area, geographical_area_id: 'FR' }
 
       it { is_expected.to be true }
     end
 
-    context 'when area not in countries list' do
+    context 'when area not in countries list and there is no show_proofs_for_geographical_areas list' do
       let(:area) { build :geographical_area, geographical_area_id: 'DE' }
 
       it { is_expected.to be false }
@@ -438,13 +438,6 @@ RSpec.describe RulesOfOrigin::Scheme do
       let(:scheme) { build :rules_of_origin_scheme, show_proofs_for_geographical_areas: %w[AU] }
 
       it { is_expected.to be true }
-    end
-
-    context 'when show_proofs_for_geographical_areas is not specified' do
-      let(:area) { build :geographical_area, geographical_area_id: 'AU' }
-      let(:scheme) { build :rules_of_origin_scheme }
-
-      it { is_expected.to be false }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,6 @@ Capybara.register_driver(:selenium_chrome_headless) do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument('--headless')
 
-  Webdrivers::Chromedriver.required_version = '114.0.5735.90'
   Capybara::Selenium::Driver.new(
     app, browser: :chrome, options:
   )

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -9,7 +9,14 @@ VCR.configure do |c|
   c.default_cassette_options = { match_requests_on: [:path] }
   c.configure_rspec_metadata!
   c.ignore_request do |request|
-    if request.uri.start_with?('https://chromedriver.storage.googleapis.com')
+    chrome_urls = [
+      'https://chromedriver.storage.googleapis.com',
+      'https://googlechromelabs.github.io/',
+      'https://edgedl.me.gvt1.com/',
+    ]
+    starts_with_chrome_url = chrome_urls.any? { |url| request.uri.start_with?(url) }
+
+    if starts_with_chrome_url
       true
     else
       URI(request.uri).host.in?(%w[localhost 127.0.0.1]) &&


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3611

### What?

I have added/removed/altered:

- [x] Added support for overriding when we should show proofs for specific areas
- [x] Used the enum idiom for simple business logic on the measure type
- [x] Extracted the rules of origin condition popup logic into a helper and not in the view
 
### Why?

I am doing this because:

- The override is necessary to force showing proofs for specific geographical area ids, only
- The enum idiom is just much cleaner and more consistent with the frontend application
- The logic for this view was misplaced, complex and hard to read in the middle of the view
