### PR TITLE
Drop the support for locale in the URL

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,8 +7,6 @@ class ApplicationController < ActionController::Base
 
   before_action :maintenance_mode_if_active
 
-  around_action :set_locale
-
   before_action :set_cache
   before_action :set_last_updated
   before_action :set_path_info
@@ -132,17 +130,6 @@ class ApplicationController < ActionController::Base
 
   def set_path_info
     @path_info = { search_suggestions_path: search_suggestions_path(format: :json) }
-  end
-
-  def set_locale
-    I18n.locale = locale_is_valid? ? params[:locale].to_sym : I18n.default_locale
-    yield
-    I18n.locale = I18n.default_locale
-  end
-
-  def locale_is_valid?
-    params[:locale].presence &&
-      I18n.available_locales.include?(params[:locale]&.to_sym)
   end
 
   def country

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ require 'trade_tariff_frontend/request_forwarder'
 require 'routing_filter/service_path_prefix_handler'
 
 Rails.application.routes.draw do
-  filter :locale
   filter :service_path_prefix_handler
   default_url_options(host: TradeTariffFrontend.host)
 

--- a/spec/features/locale_spec.rb
+++ b/spec/features/locale_spec.rb
@@ -12,12 +12,6 @@ RSpec.describe 'Page banner' do
     it { is_expected.to have_css 'header.govuk-header a', text: 'UK Integrated Online Tariff' }
   end
 
-  context 'with locale prefix' do
-    before { visit '/cy/find_commodity' }
-
-    it { is_expected.to have_css 'header.govuk-header a', text: 'UK Integrated Online Tariff in Welsh' }
-  end
-
   context 'with invalid locale prefix' do
     before { visit '/fr/find_commodity' }
 
@@ -34,21 +28,5 @@ RSpec.describe 'Page banner' do
     before { visit '/xi/find_commodity' }
 
     it { is_expected.to have_css 'header.govuk-header a', text: 'Northern Ireland Online Tariff' }
-  end
-
-  context 'with locale and service prefix' do
-    before { visit '/xi/cy/find_commodity' }
-
-    it { is_expected.to have_css 'header.govuk-header a', text: 'Northern Ireland Online Tariff in Welsh' }
-  end
-
-  context 'with missing welsh translation' do
-    before do
-      stub_api_request('/sections').to_return jsonapi_response(:sections, [])
-
-      visit '/cy/browse'
-    end
-
-    it { is_expected.to have_content 'Switch to the Northern Ireland Online Tariff' }
   end
 end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4457

### What?
This PR drops the support for locale in the URL. 

### Why?
The reasons are:
- The "filter :locale" of the Gem routing-filter does not work with Rails 7.1, and it is not well maintained, so this commit is a step forward to drop the dependencies with that gem. (see https://github.com/svenfuchs/routing-filter/issues/83)
- TT does not need to support the Welsh language
