### PR TITLE
HOTT-3779: Fix identifier class width

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -82,9 +82,32 @@ module CommoditiesHelper
         concat(content_tag(:div, vat_overview_measure_duty_amounts(commodity), class: 'vat', aria: { describedby: 'commodity-vat-title' }))
       end
 
-      concat(content_tag(:div, third_country_overview_measure_duty_amounts(commodity), class: 'duty', aria: { describedby: 'commodity-duty-title' }))
-      concat(content_tag(:div, supplementary_unit_overview_measure_duty_amounts(commodity), class: 'supplementary-units', aria: { describedby: 'commodity-supplementary-title' }))
-      concat(content_tag(:div, segmented_commodity_code(abbreviate_commodity_code(commodity), coloured: true), class: 'identifier', aria: { describedby: "commodity-#{commodity.short_code}" }))
+      concat(
+        content_tag(
+          :div,
+          third_country_overview_measure_duty_amounts(commodity),
+          class: 'duty',
+          aria: { describedby: 'commodity-duty-title' },
+        ),
+      )
+
+      concat(
+        content_tag(
+          :div,
+          supplementary_unit_overview_measure_duty_amounts(commodity),
+          class: 'supplementary-units',
+          aria: { describedby: 'commodity-supplementary-title' },
+        ),
+      )
+
+      concat(
+        content_tag(
+          :div,
+          segmented_commodity_code(abbreviate_commodity_code(commodity), coloured: true),
+          class: "identifier service-#{TradeTariffFrontend::ServiceChooser.service_name}",
+          aria: { describedby: "commodity-#{commodity.short_code}" },
+        ),
+      )
     end
   end
 

--- a/app/views/commodities/_commodity.html.erb
+++ b/app/views/commodities/_commodity.html.erb
@@ -4,7 +4,7 @@
       <%= commodity.to_s.html_safe %>
     </span>
 
-    <div class='sub_heading_commodity_code_block pull-right'>
+    <div class="identifier service-<%= TradeTariffFrontend::ServiceChooser.service_name %>">
       <% unless commodity.umbrella_code? %>
         <%= segmented_commodity_code abbreviate_commodity_code(commodity), coloured: true %>
       <% end %>

--- a/app/webpacker/packs/print.scss
+++ b/app/webpacker/packs/print.scss
@@ -530,25 +530,6 @@ li.open {
     .open {
       background-position:0 -386px;
     }
-
-    .sub_heading_commodity_code_block {
-      color: #696969;
-      width: 150px;
-      font-weight: normal;
-      font-family: ntatabularnumbers, "Helvetica Neue", Arial, Helvetica, sans-serif;
-
-      .chapter-code, .heading-code, .commodity-code {
-        float: left;
-      }
-
-      .code-text {
-        text-align: center;
-      }
-
-      @media (max-width: 640px) {
-        display: none;
-      }
-    }
   }
 
   .conditions,

--- a/app/webpacker/src/stylesheets/_commodity-tree.scss
+++ b/app/webpacker/src/stylesheets/_commodity-tree.scss
@@ -299,14 +299,28 @@ article.tariff {
 
         @media (min-width: $desktop-min-width) {
           color: $govuk-text-colour;
-          width: 124px;
           position: absolute;
           right: 0;
           top: -.05em;
         }
+
         div {
           text-align: center;
           float: left;
+        }
+      }
+
+      // service-uk includes a vat column so needs to be shunted further right by its width
+      .service-uk.identifier {
+        @media (min-width: $desktop-min-width) {
+          width: $identifier-width-desktop-uk;
+        }
+      }
+
+      // service-xi excludes a vat column so needs to be shunted further right by its width
+      .service-xi.identifier {
+        @media (min-width: $desktop-min-width) {
+          width: $identifier-width-desktop-xi;
         }
       }
 
@@ -431,25 +445,6 @@ article.tariff {
         border-top-color: inherit;
       }
     }
-
-    .sub_heading_commodity_code_block {
-      width: 124px;
-      font-weight: normal;
-      font-family: ntatabularnumbers, "Helvetica Neue", Arial, Helvetica, sans-serif;
-
-      .chapter-code, .heading-code, .commodity-code {
-        float: left;
-        line-height: 30px;
-      }
-
-      .code-text {
-        text-align: center;
-      }
-
-      @media (max-width: 640px) {
-        display: none;
-      }
-    }
   }
 
   .conditions,
