### PR TITLE
Changes the order of the Disallow directive.

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,7 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 User-Agent: *
-Allow: /exchange_rates
 Disallow: /
+Allow: /exchange_rates
+Allow: /tools
+Allow: /news
+Allow: /help


### PR DESCRIPTION
### What?
Disallow should come first, otherwise it might block the entire website from being indexed (and it looks like this is the case for OTT).

This PR allows: /exchange_rates, /tools, /news and /helps
And it blocks the indexing of all the other URLs.

### Jira link
https://transformuk.atlassian.net/browse/HOTT-4883

### Why?
To make some pages searchable (/exchange_rates, /tools, /news and /helps).