### PR TITLE
HOTT-4437: Set Secure Flag on Cookies

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,10 @@
 # Be sure to restart your server when you modify this file.
 
-TradeTariffFrontend::Application.config.session_store :cookie_store, key: '_tradetarifffrontend_session'
+TradeTariffFrontend::Application.config.session_store(
+  :cookie_store,
+  key: '_tradetarifffrontend_session',
+  secure: Rails.env.production?,
+)
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
### Jira link

[HOTT-4437](https://transformuk.atlassian.net/browse/HOTT-4437)

### What?

I have added/removed/altered:

- Set `secure` on the session store cookie when `Rails.env` is `production`.

### Why?

I am doing this because:

- This was identified in the security review.
