### PR TITLE
Further changes to the 99l help page

### DIFF
--- a/app/views/pages/changes_999l.html.erb
+++ b/app/views/pages/changes_999l.html.erb
@@ -46,16 +46,16 @@
     </p>
 
     <h3 class="govuk-heading-s">
-      IMPORT MEASURES WHERE A REPLACEMENT FOR 999L IS STILL IN PROGRESS
+      CHANGES IN PROGRESS
     </h3>
 
     <p class="govuk-body-m">
 
-      We will update this page and issue a new Stop Press to advise when it is live and ready for use
+      These measure changes are not yet live in CDS. We hope this will provide advance notice for most codes that will be in use. We will amend this document as updates are accepted into CDS. Please note that until the codes are valid in CDS they cannot be used in a declaration.
 
       <div class="govuk-list">
         <ul>
-          <li><b>724</b> Fluorinated Gas</li>
+          <li>Measure: 724 Fluorinated Gas</li>
 
         </ul>
       </div>


### PR DESCRIPTION
HOTT-4997

Couldnt see where these changes are referenced in the orginal document but have been sent via email:

<img width="1110" alt="Screenshot 2024-02-06 at 16 06 01" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/5055757/63396c52-93c7-4bbe-a1be-cda8328699f1">


Screenshot of changes
<img width="744" alt="Screenshot 2024-02-07 at 09 52 43" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/5055757/52d3f652-6e8c-4cd8-9a60-7fabf35cadd2">
