### PR TITLE
HOTT-4276: Display message if any import measures are supplementary

### DIFF
--- a/app/services/declarable_unit_service.rb
+++ b/app/services/declarable_unit_service.rb
@@ -19,6 +19,8 @@ class DeclarableUnitService
 
     return uk_import_measures.supplementary.first&.measure_components&.first&.unit_for_classification if uk_import_measures.supplementary.any?
 
+    return I18n.t('declarable.supplementary_unit_classifications.some') if !picked_country? && uk_declarable.import_measures.excluding_channel_islands.supplementary.any?
+
     unit_measures = picked_country? ? uk_import_measures.unit : uk_import_measures.unit.erga_omnes
 
     unit_measure_units = units_for(unit_measures)
@@ -38,6 +40,8 @@ class DeclarableUnitService
                          end
 
     return xi_import_measures.supplementary.first&.measure_components&.first&.unit_for_classification if xi_import_measures.supplementary.any?
+
+    return I18n.t('declarable.supplementary_unit_classifications.some') if !picked_country? && xi_declarable.import_measures.excluding_channel_islands.supplementary.any?
 
     unit_measures = picked_country? ? xi_import_measures.unit : xi_import_measures.unit.erga_omnes
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,9 @@ en:
       excise: >-
         There are no supplementary unit measures assigned to this commodity, however you will need to declare the unit of import (%{units}) for excise purposes.
       none: "There are no supplementary unit measures assigned to this commodity"
+      some: >-
+        There are no supplementary units globally assigned to this commodity. 
+        Select a country of import / export to check on supplementary units for a specific country, or scroll down to the import duties section.
   import_destination:
     uk: United Kingdom
     xi: Northern Ireland

--- a/spec/services/declarable_unit_service_spec.rb
+++ b/spec/services/declarable_unit_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DeclarableUnitService do
       context 'when there are supplementary units in another geography' do
         let(:uk_import_measures) { [attributes_for(:measure, :import_export_supplementary, geographical_area_id: 'IT')] }
 
-        it { is_expected.to eq('There are no supplementary unit measures assigned to this commodity') }
+        it { is_expected.to match(/There are no supplementary units globally assigned to this commodity/) }
       end
 
       context 'when the country is provided and there are unit measures' do
@@ -93,9 +93,9 @@ RSpec.describe DeclarableUnitService do
       end
 
       context 'when there are supplementary units in another geography' do
-        let(:uk_import_measures) { [attributes_for(:measure, :import_export_supplementary, geographical_area_id: 'IT')] }
+        let(:xi_import_measures) { [attributes_for(:measure, :import_export_supplementary, geographical_area_id: 'IT')] }
 
-        it { is_expected.to eq('There are no supplementary unit measures assigned to this commodity') }
+        it { is_expected.to match(/There are no supplementary units globally assigned to this commodity/) }
       end
 
       context 'when the country is provided and there are unit measures' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4276

### What?

I have added/removed/altered:

- [ ] Displayed message if any import measures are supplementary

### Why?

I am doing this because:

- it will make it easier for users to know if any import measures are supplementary

### Have you? (optional)

- [ ] Reviewed view changes with stake holders

<img width="1305" alt="Screenshot 2023-12-08 at 11 32 50" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/b001c852-6b54-4e81-b331-a3b2b2e1842d">

