### PR TITLE
HOTT-5216: Extend the GoodsNomenclature info page to show exemptions

### DIFF
--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -8,6 +8,7 @@ class GreenLanes::CategoryAssessment
 
   has_one :geographical_area
   has_many :excluded_geographical_areas, class_name: 'GeographicalArea'
+  has_many :exemptions, polymorphic: true
 
   def find(id, opts = {})
     raise NotImplementedError, 'This method is not implemented'

--- a/app/views/green_lanes/category_assessments/_category.html.erb
+++ b/app/views/green_lanes/category_assessments/_category.html.erb
@@ -24,7 +24,21 @@
           </h2>
         </div>
         <div id="accordion-default-content-1" class="govuk-accordion__section-content">
+          <h3 class="govuk-heading-s">Geographical Area</h3>
           <p class="govuk-body"><%= ca.geographical_area %></p>
+          <% if ca.excluded_geographical_areas.any? %>
+            <h3 class="govuk-heading-s">Excluded Geographical Area</h3>
+            <% ca.excluded_geographical_areas.each do |ga| %>
+              <p class="govuk-body"><%= ga.geographical_area %></p>
+            <% end %>
+          <% end %>
+          <% if ca.exemptions.any? %>
+            <% ca.exemptions.each do |ex| %>
+              <h3 class="govuk-heading-s"><%= ex.class.model_name.human %></h3>
+              <p class="govuk-body"><%= ex.code %></p>
+              <p class="govuk-body"><%= ex.description %></p>
+            <% end %>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/app/views/green_lanes/category_assessments/_category.html.erb
+++ b/app/views/green_lanes/category_assessments/_category.html.erb
@@ -28,15 +28,24 @@
           <p class="govuk-body"><%= ca.geographical_area %></p>
           <% if ca.excluded_geographical_areas.any? %>
             <h3 class="govuk-heading-s">Excluded Geographical Area</h3>
-            <% ca.excluded_geographical_areas.each do |ga| %>
-              <p class="govuk-body"><%= ga.geographical_area %></p>
-            <% end %>
+            <p class="govuk-body"><%= ca.excluded_geographical_areas.map(&:description).to_sentence %></p>
           <% end %>
           <% if ca.exemptions.any? %>
+            <h3 class="govuk-heading-s">Exemptions</h3>
             <% ca.exemptions.each do |ex| %>
-              <h3 class="govuk-heading-s"><%= ex.class.model_name.human %></h3>
-              <p class="govuk-body"><%= ex.code %></p>
-              <p class="govuk-body"><%= ex.description %></p>
+              <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    <%= ex.code %>
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <%= ex.description %>
+                  </dd>
+                  <dd class="govuk-summary-list__actions">
+                    <%= ex.class.model_name.human %>
+                  </dd>
+                </div>
+              </dl>
             <% end %>
           <% end %>
         </div>

--- a/spec/factories/additional_code_factory.rb
+++ b/spec/factories/additional_code_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :additional_code do
+    resource_type {'additional_code'}
     additional_code_type_id { Forgery(:basic).text(exactly: 1).upcase }
     additional_code { Forgery(:basic).text(exactly: 3).upcase }
     code { Forgery(:basic).text(exactly: 4).upcase }

--- a/spec/factories/additional_code_factory.rb
+++ b/spec/factories/additional_code_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :additional_code do
-    resource_type {'additional_code'}
+    resource_type { 'additional_code' }
     additional_code_type_id { Forgery(:basic).text(exactly: 1).upcase }
     additional_code { Forgery(:basic).text(exactly: 3).upcase }
     code { Forgery(:basic).text(exactly: 4).upcase }

--- a/spec/factories/certificate_factory.rb
+++ b/spec/factories/certificate_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :certificate do
+    resource_type {'certificate'}
     certificate_type_code { Forgery(:basic).text(exactly: 1).upcase }
     certificate_code { Forgery(:basic).text(exactly: 3).upcase }
     description { Forgery(:basic).text }

--- a/spec/factories/certificate_factory.rb
+++ b/spec/factories/certificate_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :certificate do
-    resource_type {'certificate'}
+    resource_type { 'certificate' }
     certificate_type_code { Forgery(:basic).text(exactly: 1).upcase }
     certificate_code { Forgery(:basic).text(exactly: 3).upcase }
     description { Forgery(:basic).text }

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -15,5 +15,14 @@ FactoryBot.define do
       category { %w[1 2 3].sample }
       theme { %w[Sanction Food Other].sample }
     end
+
+    trait :with_exemptions do
+      exemptions do
+        [
+          attributes_for(:certificate),
+          attributes_for(:additional_code),
+        ]
+      end
+    end
   end
 end

--- a/spec/factories/green_lanes/goods_nomenclature_factory.rb
+++ b/spec/factories/green_lanes/goods_nomenclature_factory.rb
@@ -13,5 +13,11 @@ FactoryBot.define do
     applicable_category_assessments do
       attributes_for_list :category_assessment, assessment_count
     end
+
+    trait :with_applicable_category_assessments_exemptions do
+      applicable_category_assessments do
+        attributes_for_list :category_assessment, assessment_count, :with_exemptions
+      end
+    end
   end
 end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -18,7 +18,14 @@ RSpec.describe GreenLanes::CategoryAssessment do
       ]
     end
 
+    let(:exemptions) do
+      %i[
+        exemptions
+      ]
+    end
+
     it { is_expected.to include :geographical_area }
     it { is_expected.to include :excluded_geographical_areas }
+    it { is_expected.to include :exemptions }
   end
 end

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -51,6 +51,31 @@ RSpec.describe GreenLanes::CategoryAssessmentsController, type: :request do
       it { is_expected.to have_http_status :ok }
       it { is_expected.to have_attributes content_type: %r{text/html} }
     end
+
+    context 'when category assessments with exemptions' do
+      let(:goods_nomenclature) do
+        build :green_lanes_goods_nomenclature,
+              :with_applicable_category_assessments_exemptions
+      end
+      let(:make_request) do
+        post green_lanes_category_assessments_path, params: {
+          green_lanes_category_assessment_search: {
+            commodity_code: goods_nomenclature.goods_nomenclature_item_id,
+            country: '',
+          },
+        }
+      end
+
+      before do
+        allow(GreenLanes::GoodsNomenclature).to receive(:find)
+                                                  .with(goods_nomenclature.goods_nomenclature_item_id,
+                                                        filter: { geographical_area_id: '' })
+                                                  .and_return goods_nomenclature
+      end
+
+      it { is_expected.to have_http_status :ok }
+      it { is_expected.to have_attributes content_type: %r{text/html} }
+    end
   end
 
   describe 'GET #show' do


### PR DESCRIPTION
### Jira link

[HOTT-5216](https://transformuk.atlassian.net/browse/HOTT-5216)

### What?

I have added/removed/altered:

- [ ] Extended the api client to deserialize the exemptions, geographical area and excluded geographical area fields

### Why?

I am doing this because:

- To include this information in front end category assessment information page
-
-

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes
