### PR TITLE
OTT-2 Spacing and Sizing changes

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -23,7 +23,7 @@
 
   <!-- Import tab -->
   <div class="govuk-tabs__panel" id="import">
-    <h2 class="govuk-heading-l"><%= measures_heading(anchor: 'import') %></h2>
+    <h2 class="govuk-heading-m"><%= measures_heading(anchor: 'import') %></h2>
 
     <%= render 'declarables/consigned', declarable: declarable %>
 

--- a/app/webpacker/src/stylesheets/_ancestors-tree.scss
+++ b/app/webpacker/src/stylesheets/_ancestors-tree.scss
@@ -1,5 +1,5 @@
 .commodity-ancestors {
-  margin-bottom: 1em;
+  margin-bottom: 40px;
   padding: 1em 0 0.5em 1em;
   background-color: $shaded-panel-background-colour;
 

--- a/app/webpacker/src/stylesheets/_header.scss
+++ b/app/webpacker/src/stylesheets/_header.scss
@@ -1,4 +1,8 @@
 .tariff-search {
+  margin-bottom: 40px;
+}
+
+.commodity-header{
   margin-bottom: 20px;
 }
 

--- a/app/webpacker/src/stylesheets/_switch_uk_xi_panel.scss
+++ b/app/webpacker/src/stylesheets/_switch_uk_xi_panel.scss
@@ -35,7 +35,7 @@ header {
 
   .switch-service-control {
     @include govuk-media-query($from: tablet) {
-      margin-top: 0.8em;
+      margin-top: 0.0em;
     }
 
     @include govuk-media-query($until: tablet) {

--- a/app/webpacker/src/stylesheets/_tabs.scss
+++ b/app/webpacker/src/stylesheets/_tabs.scss
@@ -74,3 +74,7 @@
     text-decoration: none;
   }
 }
+
+.new_trading_partner + .govuk-tabs{
+  margin-top: 40px;
+}

--- a/app/webpacker/src/stylesheets/tariff-custom.scss
+++ b/app/webpacker/src/stylesheets/tariff-custom.scss
@@ -78,3 +78,13 @@
 body {
   font-family: $govuk-font-family-gds-transport !important;
 }
+
+.govuk-breadcrumbs + .govuk-main-wrapper {
+  padding-top: 30px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-summary-list {
+    margin-bottom: 20px; 
+  }
+}


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-2

### What?

I have altered:

- [x] Various scss and HTML for UCD changes to changes spacing between components to 40px/20px and headings font size to match as specified.

### Why?

I am doing this because:

- This is part of the Epic https://transformuk.atlassian.net/browse/OTT-1 hence the PR into a feature branch

BEFORE
![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/127106895/1d52ee83-79f4-4501-9fc0-3ba275d3811c)

AFTER
![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/127106895/384ea80f-2504-48ce-8923-a7b5b578c93d)
