### PR TITLE
HOTT-4725: Tactical UI changes to the legacy search

### DIFF
--- a/app/helpers/search_results_helper.rb
+++ b/app/helpers/search_results_helper.rb
@@ -1,4 +1,25 @@
 module SearchResultsHelper
+  def descriptions_with_other_handling(commodity)
+    ancestor_descriptions = commodity.ancestor_descriptions.reverse
+    return sanitize commodity.description.to_s unless commodity.description.to_s.match(/^other/i)
+
+    descriptions = []
+
+    ancestor_descriptions.each do |ancestor_description|
+      if ancestor_description.to_s.match(/^other/i)
+        descriptions.unshift(ancestor_description.to_s)
+      else
+        descriptions.unshift(ancestor_description.to_s)
+        break
+      end
+    end
+
+    descriptions[-1] = "<strong>#{descriptions.last}</strong>"
+    descriptions = descriptions.join(' > ')
+
+    sanitize descriptions
+  end
+
   def toggle_beta_search_inset_text
     if beta_search_enabled?
       switch_link = link_to('switch back to legacy search', toggle_beta_search_path)

--- a/app/helpers/search_results_helper.rb
+++ b/app/helpers/search_results_helper.rb
@@ -1,20 +1,18 @@
 module SearchResultsHelper
   def descriptions_with_other_handling(commodity)
-    ancestor_descriptions = commodity.ancestor_descriptions.reverse
     return sanitize commodity.description.to_s unless commodity.description.to_s.match(/^other/i)
+
+    ancestor_descriptions = commodity.ancestor_descriptions.reverse
 
     descriptions = []
 
     ancestor_descriptions.each do |ancestor_description|
-      if ancestor_description.to_s.match(/^other/i)
-        descriptions.unshift(ancestor_description.to_s)
-      else
-        descriptions.unshift(ancestor_description.to_s)
-        break
-      end
+      descriptions.unshift(ancestor_description.to_s)
+
+      break unless ancestor_description.to_s.match(/^other/i)
     end
 
-    descriptions[-1] = "<strong>#{descriptions.last}</strong>"
+    descriptions[-1] = tag.strong(descriptions.last)
     descriptions = descriptions.join(' > ')
 
     sanitize descriptions

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -2,7 +2,7 @@ class Commodity < GoodsNomenclature
   include Changeable
   include Declarable
 
-  attr_accessor :parent_sid
+  attr_accessor :parent_sid, :ancestor_descriptions, :score
 
   has_one :heading
   # vat_measure is used for commodities under the heading only

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -32,6 +32,7 @@ class Search
       resource_id:,
     )
     response = TariffJsonapiParser.new(response.body).parse
+
     Outcome.new(response)
   end
 

--- a/app/models/search/base_match.rb
+++ b/app/models/search/base_match.rb
@@ -18,7 +18,22 @@ class Search
       def array_attr_writer(*names)
         names.each do |name|
           define_method("#{name}=") do |entry_data|
-            instance_variable_set("@#{name}", entry_data.map { |ed| name.to_s.singularize.capitalize.constantize.new(ed['_source'].key?('reference') ? ed['_source']['reference'] : ed['_source']) })
+            instance_variable_set(
+              "@#{name}",
+              entry_data.map do |ed|
+                klass = name.to_s.singularize.capitalize.constantize
+
+                attributes = if ed['_source'].key?('reference')
+                               ed['_source']['reference']
+                             else
+                               ed['_source']
+                             end
+
+                attributes['score'] = ed['_score'] if ed['_score'].present?
+
+                klass.new(attributes)
+              end,
+            )
           end
         end
       end

--- a/app/models/search/base_match.rb
+++ b/app/models/search/base_match.rb
@@ -17,12 +17,12 @@ class Search
 
       def array_attr_writer(*names)
         names.each do |name|
+          klass = name.to_s.singularize.capitalize.constantize
+
           define_method("#{name}=") do |entry_data|
             instance_variable_set(
               "@#{name}",
               entry_data.map do |ed|
-                klass = name.to_s.singularize.capitalize.constantize
-
                 attributes = if ed['_source'].key?('reference')
                                ed['_source']['reference']
                              else

--- a/app/models/search/goods_nomenclature_match.rb
+++ b/app/models/search/goods_nomenclature_match.rb
@@ -12,7 +12,12 @@ class Search
     array_attr_writer :sections, :chapters, :headings, :commodities
 
     def commodities=(commodity_data)
-      @commodities = commodity_data.map { |cd| Commodity.new(cd['_source']) }
+      @commodities = commodity_data.map do |cd|
+        attributes = cd['_source']
+        attributes['score'] = cd['_score'] if cd['_score'].present?
+
+        Commodity.new(attributes)
+      end
 
       self.commodity_headings = @commodities
     end

--- a/app/models/search/outcome.rb
+++ b/app/models/search/outcome.rb
@@ -18,6 +18,10 @@ class Search
       }
     end
 
