### PR TITLE
BAU: Don't log healthchecks in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,11 @@ Rails.application.configure do
       JSON.parse(ENV['VCAP_APPLICATION']).except('application_uris', 'host', 'application_name', 'space_id', 'port', 'uris', 'application_version'),
     )
   end
-  config.lograge.ignore_actions = ['HealthcheckController#index']
+
+  config.lograge.ignore_actions = [
+    'HealthcheckController#index',
+    'HealthcheckController#checkz',
+  ]
 
   # set default_url_options
   config.action_controller.default_url_options = {


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Ignored `checkz` action of the healthcheck controller in lograge options.

### Why?

I am doing this because:

- We don't need this to be logged in production mode, it's just noise.