### PR TITLE
HOTT-4748: Feedback banner top

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,7 @@
     </div>
     <%= render 'shared/search_banner' if TradeTariffFrontend.search_banner? && @search %>
     <%= render 'news_items/header_banner', news_item: News::Item.latest_banner unless @skip_news_banner %>
-    <%= render 'shared/feedback_banner' unless @feedback %>
+    <%= render 'shared/feedback_banner' %>
   </header>
 
   <div class="tariff service govuk-width-container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,6 +61,7 @@
     </div>
     <%= render 'shared/search_banner' if TradeTariffFrontend.search_banner? && @search %>
     <%= render 'news_items/header_banner', news_item: News::Item.latest_banner unless @skip_news_banner %>
+    <%= render 'shared/feedback_banner' unless @feedback %>
   </header>
 
   <div class="tariff service govuk-width-container">

--- a/app/views/shared/_feedback_banner.html.erb
+++ b/app/views/shared/_feedback_banner.html.erb
@@ -1,0 +1,10 @@
+<% unless @feedback %>
+<div class="tariff-feedback-banner">
+  <div class="phase-banner govuk-width-container">
+    <p>
+      <strong class="phase-tag">FEEDBACK</strong>
+      <span>Tell us what you think - your <%= link_to 'feedback', feedback_path %> will help us improve.</span>
+    </p>
+  </div>
+</div>
+<% end %>

--- a/app/views/shared/_feedback_banner.html.erb
+++ b/app/views/shared/_feedback_banner.html.erb
@@ -1,9 +1,13 @@
 <% unless @feedback %>
 <div class="tariff-feedback-banner">
-  <div class="phase-banner govuk-width-container">
-    <p>
-      <strong class="phase-tag">FEEDBACK</strong>
-      <span>Tell us what you think - your <%= link_to 'feedback', feedback_path %> will help us improve.</span>
+  <div class="govuk-phase-banner govuk-width-container">
+    <p class="govuk-phase-banner__content">
+      <strong class="govuk-tag govuk-phase-banner__content__tag">
+        FEEDBACK
+      </strong>
+      <span class="govuk-phase-banner__text">
+        Tell us what you think - your <%= link_to 'feedback', feedback_path, class: 'govuk-link' %> will help us improve.
+      </span>
     </p>
   </div>
 </div>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -69,3 +69,4 @@ $govuk-images-path: '~govuk-frontend/govuk/assets/images/';
 @import '../src/stylesheets/help_popup';
 @import '../src/stylesheets/govuk-frontend-extensions';
 @import '../src/stylesheets/exchange_rates';
+@import '../src/stylesheets/feedback_banner';

--- a/app/webpacker/src/stylesheets/_feedback_banner.scss
+++ b/app/webpacker/src/stylesheets/_feedback_banner.scss
@@ -5,3 +5,9 @@
     padding-top: govuk-spacing(4);
   }
 }
+
+.tariff-header-banner + .tariff-feedback-banner {
+  .govuk-phase-banner {
+    padding-top: govuk-spacing(2) ;
+  }
+}

--- a/app/webpacker/src/stylesheets/_feedback_banner.scss
+++ b/app/webpacker/src/stylesheets/_feedback_banner.scss
@@ -1,0 +1,25 @@
+.tariff-feedback-banner {
+  background-color: govuk-colour("white");
+
+  .phase-tag {
+    color: govuk-colour("white");
+    background-color: govuk-colour("blue");
+    letter-spacing: 1px;
+    padding: 1px 4px 0;
+    margin: 0 5px 0 0;
+  }
+
+  .phase-banner {
+    border-bottom: 1px solid #bfc1c3;
+  }
+
+  p {
+    @include govuk-font($size: 16);
+    margin-bottom: 0;
+  }
+
+  .govuk-width-container {
+    padding-top: govuk-spacing(4);
+    padding-bottom: govuk-spacing(2);
+  }
+}

--- a/app/webpacker/src/stylesheets/_feedback_banner.scss
+++ b/app/webpacker/src/stylesheets/_feedback_banner.scss
@@ -1,25 +1,7 @@
 .tariff-feedback-banner {
   background-color: govuk-colour("white");
 
-  .phase-tag {
-    color: govuk-colour("white");
-    background-color: govuk-colour("blue");
-    letter-spacing: 1px;
-    padding: 1px 4px 0;
-    margin: 0 5px 0 0;
-  }
-
-  .phase-banner {
-    border-bottom: 1px solid #bfc1c3;
-  }
-
-  p {
-    @include govuk-font($size: 16);
-    margin-bottom: 0;
-  }
-
   .govuk-width-container {
     padding-top: govuk-spacing(4);
-    padding-bottom: govuk-spacing(2);
   }
 }

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -32,4 +32,14 @@ RSpec.feature 'Feedback', type: :feature do
     expect(page).to have_css 'h1', text: 'Feedback submitted'
     expect(page).not_to have_css 'a', text: 'Return to page'
   end
+
+  scenario 'feedback banner is not shown on feedback page' do
+    visit '/404'
+    expect(page).to have_css 'a', text: 'feedback'
+    expect(page).to have_css 'p', text: 'Tell us what you think - your feedback will help us improve.'
+
+    click_on 'feedback'
+    expect(page).not_to have_css 'a', text: 'feedback'
+    expect(page).not_to have_css 'p', text: 'Tell us what you think - your feedback will help us improve.'
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4748

### What?

I have added/removed/altered:

- [ ] Added Feedback banner on top of all pages except on the feedback page itself

### Why?

I am doing this because:

- This will allow users to easily send us feedback

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

<img width="1082" alt="Screenshot 2024-01-16 at 16 22 12" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/e2bee1c1-cccf-4dd8-a9b3-dee6f56190af">
<img width="1008" alt="Screenshot 2024-01-16 at 16 22 23" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/e6aa1759-e7c4-4396-97a0-f3c59b19a69e">
<img width="988" alt="Screenshot 2024-01-16 at 16 22 33" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/84173275-a37e-4249-9610-901b19bcd5cc">
<img width="576" alt="Screenshot 2024-01-16 at 16 30 25" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/143133fc-861e-44e4-bd88-325dc3250a54">

