### PR TITLE
HOTT-5171: Add GreenLanes api client models

### DIFF
--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -1,0 +1,15 @@
+require 'api_entity'
+
+class GreenLanes::CategoryAssessment
+  include ApiEntity
+
+  attr_accessor :category,
+                :theme
+
+  has_one :geographical_area
+  has_many :excluded_geographical_areas, class_name: 'GeographicalArea'
+
+  def find(id, opts = {})
+    raise NotImplementedError, 'This method is not implemented'
+  end
+end

--- a/app/models/green_lanes/goods_nomenclature.rb
+++ b/app/models/green_lanes/goods_nomenclature.rb
@@ -1,0 +1,19 @@
+require 'api_entity'
+
+class GreenLanes::GoodsNomenclature
+  include ApiEntity
+
+  attr_accessor :goods_nomenclature_item_id,
+                :description,
+                :formatted_description,
+                :validity_start_date,
+                :validity_end_date,
+                :description_plain,
+                :producline_suffix
+
+  has_many :applicable_category_assessments, class_name: 'GreenLanes::CategoryAssessment'
+
+  def all(opts = {})
+    raise NotImplementedError, 'This method is not implemented'
+  end
+end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe GreenLanes::CategoryAssessment do
+  subject(:category_assessment) { build(:category_assessment) }
+
+  describe '.relationships' do
+    let(:expected_relationships) do
+      %i[
+        geographical_area
+        excluded_geographical_areas
+      ]
+    end
+
+    it { expect(described_class.relationships).to match_array(expected_relationships) }
+  end
+end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -4,13 +4,21 @@ RSpec.describe GreenLanes::CategoryAssessment do
   subject(:category_assessment) { build(:category_assessment) }
 
   describe '.relationships' do
-    let(:expected_relationships) do
+    subject { described_class.relationships }
+
+    let(:geographical_area) do
       %i[
         geographical_area
+      ]
+    end
+
+    let(:excluded_geographical_areas) do
+      %i[
         excluded_geographical_areas
       ]
     end
 
-    it { expect(described_class.relationships).to match_array(expected_relationships) }
+    it { is_expected.to include :geographical_area }
+    it { is_expected.to include :excluded_geographical_areas }
   end
 end

--- a/spec/models/green_lanes/goods_nomenclature_spec.rb
+++ b/spec/models/green_lanes/goods_nomenclature_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe GreenLanes::GoodsNomenclature do
   subject(:goods_nomenclature) { build(:goods_nomenclature) }
 
   describe '.relationships' do
-    let(:expected_relationships) do
+    subject { described_class.relationships }
+
+    let(:applicable_category_assessments) do
       %i[
         applicable_category_assessments
       ]
     end
 
-    it { expect(described_class.relationships).to match_array(expected_relationships) }
+    it { is_expected.to include :applicable_category_assessments }
   end
 end

--- a/spec/models/green_lanes/goods_nomenclature_spec.rb
+++ b/spec/models/green_lanes/goods_nomenclature_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe GreenLanes::GoodsNomenclature do
+  subject(:goods_nomenclature) { build(:goods_nomenclature) }
+
+  describe '.relationships' do
+    let(:expected_relationships) do
+      %i[
+        applicable_category_assessments
+      ]
+    end
+
+    it { expect(described_class.relationships).to match_array(expected_relationships) }
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-5171](https://transformuk.atlassian.net/browse/HOTT-5171)

### What?

I have added/removed/altered:

- [ ] Added a green lanes goods api models to the frontend

### Why?

I am doing this because:

- We need to fetch data from the green lanes goods nomenclature api and show it on an debug UI page

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes
