### PR TITLE
HOTT-5215: Add filtering the Goods Nomenclature page by geo area

### DIFF
--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -12,7 +12,8 @@ module GreenLanes
       if @category_assessments_search.valid?
         @goods_nomenclature = GreenLanes::GoodsNomenclature.find(
           @category_assessments_search.commodity_code,
-          filter: { geographical_area_id: @category_assessments_search.country})
+          filter: { geographical_area_id: @category_assessments_search.country },
+        )
       else
         render :show
       end

--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -10,16 +10,18 @@ module GreenLanes
       @category_assessments_search = CategoryAssessmentSearch.new(ca_search_params)
 
       if @category_assessments_search.valid?
-        @goods_nomenclature = GreenLanes::GoodsNomenclature.find(@category_assessments_search.commodity_code)
+        @goods_nomenclature = GreenLanes::GoodsNomenclature.find(
+          @category_assessments_search.commodity_code,
+          filter: { geographical_area_id: @category_assessments_search.country})
       else
-        render :index
+        render :show
       end
     end
 
     private
 
     def ca_search_params
-      params.require(:green_lanes_category_assessment_search).permit(:commodity_code)
+      params.require(:green_lanes_category_assessment_search).permit(:commodity_code, :country)
     end
 
     def check_allowed

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -8,6 +8,7 @@ class GreenLanes::CategoryAssessment
 
   has_one :geographical_area
   has_many :excluded_geographical_areas, class_name: 'GeographicalArea'
+  has_many :exemptions, polymorphic: true
 
   def find(id, opts = {})
     raise NotImplementedError, 'This method is not implemented'

--- a/app/models/green_lanes/category_assessment_search.rb
+++ b/app/models/green_lanes/category_assessment_search.rb
@@ -4,7 +4,8 @@ class GreenLanes::CategoryAssessmentSearch
   include ActiveModel::Model
 
   attr_accessor   :commodity_code,
-                  :commit
+                  :country
 
   validates :commodity_code, presence: true, length: { minimum: 6, maximum: 10 }
+
 end

--- a/app/models/green_lanes/category_assessment_search.rb
+++ b/app/models/green_lanes/category_assessment_search.rb
@@ -7,5 +7,4 @@ class GreenLanes::CategoryAssessmentSearch
                   :country
 
   validates :commodity_code, presence: true, length: { minimum: 6, maximum: 10 }
-
 end

--- a/app/views/green_lanes/category_assessments/_category.html.erb
+++ b/app/views/green_lanes/category_assessments/_category.html.erb
@@ -24,7 +24,30 @@
           </h2>
         </div>
         <div id="accordion-default-content-1" class="govuk-accordion__section-content">
+          <h3 class="govuk-heading-s">Geographical Area</h3>
           <p class="govuk-body"><%= ca.geographical_area %></p>
+          <% if ca.excluded_geographical_areas.any? %>
+            <h3 class="govuk-heading-s">Excluded Geographical Area</h3>
+            <p class="govuk-body"><%= ca.excluded_geographical_areas.map(&:description).to_sentence %></p>
+          <% end %>
+          <% if ca.exemptions.any? %>
+            <h3 class="govuk-heading-s">Exemptions</h3>
+            <% ca.exemptions.each do |ex| %>
+              <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    <%= ex.code %>
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <%= ex.description %>
+                  </dd>
+                  <dd class="govuk-summary-list__actions">
+                    <%= ex.class.model_name.human %>
+                  </dd>
+                </div>
+              </dl>
+            <% end %>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/app/views/green_lanes/category_assessments/show.html.erb
+++ b/app/views/green_lanes/category_assessments/show.html.erb
@@ -5,16 +5,17 @@
       <%= f.govuk_text_field :commodity_code, width: 'one-quarter',
                              label: { text: 'Commodity Code'} %>
 
-      <div class="country-picker-container">
-        <%= f.hidden_field :render_errors, value: false %>
-        <%= f.hidden_field :anchor, value: nil %>
-        <%= f.label :country, 'Select Country', class: 'govuk-label' %>
-        <%= f.select :country, GeographicalArea.country_options, { include_blank: 'All countries' }, class: 'custom-select', "aria-label": "Filter measures by country" %>
+      <%= f.govuk_collection_select :country,
+                                    TradingPartner.options,
+                                    :id,
+                                    :name,
+                                    options: { include_blank: 'All countries' },
+                                    label: { text: 'Select Origin' } %>
+
+      <div class="govuk-button-group">
+        <%= f.govuk_submit('Search') %>
       </div>
-      <div class="govuk-form-group govuk-!-margin-top-6"></div>
-      <div class="govuk-fieldset search-submit">
-        <%= f.govuk_submit("Search") %>
-      </div>
+
     </fieldset>
   </div>
 <% end %>

--- a/app/views/green_lanes/category_assessments/show.html.erb
+++ b/app/views/green_lanes/category_assessments/show.html.erb
@@ -5,7 +5,16 @@
       <%= f.govuk_text_field :commodity_code, width: 'one-quarter',
                              label: { text: 'Commodity Code'} %>
 
