### PR TITLE
BAU: Fix release notes job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,6 +207,7 @@ jobs:
     docker:
       - image: cimg/ruby:3.2.2
     steps:
+      - checkout
       - tariff/notify-production-release:
           app-name: Frontend
           slack-channel: trade_tariff


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added missing `checkout` step in release note generation job

### Why?

I am doing this because:

- Release notes are failing in all deployments