### PR TITLE
HOTT-3884: Add frontend locking

### DIFF
--- a/terraform/backends/development.tfbackend
+++ b/terraform/backends/development.tfbackend
@@ -1,4 +1,5 @@
-bucket  = "terraform-state-development-844815912454"
-key     = "tariff-frontend.tfstate"
-region  = "eu-west-2"
-encrypt = true
+bucket         = "terraform-state-development-844815912454"
+key            = "tariff-frontend.tfstate"
+region         = "eu-west-2"
+encrypt        = true
+dynamodb_table = "frontend-lock-844815912454"


### PR DESCRIPTION
### Jira link

[HOTT-3884](https://transformuk.atlassian.net/browse/HOTT-3884)

### What?

I have added/removed/altered:

- Added the DynamoDB lock table to the backend configuration
- Reconfigured the backend to use this (manually)

### Why?

I am doing this because:

- We want to ensure the state has locking configured to prevent parallel Terraform runs