### PR TITLE
GL-378 Added deserialization of new API format

### DIFF
--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -3,14 +3,16 @@ require 'api_entity'
 class GreenLanes::CategoryAssessment
   include XiOnlyApiEntity
 
-  attr_accessor :category,
-                :theme
-
+  has_one :theme, class_name: 'GreenLanes::Theme'
+  has_one :measure_type
+  has_one :regulation, class_name: 'LegalAct'
   has_one :geographical_area
   has_many :excluded_geographical_areas, class_name: 'GeographicalArea'
   has_many :exemptions, polymorphic: true
 
-  def find(id, opts = {})
-    raise NotImplementedError, 'This method is not implemented'
+  delegate :category, to: :theme
+
+  def find(_id, _opts = {})
+    raise NoMethodError, 'This method is not implemented'
   end
 end

--- a/app/models/green_lanes/goods_nomenclature.rb
+++ b/app/models/green_lanes/goods_nomenclature.rb
@@ -13,12 +13,24 @@ class GreenLanes::GoodsNomenclature
 
   has_many :applicable_category_assessments, class_name: 'GreenLanes::CategoryAssessment'
 
-  def all(opts = {})
-    raise NotImplementedError, 'This method is not implemented'
+  def all(_opts = {})
+    raise NoMethodError, 'This method is not implemented'
   end
 
   def filter_by_category(category)
-    grouped = applicable_category_assessments.group_by(&:category)
-    grouped[category] || []
+    grouped_assessments[category.to_i] || []
+  end
+
+  def primary_assessments_group
+    grouped_assessments.first&.second || []
+  end
+
+  private
+
+  def grouped_assessments
+    @grouped_assessments ||= \
+      Hash[applicable_category_assessments.group_by(&:category)
+                                          .transform_keys(&:to_i)
+                                          .sort]
   end
 end

--- a/app/models/green_lanes/goods_nomenclature.rb
+++ b/app/models/green_lanes/goods_nomenclature.rb
@@ -25,8 +25,6 @@ class GreenLanes::GoodsNomenclature
     grouped_assessments.first&.second || []
   end
 
