### PR TITLE
Update various dependencies to fix Webpacker compilation error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,17 @@ To create or update autoscaling policy for your application run:
 
 Current autosscaling policy files are [here](https://github.com/trade-tariff/trade-tariff-frontend/tree/main/config/autoscaling).
 
+## Troubleshooting
 
+Sometimes, when trying to load the front page, you get the error: **[Webpacker] Compilation failed**
 
-
-
-
-
-
-
-
-
-
+Try to clear Yarn and Webpacker Cache:
+```
+$ yarn cache clean
+$ rails tmp:cache:clear
+```
+and update npm modules:
+```
+rm yarn.lock
+yarn install
+```


### PR DESCRIPTION
### What?

Update various dependencies to fix the error:
[Webpacker] Compilation failed

Possibly not all the updates were necessary for the fix, but I am keeping them since they are not major updates.

### Why?
To fix this error:

```
[Webpacker] Compilation failed:
node:internal/crypto/hash:68
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:68:19)
    at Object.createHash (node:crypto:138:10)
    at module.exports (/home/ale/prj/hmrc/trade-tariff-frontend/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/ale/prj/hmrc/trade-tariff-frontend/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/home/ale/prj/hmrc/trade-tariff-frontend/node_modules/webpack/lib/NormalModule.js:471:10)
    at /home/ale/prj/hmrc/trade-tariff-frontend/node_modules/webpack/lib/NormalModule.js:503:5
    at /home/ale/prj/hmrc/trade-tariff-frontend/node_modules/webpack/lib/NormalModule.js:358:12
    at /home/ale/prj/hmrc/trade-tariff-frontend/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/home/ale/prj/hmrc/trade-tariff-frontend/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (/home/ale/prj/hmrc/trade-tariff-frontend/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
    at /home/ale/prj/hmrc/trade-tariff-frontend/node_modules/loader-runner/lib/LoaderRunner.js:236:3
    at context.callback (/home/ale/prj/hmrc/trade-tariff-frontend/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /home/ale/prj/hmrc/trade-tariff-frontend/node_modules/babel-loader/lib/index.js:44:71 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```