+    def commodities
+      (reference_commodities + goods_nomenclature_commodities).sort_by(&:score).reverse
+    end
+
     def any?
       (goods_nomenclature_match.present? && goods_nomenclature_match.any?) ||
         (reference_match.present? && reference_match.any?)
@@ -96,5 +100,15 @@ class Search
     end
 
     delegate :size, to: :all
+
+    private
+
+    def reference_commodities
+      reference_match.commodities.presence || []
+    end
+
+    def goods_nomenclature_commodities
+      goods_nomenclature_match.commodities.presence || []
+    end
   end
 end

--- a/app/models/search/outcome.rb
+++ b/app/models/search/outcome.rb
@@ -19,7 +19,10 @@ class Search
     end
 
     def commodities
-      (reference_commodities + goods_nomenclature_commodities).sort_by(&:score).reverse
+      (reference_commodities + goods_nomenclature_commodities)
+        .sort_by(&:score)
+        .reverse
+        .filter(&:declarable)
     end
 
     def any?

--- a/app/views/search/_commodity.html.erb
+++ b/app/views/search/_commodity.html.erb
@@ -1,10 +1,15 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell">
+  <td class="govuk-table__cell commodity-result">
     <a href="<%= commodity_path(commodity) %>" aria-describedby="code-for-commodity-<%= commodity.id %>">
-      <%= sanitize commodity.description %>
+      <% if commodity.ancestor_descriptions.present? %>
+        <%= descriptions_with_other_handling(commodity) %>
+      <% else %>
+        <%= sanitize commodity.description %>
+      <% end %>
+
       <span class="govuk-visually-hidden">
         (code <%= commodity.code %>)
-      </span>    
+      </span>
     </a>
   </td>
 

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -8,7 +8,7 @@
           <col width="180">
         </colgroup>
         <caption class="govuk-table__caption govuk-heading-m govuk-!-margin-top-6">
-          Commodities matching &lsquo;<%= @search %>&rsquo;
+          Best commodity matches for &lsquo;<%= @search %>&rsquo;
         </caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -1,7 +1,7 @@
 <%= page_header "Search results for &lsquo;#{h @search.q}&rsquo;".html_safe %>
 <article class="search-results govuk-!-padding-top-1">
   <% if @results.any? %>
-    <% if @results.reference_match.commodities.any? %>
+    <% if @results.commodities.any? %>
       <table class="govuk-table govuk-!-padding-bottom-7">
         <colgroup>
           <col width="*">
@@ -17,7 +17,7 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <%= render partial: 'search/commodity', collection: @results.reference_match.commodities %>
+          <%= render partial: 'search/commodity', collection: @results.commodities %>
         </tbody>
       </table>
     <% end %>

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     overview_measures { [] }
     import_trade_summary {}
     ancestors { [] }
