### PR TITLE
OTT-2 Updated views to use GDS spacing as required.

### DIFF
--- a/app/views/commodities/_header.html.erb
+++ b/app/views/commodities/_header.html.erb
@@ -1,5 +1,5 @@
 <%= page_header do %>
-  <h1 class="govuk-heading-l commodity-header" data-comm-code="<%= commodity_code %>">
+  <h1 class="govuk-heading-l commodity-header govuk-!-margin-bottom-4" data-comm-code="<%= commodity_code %>">
     Commodity <%= segmented_commodity_code commodity_code %>
     <div class="copy_code" id="copy_code">
       <span id="copy_comm_code" class="pseudo-link govuk-link">Copy commodity code</span><br>

--- a/app/views/goods_nomenclatures/_ancestors.html.erb
+++ b/app/views/goods_nomenclatures/_ancestors.html.erb
@@ -1,4 +1,4 @@
-<nav class="commodity-ancestors"
+<nav class="commodity-ancestors govuk-!-margin-bottom-7"
      aria-label="A list of commodity code <%= goods_nomenclature.code %>'s section, chapter and other parent commodity codes">
   <a href="#import" class="govuk-skip-link" data-module="govuk-skip-link">
     Skip to information about importing commodity <%= goods_nomenclature.code %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,7 +67,7 @@
   <div class="tariff service govuk-width-container">
     <%= render 'shared/top_breadcrumbs' %>
 
-    <main id="content" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" role="main">
+    <main id="content" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing govuk-!-padding-top-7" role="main">
       <%= render 'shared/phase_banner' if ENV['NOTICE_BANNER'] %>
       <%= yield :before_main_content %>
 

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-tabs" data-module="govuk-tabs">
+<div class="govuk-tabs govuk-!-margin-top-0" data-module="govuk-tabs">
   <ul class="govuk-tabs__list">
     <li class="govuk-tabs__list-item">
       <a class="govuk-tabs__tab" href="#import">Import</a>
@@ -23,7 +23,7 @@
 
   <!-- Import tab -->
   <div class="govuk-tabs__panel" id="import">
-    <h2 class="govuk-heading-l"><%= measures_heading(anchor: 'import') %></h2>
+    <h2 class="govuk-heading-m"><%= measures_heading(anchor: 'import') %></h2>
 
     <%= render 'declarables/consigned', declarable: declarable %>
 

--- a/app/views/shared/_country_picker.html.erb
+++ b/app/views/shared/_country_picker.html.erb
@@ -1,4 +1,4 @@
-<%= form_for TradingPartner.new(country: params['country']), method: :patch, url: trading_partners_path do |f| %>
+<%= form_for TradingPartner.new(country: params['country']), method: :patch, url: trading_partners_path,  html: { class: 'govuk-!-margin-bottom-7' } do |f| %>
   <fieldset class="govuk-fieldset country-picker js-country-picker govuk-!-font-size-16">
     <div class="country-picker-container">
       <%= f.hidden_field :render_errors, value: false %>

--- a/app/views/shared/_top_breadcrumbs.html.erb
+++ b/app/views/shared/_top_breadcrumbs.html.erb
@@ -1,5 +1,5 @@
 <% if @section %>
-  <nav class="govuk-breadcrumbs govuk-!-display-none-print" aria-label="Breadcrumb">
+  <nav class="govuk-breadcrumbs govuk-!-display-none-print govuk-!-margin-bottom-0" aria-label="Breadcrumb">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">
         <%= link_to "Home", home_path, class:'govuk-breadcrumbs__link' %>

--- a/app/views/shared/context_tables/_commodity.html.erb
+++ b/app/views/shared/context_tables/_commodity.html.erb
@@ -1,4 +1,4 @@
-<dl class="govuk-summary-list">
+<dl class="govuk-summary-list govuk-!-margin-bottom-4">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       Commodity

--- a/app/views/shared/search/_search_form.html.erb
+++ b/app/views/shared/search/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag perform_search_path, method: :get, class: "tariff-search #{@section_css}", id: "new_search" do |f| %>
+<%= form_tag perform_search_path, method: :get, class: "tariff-search #{@section_css} govuk-!-padding-bottom-7", id: "new_search" do |f| %>
   <div class="search-header js-search-header">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/webpacker/src/stylesheets/_header.scss
+++ b/app/webpacker/src/stylesheets/_header.scss
@@ -1,7 +1,3 @@
-.tariff-search {
-  margin-bottom: 20px;
-}
-
 .search-header {
   .searchfield {
     position: relative;


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-2

### What?

I have altered:

- [x] Various HTML for UCD changes to spacing between components to 40px/20px and headings font size to match as specified.

### Why?

I am doing this because:

- This is part of the Epic https://transformuk.atlassian.net/browse/OTT-1 hence the PR into a feature branch

BEFORE
![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/127106895/13c8cb7f-4909-4647-b2ce-62d22b4f49ea)

AFTER
![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/127106895/0801f0f6-2bdf-4420-a48d-eb6e06412b26)