-      <%= f.govuk_submit("Search") %>
+      <div class="country-picker-container">
+        <%= f.hidden_field :render_errors, value: false %>
+        <%= f.hidden_field :anchor, value: nil %>
+        <%= f.label :country, 'Select Country', class: 'govuk-label' %>
+        <%= f.select :country, GeographicalArea.country_options, { include_blank: 'All countries' }, class: 'custom-select', "aria-label": "Filter measures by country" %>
+      </div>
+      <div class="govuk-form-group govuk-!-margin-top-6"></div>
+      <div class="govuk-fieldset search-submit">
+        <%= f.govuk_submit("Search") %>
+      </div>
     </fieldset>
   </div>
 <% end %>

--- a/spec/factories/additional_code_factory.rb
+++ b/spec/factories/additional_code_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :additional_code do
+    resource_type { 'additional_code' }
     additional_code_type_id { Forgery(:basic).text(exactly: 1).upcase }
     additional_code { Forgery(:basic).text(exactly: 3).upcase }
     code { Forgery(:basic).text(exactly: 4).upcase }

--- a/spec/factories/certificate_factory.rb
+++ b/spec/factories/certificate_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :certificate do
+    resource_type { 'certificate' }
     certificate_type_code { Forgery(:basic).text(exactly: 1).upcase }
     certificate_code { Forgery(:basic).text(exactly: 3).upcase }
     description { Forgery(:basic).text }

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -15,5 +15,14 @@ FactoryBot.define do
       category { %w[1 2 3].sample }
       theme { %w[Sanction Food Other].sample }
     end
+
+    trait :with_exemptions do
+      exemptions do
+        [
+          attributes_for(:certificate),
+          attributes_for(:additional_code),
+        ]
+      end
+    end
   end
 end

--- a/spec/factories/green_lanes/goods_nomenclature_factory.rb
+++ b/spec/factories/green_lanes/goods_nomenclature_factory.rb
@@ -13,5 +13,11 @@ FactoryBot.define do
     applicable_category_assessments do
       attributes_for_list :category_assessment, assessment_count
     end
+
+    trait :with_applicable_category_assessments_exemptions do
+      applicable_category_assessments do
+        attributes_for_list :category_assessment, assessment_count, :with_exemptions
+      end
+    end
   end
 end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -18,7 +18,14 @@ RSpec.describe GreenLanes::CategoryAssessment do
       ]
     end
 
+    let(:exemptions) do
+      %i[
+        exemptions
+      ]
+    end
+
     it { is_expected.to include :geographical_area }
     it { is_expected.to include :excluded_geographical_areas }
+    it { is_expected.to include :exemptions }
   end
 end

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -51,6 +51,31 @@ RSpec.describe GreenLanes::CategoryAssessmentsController, type: :request do
       it { is_expected.to have_http_status :ok }
       it { is_expected.to have_attributes content_type: %r{text/html} }
     end
+
+    context 'when category assessments with exemptions' do
+      let(:goods_nomenclature) do
+        build :green_lanes_goods_nomenclature,
+              :with_applicable_category_assessments_exemptions
+      end
+      let(:make_request) do
+        post green_lanes_category_assessments_path, params: {
+          green_lanes_category_assessment_search: {
+            commodity_code: goods_nomenclature.goods_nomenclature_item_id,
+            country: '',
+          },
+        }
+      end
+
+      before do
+        allow(GreenLanes::GoodsNomenclature).to receive(:find)
+                                                  .with(goods_nomenclature.goods_nomenclature_item_id,
+                                                        filter: { geographical_area_id: '' })
+                                                  .and_return goods_nomenclature
+      end
+
+      it { is_expected.to have_http_status :ok }
+      it { is_expected.to have_attributes content_type: %r{text/html} }
+    end
   end
 
   describe 'GET #show' do

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -9,21 +9,50 @@ RSpec.describe GreenLanes::CategoryAssessmentsController, type: :request do
 
   let(:goods_nomenclature) { build :green_lanes_goods_nomenclature }
 
-  describe 'GET #create' do
-    before do
-      allow(GreenLanes::GoodsNomenclature).to receive(:find)
-                         .with(goods_nomenclature.goods_nomenclature_item_id)
-                         .and_return goods_nomenclature
+  describe 'POST #create' do
+    context 'search by commodity code' do
+      before do
+        allow(GreenLanes::GoodsNomenclature).to receive(:find)
+                                                  .with(goods_nomenclature.goods_nomenclature_item_id,
+                                                        filter: { geographical_area_id: ''})
+                                                  .and_return goods_nomenclature
+      end
+
+      let(:make_request) { post green_lanes_category_assessments_path, params: {
+        green_lanes_category_assessment_search: {
+          commodity_code: goods_nomenclature.goods_nomenclature_item_id,
+          country: ''
+        } } }
+
+      it { is_expected.to have_http_status :ok }
+      it { is_expected.to have_attributes content_type: %r{text/html} }
     end
 
