### PR TITLE
BAU: Enable access to the updates api

### DIFF
--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -61,6 +61,7 @@ module TradeTariffFrontend
       simplified_procedural_code_measures
       bulk_searches
       exchange_rates
+      updates
     ]
   end
 


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added access to the updates api to api users

### Why?

I am doing this because:

- This is so they can invalidate their caches
