### PR TITLE
HOTT-4745-4760-4746: New feedback form

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -4,12 +4,14 @@ class FeedbackController < ApplicationController
                 :disable_last_updated_footnote
 
   def new
+    session[:feedback_referrer] = request.referer
     @feedback = Feedback.new
   end
 
   def create
     @feedback = Feedback.new(feedback_params)
     @feedback.authenticity_token = params[:authenticity_token]
+    @feedback.referrer = session[:feedback_referrer]
 
     if @feedback.valid?
       FrontendMailer.new_feedback(@feedback).deliver_now
@@ -21,7 +23,9 @@ class FeedbackController < ApplicationController
     end
   end
 
-  def thanks; end
+  def thanks
+    @referrer = session.delete(:feedback_referrer)
+  end
 
   private
 

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -26,6 +26,6 @@ class FeedbackController < ApplicationController
   private
 
   def feedback_params
-    params.require(:feedback).permit(:name, :email, :message, :telephone)
+    params.require(:feedback).permit(:message, :telephone)
   end
 end

--- a/app/mailers/frontend_mailer.rb
+++ b/app/mailers/frontend_mailer.rb
@@ -6,10 +6,7 @@ class FrontendMailer < ActionMailer::Base
 
   def new_feedback(feedback)
     @message = feedback.message
-    @name = feedback.name.presence
-    @email = feedback.email.presence || TradeTariffFrontend.from_email
 
-    mail subject: 'Trade Tariff Feedback',
-         reply_to: @email
+    mail subject: 'Trade Tariff Feedback'
   end
 end

--- a/app/mailers/frontend_mailer.rb
+++ b/app/mailers/frontend_mailer.rb
@@ -6,6 +6,7 @@ class FrontendMailer < ActionMailer::Base
 
   def new_feedback(feedback)
     @message = feedback.message
+    @url = feedback.referrer
 
     mail subject: 'Trade Tariff Feedback'
   end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -7,16 +7,10 @@ class Feedback
 
   include ActiveModel::Model
 
-  attr_accessor :message, :name, :email, :telephone, :authenticity_token
+  attr_accessor :message, :telephone, :authenticity_token
 
   validates :message, presence: true,
                       length: { minimum: 10, maximum: 500 }
-
-  validates :name, length: { maximum: 100 }
-
-  validates :email, length: { maximum: 100 },
-                    format: { with: URI::MailTo::EMAIL_REGEXP },
-                    allow_blank: true
 
   validates :authenticity_token, presence: true,
                                  length: { minimum: 50, maximum: 100 }

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -7,7 +7,7 @@ class Feedback
 
   include ActiveModel::Model
 
-  attr_accessor :message, :telephone, :authenticity_token
+  attr_accessor :message, :telephone, :authenticity_token, :referrer
 
   validates :message, presence: true,
                       length: { minimum: 10, maximum: 500 }

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -10,34 +10,21 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <%= page_header 'Send your feedback' %>
+    <%= page_header 'Give feedback on Online Trade Tariff' %>
 
     <p class="form-hint govuk-hint">
-      Don't include any personal information. This form is for submitting feedback on the website. If you have a question
-      related to classifying a good then
-      <%= link_to 'please contact HMRC', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', target: '_blank' %>.
-      If you have a complaint about the phone service then
-      <%= link_to 'please see this page', 'https://www.gov.uk/guidance/complain-to-hm-revenue-and-customs', target: '_blank' %>.
+      Tell us how to improve our service.<br>
+      Feedback is anonymous. Do not include any personal information.
     </p>
 
     <%= form_for @feedback, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_text_area :message,
-                            label: { text: 'Did something go wrong? What went well? How can we improve the service?' },
+                            label: nil,
                             max_chars: 500 %>
 
-      <p class="form-hint govuk-hint">
-        Optionally, leave your contact details, so that we can get back to you in response to your feedback.
+      <p class="form-hint">
+        If you have any questions or need assistance, <%= link_to 'contact HMRC', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', target: '_blank' %>.
       </p>
-
-      <%= f.govuk_text_field :name,
-                             label: { text: 'Name (optional)' },
-                             width: 20,
-                             max_chars: 100 %>
-
-      <%= f.govuk_text_field :email,
-                             label: { text: 'Email (optional)' },
-                             width: 20,
-                             max_chars: 100 %>
 
       <div style="display: none;">
         <%= f.govuk_phone_field :telephone,

--- a/app/views/feedback/thanks.html.erb
+++ b/app/views/feedback/thanks.html.erb
@@ -10,9 +10,18 @@
 
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">
-    Thank you for your feedback.
+    Feedback submitted
   </h1>
