### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'yajl-ruby'
 # Assets
 gem 'bootsnap', require: false
 gem 'kaminari'
-gem 'responders'
 gem 'webpacker'
 
 # gov UK

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -544,9 +544,6 @@ GEM
     regexp_parser (2.8.1)
     request_store (1.5.1)
       rack (>= 1.4)
-    responders (3.1.1)
-      actionpack (>= 5.2)
-      railties (>= 5.2)
     rexml (3.2.6)
     rinku (2.0.6)
     rouge (4.1.3)
@@ -691,7 +688,6 @@ DEPENDENCIES
   rails (~> 7.0)
   rails-controller-testing!
   redis
-  responders
   routing-filter!
   rspec-rails
   rspec_junit_formatter

--- a/app/controllers/changes_controller.rb
+++ b/app/controllers/changes_controller.rb
@@ -1,10 +1,10 @@
 class ChangesController < ApplicationController
-  respond_to :atom
-
   def index
     @changes = ChangesPresenter.new(changeable.changes(query_params))
 
-    respond_with(@changes)
+    respond_to do |format|
+      format.atom { render atom: @changes }
+    end
   end
 
   helper_method :changeable

--- a/app/presenters/measure_change_presenter.rb
+++ b/app/presenters/measure_change_presenter.rb
@@ -4,7 +4,7 @@ class MeasureChangePresenter < ChangePresenter
   end
 
   def content
-    "'#{change_record.measure_type.description}' #{change_record.destination} measure #{operation_name} for #{change.record.geographical_area} on #{change.operation_date}"
+    "'#{change_record.measure_type.description}' #{change_record.destination} measure #{operation_name} for #{change.record.geographical_area} on #{change.operation_date.to_fs}"
   end
 
   def anchor_link

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe PagesController, type: :request do
     context 'when howto format is html' do
       let(:howto) { 'origin.html' }
 
-      it { expect { do_request }.not_to raise_error(ActionController::RoutingError) }
+      it { expect { do_request }.not_to raise_error }
     end
 
     context 'when howto format is not html' do


### PR DESCRIPTION
### What?
- Replace implicit to_s to to_fs. (To fix warning deprecation)
- Remove gem responder.
- Fix WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)

### Why?
To keep code clean and updated.
