### PR TITLE
HOTT-5080: Sanitize quotas on footnote description field to fix all t…

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -149,6 +149,11 @@ module CommoditiesHelper
     end
   end
 
+  def sanitize_quotes(text)
+    text.gsub(/[\u2018\u2019]/, "'") # Replace left and right single quotes
+        .gsub(/[\u201C\u201D]/, '"') # Replace left and right double quotes
+  end
+
   private
 
   def chapter_and_heading_codes(code)

--- a/app/views/footnotes/_footnote.html.erb
+++ b/app/views/footnotes/_footnote.html.erb
@@ -1,6 +1,10 @@
 <% if footnote&.code.present? %>
   <tr class="govuk-table__row" >
     <th scope="row" class="govuk-table__header"><%= footnote.code %></th>
-    <td class="govuk-table__cell footnote-list"><%= sanitize footnote.formatted_description, tags: %w[strong em a ul li p br b em ol sub sup u ul], attributes: %w[href target rel] %></td>
+    <td class="govuk-table__cell footnote-list">
+      <%= sanitize sanitize_quotes(footnote.formatted_description),
+        tags: %w[strong em a ul li p br b em ol sub sup u ul],
+        attributes: %w[href target rel] %>
+    </td>
   </tr>
 <% end %>

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -333,4 +333,14 @@ RSpec.describe CommoditiesHelper, type: :helper do
       it { is_expected.to be_html_safe }
     end
   end
+
+  describe '#sanitize_quotes' do
+    subject(:sanitize_quotes) { helper.sanitize_quotes(bad_hyperlink) }
+
+    let(:bad_hyperlink) { '<a href=”https://www.gov.uk”>' }
+
+    it 'replaces double comma quotation mark to simple quotation mark' do
+      expect(sanitize_quotes).to eq('<a href="https://www.gov.uk">')
+    end
+  end
 end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-5080

### What?
Sanitize quotas on footnote description fields to fix all the broken hyperlinks in them.

### Why?
To fix hyperlinks.
