### PR TITLE
Update bundler 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -710,4 +710,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.2.32
+   2.4.22


### PR DESCRIPTION
### What?
Update bundler to remove warning "`DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated.", which is present many times when running spec tests.

### Why?
To stop using the deprecated method.