### PR TITLE
Fix and refactor additional_code_search_form.

### DIFF
--- a/app/forms/additional_code_search_form.rb
+++ b/app/forms/additional_code_search_form.rb
@@ -13,10 +13,14 @@ class AdditionalCodeSearchForm
 
   attr_writer :page
 
+  def initialize(*args)
+    super(*args)
+
+    sanitize_code!
+  end
+
   def validate_code
     if code.present?
-      sanitize_code!
-
       errors.add(:code, :length) unless code.length == 4
       errors.add(:code, :invalid_characters) unless code =~ /\A([A-Z]|[0-9]){4}\z/
       errors.add(:code, :wrong_type) unless type.in?(self.class.possible_types)
@@ -61,6 +65,8 @@ class AdditionalCodeSearchForm
   private
 
   def sanitize_code!
+    return if code.nil?
+
     code.strip!
     code.upcase!
   end

--- a/spec/forms/additional_code_search_form_spec.rb
+++ b/spec/forms/additional_code_search_form_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe AdditionalCodeSearchForm, type: :model, vcr: { cassette_name: 'se
 
       it { is_expected.to be_nil }
     end
+
+    context 'when the code start with a space' do
+      let(:params) { { code: ' 8180' } }
+
+      it { is_expected.to eq('8') }
+    end
   end
 
   describe '#to_params' do

--- a/spec/forms/additional_code_search_form_spec.rb
+++ b/spec/forms/additional_code_search_form_spec.rb
@@ -41,13 +41,6 @@ RSpec.describe AdditionalCodeSearchForm, type: :model, vcr: { cassette_name: 'se
       it { expect(form.errors[:code]).to be_present }
     end
 
-    context 'when the code include initial and ending spaces' do
-      let(:params) { { code: '  a180 ' } }
-
-      it { is_expected.to be_valid }
-      it { is_expected.to have_attributes(code: 'A180') }
-    end
-
     context 'when the code has invalid characters' do
       let(:params) { { code: 'a18-' } }
 
@@ -78,8 +71,8 @@ RSpec.describe AdditionalCodeSearchForm, type: :model, vcr: { cassette_name: 'se
       it { is_expected.to be_nil }
     end
 
-    context 'when the code start with a space' do
-      let(:params) { { code: ' 8180' } }
+    context 'when the code include initial and ending spaces' do
+      let(:params) { { code: ' 8180 ' } }
 
       it { is_expected.to eq('8') }
     end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4385

### What?
The form generated a 404 when the code field starts space.

While fixing the tests, I've made a small refactor: I separated the sanitize and validated concerns (now we do not need to sanitize the form before calling sanitise).

### Why?
We got Sentry errors: https://engine-le.sentry.io/issues/4632324212/?alert_rule_id=3445731&alert_type=issue&notification_uuid=e92937c0-d941-4b61-9dc6-9b05674c1172&project=5557002&referrer=slack

Screenshot of the error:
 
![Screenshot from 2023-11-14 14-15-14](https://github.com/trade-tariff/trade-tariff-frontend/assets/58971/54cd9bc2-8767-4621-9ed0-6c8ffddf3e67)
