### PR TITLE
HOTT-4284-Show-Commodities in A-Z Index

### DIFF
--- a/app/controllers/search_references_controller.rb
+++ b/app/controllers/search_references_controller.rb
@@ -1,7 +1,7 @@
 class SearchReferencesController < ApplicationController
   def show
     @search_references = SearchReferencesPresenter.new(
-      SearchReference.all(query: { letter: })
+      SearchReference.all(query: { letter: }),
     )
   end
 

--- a/app/controllers/search_references_controller.rb
+++ b/app/controllers/search_references_controller.rb
@@ -2,7 +2,6 @@ class SearchReferencesController < ApplicationController
   def show
     @search_references = SearchReferencesPresenter.new(
       SearchReference.all(query: { letter: })
-                     .reject { |ref| ref.attributes['referenced_class'] == 'Commodity' },
     )
   end
 

--- a/app/views/search_references/show.html.erb
+++ b/app/views/search_references/show.html.erb
@@ -31,7 +31,11 @@
           </td>
           <td class="govuk-table__cell govuk-table__cell--numeric">
            <span class="govuk-visually-hidden">Code: </span>
-            <%= segmented_commodity_code abbreviate_code(search_reference.referenced_id) %>
+            <% if search_reference.referenced_class == "Commodity" %>
+              <%= segmented_commodity_code search_reference.referenced_id %>
+            <% else %>
+              <%= segmented_commodity_code abbreviate_code(search_reference.referenced_id) %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/spec/controllers/search_references_controller_spec.rb
+++ b/spec/controllers/search_references_controller_spec.rb
@@ -45,12 +45,12 @@ RSpec.describe SearchReferencesController, type: :controller do
     end
 
     context 'when looking for the relevant commodities' do
-      it 'doesn\'t renders the Mascarpone title' do
-        expect(response.body).not_to include 'Mascarpone'
+      it 'renders the Mascarpone title' do
+        expect(response.body).to include 'Mascarpone'
       end
 
-      it 'doesn\'t renders links to commodities' do
-        expect(response.body).not_to include '/commodities/0406105090'
+      it 'does renders links to commodities' do
+        expect(response.body).to include '/commodities/0406105090'
       end
     end
   end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4284

### What?

I have added/removed/altered:

- [x] Added conditional statement for commodity id in search references view
- [x] Removed Reject Commodities Filter from SearchReferences

### Why?

I am doing this because:

- To show Commodities in the A-Z index pages displaying the 10-digit ID