### PR TITLE
Fix various deprecation warnings

### DIFF
--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe PagesController, type: :request do
     context 'when howto format is html' do
       let(:howto) { 'origin.html' }
 
-      it { expect { do_request }.not_to raise_error(ActionController::RoutingError) }
+      it { expect { do_request }.not_to raise_error }
     end
 
     context 'when howto format is not html' do


### PR DESCRIPTION
### Jira link
No jira link

### What?
- Fix DEPRECATION WARNING: Setting action_dispatch.show_exceptions to true is deprecated. Set to :all instead.
- Remove Rspec Warning: WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby
- Fix DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2.
- Fix DEPRECATION WARNING: Setting action_dispatch.show_exceptions to false is deprecated. Set to :none instead.


### Why?
To keep the system updated.
