### PR TITLE
HOTT-4822 Add approval before releasing to dev server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,15 +271,21 @@ workflows:
           ssm_parameter: "/development/FRONTEND_ECR_URL"
           <<: *filter-not-main
 
-      - apply-terraform:
-          name: apply-terraform-dev
-          context: trade-tariff-terraform-aws-development
-          environment: development
+      - confirm-deploy-for-qa?:
+          type: approval
           requires:
             - jest-tests
             - test
             - plan-terraform-dev
             - build-and-push-dev
+          <<: *filter-not-main
+
+      - apply-terraform:
+          name: apply-terraform-dev
+          context: trade-tariff-terraform-aws-development
+          environment: development
+          requires:
+            - confirm-deploy-for-qa?
           <<: *filter-not-main
 
       - tariff/smoketests:


### PR DESCRIPTION
### Jira link

HOTT-4822

### What?

I have added/removed/altered:

- [x] Added an approval step before deploying to the Dev server

### Why?

I am doing this because:

- Whilst it arguably adds friction to the dev process pre-merge, it makes the dev server QA-able, in turn removing friction around the process post-merge which is where our actual primary contention is

### Deployment risks (optional)

- Low, should only impact dev server
