### PR TITLE
HOTT-4749: Bottom feedback banner with choice selection

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -6,12 +6,15 @@ class FeedbackController < ApplicationController
   def new
     session[:feedback_referrer] = request.referer
     @feedback = Feedback.new
+    @feedback.page_useful = params[:page_useful]
   end
 
   def create
     @feedback = Feedback.new(feedback_params)
     @feedback.authenticity_token = params[:authenticity_token]
     @feedback.referrer = session[:feedback_referrer]
+
+    return redirect_to(find_commodity_path) unless @feedback.valid_page_useful_options?
 
     if @feedback.valid?
       FrontendMailer.new_feedback(@feedback).deliver_now
@@ -30,6 +33,6 @@ class FeedbackController < ApplicationController
   private
 
   def feedback_params
-    params.require(:feedback).permit(:message, :telephone)
+    params.require(:feedback).permit(:message, :telephone, :page_useful)
   end
 end

--- a/app/mailers/frontend_mailer.rb
+++ b/app/mailers/frontend_mailer.rb
@@ -7,6 +7,7 @@ class FrontendMailer < ActionMailer::Base
   def new_feedback(feedback)
     @message = feedback.message
     @url = feedback.referrer
+    @page_useful = feedback.page_useful
 
     mail subject: 'Trade Tariff Feedback'
   end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -7,7 +7,7 @@ class Feedback
 
   include ActiveModel::Model
 
-  attr_accessor :message, :telephone, :authenticity_token, :referrer
+  attr_accessor :message, :telephone, :authenticity_token, :referrer, :page_useful
 
   validates :message, presence: true,
                       length: { minimum: 10, maximum: 500 }
@@ -20,6 +20,10 @@ class Feedback
 
   def record_delivery!
     Rails.cache.write(tracking_token, tracking_token_count + 1, expires_in: TOKEN_TRACKING_LIFETIME)
+  end
+
+  def valid_page_useful_options?
+    [nil, '', 'yes', 'no'].include?(page_useful)
   end
 
   private

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -34,6 +34,8 @@
                              max_chars: 100 %>
       </div>
 
+      <%= f.hidden_field :page_useful %>
+
       <%= f.govuk_submit 'Submit feedback' %>
     <% end %>
   </div>

--- a/app/views/frontend_mailer/new_feedback.html.erb
+++ b/app/views/frontend_mailer/new_feedback.html.erb
@@ -5,3 +5,5 @@
 <% if @url %>
   <p>URL: <%= @url %></p>
 <% end %>
+
+<p>Found this page useful: <%= @page_useful if @page_useful %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -88,6 +88,8 @@
     </main>
   </div>
 
+  <%= render 'shared/feedback_useful_banner' unless @feedback %>
+
   <footer id="footer" class="govuk-footer govuk-!-display-none-print" role="contentinfo">
     <div class="govuk-width-container">
       <div class="govuk-footer__navigation">

--- a/app/views/shared/_feedback_useful_banner.html.erb
+++ b/app/views/shared/_feedback_useful_banner.html.erb
@@ -1,0 +1,20 @@
+<div class="feedback-useful-banner govuk-width-container">
+  <div class="feedback-useful-container">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <p>is this page useful?</p>
+        <li class="govuk-footer__inline-list-item">
+          <%= link_to 'Yes', feedback_path(page_useful: 'yes'), class: 'govuk-button govuk-button--secondary' %>
+        </li>
+        <li class="govuk-footer__inline-list-item">
+          <%= link_to 'No', feedback_path(page_useful: 'no'), class: 'govuk-button govuk-button--secondary' %>
+        </li>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <li class="govuk-footer__inline-list-item">
+            <%= link_to 'Report a problem with this page', feedback_path, class: 'govuk-button govuk-button--secondary report-problem' %>
+        </li>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -69,3 +69,4 @@ $govuk-images-path: '~govuk-frontend/govuk/assets/images/';
 @import '../src/stylesheets/help_popup';
 @import '../src/stylesheets/govuk-frontend-extensions';
 @import '../src/stylesheets/exchange_rates';
