### PR TITLE
HOTT-4272: Disabled last updated footnote on exchange rates

### DIFF
--- a/app/controllers/exchange_rates_controller.rb
+++ b/app/controllers/exchange_rates_controller.rb
@@ -1,5 +1,5 @@
 class ExchangeRatesController < ApplicationController
-  before_action :disable_search_form, :disable_switch_service_banner
+  before_action :disable_search_form, :disable_switch_service_banner, :disable_last_updated_footnote
   before_action :validate_rate_type!
 
   def index


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4272

### What?

I have added/removed/altered:

- [ ] Disabled last updated footnote on exchange rates

### Why?

I am doing this because:

-  it was misleading for it to show exchange rates

<img width="1241" alt="Screenshot 2023-11-13 at 16 46 10" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/cc9ccd90-3169-41d5-bf04-e8eeaf5aaf49">

