### PR TITLE
BAU: Fixes filter to only include main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ filter-release: &filter-release
     tags:
       only: /^release-202[\d-]+/
     branches:
-      ignore: /.*/
+      only: main
 
 orbs:
   aws-cli: circleci/aws-cli@2.0.3


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes release filter in circle ci configuration

### Why?

I am doing this because:

- This is required to make sure we can release
