### PR TITLE
HOTT-4277: Enable exchange rates in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 User-Agent: *
+Allow: /exchange_rates
 Disallow: /


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4277

### What?

I have added/removed/altered:

- [ ] Enabled exchange rates in robots.txt because page descriptions aren't showing in Google search and Google recommends doing this https://support.google.com/webmasters/answer/7489871?hl=en#zippy=%2Cthis-is-my-site%2Cthe-page-is-blocked-by-robotstxt

### Why?

I am doing this because:

- because page descriptions aren't showing in Google search


<img width="1202" alt="Screenshot 2023-12-20 at 09 57 40" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/88896c2f-f6e6-4596-8995-b132f10068d0">