-  <div class="govuk-panel__body">
-    We will get back to you shortly.
-  </div>
 </div>
+
+<p>Thank you for your valuable feedback.</p>
+
+<h2>What happens next</h2>
+
+<p>We’ve sent your feedback to the Online Trade Tariff team</p>
+
+<% if @referrer.present? %>
+  <p>
+    <a href=<%= @referrer %>>Return to page</a>
+  </p>
+<% end %>

--- a/app/views/frontend_mailer/new_feedback.html.erb
+++ b/app/views/frontend_mailer/new_feedback.html.erb
@@ -1,7 +1,3 @@
 <p>Hello,</p>
 
 <p><%= @message %></p>
-
-<% if @name || @email %>
-  <p>Contact details: <%= [@name, @email].map(&:presence).compact.join(', ') %></p>
-<% end %>

--- a/app/views/frontend_mailer/new_feedback.html.erb
+++ b/app/views/frontend_mailer/new_feedback.html.erb
@@ -1,3 +1,7 @@
 <p>Hello,</p>
 
 <p><%= @message %></p>
+
+<% if @url %>
+  <p>URL: <%= @url %></p>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -355,12 +355,7 @@ en:
           attributes:
             message:
               blank: Enter your feedback
-              too_long: The feedback must be %{count} characters or fewer
-            name:
-              too_long: The name must be %{count} characters or fewer
-            email:
-              invalid: Enter an email address in the correct format, like name@example.com
-              too_long: The email must be %{count} characters or fewer
+              too_long: Edit your response to under %{count} characters
 
         rules_of_origin/steps/scheme:
           attributes:

--- a/spec/factories/feedback_factory.rb
+++ b/spec/factories/feedback_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :feedback do
     message { 'Hello world' }
+    referrer { 'https://example.com' }
 
     trait :with_authenticity_token do
       authenticity_token do

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.feature 'Feedback', type: :feature do
+  before do
+    ActionController::Base.allow_forgery_protection = true
+  end
+
+  after do
+    ActionController::Base.allow_forgery_protection = false
+  end
+
+  scenario 'with original page URL' do
+    visit '/404'
+    expect(page).to have_css 'h1', text: 'Page not found'
+
+    click_on 'Feedback'
+    expect(page).to have_css 'h1', text: 'Give feedback on Online Trade Tariff'
+    fill_in 'feedback[message]', with: 'Some random feedback'
+    click_button 'Submit feedback'
+
+    expect(page).to have_css 'h1', text: 'Feedback submitted'
+    expect(page).to have_css 'a', text: 'Return to page'
+    expect(page).to have_link nil, href: /404/
+  end
+
+  scenario 'when original page is feedback page' do
+    visit feedback_path
+    expect(page).to have_css 'h1', text: 'Give feedback on Online Trade Tariff'
+    fill_in 'feedback[message]', with: 'Some random feedback'
+    click_button 'Submit feedback'
+
+    expect(page).to have_css 'h1', text: 'Feedback submitted'
+    expect(page).not_to have_css 'a', text: 'Return to page'
+  end
+end

--- a/spec/mailers/frontend_mailer_spec.rb
+++ b/spec/mailers/frontend_mailer_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe FrontendMailer, type: :mailer do
+  describe '#new_feedback' do
+    subject(:mail) { described_class.new_feedback(feedback).tap(&:deliver_now) }
+
+    let(:feedback) { build(:feedback) }
+
+    it { expect(mail.subject).to eq('Trade Tariff Feedback') }
+    it { expect(mail.from).to eq(['no-reply@example.com']) }
+    it { expect(mail.to).to eq(['support@example.com']) }
+  end
+end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -6,14 +6,6 @@ RSpec.describe Feedback do
     it { is_expected.to validate_length_of(:message).is_at_least 10 }
     it { is_expected.to validate_length_of(:message).is_at_most 500 }
 
-    it { is_expected.to validate_length_of(:name).is_at_most 100 }
-
-    it { is_expected.to validate_length_of(:email).is_at_most 100 }
-    it { is_expected.to allow_value('hello@world.com').for(:email) }
-    it { is_expected.not_to allow_value('hello@').for(:email) }
-    it { is_expected.not_to allow_value('@world.com').for(:email) }
-    it { is_expected.not_to allow_value('hello').for(:email) }
-
     it { is_expected.to validate_presence_of :authenticity_token }
     it { is_expected.to validate_length_of(:authenticity_token).is_at_least 50 }
     it { is_expected.to validate_length_of(:authenticity_token).is_at_most 100 }

