### PR TITLE
HOTT-3473: Added exchange rates link to tools page

### DIFF
--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -12,6 +12,15 @@
     <%= page_header 'Tariff tools' %>
 
     <ul class="govuk-list">
+      <% if TradeTariffFrontend::ServiceChooser.uk? %>
+        <li>
+          <p>
+            <%= link_to t('breadcrumb.exchange_rates'), exchange_rates_path %>
+            <br>
+            Check the official HMRC foreign exchange rates for Customs & VAT in online (HTML), CSV and XML formats.
+          </p>
+        </li>
+      <% end %>
       <li>
         <p>
           <%= link_to t('breadcrumb.simplified_procedural_values'), simplified_procedural_values_path %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3473

Important: Do not merge until Chris approves

### What?

I have added/removed/altered:

- [ ] Added exchange rates link to tools page

### Why?

I am doing this because:

- We need to link to exchange rates from the tools page

<img width="1060" alt="Screenshot 2023-09-04 at 10 39 11" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/3c6a4451-b9a0-4bc2-b74c-fe6606f57523">

