### PR TITLE
HOTT-4303 Specs shouldnt depend on local config

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,4 @@
 ALLOW_SEARCH=true
-API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3018","xi":"http://localhost:3019" }
 AWS_ACCESS_KEY_ID=aws_access_key_id
 AWS_BUCKET_NAME=trade-tariff-frontend
 AWS_REGION=us-east-1

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,7 @@ module TradeTariffFrontend
 
     # Trade Tariff Backend API Version
     config.x.backend.api_version = ENV['TARIFF_API_VERSION'] || 1
+    config.x.backend.url_options = JSON.parse(ENV['API_SERVICE_BACKEND_URL_OPTIONS'] || '{}')
 
     config.grouped_measure_types = config_for(:grouped_measure_types)
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,4 +62,7 @@ Rails.application.configure do
     interval_randomness: 0,
     backoff_factor: 0,
   }
+
+  config.x.backend.url_options = { 'uk' => 'http://localhost:3018',
+                                   'xi' => 'http://localhost:3019' }
 end

--- a/lib/trade_tariff_frontend/service_chooser.rb
+++ b/lib/trade_tariff_frontend/service_chooser.rb
@@ -33,11 +33,7 @@ module TradeTariffFrontend
     end
 
     def service_choices
-      @service_choices ||= begin
-        api_options = ENV.fetch('API_SERVICE_BACKEND_URL_OPTIONS', '{}')
-
-        JSON.parse(api_options)
-      end
+      @service_choices ||= Rails.application.config.x.backend.url_options
     end
 
     def service_choice=(service_choice)


### PR DESCRIPTION
Previously if the api backend was something other than localhost in an env var, then this would override the version in `.env.test` and some specs would fail. This corrects that.

### Jira link

HOTT-4303

### What?

I have added/removed/altered:

- [x] Changed the test environment to ignore env vars for the urls to the backend

### Why?

I am doing this because:

- If the env var is already configured in the shell environment (for use in development mode), then the version in `.env.test` has no effect, and some of the tests start failing. If the tests expect the backend to be configured a certain way we should lock it to that in the test environment

### Deployment risks (optional)

- Some, changes the code linking to the backend - though it continues to follow the same process and env vars