+    ancestor_descriptions { [] }
 
     meta do
       {
@@ -172,6 +173,16 @@ FactoryBot.define do
 
     trait :without_ancestors do
       ancestors { [] }
+    end
+
+    trait :with_ancestor_descriptions do
+      description { 'Horses' }
+      ancestor_descriptions { ['Live animals', 'Live horses, asses, mules and hinnies', 'Horses'] }
+    end
+
+    trait :with_other_ancestor_descriptions do
+      description { 'Other' }
+      ancestor_descriptions { ['Live animals', 'Live horses, asses, mules and hinnies', 'Other', 'Other', 'Other'] }
     end
   end
 end

--- a/spec/factories/search_outcome_factory.rb
+++ b/spec/factories/search_outcome_factory.rb
@@ -1,0 +1,123 @@
+FactoryBot.define do
+  factory :search_outcome, class: 'Search::Outcome' do
+    trait :fuzzy_match do
+      type { 'fuzzy_match' }
+      goods_nomenclature_match do
+        {
+          "chapters": [],
+          "commodities": [
+            {
+              "_index": 'tariff-commodities-uk',
+              "_id": '54631',
+              "_score": 13.415359,
+              "_source": {
+                "id": 54_631,
+                "goods_nomenclature_item_id": '9603210000',
+                "producline_suffix": '80',
+                "validity_start_date": '1972-01-01T00:00:00.000Z',
+                "validity_end_date": nil,
+                "description": 'Toothbrushes, including dental-plate brushes',
+                "description_indexed": 'toothbrushes, including dental-plate brushes toothbrushes, shaving brushes, hairbrushes, nail brushes, eyelash brushes and other toilet brushes for use on the person, including such brushes constituting parts of appliances brooms, brushes (including brushes constituting parts of machines, appliances or vehicles), hand-operated mechanical floor sweepers miscellaneous manufactured articles',
+                "number_indents": 2,
+                "declarable": true,
+                "ancestor_descriptions": [
+                  'Miscellaneous manufactured articles',
+                  'Brooms, brushes (including brushes constituting parts of machines, appliances or vehicles), hand-operated mechanical floor sweepers, not motorised, mops and feather dusters; prepared knots and tufts for broom or brush making; paint pads and rollers; squeegees (other than roller squeegees)',
+                  'Toothbrushes, shaving brushes, hairbrushes, nail brushes, eyelash brushes and other toilet brushes for use on the person, including such brushes constituting parts of appliances',
+                  'Toothbrushes, including dental-plate brushes',
+                ],
+                "section": {
+                  "numeral": 'XX',
+                  "title": 'Miscellaneous manufactured articles',
+                  "position": 20,
+                },
+                "chapter": {
+                  "goods_nomenclature_sid": 54_615,
+                  "goods_nomenclature_item_id": '9600000000',
+                  "producline_suffix": '80',
+                  "validity_start_date": '1971-12-31T00:00:00.000Z',
+                  "validity_end_date": nil,
+                  "description": 'Miscellaneous manufactured articles',
+                  "guides": [],
+                },
+                "heading": {
+                  "goods_nomenclature_sid": 54_628,
+                  "goods_nomenclature_item_id": '9603000000',
+                  "producline_suffix": '80',
+                  "validity_start_date": '1972-01-01T00:00:00.000Z',
+                  "validity_end_date": nil,
+                  "description": 'Brooms, brushes (including brushes constituting parts of machines, appliances or vehicles), hand-operated mechanical floor sweepers, not motorised, mops and feather dusters; prepared knots and tufts for broom or brush making; paint pads and rollers; squeegees (other than roller squeegees)',
+                  "number_indents": 0,
+                },
+              },
+            },
+          ],
+          "headings": [],
+          "sections": [],
+        }
+      end
+
+      reference_match do
+        {
+          "chapters": [],
+          "commodities": [
+            {
+              "_index": 'tariff-search_references-uk',
+              "_id": '9717',
+              "_score": 8.104948,
+              "_source": {
+                "title": 'electric toothbrushes, electric',
+                "title_indexed": 'electric toothbrushes, electric',
+                "reference_class": 'Commodity',
+                "reference": {
+                  "id": 49_912,
+                  "goods_nomenclature_item_id": '8509800000',
+                  "producline_suffix": '80',
+                  "validity_start_date": '1972-01-01T00:00:00.000Z',
+                  "validity_end_date": nil,
+                  "description": 'Other appliances',
+                  "description_indexed": 'other appliances electromechanical domestic appliances, with self-contained electric motor electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles',
+                  "number_indents": 1,
+                  "declarable": true,
+                  "ancestor_descriptions": [
+                    'Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles',
+                    'Electromechanical domestic appliances, with self-contained electric motor, other than vacuum cleaners of heading 8508',
+                    'Other appliances',
+                  ],
+                  "section": {
+                    "numeral": 'XVI',
+                    "title": 'Machinery and mechanical appliances; electrical equipment; parts thereof, sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles',
+                    "position": 16,
+                  },
+                  "chapter": {
+                    "goods_nomenclature_sid": 49_496,
+                    "goods_nomenclature_item_id": '8500000000',
+                    "producline_suffix": '80',
+                    "validity_start_date": '1971-12-31T00:00:00.000Z',
+                    "validity_end_date": nil,
+                    "description": 'Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles',
+                    "guides": [],
+                  },
+                  "heading": {
+                    "goods_nomenclature_sid": 49_905,
+                    "goods_nomenclature_item_id": '8509000000',
+                    "producline_suffix": '80',
+                    "validity_start_date": '1972-01-01T00:00:00.000Z',
+                    "validity_end_date": nil,
+                    "description": 'Electromechanical domestic appliances, with self-contained electric motor, other than vacuum cleaners of heading 8508',
+                    "number_indents": 0,
+                  },
+                  "class": 'Commodity',
+                },
+              },
+            },
+          ],
+          "headings": [],
+          "sections": [],
+        }
+      end
+    end
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/helpers/search_results_helper_spec.rb
+++ b/spec/helpers/search_results_helper_spec.rb
@@ -1,6 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe SearchResultsHelper, type: :helper do
+  describe '#descriptions_with_other_handling' do
+    subject(:descriptions_with_other_handling) { helper.descriptions_with_other_handling(commodity) }
+
+    context 'when the commodity description is "other"' do
+      let(:commodity) { build(:commodity, :with_other_ancestor_descriptions) }
+
+      it { is_expected.to eq('Live horses, asses, mules and hinnies &gt; Other &gt; Other &gt; <strong>Other</strong>') }
+      it { is_expected.to be_html_safe }
+    end
+
+    context 'when the commodity description is not "other"' do
+      let(:commodity) { build(:commodity, :with_ancestor_descriptions) }
+
+      it { is_expected.to eq('Horses') }
+      it { is_expected.to be_html_safe }
+    end
+  end
+
   describe '#toggle_beta_search_inset_text' do
     subject(:toggle_beta_search_inset_text) { helper.toggle_beta_search_inset_text }
 

--- a/spec/models/search/outcome_spec.rb
+++ b/spec/models/search/outcome_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Search::Outcome do
+  describe '#commodities' do
+    subject(:commodities) { outcome.commodities }
+
+    let(:outcome) { build(:search_outcome, :fuzzy_match) }
+
+    it { expect(commodities.count).to eq(outcome.reference_match.commodities.count + outcome.goods_nomenclature_match.commodities.count) }
+    it { is_expected.to all(be_a(Commodity)) }
+  end
+end

--- a/spec/views/search/_commodity.html.erb_spec.rb
+++ b/spec/views/search/_commodity.html.erb_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe 'search/_commodity', type: :view do
+  subject { render }
+
+  before { allow(view).to receive(:commodity).and_return(commodity) }
+
+  context 'when there are ancestor descriptions' do
+    let(:commodity) { build(:commodity, :with_other_ancestor_descriptions) }
+
+    it { is_expected.to have_css('td.govuk-table__cell > a > strong', text: 'Other') }
+  end
+
+  context 'when there are no ancestor descriptions' do
+    let(:commodity) { build(:commodity, description: 'Horses') }
+
+    it { is_expected.to have_css('td.govuk-table__cell > a', text: 'Horses') }
+  end
+end

--- a/spec/views/search/search.html.erb_spec.rb
+++ b/spec/views/search/search.html.erb_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe 'search/search', type: :view do
   let(:outcome) { build(:search_outcome, :fuzzy_match) }
   let(:search) { build(:search, q: 'toothbrush') }
 
-  it { is_expected.to have_css('article.search-results > table > caption', text: 'Commodities matching') }
+  it { is_expected.to have_css('article.search-results > table > caption', text: 'Best commodity matches for') }
   it { is_expected.to have_css('.commodity-result', count: 2) }
 end

--- a/spec/views/search/search.html.erb_spec.rb
+++ b/spec/views/search/search.html.erb_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe 'search/search', type: :view do
+  subject { render }
+
+  before do
+    assign(:results, outcome)
+    assign(:search, search)
+  end
+
+  let(:outcome) { build(:search_outcome, :fuzzy_match) }
+  let(:search) { build(:search, q: 'toothbrush') }
+
+  it { is_expected.to have_css('article.search-results > table > caption', text: 'Commodities matching') }
+  it { is_expected.to have_css('.commodity-result', count: 2) }
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4725

![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/8156884/23b98c22-8ca7-4cfa-a18c-4ec4f434b234)


### What?

I have added/removed/altered:

- [x] Added context to commodity descriptions that are simply 'other'
- [x] Added results from the commodities index to the commodities list
- [x] Added a bunch of coverage

### Why?

I am doing this because:

- This helps with some of the raised issues from the HMRC team and gives us some breathing room for strategic fixes
