### PR TITLE
HOTT-4525 Take out the option index text on iOS

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+app/webpacker/src/javascripts/commodities.js

--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -12,6 +12,10 @@
   const debounce = require('./debounce');
   const htmlEscaper = require('html-escaper');
 
+  const isIosDevice = function() {
+    return typeof navigator !== 'undefined' && !!(navigator.userAgent.match(/(iPod|iPhone|iPad)/g) && navigator.userAgent.match(/AppleWebKit/g))
+  }
+
   global.GOVUK = global.GOVUK || {};
   /**
     @name GOVUK.tariff
@@ -613,6 +617,15 @@
 
                 if (suggestionType) {
                   text = text.replace(suggestionType, '');
+                }
+
+                // accessible-autocomplete adds the index of the options into
+                // the option text on ios for some reason
+                // That breaks search so strip it back out
+                // FIXME: Solve event handling so we can just handle submission
+                // in onConfirm and avoid all this complexity
+                if (isIosDevice()) {
+                  text = text.replace(/ \d+ of \d+$/, '');
                 }
 
                 form.find('.js-commodity-picker-target').val(text);


### PR DESCRIPTION
### Jira link

HOTT-4525

### What?

I have added/removed/altered:

- [x] Strip the ' <X> of <Y>' from the option text 
- [x] Exclude commodities.js from the linter

### Why?

I am doing this because:

- Accessible-autocomplete is adding to the end of the option text
- Its non-compliant but relinting the whole file is a bigger task

### Have you? (optional)

- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low, constrained to only impact iOS devices

### Notes

This is really not a nice solution. The correct fix is to push all this into onConfirm and have it work with the unmodified option content _but_ that means reworking the event handling and I've not been able to get the existing tab behaviour correct with the event handling rework
