### PR TITLE
HOTT-4464 Fixing timing issues in JS specs

### DIFF
--- a/spec/features/search_banner_spec.rb
+++ b/spec/features/search_banner_spec.rb
@@ -13,21 +13,16 @@ RSpec.describe 'Search banner', js: true do
         page.find('.tariff-search-banner .autocomplete__input').click
 
         page.find('.tariff-search-banner .autocomplete__input').set('gold')
-        sleep 1.5
 
+        expect(page).to have_css('.tariff-search-banner .autocomplete__option')
         expect(page.find('.tariff-search-banner .autocomplete__option:first-of-type').text).to eq('gold')
 
-        using_wait_time 1 do
-          expect(page.find_all('.tariff-search-banner .autocomplete__option').length).to be > 1
-        end
+        expect(page.find_all('.tariff-search-banner .autocomplete__option').length).to be > 1
 
         expect(page.find('.tariff-search-banner .autocomplete__option:first-of-type').text).to eq('gold')
         expect(page).to have_content('goldsmiths')
 
         page.find('.tariff-search-banner .autocomplete__option:first-of-type').click
-
-        # trying to see if redirect done by JS needs some sleep to be caught up
-        sleep 1
 
         expect(page).to have_content('Search results for ‘gold’')
       end
@@ -45,16 +40,12 @@ RSpec.describe 'Search banner', js: true do
 
         page.find('.tariff-search-banner .autocomplete__input').set('dsauidoasuiodsa')
 
-        sleep 1.5
+        expect(page).to have_css('.tariff-search-banner .autocomplete__option')
 
         expect(page.find_all('.tariff-search-banner .autocomplete__option').length).to eq(1)
         expect(page.find('.tariff-search-banner .autocomplete__option:first-of-type').text).to eq('dsauidoasuiodsa')
-        sleep 1
 
         page.find('.tariff-search-banner .autocomplete__option:first-of-type').click
-
-        # trying to see if redirect done by JS needs some sleep to be caught up
-        sleep 1
 
         expect(page).to have_content('Search results for ‘dsauidoasuiodsa’')
         expect(page).to have_content('There are no results matching your query.')

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -26,23 +26,16 @@ RSpec.describe 'Search', js: true do
           visit find_commodity_path
 
           page.find('#new_search .autocomplete__input#q').click
-
           page.find('#new_search .autocomplete__input#q').set('gold')
-          sleep 1.5
 
+          expect(page).to have_css('#new_search .autocomplete__option')
+          expect(page.find_all('#new_search .autocomplete__option').length).to be > 1
           expect(page.find('#new_search .autocomplete__option:first-of-type').text).to eq('gold')
-
-          using_wait_time 1 do
-            expect(page.find_all('#new_search .autocomplete__option').length).to be > 1
-          end
 
           expect(page.find('#new_search .autocomplete__option:first-of-type').text).to eq('gold')
           expect(page).to have_content('goldsmiths')
 
           page.find('#new_search .autocomplete__option:first-of-type').click
-
-          # trying to see if redirect done by JS needs some sleep to be caught up
-          sleep 1.5
 
           expect(page).to have_content('Search results for ‘gold’')
         end
@@ -58,14 +51,10 @@ RSpec.describe 'Search', js: true do
 
           page.find('#new_search .autocomplete__input#q').set('dsauidoasuiodsa')
 
-          sleep 1.5
-
+          expect(page).to have_css('#new_search .autocomplete__option')
           expect(page.find_all('#new_search .autocomplete__option').length).to eq(1)
           expect(page.find('#new_search .autocomplete__option:first-of-type').text).to eq('dsauidoasuiodsa')
           page.find('#new_search .autocomplete__option:first-of-type').click
-
-          # trying to see if redirect done by JS needs some sleep to be caught up
-          sleep 1.5
 
           expect(page).to have_content('Search results for ‘dsauidoasuiodsa’')
           expect(page).to have_content('There are no results matching your query.')
@@ -83,21 +72,15 @@ RSpec.describe 'Search', js: true do
           page.find('#new_search .autocomplete__input#q').click
 
           page.find('#new_search .autocomplete__input#q').set('gold')
-          sleep 1.5
+          expect(page).to have_css('#new_search .autocomplete__option')
 
           expect(page.find('#new_search .autocomplete__option:first-of-type').text).to eq('gold')
