### PR TITLE
HOTT-4269 SearchReferencePresenter updated for A-Z Index Page

### DIFF
--- a/app/presenters/search_reference_presenter.rb
+++ b/app/presenters/search_reference_presenter.rb
@@ -1,6 +1,6 @@
 class SearchReferencePresenter < SimpleDelegator
   def to_s
-    title.titleize
+    title.capitalize
   end
 
   def link

--- a/spec/controllers/search_references_controller_spec.rb
+++ b/spec/controllers/search_references_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe SearchReferencesController, type: :controller do
 
     context 'when looking for the relevant sections' do
       it 'renders the Machine Tools title' do
-        expect(response.body).to include 'Machine Tools'
+        expect(response.body).to include 'Machine tools'
       end
 
       it 'renders links to relevant sections' do

--- a/spec/features/search_references_spec.rb
+++ b/spec/features/search_references_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe 'a-z index', vcr: { cassette_name: 'search_references#az_index' }
   end
 
   it {
-    expect(page).to have_content(search_reference.title.titleize.squeeze(' '))
+    expect(page).to have_content(search_reference.title.capitalize.squeeze(' '))
   }
 end

--- a/spec/presenters/search_reference_presenter_spec.rb
+++ b/spec/presenters/search_reference_presenter_spec.rb
@@ -19,12 +19,9 @@ RSpec.describe SearchReferencePresenter do
   end
 
   describe '#to_s' do
-    it 'returns the correct string' do
-      expect(presented.to_s).to eq('Tomatoes')
-    end
+    let(:search_reference) { build :search_reference, title: 'semi-skimmed milk, not powdered' }
 
     it 'capitalizes the first letter of the string and leaves the rest as is' do
-      presented.title = 'semi-skimmed milk, not powdered'
       expect(presented.to_s).to eq('Semi-skimmed milk, not powdered')
     end
   end

--- a/spec/presenters/search_reference_presenter_spec.rb
+++ b/spec/presenters/search_reference_presenter_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe SearchReferencePresenter do
   end
 
   describe '#to_s' do
-    it { expect(presented.to_s).to eq('Tomatoes') }
+    it 'returns the correct string' do
+      expect(presented.to_s).to eq('Tomatoes')
+    end
+
+    it 'capitalizes the first letter of the string and leaves the rest as is' do
+      presented.title = 'semi-skimmed milk, not powdered'
+      expect(presented.to_s).to eq('Semi-skimmed milk, not powdered')
+    end
   end
 end


### PR DESCRIPTION
as A-Z Index page should capitalise the first letter of the whole string (not every word) Otherwise, leave exactly as-is

### Jira link
https://transformuk.atlassian.net/browse/HOTT-4269

### What?

I have altered:

- [x] SearchReferencePresenter.rb to_s override to capitalize instead of titleize (and added a spec)

### Why?

I am doing this because:

- The A-Z Index Page was mutating titles of commodities (removing hyphens and making each word capitalised instead of just capitalising just the first word and leaving the rest as is.
