### PR TITLE
HOTT-4301 set NODE_OPTIONS in dev and test

### DIFF
--- a/bin/webpack
+++ b/bin/webpack
@@ -3,6 +3,10 @@
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 ENV["NODE_ENV"]  ||= "development"
 
+unless ENV["RAILS_ENV"] == "production"
+  ENV["NODE_OPTIONS"] = "--openssl-legacy-provider"
+end
+
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)


### PR DESCRIPTION
### Jira link

HOTT-4301

### What?

I have added/removed/altered:

- [x] Set the required NODE_OPTIONS env var to allow Webpack 4 to work with OpenSSL 3

### Why?

I am doing this because:

- Webpacker requires webpack v4
- Webpack v4 needs MD4
- OpenSSL 3 hides MD4 behind a config option
- Setting it via `.env` files works for specs but not for dynamic compilation via `rails s` or via `rails webpacker:compile` - because the env files are loaded during app initialization and the app is seems not to be initialized for the webpacker process

### Deployment risks (optional)

- None, only affects `bin/webpack` binary
