### PR TITLE
Remove full stops from the H1 titles on Exchange rate pages.

### DIFF
--- a/app/views/exchange_rates/index.html.erb
+++ b/app/views/exchange_rates/index.html.erb
@@ -23,9 +23,9 @@
     <span class="govuk-caption-xl"><%= trade_tariff_heading %></span>
     <h1>
       <% if @period_list.monthly? %>
-        <%= @period_list.year %> HMRC <%= @period_list.type %> currency exchange rates.
+        <%= @period_list.year %> HMRC <%= @period_list.type %> currency exchange rates
       <% else %>
-        HMRC <%= @period_list.type %> currency exchange rates.
+        HMRC <%= @period_list.type %> currency exchange rates
       <% end %>
     </h1>
 


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4232

### What?
Remove full stops from the H1 titles on Exchange rate pages.

### Why?
Because it breaks the [gov.uk](http://gov.uk/) style guide to have full stops on titles.