### PR TITLE
OTT-14 Updated Javascript following changes to _country_picker.html.erb html GDS Hierarchy

### DIFF
--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -551,9 +551,10 @@
               },
               onConfirm: function(confirmed) {
                 const code = /\((\w\w)\)/.test(confirmed) ? /\((\w\w)\)/.exec(confirmed)[1] : null;
-                $(this.selectElement).val(code);
-                $(this.selectElement).siblings('input[name$="[anchor]"]').val(window.location.hash.substring(1)); // maintain the tab
-                $(this.selectElement).parents('form:first').trigger('submit');
+                element.val(code);
+                const anchorInput = element.closest('.govuk-fieldset').find('input[name$="[anchor]"]');
+                anchorInput.val(window.location.hash.substring(1)); // maintain the tab
+                element.parents('form:first').trigger('submit');
               },
             });
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-14

### What?

I have altered:

- [x] js-country-picker-select as it wasn't maintaining the current tab (ie. Origin) due to the change in HTML hierarchy in _country_picker.html.erb

### Why?

I am doing this because:

- HTML Hierarchy had to change to meet GDS guidelines thus causing the js to maintain the tab.
- Solution was to select the closest anchor field that matched outside of the govuk-fieldset container. 