### PR TITLE
Fixes for HOTT-4678 Iceland-Norway ROO  Packaging defintions

### DIFF
--- a/app/models/rules_of_origin/steps/components_definition.rb
+++ b/app/models/rules_of_origin/steps/components_definition.rb
@@ -11,6 +11,10 @@ module RulesOfOrigin
         chosen_scheme.article('packaging')&.content
       end
 
+      def packaging_retail_text
+        chosen_scheme.article('packaging_retail')&.content
+      end
+
       def accessories_text
         chosen_scheme.article('accessories')&.content
       end

--- a/app/views/rules_of_origin/steps/_components_definition.html.erb
+++ b/app/views/rules_of_origin/steps/_components_definition.html.erb
@@ -39,6 +39,12 @@
                                                    article_match: find_article_reference(form.object.packaging_text) if find_article_reference(form.object.packaging_text) %>
   </div>
 
+  <div class="tariff-markdown">
+    <%= govspeak remove_article_reference(form.object.packaging_retail_text) %>
+    <%= render 'shared/origin_reference_document', origin_reference_document: form.object.origin_reference_document,
+               article_match: find_article_reference(form.object.packaging_retail_text) if find_article_reference(form.object.packaging_retail_text) %>
+  </div>
+
   <% if form.object.accessories_text %>
     <h3 class="govuk-heading-s">
       <%= t '.accessories', scheme_title: form.object.scheme_title %>

--- a/spec/models/rules_of_origin/steps/components_definition_spec.rb
+++ b/spec/models/rules_of_origin/steps/components_definition_spec.rb
@@ -6,5 +6,6 @@ RSpec.describe RulesOfOrigin::Steps::ComponentsDefinition do
 
   it_behaves_like 'an article accessor', :neutral_elements_text, 'neutral-elements'
   it_behaves_like 'an article accessor', :packaging_text, 'packaging'
+  it_behaves_like 'an article accessor', :packaging_retail_text, 'packaging_retail'
   it_behaves_like 'an article accessor', :accessories_text, 'accessories'
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4678

### What?

I have 

- [x] Added accessor and placeholder for packaging retail

### Why?

I am doing this because:

-The ROO wizard wasn't splitting the different packaging on the components page with their specific articles and there is an extra .md file now