-  private
-
   def grouped_assessments
     @grouped_assessments ||= \
       Hash[applicable_category_assessments.group_by(&:category)

--- a/app/models/green_lanes/theme.rb
+++ b/app/models/green_lanes/theme.rb
@@ -1,0 +1,18 @@
+module GreenLanes
+  class Theme
+    include XiOnlyApiEntity
+
+    attr_accessor :category,
+                  :theme
+
+    alias_method :section, :resource_id
+
+    def find(_id, _opts = {})
+      raise NoMethodError, 'This method is not implemented'
+    end
+
+    def to_s
+      "#{section} #{theme}"
+    end
+  end
+end

--- a/app/models/meursing_lookup/steps/tree.rb
+++ b/app/models/meursing_lookup/steps/tree.rb
@@ -24,7 +24,7 @@ module MeursingLookup
       end
 
       def current_meursing_code_level
-        raise NotImplementedError, 'Implement this where this module is included'
+        raise NoMethodError, 'Implement this where this module is included'
       end
 
       def starch_answer

--- a/app/views/green_lanes/category_assessments/_categories.html.erb
+++ b/app/views/green_lanes/category_assessments/_categories.html.erb
@@ -1,15 +1,8 @@
-<% if @goods_nomenclature.filter_by_category('1').any?%>
-  <h2>Category 1 Assessments</h2>
+<% if assessments.any?%>
+  <h2>Category <%= assessments.first.category %> Assessments</h2>
   <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
     <%= render partial: 'green_lanes/category_assessments/category',
-               collection: @goods_nomenclature.filter_by_category('1') %>
-  </div>
-<% elsif @goods_nomenclature.filter_by_category('2').any?%>
-  <h2>Category 2 Assessments</h2>
-
-  <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-    <%= render partial: 'green_lanes/category_assessments/category',
-               collection: @goods_nomenclature.filter_by_category('2') %>
+               collection: assessments %>
   </div>
 <% else %>
   <h2>There are no Applicable Category Assessments</h2>

--- a/app/views/green_lanes/category_assessments/_categories.html.erb
+++ b/app/views/green_lanes/category_assessments/_categories.html.erb
@@ -1,9 +1,11 @@
-<% if assessments.any?%>
-  <h2>Category <%= assessments.first.category %> Assessments</h2>
+<% assessments.each do |category, assessments_for_category| %>
+  <h2>Category <%= category %> Assessments</h2>
   <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
     <%= render partial: 'green_lanes/category_assessments/category',
-               collection: assessments %>
+               collection: assessments_for_category %>
   </div>
-<% else %>
+<% end %>
+
+<% if assessments.none?%>
   <h2>There are no Applicable Category Assessments</h2>
 <% end %>

--- a/app/views/green_lanes/category_assessments/_category.html.erb
+++ b/app/views/green_lanes/category_assessments/_category.html.erb
@@ -16,18 +16,27 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <h3 class="govuk-heading-s">Measure Type</h3>
+    <p><%= category.measure_type.id %></p>
   </div>
   <div class="govuk-grid-column-one-half">
     <h3 class="govuk-heading-s">Measure Type Description</h3>
+    <p><%= category.measure_type.description %></p>
   </div>
 </div>
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <h3 class="govuk-heading-s">EU Regulation ID</h3>
+    <p><%= category.regulation.regulation_code %></p>
   </div>
   <div class="govuk-grid-column-one-half">
     <h3 class="govuk-heading-s">EU Regulation Description</h3>
+    <p><%= category.regulation.description %></p>
+    <% if category.regulation.regulation_url.present? %>
+    <p>
+      <%= link_to 'Further information', category.regulation.regulation_url, target: '_blank' %>
+    </p>
+    <% end %>
   </div>
 </div>
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/app/views/green_lanes/category_assessments/create.html.erb
+++ b/app/views/green_lanes/category_assessments/create.html.erb
@@ -26,6 +26,6 @@
     </dl>
 
     <%= render 'green_lanes/category_assessments/categories',
-               assessments: @goods_nomenclature.primary_assessments_group %>
+               assessments: @goods_nomenclature.grouped_assessments %>
   <% end %>
 </article>

--- a/app/views/green_lanes/category_assessments/create.html.erb
+++ b/app/views/green_lanes/category_assessments/create.html.erb
@@ -1,6 +1,6 @@
 <%= render 'search_form', search_form: @category_assessments_search %>
 
-<%= page_header "Search results for #{h @category_assessments_search.commodity_code}" %>
+<%= page_header "Search results for #{@category_assessments_search.commodity_code}" %>
 
 <article class="search-results govuk-!-padding-top-1">
   <% if @goods_nomenclature.present? %>
@@ -25,6 +25,7 @@
       </div>
     </dl>
 
-    <%= render 'green_lanes/category_assessments/categories' %>
+    <%= render 'green_lanes/category_assessments/categories',
+               assessments: @goods_nomenclature.primary_assessments_group %>
   <% end %>
 </article>

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -1,19 +1,16 @@
 FactoryBot.define do
-  factory :category_assessment, class: 'GreenLanes::GoodsNomenclature' do
+  factory :category_assessment, class: 'GreenLanes::CategoryAssessment' do
     transient do
       geographical_area_id { 'FR' }
+      category { 2 }
     end
 
-    category { '1' }
-    theme { 'Sanction' }
+    theme        { attributes_for :green_lanes_theme, category: }
+    measure_type { attributes_for :measure_type }
+    regulation   { attributes_for :legal_act }
 
     geographical_area do
       attributes_for(:geographical_area, id: geographical_area_id)
-    end
-
-    trait :random_category do
-      category { %w[1 2 3].sample }
-      theme { %w[Sanction Food Other].sample }
     end
 
     trait :with_exemptions do

--- a/spec/factories/green_lanes/theme_factory.rb
+++ b/spec/factories/green_lanes/theme_factory.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :green_lanes_theme, class: 'GreenLanes::Theme' do
+    category { 1 }
+    sequence(:resource_id) { |n| "#{category}.#{n}" }
+
+    description do
+      <<~EODESCRIPTION
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magnam aliquam quaerat voluptatem.
+      EODESCRIPTION
+    end
+
+    trait :category2 do
+      category { 2 }
+    end
+  end
+end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -1,31 +1,21 @@
 require 'spec_helper'
 
 RSpec.describe GreenLanes::CategoryAssessment do
-  subject(:category_assessment) { build(:category_assessment) }
+  subject(:category_assessment) { build :category_assessment }
 
   describe '.relationships' do
     subject { described_class.relationships }
 
-    let(:geographical_area) do
-      %i[
-        geographical_area
-      ]
-    end
-
-    let(:excluded_geographical_areas) do
-      %i[
-        excluded_geographical_areas
-      ]
-    end
-
-    let(:exemptions) do
-      %i[
-        exemptions
-      ]
-    end
-
     it { is_expected.to include :geographical_area }
     it { is_expected.to include :excluded_geographical_areas }
     it { is_expected.to include :exemptions }
+    it { is_expected.to include :theme }
+    it { is_expected.to include :measure_type }
+    it { is_expected.to include :regulation }
+  end
+
+  describe 'attributes' do
+    it { is_expected.to have_attributes category: category_assessment.theme.category }
+    it { is_expected.to have_attributes theme: category_assessment.theme }
   end
 end

--- a/spec/models/green_lanes/goods_nomenclature_spec.rb
+++ b/spec/models/green_lanes/goods_nomenclature_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GreenLanes::GoodsNomenclature do
-  subject(:goods_nomenclature) { build(:goods_nomenclature) }
+  subject(:goods_nomenclature) { build(:green_lanes_goods_nomenclature) }
 
   describe '.relationships' do
     subject { described_class.relationships }
@@ -13,5 +13,47 @@ RSpec.describe GreenLanes::GoodsNomenclature do
     end
 
     it { is_expected.to include :applicable_category_assessments }
+  end
+
+  describe '#primary_assessments_group' do
+    subject { goods_nomenclature.primary_assessments_group }
+
+    let :goods_nomenclature do
+      build :green_lanes_goods_nomenclature,
+            applicable_category_assessments: assessments
+    end
+
+    context 'with only category 1' do
+      let(:assessments) { attributes_for_pair :category_assessment, category: 1 }
+
+      it { is_expected.to have_attributes length: 2 }
+      it { is_expected.to all have_attributes category: 1 }
+    end
+
+    context 'with only category 2' do
+      let(:assessments) { attributes_for_pair :category_assessment, category: 2 }
+
+      it { is_expected.to have_attributes length: 2 }
+      it { is_expected.to all have_attributes category: 2 }
+    end
+
+    context 'with mix of category 1 and category 2' do
+      let :assessments do
+        [
+          attributes_for(:category_assessment, category: 2),
+          attributes_for(:category_assessment, category: 1),
+        ]
+      end
+
+      it { is_expected.to have_attributes length: 1 }
+      it { is_expected.to all have_attributes category: 1 }
+    end
+
+    context 'with no assessments' do
+      let(:assessments) { [] }
+
+      it { is_expected.to have_attributes length: 0 }
+      it { is_expected.to be_instance_of Array }
+    end
   end
 end

--- a/spec/models/green_lanes/goods_nomenclature_spec.rb
+++ b/spec/models/green_lanes/goods_nomenclature_spec.rb
@@ -23,21 +23,21 @@ RSpec.describe GreenLanes::GoodsNomenclature do
             applicable_category_assessments: assessments
     end
 
-    context 'with only category 1' do
+    context 'with only category 1 assessments' do
       let(:assessments) { attributes_for_pair :category_assessment, category: 1 }
 
       it { is_expected.to have_attributes length: 2 }
       it { is_expected.to all have_attributes category: 1 }
     end
 
-    context 'with only category 2' do
+    context 'with only category 2 assessments' do
       let(:assessments) { attributes_for_pair :category_assessment, category: 2 }
 
       it { is_expected.to have_attributes length: 2 }
       it { is_expected.to all have_attributes category: 2 }
     end
 
-    context 'with mix of category 1 and category 2' do
+    context 'with both of category 1 and category 2 assessments' do
       let :assessments do
         [
           attributes_for(:category_assessment, category: 2),

--- a/spec/models/green_lanes/theme_spec.rb
+++ b/spec/models/green_lanes/theme_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe GreenLanes::Theme do
+  subject(:theme) { build :green_lanes_theme }
+
+  it { is_expected.to respond_to :section }
+  it { is_expected.to respond_to :theme }
+  it { is_expected.to respond_to :category }
+
+  describe 'attributes' do
+    it { is_expected.to have_attributes to_s: "#{theme.section} #{theme.theme}" }
+  end
+end


### PR DESCRIPTION
### Jira link

GL-378

### What?

I have added/removed/altered:

- [x] Added ApiEntity model for Theme
- [x] Added relationships for measure types and regulations
- [x] Show measure types and regulations on debug ui
- [x] Also replaced problematic usage of NotImplementedError because it doesn't inherit from StandardError so doesn't get rescued
- [x] Changed UI to show both Cat 1 and Cat 2 assessments at the same time

### Why?

I am doing this because:

- So we can show results from the latest API format

### Deployment risks (optional)

- Low, debug screen for internal usage for now
