### PR TITLE
HOTT-4303 Fix running chrome specs in a container

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,9 +23,18 @@ Capybara.default_max_wait_time = 5
 require 'capybara/cuprite'
 Capybara.javascript_driver = :cuprite
 Capybara.register_driver(:cuprite) do |app|
-  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800],
-                                     process_timeout: 30,
-                                     timeout: 30)
+  opts = {
+    window_size: [1200, 800],
+    process_timeout: 30,
+    timeout: 30,
+  }
+
+  if File.exist?('/.dockerenv') || # check for docker
+      File.exist?('/run/.containerenv') # check for podman + other oci runtimes
+    opts[:browser_options] = { 'no-sandbox': nil }
+  end
+
+  Capybara::Cuprite::Driver.new(app, **opts)
 end
 
 VCR.use_cassette('geographical_areas#1013') do


### PR DESCRIPTION
### Jira link

HOTT-4303

### What?

I have added/removed/altered:

- [x] Disable the chrome sandbox when running in a container

### Why?

I am doing this because:

- The chrome sandbox is itself a container and you do not have permissions to create a container when already inside a container

### Deployment risks (optional)

- Low, only affects specs and should only take effect when inside a container