@@ -484,75 +479,6 @@ article.tariff {
   margin-bottom: 1em;
   padding: 1em 0 0.5em 1em;
   background-color: $shaded-panel-background-colour;
-
-  ol li {
-    margin-bottom: 0.5em;
-
-    > * {
-      @include govuk-font($size: 16) ;
-      line-height: 21.05px !important ;
-      display: grid;
-      grid-auto-flow: dense;
-      grid-template-columns: [row-start] 6fr [identifier-start] 2fr [row-end];
-      grid-column-gap: 10px;
-      position: relative;
-
-      @include govuk-media-query($from: tablet) {
-        grid-template-columns: [row-start] 7fr [identifier-start] 2fr [row-end];
-      }
-    }
-
-    @for $i from 2 through 16 {
-      &:nth-of-type(#{$i}) {
-        .commodity-ancestors__descriptor {
-          margin-left: ($i - 2) * 10 + 10px;
-
-          &::before {
-            left: ($i - 2) * 10 - 2px;
-          }
-
-          @include govuk-media-query($from: tablet) {
-            margin-left: ($i - 2) * 20 + 20px;
-
-            &::before {
-              left: ($i - 2) * 20 + 4px;
-            }
-          }
-        }
-      }
-    }
-
-    .commodity-ancestors__identifier {
-      grid-column-start: identifier-start;
-      white-space: nowrap;
-    }
-
-    .commodity-ancestors__descriptor {
-      grid-column-start: row-start;
-      display: inline-block;
-      line-height: 1.3em;
-    }
-
-    &:last-of-type .commodity-ancestors__descriptor {
-      font-weight: bold;
-    }
-
-    &:not(:first-of-type) .commodity-ancestors__descriptor::before {
-      text-decoration: none;
-      display: inline-block;
-      padding: 0;
-      margin: 0 1em 0 0;
-      color: $govuk-text-colour;
-      content: '\002514';
-      font-size: 12px;
-      position: absolute;
-      top: 0.125em;
-
-      @include govuk-media-query($from: tablet) {
-        top: 0.15em;
-      }
-    }
-  }
 }
 
 .additional-code-table {

--- a/app/webpacker/src/stylesheets/_variables.scss
+++ b/app/webpacker/src/stylesheets/_variables.scss
@@ -38,6 +38,8 @@ $supplementary-units-width-desktop: 120px;
 
 $identifier-width: $chapter-code-width+$heading-code-width+$commodity-code-width + 10px;
 $identifier-width-desktop: $chapter-code-width+$heading-code-width+$commodity-code-width-desktop+$vat-width-desktop+$duty-width-desktop+$supplementary-units-width-desktop;
+$identifier-width-desktop-uk: 130px;
+$identifier-width-desktop-xi: 220px;
 
 $table-row-standard-height: 1.31579em;
 $small-table-breakpoint: 840px;

--- a/spec/views/commodities/_commodity.html.erb_spec.rb
+++ b/spec/views/commodities/_commodity.html.erb_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'commodities/_commodity', type: :view do
   subject(:rendered_page) do
     render 'commodities/commodity', commodity:, initial_indent: 1
@@ -16,7 +14,7 @@ RSpec.describe 'commodities/_commodity', type: :view do
 
       it 'will show the commodity code' do
         expect(rendered_page).to have_css \
-          'li.has_children > .sub_heading_commodity_code_block .segmented-commodity-code'
+          'li.has_children > .identifier.service-uk .segmented-commodity-code'
       end
 
       it 'shows the children with their codes' do
@@ -29,7 +27,7 @@ RSpec.describe 'commodities/_commodity', type: :view do
     context 'with producline_suffix of 10' do
       let(:producline_suffix) { '10' }
 
-      it { is_expected.to have_css 'li.has_children > .sub_heading_commodity_code_block' }
+      it { is_expected.to have_css 'li.has_children > .identifier.service-uk' }
 
       it 'will not show the commodity code' do
         expect(rendered_page).not_to have_css \


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3779

XI after

![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/8156884/a01ffdf3-bb94-4940-b51d-323770073db3)

UK after

![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/8156884/271c231c-571c-4c35-b2fc-472d3d365184)

XI before

![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/8156884/01699ba7-c5a9-42f9-98fd-7e4849f9f8f3)

UK before

![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/8156884/d5d5560c-e6f2-4150-8f44-9805da6f8a80)


### What?

I have added/removed/altered:

- [x] Consolidates umbrella/regular identifier types
- [x] Removes duplicate scss definitions in print/tree scss files
- [x] Annotates umbrella/regular tree nodes with the service
- [x] Adds custom handling for the service to apply a specific width for the identifier
- [x] Removes inline width value that deviates from the variable pattern
- [x] Removes completely unused/complex ol li-selecting scss (we use ul for the tree items)

### Why?

I am doing this because:

- This whole thing was a mess and needed consolidating
- This fixes a specific issue with the display of the identifier column on the heading/subheading pages