-
-          using_wait_time 1 do
-            expect(page.find_all('#new_search .autocomplete__option').length).to be > 1
-          end
+          expect(page.find_all('#new_search .autocomplete__option').length).to be > 1
 
           expect(page.find('#new_search .autocomplete__option:first-of-type').text).to eq('gold')
           expect(page).to have_content('goldsmiths')
 
           page.find('#new_search .autocomplete__option:first-of-type').click
-
-          # trying to see if redirect done by JS needs some sleep to be caught up
-          sleep 1
 
           expect(page).to have_content('Search results for ‘gold’')
         end
@@ -141,12 +124,10 @@ RSpec.describe 'Search', js: true do
           page.find('#year').set('2022')
           page.find('input[name="new_search"]').click
 
-          using_wait_time 5 do
-            expect(page).to have_content('Quota search results')
-            expect(page).to have_content('050088')
-            expect(page).to have_link('2106909800', href: '/subheadings/2106909800-80?day=16&month=3&year=2022')
-            expect(page).to have_content('All countries (1011)')
-          end
+          expect(page).to have_content('Quota search results')
+          expect(page).to have_content('050088')
+          expect(page).to have_link('2106909800', href: '/subheadings/2106909800-80?day=16&month=3&year=2022')
+          expect(page).to have_content('All countries (1011)')
         end
       end
     end
@@ -187,11 +168,9 @@ RSpec.describe 'Search', js: true do
           page.find('#cas').set('121-17-5')
           page.find('input[name="new_search"]').click
 
-          using_wait_time 1 do
-            expect(page).to have_content('Chemical search results for “121-17-5”')
-            expect(page).to have_content('4-chloro-alpha,alpha,alpha-trifluoro-3-nitrotoluene')
-            expect(page).to have_link('Other', href: '/commodities/2904990000')
-          end
+          expect(page).to have_content('Chemical search results for “121-17-5”')
+          expect(page).to have_content('4-chloro-alpha,alpha,alpha-trifluoro-3-nitrotoluene')
+          expect(page).to have_link('Other', href: '/commodities/2904990000')
         end
       end
 
@@ -204,12 +183,10 @@ RSpec.describe 'Search', js: true do
           page.find('#name').set('benzene')
           page.find('input[name="new_search"]').click
 
-          using_wait_time 1 do
-            expect(page).to have_content('Chemical search results for “benzene”')
-            expect(page).to have_content('22199-08-2')
-            expect(page).to have_content('4-amino-N-(pyrimidin-2(1H)-ylidene-κN 1)benzenesulfonamidato-κOsilver')
-            expect(page).to have_link('Other', href: '/commodities/2843290000')
-          end
+          expect(page).to have_content('Chemical search results for “benzene”')
+          expect(page).to have_content('22199-08-2')
+          expect(page).to have_content('4-amino-N-(pyrimidin-2(1H)-ylidene-κN 1)benzenesulfonamidato-κOsilver')
+          expect(page).to have_link('Other', href: '/commodities/2843290000')
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,10 +18,14 @@ Dir[Rails.root.join('app/models/*.rb')].sort.each { |f| require f }
 require 'capybara/rails'
 require 'capybara/rspec'
 
+Capybara.default_max_wait_time = 5
+
 require 'capybara/cuprite'
 Capybara.javascript_driver = :cuprite
 Capybara.register_driver(:cuprite) do |app|
-  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800])
+  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800],
+                                     process_timeout: 30,
+                                     timeout: 30)
 end
 
 VCR.use_cassette('geographical_areas#1013') do


### PR DESCRIPTION
### Jira link

HOTT-4464

### What?

I have added/removed/altered:

- [x] Increased the max time out for any one test in js specs from 2 to 5 seconds
- [x] Removed override code (`using_wait_until`) which dropped it from 2 to 1 seconds ??
- [x] Removed sleeps, these are replaced with calls to `has_css` - which, like `have_content`, will block until either the document element becomes available or max_wait_timeout is reached
- [x] Changed the cuprite config to wait longer for chrome to become available

### Why?

I am doing this because:

- The timing issues shouldn't require sleeps in specs to resolve - allowing Capybara to wait longer for a `have_css`/`have_content` condition to become true should resolve this whilst also allowing it to complete faster if it becomes true sooner
- The drops of wait timer were likely to increase failures rather than reduce them
- The cuprite config change is a bit speculative, its referenced in this github ticket against capybara - https://github.com/rubycdp/cuprite/issues/127. It shouldn't take longer as I understand it

### Deployment risks (optional)

- Low, should hopefully improve test suite reliability
