### PR TITLE
HOTT-5261 Added missing error message for Feedbacks form

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,6 +357,7 @@ en:
             message:
               blank: Enter your feedback
               too_long: Edit your response to under %{count} characters
+              too_short: Edit your response to be over %{count} characters
 
         rules_of_origin/steps/scheme:
           attributes:


### PR DESCRIPTION
### Jira link

HOTT-5261

### What?

I have added/removed/altered:

- [x] Added missing error message when feedback message is too short

### Why?

I am doing this because:

- Design system expects full error messages to be shown

### Deployment risks (optional)

- Low
