### PR TITLE
HOTT-5096 Test dependabot PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ filter-not-main: &filter-not-main
     branches:
       ignore:
         - main
-        - /^dependabot/(?!docker/).*/
         - /^hotfix\/.+/
 
 filter-main: &filter-main


### PR DESCRIPTION
### Jira link

HOTT-5096

### What?

I have added/removed/altered:

- [x] Added in testing for dependabot PRs

### Why?

I am doing this because:

- currently dependabot PRs can get all the way out to production without every running the test suite

### Deployment risks (optional)

- Low tightens CI standards
