### PR TITLE
HOTT-4326: Enable emails from specific controlled zone

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -131,7 +131,7 @@ module "service" {
     },
     {
       name  = "TARIFF_FROM_EMAIL"
-      value = "Tariff Frontend [${title(var.environment)}] <no-reply@trade-tariff.service.gov.uk>"
+      value = "Tariff Frontend [${title(var.environment)}] <no-reply@${var.base_domain}>"
     },
     {
       name  = "TARIFF_TO_EMAIL"


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4326

### What?

I have added/removed/altered:

- [x] Added base domain to noreply address

### Why?

I am doing this because:

- This enables sending via the verified identity that is associated with the owned zone of each environment
