### PR TITLE
Fix all warnings about date conversions.

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -17,7 +17,9 @@ class GoodsNomenclature
   has_many :ancestors, polymorphic: true
 
   def validity_start_date=(validity_start_date)
-    @attributes['validity_start_date'] = Date.parse(validity_start_date.to_s) if validity_start_date.present?
+    return unless validity_start_date.present?
+
+    @attributes['validity_start_date'] = validity_start_date.to_date
   end
 
   def validity_start_date
@@ -25,7 +27,9 @@ class GoodsNomenclature
   end
 
   def validity_end_date=(validity_end_date)
-    @attributes['validity_end_date'] = Date.parse(validity_end_date.to_s) if validity_end_date.present?
+    return unless validity_end_date.present?
+
+    @attributes['validity_end_date'] = validity_end_date.to_date
   end
 
   def validity_end_date

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -17,7 +17,7 @@ class GoodsNomenclature
   has_many :ancestors, polymorphic: true
 
   def validity_start_date=(validity_start_date)
-    return unless validity_start_date.present?
+    return if validity_start_date.blank?
 
     @attributes['validity_start_date'] = validity_start_date.to_date
   end
@@ -27,7 +27,7 @@ class GoodsNomenclature
   end
 
   def validity_end_date=(validity_end_date)
-    return unless validity_end_date.present?
+    return if validity_end_date.blank?
 
     @attributes['validity_end_date'] = validity_end_date.to_date
   end

--- a/app/presenters/exact_match_results_presenter.rb
+++ b/app/presenters/exact_match_results_presenter.rb
@@ -6,7 +6,7 @@ class ExactMatchResultsPresenter
 
   def as_json(opts = {})
     klass = @search_results.entry['endpoint'].singularize.camelize.constantize
-    entity = klass.find(@search_results.entry['id'], as_of: @search.date.to_s)
+    entity = klass.find(@search_results.entry['id'], as_of: @search.date.to_fs)
     ["::SearchResult::#{entity.class.name}Serializer".constantize.new(entity).as_json(opts)]
   end
 end

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -7,7 +7,7 @@ class SearchPresenter
   def as_json(opts = {})
     {
       q: @search.q,
-      as_of: @search.date.to_s,
+      as_of: @search.date.to_fs,
       results: @search_results.as_json(opts),
     }
   end

--- a/app/serializers/search_result/chapter_serializer.rb
+++ b/app/serializers/search_result/chapter_serializer.rb
@@ -5,8 +5,8 @@ module SearchResult
       {
         type: 'chapter',
         goods_nomenclature_item_id:,
-        validity_start_date: validity_start_date.to_s,
-        validity_end_date: validity_end_date.to_s,
+        validity_start_date: validity_start_date.to_fs,
+        validity_end_date: validity_end_date.to_fs,
         description:,
       }
     end

--- a/app/serializers/search_result/commodity_serializer.rb
+++ b/app/serializers/search_result/commodity_serializer.rb
@@ -9,8 +9,8 @@ module SearchResult
         number_indents:,
         producline_suffix:,
         type: 'commodity',
-        validity_end_date: validity_end_date.to_s,
-        validity_start_date: validity_start_date.to_s,
+        validity_end_date: validity_end_date.to_fs,
+        validity_start_date: validity_start_date.to_fs,
       }
     end
   end

--- a/app/serializers/search_result/heading_serializer.rb
+++ b/app/serializers/search_result/heading_serializer.rb
@@ -10,8 +10,8 @@ module SearchResult
         number_indents:,
         producline_suffix:,
         type: 'heading',
-        validity_end_date: validity_end_date.to_s,
-        validity_start_date: validity_start_date.to_s,
+        validity_end_date: validity_end_date.to_fs,
+        validity_start_date: validity_start_date.to_fs,
       }
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -333,13 +333,13 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     context 'with String Dates' do
-      subject { govuk_date_range from.to_s, to.to_s }
+      subject { govuk_date_range from.to_fs, to.to_fs }
 
       it { is_expected.to eql '1 January 2022 to 1 June 2022' }
     end
 
     context 'with String Dates with Times' do
-      subject { govuk_date_range "#{from} 01:01:00", "#{to} 01:02:00" }
+      subject { govuk_date_range "#{from.to_fs} 01:01:00", "#{to.to_fs} 01:02:00" }
 
       it { is_expected.to eql '1 January 2022 to 1 June 2022' }
     end

--- a/spec/models/tariff_date_spec.rb
+++ b/spec/models/tariff_date_spec.rb
@@ -48,11 +48,11 @@ RSpec.describe TariffDate do
     subject(:tariff_date) { described_class.new(Date.parse('2021-01-01')) }
 
     it 'defaults to :date format when not passing a format' do
-      expect(tariff_date.to_s).to eq('2021-01-01')
+      expect(tariff_date.to_fs).to eq('2021-01-01')
     end
 
     it 'uses the passed format when passing a format' do
-      expect(tariff_date.to_s(:short)).to eq('1 Jan 2021')
+      expect(tariff_date.to_fs(:short)).to eq('1 Jan 2021')
     end
   end
 end

--- a/spec/serializers/search_result/commodity_serializer_spec.rb
+++ b/spec/serializers/search_result/commodity_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SearchResult::CommoditySerializer do
     it { is_expected.to include 'description' => commodity.description }
     it { is_expected.to include 'number_indents' => commodity.number_indents }
     it { is_expected.to include 'producline_suffix' => commodity.producline_suffix }
-    it { is_expected.to include 'validity_start_date' => commodity.validity_start_date.to_s }
-    it { is_expected.to include 'validity_end_date' => commodity.validity_end_date.to_s }
+    it { is_expected.to include 'validity_start_date' => commodity.validity_start_date.to_fs }
+    it { is_expected.to include 'validity_end_date' => commodity.validity_end_date.to_fs }
   end
 end

--- a/spec/serializers/search_result/heading_serializer_spec.rb
+++ b/spec/serializers/search_result/heading_serializer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SearchResult::HeadingSerializer do
     it { is_expected.to include 'description' => heading.description }
     it { is_expected.to include 'number_indents' => heading.number_indents }
     it { is_expected.to include 'producline_suffix' => heading.producline_suffix }
-    it { is_expected.to include 'validity_start_date' => heading.validity_start_date.to_s }
-    it { is_expected.to include 'validity_end_date' => heading.validity_end_date.to_s }
+    it { is_expected.to include 'validity_start_date' => heading.validity_start_date.to_fs }
+    it { is_expected.to include 'validity_end_date' => heading.validity_end_date.to_fs }
   end
 end

--- a/spec/serializers/search_result/subheading_serializer_spec.rb
+++ b/spec/serializers/search_result/subheading_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SearchResult::SubheadingSerializer do
     it { is_expected.to include 'description' => subheading.description }
     it { is_expected.to include 'number_indents' => subheading.number_indents }
     it { is_expected.to include 'producline_suffix' => subheading.producline_suffix }
-    it { is_expected.to include 'validity_start_date' => subheading.validity_start_date.to_s }
-    it { is_expected.to include 'validity_end_date' => subheading.validity_end_date.to_s }
+    it { is_expected.to include 'validity_start_date' => subheading.validity_start_date.to_fs }
+    it { is_expected.to include 'validity_end_date' => subheading.validity_end_date.to_fs }
   end
 end


### PR DESCRIPTION
### What?

Fix all warnings about date conversions:
DEPRECATION WARNING: Using a :default format for Date#to_s is deprecated. Please use Date#to_fs instead.
### Why?

I am doing this because:
- It generates lots of noise when running spec tests
- This is deprecated and will be removed in the following Rails versions.