### PR TITLE
HOTT-5222: The UK tariff is not showing 'legal basis' for measures

### DIFF
--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -58,7 +58,7 @@
     <% end %>
   </td>
 
-  <td class="legal-base-col govuk-table__cell govuk-table__header--numeric">
+  <td class="govuk-table__cell govuk-table__header--numeric">
     <%= legal_act_regulation_url_link_for(measure) %>
   </td>
 

--- a/app/views/measures/grouped/_table.html.erb
+++ b/app/views/measures/grouped/_table.html.erb
@@ -29,7 +29,7 @@
       <% end %>
 
       <th class="govuk-table__header">Conditions</th>
-      <th class="govuk-table__header legal-base-col" title="Opens in a new window">Legal base</th>
+      <th class="govuk-table__header" title="Opens in a new window">Legal base</th>
       <th class="govuk-table__header">Footnotes</th>
     </tr>
   </thead>


### PR DESCRIPTION
### Jira link

[HOTT-5222](https://transformuk.atlassian.net/browse/HOTT-5222)

### What?

I have added/removed/altered:

- [ ] Fixed prod bug


### Why?

I am doing this because:

- commodity page doesn't display ‘legal basis’ column 
-
-

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes


