### PR TITLE
HOTT-4479:CI changes to enable green lanes debug page

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -40,3 +40,7 @@ data "aws_ssm_parameter" "ecr_url" {
 data "aws_secretsmanager_secret" "sentry_dsn" {
   name = "frontend-sentry-dsn"
 }
+
+data "aws_secretsmanager_secret" "green_lanes_api_token" {
+  name = "frontend-green-lanes-api-token"
+}

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -41,6 +41,6 @@ data "aws_secretsmanager_secret" "sentry_dsn" {
   name = "frontend-sentry-dsn"
 }
 
-data "aws_secretsmanager_secret" "green_lanes_api_token" {
-  name = "frontend-green-lanes-api-token"
+data "aws_secretsmanager_secret" "green_lanes_api_tokens" {
+  name = "backend-green-lanes-api-tokens"
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -11,6 +11,7 @@ data "aws_iam_policy_document" "secrets" {
       data.aws_secretsmanager_secret.redis_connection_string.arn,
       data.aws_secretsmanager_secret.frontend_secret_key_base.arn,
       data.aws_secretsmanager_secret.sentry_dsn.arn,
+      data.aws_secretsmanager_secret.green_lanes_api_token.arn,
     ]
   }
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "secrets" {
       data.aws_secretsmanager_secret.redis_connection_string.arn,
       data.aws_secretsmanager_secret.frontend_secret_key_base.arn,
       data.aws_secretsmanager_secret.sentry_dsn.arn,
-      data.aws_secretsmanager_secret.green_lanes_api_token.arn,
+      data.aws_secretsmanager_secret.green_lanes_api_tokens.arn,
     ]
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -164,5 +164,9 @@ module "service" {
       name      = "SENTRY_DSN"
       valueFrom = data.aws_secretsmanager_secret.sentry_dsn.arn
     },
+    {
+      name      = "GREEN_LANES_API_TOKEN"
+      valueFrom = data.aws_secretsmanager_secret.green_lanes_api_token.arn
+    },
   ]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -166,7 +166,7 @@ module "service" {
     },
     {
       name      = "GREEN_LANES_API_TOKEN"
-      valueFrom = data.aws_secretsmanager_secret.green_lanes_api_token.arn
+      valueFrom = data.aws_secretsmanager_secret.green_lanes_api_tokens.arn
     },
   ]
 }


### PR DESCRIPTION
### Jira link

[HOTT-4479](https://transformuk.atlassian.net/browse/HOTT-4479)

### What?

I have added/removed/altered:

- [ ] Added authorisation header for back end green lanes api access

### Why?

I am doing this because:

- his token need to be passed to access green lanes api
-
-

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

