### PR TITLE
Fix Broken RoO Proofs ORD URL

### DIFF
--- a/app/helpers/rules_of_origin_helper.rb
+++ b/app/helpers/rules_of_origin_helper.rb
@@ -58,7 +58,7 @@ module RulesOfOriginHelper
   end
 
   def replace_ord_url(content, ord)
-    content.gsub("{ord_url}", asset_path(ord.document_path))
+    content.gsub('{ord_url}', asset_path(ord.document_path))
   end
 
   def restrict_wrapping(content)

--- a/app/helpers/rules_of_origin_helper.rb
+++ b/app/helpers/rules_of_origin_helper.rb
@@ -57,6 +57,11 @@ module RulesOfOriginHelper
     content.scan(/{{(.*)}}/i).first&.first if content
   end
 
+  def insert_ord_url(content, ord, placeholder)
+    url = link_to 'origin reference document', asset_path(ord.document_path)
+    content.gsub!(placeholder, url)
+  end
+
   def restrict_wrapping(content)
     safe_content = html_escape(content)
 

--- a/app/helpers/rules_of_origin_helper.rb
+++ b/app/helpers/rules_of_origin_helper.rb
@@ -57,9 +57,8 @@ module RulesOfOriginHelper
     content.scan(/{{(.*)}}/i).first&.first if content
   end
 
-  def insert_ord_url(content, ord, placeholder)
-    url = link_to 'origin reference document', asset_path(ord.document_path)
-    content.gsub!(placeholder, url)
+  def replace_ord_url(content, ord)
+    content.gsub("{ord_url}", asset_path(ord.document_path))
   end
 
   def restrict_wrapping(content)

--- a/app/views/rules_of_origin/_proofs.html.erb
+++ b/app/views/rules_of_origin/_proofs.html.erb
@@ -15,7 +15,8 @@
     <div class="tariff-markdown stacked-govuk-details">
       <% scheme.proofs.each do |proof| %>
         <%= render 'shared/details', summary: proof.summary,
-                                     content: govspeak(proof.content) %>
+                                     content: govspeak(proof.content),
+                                     origin_reference_document: scheme.origin_reference_document%>
       <% end %>
     </div>
 

--- a/app/views/rules_of_origin/proofs/index.html.erb
+++ b/app/views/rules_of_origin/proofs/index.html.erb
@@ -24,7 +24,8 @@
   <div class="stacked-govuk-details">
     <% scheme.proofs.each do |proof| %>
       <%= render 'shared/details', summary: proof.summary,
-                                   content: govspeak(proof.content) %>
+                                   content: govspeak(proof.content),
+                                   origin_reference_document: scheme.origin_reference_document%>
     <% end %>
   </div>
 <% end %>

--- a/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
+++ b/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
@@ -25,7 +25,8 @@
   <div class="stacked-govuk-details tariff-markdown">
     <% current_step.proofs.each do |proof| %>
       <%= render 'shared/details', summary: proof.summary,
-                                   content: govspeak(proof.content) \
+                                   content: govspeak(proof.content),
+                                   origin_reference_document: current_step.origin_reference_document \
           if proof.content.present? %>
     <% end %>
   </div>

--- a/app/views/shared/_details.html.erb
+++ b/app/views/shared/_details.html.erb
@@ -6,6 +6,7 @@
   </summary>
   <div class="govuk-details__text">
     <% if defined?(origin_reference_document) && origin_reference_document %>
+      <% insert_ord_url content, origin_reference_document, "{ord_url}" %>
       <%= govspeak remove_article_reference(content) %>
       <%= render 'shared/origin_reference_document', origin_reference_document: origin_reference_document,
                                                     article_match: find_article_reference(content) if find_article_reference(content) %>

--- a/app/views/shared/_details.html.erb
+++ b/app/views/shared/_details.html.erb
@@ -6,8 +6,8 @@
   </summary>
   <div class="govuk-details__text">
     <% if defined?(origin_reference_document) && origin_reference_document %>
-      <% insert_ord_url content, origin_reference_document, "{ord_url}" %>
-      <%= govspeak remove_article_reference(content) %>
+      <%  %>
+      <%= govspeak remove_article_reference replace_ord_url content, origin_reference_document %>
       <%= render 'shared/origin_reference_document', origin_reference_document: origin_reference_document,
                                                     article_match: find_article_reference(content) if find_article_reference(content) %>
     <% else %>

--- a/spec/helpers/rules_of_origin_helper_spec.rb
+++ b/spec/helpers/rules_of_origin_helper_spec.rb
@@ -130,6 +130,28 @@ RSpec.describe RulesOfOriginHelper, type: :helper do
     end
   end
 
