### PR TITLE
HOTT-5063: Use environment based emails and always receive a copy of all feedback emails

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -24,6 +24,7 @@ STW_URI='https://check-how-to-import-export-goods.service.gov.uk/manage-this-tra
 TARIFF_API_VERSION=2
 TARIFF_FROM_EMAIL=no-reply@example.com
 TARIFF_TO_EMAIL=support@example.com
+TARIFF_SUPPORT_EMAIL=support@example.com
 UPDATED_NAVIGATION=true
 WEBCHAT_URL='test-online-services-helpdesk'
 WELSH=true

--- a/.env.test
+++ b/.env.test
@@ -21,6 +21,7 @@ STW_URI='https://test.com/stw-testing'
 TARIFF_API_VERSION=2
 TARIFF_FROM_EMAIL=no-reply@example.com
 TARIFF_TO_EMAIL=support@example.com
+TARIFF_SUPPORT_EMAIL=support@example.com
 UPDATED_NAVIGATION=true
 WEBCHAT_URL='test-online-services-helpdesk'
 WELSH=true

--- a/.env.test
+++ b/.env.test
@@ -25,4 +25,3 @@ TARIFF_SUPPORT_EMAIL=support@example.com
 UPDATED_NAVIGATION=true
 WEBCHAT_URL='test-online-services-helpdesk'
 WELSH=true
-

--- a/app/mailers/frontend_mailer.rb
+++ b/app/mailers/frontend_mailer.rb
@@ -2,7 +2,8 @@
 class FrontendMailer < ActionMailer::Base
   # rubocop:enable Rails/ApplicationMailer
   default from: TradeTariffFrontend.from_email,
-          to: TradeTariffFrontend.to_email
+          to: TradeTariffFrontend.to_email,
+          bcc: TradeTariffFrontend.support_email
 
   def new_feedback(feedback)
     @message = feedback.message

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -90,6 +90,10 @@ module TradeTariffFrontend
     ENV['TARIFF_TO_EMAIL']
   end
 
+  def support_email
+    ENV['TARIFF_SUPPORT_EMAIL']
+  end
+
   def currency_default
     currency_default_gbp? ? 'GBP' : 'EUR'
   end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -52,6 +52,7 @@ Terraform to deploy the service into AWS.
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Smallest number of tasks the service can scale-in to. | `number` | `1` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | `2` | no |
+| <a name="input_tariff_email_to"></a> [tariff\_email\_to](#input\_tariff\_email\_to) | Email address to send emails to. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -1,5 +1,6 @@
-region      = "eu-west-2"
-environment = "development"
-base_domain = "dev.trade-tariff.service.gov.uk"
-cpu         = 1024
-memory      = 2048
+region          = "eu-west-2"
+environment     = "development"
+base_domain     = "dev.trade-tariff.service.gov.uk"
+cpu             = 1024
+memory          = 2048
+tariff_email_to = "hmrc-trade-tariff-support-g@digital.hmrc.gov.uk"

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -1,8 +1,9 @@
-region        = "eu-west-2"
-environment   = "production"
-base_domain   = "trade-tariff.service.gov.uk"
-cpu           = 4096
-memory        = 8192
-service_count = 4
-min_capacity  = 2
-max_capacity  = 16
+region          = "eu-west-2"
+environment     = "production"
+base_domain     = "trade-tariff.service.gov.uk"
+cpu             = 4096
+memory          = 8192
+service_count   = 4
+min_capacity    = 2
+max_capacity    = 16
+tariff_email_to = "online.tariff.feedback@hmrc.gov.uk"

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -1,8 +1,9 @@
-region        = "eu-west-2"
-environment   = "staging"
-base_domain   = "staging.trade-tariff.service.gov.uk"
-cpu           = 1024
-memory        = 2048
-service_count = 4
-min_capacity  = 2
-max_capacity  = 8
+region          = "eu-west-2"
+environment     = "staging"
+base_domain     = "staging.trade-tariff.service.gov.uk"
+cpu             = 1024
+memory          = 2048
+service_count   = 4
+min_capacity    = 2
+max_capacity    = 8
+tariff_email_to = "hmrc-trade-tariff-support-g@digital.hmrc.gov.uk"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -131,7 +131,7 @@ module "service" {
     },
     {
       name  = "TARIFF_TO_EMAIL"
-      value = "hmrc-trade-tariff-support-g@digital.hmrc.gov.uk"
+      value = var.tariff_email_to
     },
     {
       name  = "WEB_CONCURRENCY"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -135,7 +135,7 @@ module "service" {
     },
     {
       name  = "TARIFF_SUPPORT_EMAIL"
-      value = "ata.dahri1@digital.hmrc.gov.uk"
+      value = "ata-ul-rouf.dahri@transformuk.com"
     },
     {
       name  = "WEB_CONCURRENCY"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -135,7 +135,7 @@ module "service" {
     },
     {
       name  = "TARIFF_SUPPORT_EMAIL"
-      value = "ata-ul-rouf.dahri@transformuk.com"
+      value = "hmrc-trade-tariff-support-g@digital.hmrc.gov.uk"
     },
     {
       name  = "WEB_CONCURRENCY"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -134,6 +134,10 @@ module "service" {
       value = var.tariff_email_to
     },
     {
+      name  = "TARIFF_SUPPORT_EMAIL"
+      value = "ata.dahri1@digital.hmrc.gov.uk"
+    },
+    {
       name  = "WEB_CONCURRENCY"
       value = "4"
     },

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -45,3 +45,8 @@ variable "memory" {
   description = "Memory to allocate in MB. Powers of 2 only."
   type        = number
 }
+
+variable "tariff_email_to" {
+  description = "Email address to send emails to."
+  type        = string
+}


### PR DESCRIPTION
### Jira link

[HOTT-<5063>](https://transformuk.atlassian.net/browse/HOTT-5063)

### What?

I have added/removed/altered:

- [ ] Use environment based emails
- [ ] added support email

### Why?

I am doing this because:

- We need to email HMRC in production environment
- We need to always receive a copy of all frontend emails in all environments

localhost
<img width="1183" alt="Screenshot 2024-02-28 at 14 57 25" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/490e46ca-a7ab-402a-9f5d-25b1cc06e01e">

Gmail to address used for temporary test
<img width="1908" alt="Screenshot 2024-02-28 at 15 33 47" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/170b22f2-9d76-40b1-85bb-15d82330cb4b">

Outlook BCC address used for temporary test
<img width="1467" alt="Screenshot 2024-02-28 at 15 29 33" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/7e67a7b2-82c7-49b1-a794-ec7f4d2e9ffd">