--- a/spec/views/exchange_rates/index.html.erb_spec.rb
+++ b/spec/views/exchange_rates/index.html.erb_spec.rb
@@ -9,19 +9,17 @@ RSpec.describe 'exchange_rates/index', type: :view do
     assign :period_list, period_list
   end
 
-  pending 'uncomment routes/tests when exchange rates is ready'
+  it { is_expected.to have_css 'h1', text: "#{period_list.year} HMRC currency exchange monthly rates" }
 
-  # it { is_expected.to have_css 'h1', text: "#{period_list.year} HMRC currency exchange rates" }
+  it { is_expected.to have_css 'p', text: "Check the official #{period_list.year}" }
 
-  # it { is_expected.to have_css 'p', text: "Check the official #{period_list.year}" }
+  it { is_expected.to render_template(partial: '_document_detail') }
 
-  # it { is_expected.to render_template(partial: '_document_detail') }
+  it { is_expected.to have_css 'h3', text: "June #{period_list.exchange_rate_periods.first.year} monthly exchange rates" }
 
-  # it { is_expected.to have_css 'h3', text: "June #{period_list.exchange_rate_periods.first.year} monthly exchange rates" }
+  it { is_expected.to have_css 'a', text: period_list.exchange_rate_years.first.year.to_s }
 
-  # it { is_expected.to have_css 'a', text: "HMRC exchange rates for #{period_list.exchange_rate_years.first.year}" }
+  it { is_expected.to have_css 'dt', text: 'Published:' }
 
-  # it { is_expected.to have_css 'dt', text: 'Published:' }
-
-  # it { is_expected.to have_css 'dd', text: '25 July 2023' }
+  it { is_expected.to have_css 'dd', text: '25 July 2023' }
 end

--- a/spec/views/feedback/thanks.html.erb_spec.rb
+++ b/spec/views/feedback/thanks.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe 'feedback/thanks', type: :view do
+  subject { render }
+
+  let(:feedback) { build(:feedback) }
+
+  it { is_expected.not_to have_css 'a', text: 'Return to page' }
+
+  context 'with referrer link present' do
+    before do
+      assign :referrer, feedback.referrer
+    end
+
+    it { is_expected.to have_css 'a', text: 'Return to page' }
+    it { is_expected.to have_link nil, href: feedback.referrer }
+  end
+end

--- a/spec/views/frontend_mailer/new_feedback.html.erb_spec.rb
+++ b/spec/views/frontend_mailer/new_feedback.html.erb_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe 'frontend_mailer/new_feedback', type: :view do
+  let!(:feedback) { build(:feedback) }
+
+  before do
+    assign(:message, feedback.message)
+    render
+  end
+
+  context 'with correct email body content' do
+    it { expect(rendered).to include(feedback.message) }
+  end
+end

--- a/spec/views/frontend_mailer/new_feedback.html.erb_spec.rb
+++ b/spec/views/frontend_mailer/new_feedback.html.erb_spec.rb
@@ -8,7 +8,19 @@ RSpec.describe 'frontend_mailer/new_feedback', type: :view do
     render
   end
 
-  context 'with correct email body content' do
+  context 'with message' do
     it { expect(rendered).to include(feedback.message) }
+    it { expect(rendered).not_to include(feedback.referrer) }
+  end
+
+  context 'with message and url' do
+    before do
+      assign(:message, feedback.message)
+      assign(:url, feedback.referrer)
+      render
+    end
+
+    it { expect(rendered).to include(feedback.message) }
+    it { expect(rendered).to include(feedback.referrer) }
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4745

### What?

I have added/removed/altered:

- [ ] Updated the feedback form
- [ ] removed name and email fields
- [ ] added tests and added missing tests which should have been added with original implementation
- [ ] added original page URL to success page and email

### Why?

I am doing this because:

- We want to make the feedback process simpler for users

<img width="1171" alt="Screenshot 2024-01-04 at 14 37 56" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/faeb2f23-5822-4c82-8bd3-dc255082c642">
<img width="1056" alt="Screenshot 2024-01-04 at 14 48 58" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/a3222831-2160-4c2a-908e-282099314fe4">
<img width="348" alt="Screenshot 2024-01-09 at 15 25 38" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/66fbf7a7-69a1-4511-b5eb-69421f0aae92">
<img width="1339" alt="Screenshot 2024-01-09 at 15 26 53" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/57cd71ff-4aee-4965-b049-65a3ea31ce5a">