+@import '../src/stylesheets/feedback_useful_banner';

--- a/app/webpacker/src/stylesheets/_feedback_useful_banner.scss
+++ b/app/webpacker/src/stylesheets/_feedback_useful_banner.scss
@@ -36,7 +36,7 @@
   }
 }
 
-@media (max-width: 640px) {
+@include govuk-media-query($until: tablet) {
   .feedback-useful-banner {
     p {
       padding-top: 9px;

--- a/app/webpacker/src/stylesheets/_feedback_useful_banner.scss
+++ b/app/webpacker/src/stylesheets/_feedback_useful_banner.scss
@@ -1,0 +1,45 @@
+.feedback-useful-banner {
+  border-top: 1px solid $govuk-border-colour;
+
+  .feedback-useful-container {
+    position: relative;
+    padding: 1em;
+    background-color: govuk-colour("light-grey");
+    height: 36px;
+    padding-top: 17px;
+  }
+
+  p {
+    font-weight: bold;
+    float: left;
+    padding-top: 7px;
+    padding-left: 11px;
+    padding-right: 15px;
+  }
+
+  .govuk-button {
+    border: 1px solid govuk-colour("black");
+    box-shadow: 0 2px 0 govuk-colour("black");
+    min-width: 6em;
+  }
+}
+
+.govuk-footer {
+  border-top: 10px solid govuk-colour("blue");
+}
+
+@media (max-width: 900px) {
+  .feedback-useful-banner {
+    .report-problem {
+      display: none;
+    }
+  }
+}
+
+@media (max-width: 640px) {
+  .feedback-useful-banner {
+    p {
+      padding-top: 9px;
+    }
+  }
+}

--- a/spec/factories/feedback_factory.rb
+++ b/spec/factories/feedback_factory.rb
@@ -2,11 +2,16 @@ FactoryBot.define do
   factory :feedback do
     message { 'Hello world' }
     referrer { 'https://example.com' }
+    page_useful { 'yes' }
 
     trait :with_authenticity_token do
       authenticity_token do
         'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw'
       end
+    end
+
+    trait :with_invalid_choice do
+      page_useful { 'invalid' }
     end
   end
 end

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -32,4 +32,16 @@ RSpec.feature 'Feedback', type: :feature do
     expect(page).to have_css 'h1', text: 'Feedback submitted'
     expect(page).not_to have_css 'a', text: 'Return to page'
   end
+
+  scenario 'feedback bottombanner is not shown on feedback page' do
+    visit '/404'
+    expect(page).to have_css 'a', text: 'Yes'
+    expect(page).to have_css 'a', text: 'No'
+    expect(page).to have_css 'p', text: 'is this page useful?'
+
+    click_on 'Yes'
+    expect(page).not_to have_css 'a', text: 'Yes'
+    expect(page).not_to have_css 'a', text: 'No'
+    expect(page).not_to have_css 'p', text: 'is this page useful?'
+  end
 end

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -33,15 +33,17 @@ RSpec.feature 'Feedback', type: :feature do
     expect(page).not_to have_css 'a', text: 'Return to page'
   end
 
-  scenario 'feedback bottombanner is not shown on feedback page' do
+  scenario 'feedback bottom banner is not shown on feedback page' do
     visit '/404'
     expect(page).to have_css 'a', text: 'Yes'
     expect(page).to have_css 'a', text: 'No'
+    expect(page).to have_css 'a', text: 'Report a problem with this page'
     expect(page).to have_css 'p', text: 'is this page useful?'
 
     click_on 'Yes'
     expect(page).not_to have_css 'a', text: 'Yes'
     expect(page).not_to have_css 'a', text: 'No'
+    expect(page).not_to have_css 'a', text: 'Report a problem with this page'
     expect(page).not_to have_css 'p', text: 'is this page useful?'
   end
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -72,4 +72,18 @@ RSpec.describe Feedback do
       end
     end
   end
+
+  describe '#valid_page_useful_options?' do
+    context 'when choice is valid' do
+      let(:feedback) { build :feedback, :with_authenticity_token }
+
+      it { expect(feedback.valid_page_useful_options?).to eq(true) }
+    end
+
+    context 'when choice is invalid' do
+      let(:feedback) { build :feedback, :with_authenticity_token, :with_invalid_choice }
+
+      it { expect(feedback.valid_page_useful_options?).to eq(false) }
+    end
+  end
 end

--- a/spec/requests/feedback_controller_spec.rb
+++ b/spec/requests/feedback_controller_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 RSpec.describe FeedbackController, type: :request do
   subject { response }
 
+  let(:message) { 'This message is valid.' }
+
   describe 'GET #new' do
     before { get new_feedback_path }
 
@@ -14,7 +16,7 @@ RSpec.describe FeedbackController, type: :request do
 
     let(:params) do
       {
-        feedback: { message: 'I love falafels.' },
+        feedback: { message: },
         authenticity_token: 'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw',
       }
     end
@@ -28,13 +30,49 @@ RSpec.describe FeedbackController, type: :request do
     context 'when honeypot (telephone field) captcha data included' do
       let(:params) do
         {
-          feedback: { message: 'I love gravy.',
+          feedback: { message:,
                       telephone: '00000000000' },
           authenticity_token: 'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw',
         }
       end
 
       it { is_expected.not_to redirect_to(feedback_thanks_url) }
+
+      it 'will not send the email' do
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
+      end
+    end
+
+    context 'when valid feedback useful choice' do
+      let(:params) do
+        {
+          feedback: { message:,
+                      page_useful: 'yes' },
+          authenticity_token: 'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw',
+        }
+      end
+
+      it { is_expected.to redirect_to(feedback_thanks_url) }
+
+      it 'sends the feedback email' do
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
+
+      it 'includes users selected choice in the email' do
+        expect(ActionMailer::Base.deliveries.last.body).to include('Found this page useful: yes')
+      end
+    end
+
+    context 'when invalid feedback useful choice' do
+      let(:params) do
+        {
+          feedback: { message:,
+                      page_useful: 'invalid' },
+          authenticity_token: 'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw',
+        }
+      end
+
+      it { is_expected.to redirect_to(find_commodity_url) }
 
       it 'will not send the email' do
         expect(ActionMailer::Base.deliveries.count).to eq(0)

--- a/spec/views/frontend_mailer/new_feedback.html.erb_spec.rb
+++ b/spec/views/frontend_mailer/new_feedback.html.erb_spec.rb
@@ -23,4 +23,15 @@ RSpec.describe 'frontend_mailer/new_feedback', type: :view do
     it { expect(rendered).to include(feedback.message) }
     it { expect(rendered).to include(feedback.referrer) }
   end
+
+  context 'with page useful option' do
+    before do
+      assign(:message, feedback.message)
+      assign(:page_useful, feedback.page_useful)
+      render
+    end
+
+    it { expect(rendered).to include(feedback.message) }
+    it { expect(rendered).to include(feedback.page_useful) }
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4749

### What?

I have added/removed/altered:

- [ ] Display feedback banner at bottom of all pages except on feedback page
- [ ] Remember users choice during feedback journey
- [ ] Remember users choice if any errors occur during form submission
- [ ] Email users choice
- [ ] Only allow valid choices

### Why?

I am doing this because:

- This improves feedback collection 

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

<img width="436" alt="Screenshot 2024-01-30 at 16 19 58" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/6fdb367c-08c6-4e81-a769-1035d4ea76ce">
<img width="1391" alt="Screenshot 2024-01-30 at 16 18 27" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/c2bdad11-9cea-4109-9595-4921d9440820">
<img width="571" alt="Screenshot 2024-01-30 at 16 19 03" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/86ab75c9-5465-4bec-b2f6-e87ee9ea2c32">
