### PR TITLE
BAU: Disable beta search in dev and staging

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -47,7 +47,7 @@ module "service" {
     },
     {
       name  = "BETA_SEARCH"
-      value = var.environment == "production" ? "false" : "true"
+      value = false
     },
     {
       name  = "BETA_SEARCH_HEADING_STATISTICS_THRESHOLD"
@@ -55,7 +55,7 @@ module "service" {
     },
     {
       name  = "BETA_SEARCH_SWITCHING_ENABLED"
-      value = var.beta_search_enabled
+      value = false
     },
     {
       name  = "CORS_HOST"


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Disable beta search

### Why?

I am doing this because:

- To avoid HMRC getting confused about our tactical search improvements in legacy search