-    let(:make_request) { post green_lanes_category_assessments_path, params: { green_lanes_category_assessment_search: { commodity_code: goods_nomenclature.goods_nomenclature_item_id } } }
+    context 'search by commodity code and geographical area' do
+      before do
+        allow(GreenLanes::GoodsNomenclature).to receive(:find)
+                                                  .with(goods_nomenclature.goods_nomenclature_item_id,
+                                                        filter: { geographical_area_id: 'FR'})
+                                                  .and_return goods_nomenclature
+      end
 
-    it { is_expected.to have_http_status :ok }
-    it { is_expected.to have_attributes content_type: %r{text/html} }
+      let(:make_request) { post green_lanes_category_assessments_path, params: {
+        green_lanes_category_assessment_search: {
+          commodity_code: goods_nomenclature.goods_nomenclature_item_id,
+          country: 'FR'
+        } } }
+
+      it { is_expected.to have_http_status :ok }
+      it { is_expected.to have_attributes content_type: %r{text/html} }
+    end
   end
 
   describe 'GET #show' do
     let(:make_request) { get green_lanes_category_assessments_path }
+
+    before do
+      allow(GeographicalArea).to receive(:country_options).and_return %w['France', 'FR']
+    end
 
     it { is_expected.to have_http_status :ok }
     it { is_expected.to have_attributes content_type: %r{text/html} }

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -10,37 +10,43 @@ RSpec.describe GreenLanes::CategoryAssessmentsController, type: :request do
   let(:goods_nomenclature) { build :green_lanes_goods_nomenclature }
 
   describe 'POST #create' do
-    context 'search by commodity code' do
+    context 'when search by commodity code' do
       before do
         allow(GreenLanes::GoodsNomenclature).to receive(:find)
                                                   .with(goods_nomenclature.goods_nomenclature_item_id,
-                                                        filter: { geographical_area_id: ''})
+                                                        filter: { geographical_area_id: '' })
                                                   .and_return goods_nomenclature
       end
 
-      let(:make_request) { post green_lanes_category_assessments_path, params: {
-        green_lanes_category_assessment_search: {
-          commodity_code: goods_nomenclature.goods_nomenclature_item_id,
-          country: ''
-        } } }
+      let(:make_request) do
+        post green_lanes_category_assessments_path, params: {
+          green_lanes_category_assessment_search: {
+            commodity_code: goods_nomenclature.goods_nomenclature_item_id,
+            country: '',
+          },
+        }
+      end
 
       it { is_expected.to have_http_status :ok }
       it { is_expected.to have_attributes content_type: %r{text/html} }
     end
 
-    context 'search by commodity code and geographical area' do
+    context 'when search by commodity code and geographical area' do
       before do
         allow(GreenLanes::GoodsNomenclature).to receive(:find)
                                                   .with(goods_nomenclature.goods_nomenclature_item_id,
-                                                        filter: { geographical_area_id: 'FR'})
+                                                        filter: { geographical_area_id: 'FR' })
                                                   .and_return goods_nomenclature
       end
 
-      let(:make_request) { post green_lanes_category_assessments_path, params: {
-        green_lanes_category_assessment_search: {
-          commodity_code: goods_nomenclature.goods_nomenclature_item_id,
-          country: 'FR'
-        } } }
+      let(:make_request) do
+        post green_lanes_category_assessments_path, params: {
+          green_lanes_category_assessment_search: {
+            commodity_code: goods_nomenclature.goods_nomenclature_item_id,
+            country: 'FR',
+          },
+        }
+      end
 
       it { is_expected.to have_http_status :ok }
       it { is_expected.to have_attributes content_type: %r{text/html} }
@@ -51,7 +57,7 @@ RSpec.describe GreenLanes::CategoryAssessmentsController, type: :request do
     let(:make_request) { get green_lanes_category_assessments_path }
 
     before do
-      allow(GeographicalArea).to receive(:country_options).and_return %w['France', 'FR']
+      allow(GeographicalArea).to receive(:country_options).and_return %w[France FR]
     end
 
     it { is_expected.to have_http_status :ok }

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -56,9 +56,10 @@ RSpec.describe GreenLanes::CategoryAssessmentsController, type: :request do
   describe 'GET #show' do
     context 'when green lanes is allowed' do
       let(:make_request) { get green_lanes_category_assessments_path }
+      let(:countries) { build_list :geographical_area, 2 }
 
       before do
-        allow(GeographicalArea).to receive(:country_options).and_return %w[France FR]
+        allow(GeographicalArea).to receive(:all).and_return countries
       end
 
       it { is_expected.to have_http_status :ok }


### PR DESCRIPTION
### Jira link

[HOTT-5215](https://transformuk.atlassian.net/browse/HOTT-5215)

### What?

I have added/removed/altered:

- [ ] Extend the green lanes goods nomenclature page to allow filtering by geographical area


### Why?

I am doing this because:

- User can choose country and feeding it into the api to filtering category assessment
-
-

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes


<img width="1388" alt="Screenshot 2024-03-07 at 17 41 55" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/44141067/19da10ae-d5f2-4b68-b4e9-7f2621477969">

<img width="1384" alt="Screenshot 2024-03-07 at 17 42 34" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/44141067/084ba433-0d73-401b-a663-2938eca94595">

