### PR TITLE
HOTT-4318 Dropped no longer needed webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,5 @@ group :test do
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'vcr'
-  gem 'webdrivers'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,7 +600,7 @@ GEM
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    selenium-webdriver (4.14.0)
+    selenium-webdriver (4.15.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -633,10 +633,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -703,7 +699,6 @@ DEPENDENCIES
   simplecov
   vcr
   web-console
-  webdrivers
   webmock
   webpacker
   wizard_steps

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Here are some of the relevant Env variables:
 Requires:
 * Ruby
 * Rails
-* node & npm
+* node
 * yarn
+* chrome-for-testing and corresponding chromedriver
 
 Uses:
 * Redis


### PR DESCRIPTION
### Jira link

HOTT-4318

### What?

I have added/removed/altered:

- [x] Dropped webdrivers gem

### Why?

I am doing this because:

- it tries to automatically install chromedriver but that is no longer possible, now the developer should install a copy of chrome for testing, eg via homebrew (or install from their repos for linux)

### Deployment risks (optional)

- Low, only affects rspec
