### PR TITLE
HOTT-4201: Retire old feedback banners and links

### DIFF
--- a/app/views/pages/help_find_commodity.html.erb
+++ b/app/views/pages/help_find_commodity.html.erb
@@ -51,18 +51,4 @@
       <li><a href="https://ec.europa.eu/taxation_customs/dds2/ebti/ebti_home.jsp?Lang=en">European Binding Tariff Information decisions for Northern Ireland</a></li>
     </ul>
   </div>
-  <div class="govuk-grid-column-one-third">
-    <div class="gem-c-related-navigation">
-
-      <h2 id="related-nav-related_items-40a88cdf" class="gem-c-related-navigation__main-heading" data-track-count="sidebarRelatedItemSection">Related content</h2>
-
-      <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-related_items-40a88cdf" data-module="gem-toggle" data-gem-toggle-module-started="true">
-        <ul class="gem-c-related-navigation__link-list" data-module="gem-track-click" data-gem-track-click-module-started="true">
-          <li class="gem-c-related-navigation__link">
-            <%= link_to 'Leave feedback', feedback_path, class: "gem-c-contents-list__link govuk-link govuk-link--no-underline" %>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </div>
 </div>

--- a/app/views/rules_of_origin/_new_feature.html.erb
+++ b/app/views/rules_of_origin/_new_feature.html.erb
@@ -1,4 +1,0 @@
-<div class="govuk-inset-text tariff-inset-meursing">
-  <p>The rules of origin wizard is new functionality.</p>
-  <p>Your <%= link_to 'feedback', feedback_path %> will help us to improve it.</p>
-</div>

--- a/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
+++ b/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
@@ -50,5 +50,3 @@
     </li>
   <% end %>
 </ul>
-
-<%= render 'rules_of_origin/new_feature' %>

--- a/app/views/rules_of_origin/steps/_rules_not_met.html.erb
+++ b/app/views/rules_of_origin/steps/_rules_not_met.html.erb
@@ -95,5 +95,3 @@
     </div>
   </div>
 </div>
-
-<%= render 'rules_of_origin/new_feature' %>

--- a/spec/views/rules_of_origin/steps/_origin_requirements_met.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_origin_requirements_met.html.erb_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'rules_of_origin/steps/_origin_requirements_met', type: :view do
   it { is_expected.to have_css 'span.govuk-caption-xl', text: %r{(Im|Ex)porting.* #{wizardstore['commodity_code']}.*Japan.*UK} }
   it { is_expected.to have_css 'h1', text: /Product-specific rules met/i }
   it { is_expected.to have_css '.rules-of-origin-met-message', text: %r{#{schemes.first.title}} }
-  it { is_expected.to have_link 'feedback' }
   it { is_expected.to have_css '#next-steps a', count: 3 }
 
   context 'with duty drawback available' do

--- a/spec/views/rules_of_origin/steps/_rules_not_met.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/steps/_rules_not_met.html.erb_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe 'rules_of_origin/steps/_rules_not_met', type: :view do
   it { is_expected.to have_css '#cumulation-section a' }
   it { is_expected.to have_css '#whats-next-section.panel--coloured strong' }
   it { is_expected.to have_css '#whats-next-section a', count: 2 }
-  it { is_expected.to have_link 'feedback' }
   it { is_expected.not_to have_css '#next-steps' }
 
   context 'without tolerances article' do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4201 see ticket comments for more details

### What?

I have added/removed/altered:

- [ ] Removed old feedback banners and links

### Why?

I am doing this because:

- We are switching to new feedback banners

<img width="1076" alt="Screenshot 2024-01-17 at 16 58 02" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/da35069e-5dae-46e1-9add-9f4c70552ba9">
<img width="1048" alt="Screenshot 2024-01-17 at 16 57 50" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/4136d8f5-662b-4637-b895-1e49625e000e">

