### PR TITLE
BAU: Disable beta search in production

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 4.0"
   hashes = [
     "h1:P43vwcDPG99x5WBbmqwUPgfJrfXf6/ucAIbGlRb7k1w=",
+    "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
     "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
     "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
     "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = ">= 3.4.3"
   hashes = [
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -43,6 +43,7 @@ Terraform to deploy the service into AWS.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_base_domain"></a> [base\_domain](#input\_base\_domain) | URL of the service. | `string` | n/a | yes |
+| <a name="input_beta_search_enabled"></a> [beta\_search\_enabled](#input\_beta\_search\_enabled) | Enable beta search. | `bool` | n/a | yes |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -1,5 +1,6 @@
-region      = "eu-west-2"
-environment = "development"
-base_domain = "dev.trade-tariff.service.gov.uk"
-cpu         = 1024
-memory      = 2048
+region              = "eu-west-2"
+environment         = "development"
+base_domain         = "dev.trade-tariff.service.gov.uk"
+cpu                 = 1024
+memory              = 2048
+beta_search_enabled = true

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -1,8 +1,9 @@
-region        = "eu-west-2"
-environment   = "production"
-base_domain   = "ott-production.co.uk"
-cpu           = 1024
-memory        = 2048
-service_count = 4
-min_capacity  = 2
-max_capacity  = 8
+region              = "eu-west-2"
+environment         = "production"
+base_domain         = "ott-production.co.uk"
+cpu                 = 1024
+memory              = 2048
+service_count       = 4
+min_capacity        = 2
+max_capacity        = 8
+beta_search_enabled = false

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -1,8 +1,9 @@
-region        = "eu-west-2"
-environment   = "staging"
-base_domain   = "staging.trade-tariff.service.gov.uk"
-cpu           = 1024
-memory        = 2048
-service_count = 4
-min_capacity  = 2
-max_capacity  = 8
+region              = "eu-west-2"
+environment         = "staging"
+base_domain         = "staging.trade-tariff.service.gov.uk"
+cpu                 = 1024
+memory              = 2048
+service_count       = 4
+min_capacity        = 2
+max_capacity        = 8
+beta_search_enabled = true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -55,7 +55,7 @@ module "service" {
     },
     {
       name  = "BETA_SEARCH_SWITCHING_ENABLED"
-      value = "true"
+      value = var.beta_search_enabled
     },
     {
       name  = "CORS_HOST"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -45,3 +45,8 @@ variable "memory" {
   description = "Memory to allocate in MB. Powers of 2 only."
   type        = number
 }
+
+variable "beta_search_enabled" {
+  description = "Enable beta search."
+  type        = bool
+}


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Disable beta search in production

### Why?

I am doing this because:

- This should be turned off when we go live with the migration since this functionality hasn't been tested
