### PR TITLE
BAU: Approval should be available on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -732,8 +732,6 @@ workflows:
       - promote-to-production?:
           type: approval
           <<: *filter-main
-          requires:
-            - plan-terraform-prod
 
       - tariff/create-production-release:
           name: "create-production-release"


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Enable approval on main

### Why?

I am doing this because:

- This is required to kick off a release
