### PR TITLE
Added "require spec_helper" in .rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *.sassc
 .sass-cache
 capybara-*.html
-.rspec
 /.bundle
 /vendor/bundle
 /log/*

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper


### PR DESCRIPTION

### Jira link
No Jira.

### What?
Added .rspec file with  "--require spec_helper" to instructs RSpec to automatically require the spec_helper.rb file before running any tests.

### Why?
To allow rspec test to be run individually. 