+  describe '#insert_ord_url' do
+    context 'with matching ord placeholder in content' do
+      subject { helper.insert_ord_url content, ord, placeholder }
+
+      let(:content) { '{ord_url}' }
+      let(:ord) { build(:rules_of_origin_origin_reference_document) }
+      let(:placeholder) { '{ord_url}' }
+
+      it { is_expected.to eq '<a href="/roo_origin_reference_documents/211203_ORD_Japan_V1.1.odt">origin reference document</a>' }
+    end
+
+    context 'without matching ord placeholder in content' do
+      subject { helper.insert_ord_url content, ord, placeholder }
+
+      let(:content) { 'foo' }
+      let(:ord) { build(:rules_of_origin_origin_reference_document) }
+      let(:placeholder) { '{ord_url}' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#restrict_wrapping' do
     subject { helper.restrict_wrapping content }
 

--- a/spec/helpers/rules_of_origin_helper_spec.rb
+++ b/spec/helpers/rules_of_origin_helper_spec.rb
@@ -130,25 +130,24 @@ RSpec.describe RulesOfOriginHelper, type: :helper do
     end
   end
 
-  describe '#insert_ord_url' do
+  describe '#replace_ord_url' do
     context 'with matching ord placeholder in content' do
-      subject { helper.insert_ord_url content, ord, placeholder }
+      subject { helper.replace_ord_url content, ord }
 
-      let(:content) { '{ord_url}' }
+      let(:content) { '<a href="{ord_url}">Origin Reference Document</a>' }
       let(:ord) { build(:rules_of_origin_origin_reference_document) }
-      let(:placeholder) { '{ord_url}' }
 
-      it { is_expected.to eq '<a href="/roo_origin_reference_documents/211203_ORD_Japan_V1.1.odt">origin reference document</a>' }
+      it { is_expected.to have_link 'Origin Reference Document', href: '/roo_origin_reference_documents/211203_ORD_Japan_V1.1.odt' }
+
     end
 
     context 'without matching ord placeholder in content' do
-      subject { helper.insert_ord_url content, ord, placeholder }
+      subject { helper.replace_ord_url content, ord }
 
-      let(:content) { 'foo' }
+      let(:content) { '{foo}' }
       let(:ord) { build(:rules_of_origin_origin_reference_document) }
-      let(:placeholder) { '{ord_url}' }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to eq '{foo}' }
     end
   end
 

--- a/spec/helpers/rules_of_origin_helper_spec.rb
+++ b/spec/helpers/rules_of_origin_helper_spec.rb
@@ -138,7 +138,6 @@ RSpec.describe RulesOfOriginHelper, type: :helper do
       let(:ord) { build(:rules_of_origin_origin_reference_document) }
 
       it { is_expected.to have_link 'Origin Reference Document', href: '/roo_origin_reference_documents/211203_ORD_Japan_V1.1.odt' }
-
     end
 
     context 'without matching ord placeholder in content' do

--- a/spec/helpers/rules_of_origin_helper_spec.rb
+++ b/spec/helpers/rules_of_origin_helper_spec.rb
@@ -144,10 +144,10 @@ RSpec.describe RulesOfOriginHelper, type: :helper do
     context 'without matching ord placeholder in content' do
       subject { helper.replace_ord_url content, ord }
 
-      let(:content) { '{foo}' }
+      let(:content) { 'foo' }
       let(:ord) { build(:rules_of_origin_origin_reference_document) }
 
-      it { is_expected.to eq '{foo}' }
+      it { is_expected.to eq 'foo' }
     end
   end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4516)

### What?

I have

- [x] Added method insert_ord_url in app/helpers/rules_of_origin_helper.rb to dynamically insert a URL where there is a bespoke placeholder (ie. {ord_url} in backend origin-declaration.mds under each regions RoO proofs section) 
- [x] Updated  app/views/rules_of_origin/_proofs.html.erb to use an ORD object to insert into the method.
- [x] Updated app/views/shared/_details.html.erb to consume the new method and render the correct URL.

### Why?

I am doing this because:

- The URL to an ORD in the RoO proofs section was never correct and has to be dynamic

### Have you? 

- [x] Reviewed view changes with stake holders

### Deployment risks 

- Possible backend files with updated placeholder may not deploy but this is very rare and won't cause an error.

Screenshot of origin reference document link at bottom of the screen
![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/127106895/dc21014d-cc7e-48e1-8859-4b93d89bebbf)

