### PR TITLE
HOTT-5109: Fixed bottom banner layout on smaller mobile devices

### DIFF
--- a/app/webpacker/src/stylesheets/_feedback_useful_banner.scss
+++ b/app/webpacker/src/stylesheets/_feedback_useful_banner.scss
@@ -41,5 +41,9 @@
     p {
       padding-top: 9px;
     }
+
+    .govuk-button {
+      min-width: 3.5em;
+    }
   }
 }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-5109

### What?

I have added/removed/altered:

- [ ] Fixed mobile CSS

### Why?

I am doing this because:

- The mobile layout was broken on smaller devices

### Have you? (optional)

- [ ] Validated mobile responsive behaviour of view changes

after
<img width="694" alt="Screenshot 2024-02-13 at 10 16 36" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/7461b8fb-dbac-4b23-b17a-e6bf82389334">

before
<img width="642" alt="Screenshot 2024-02-13 at 10 16 55" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/57c7ab9e-2fa1-4fde-a63e-5a4f934aebb3">
