### PR TITLE
OTT-57: Disable links in feedback emails

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -17,6 +17,7 @@ class FeedbackController < ApplicationController
     return redirect_to(find_commodity_path) unless @feedback.valid_page_useful_options?
 
     if @feedback.valid?
+      @feedback.disable_links
       FrontendMailer.new_feedback(@feedback).deliver_now
       @feedback.record_delivery!
 

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -26,6 +26,10 @@ class Feedback
     [nil, '', 'yes', 'no'].include?(page_useful)
   end
 
+  def disable_links
+    @message = @message.gsub(/(\S)(\.)(\S)/, '\1 . \3')
+  end
+
   private
 
   def authenticity_token_reuse

--- a/spec/factories/feedback_factory.rb
+++ b/spec/factories/feedback_factory.rb
@@ -13,5 +13,9 @@ FactoryBot.define do
     trait :with_invalid_choice do
       page_useful { 'invalid' }
     end
+
+    trait :with_message_containing_link_text do
+      message { 'google.com' }
+    end
   end
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -86,4 +86,14 @@ RSpec.describe Feedback do
       it { expect(feedback.valid_page_useful_options?).to eq(false) }
     end
   end
+
+  describe '#disable_links' do
+    context 'when feedback contains link as text' do
+      let(:feedback) { build :feedback, :with_authenticity_token, :with_message_containing_link_text }
+
+      before { feedback.disable_links }
+
+      it { expect(feedback.message).to eq('google . com') }
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-57

### What?

I have added/removed/altered:

- [ ] Disabled links in feedback emails

### Why?

I am doing this because:

-  Ticket requirement was to disable these to stop people visiting malicious websites
<img width="1692" alt="Screenshot 2024-03-15 at 14 49 33" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/d2e2bb74-c4ac-4f1f-9a7e-65bf87b381bc">
<img width="1027" alt="Screenshot 2024-03-15 at 14 49 41" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/9b2df8f3-d4b8-45f5-994e-febb11c76159">

