### PR TITLE
OTT-254-Removed govuk-width-container div from Country Picker

### DIFF
--- a/app/views/shared/_country_picker.html.erb
+++ b/app/views/shared/_country_picker.html.erb
@@ -2,18 +2,18 @@
   <fieldset class="govuk-fieldset country-picker js-country-picker govuk-!-font-size-16">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-          <p class="govuk-heading-m">Select a country<p>
-          <%= f.hidden_field :render_errors, value: false %>
-          <%= f.hidden_field :anchor, value: nil %>
-          <%= f.label :country, country_picker_text %>
-            <div class="govuk-grid-row">
-              <div class="govuk-grid-column-two-thirds">
-                <%= f.select :country, GeographicalArea.country_options, { include_blank: 'All countries' }, class: 'custom-select js-country-picker-select', "aria-label": "Filter measures by country" %>
-              </div>
-              <div class="govuk-grid-column-one-third govuk-!-padding-top-2">
-                <%= link_to('Reset to all countries', goods_nomenclature_path(country: nil), class: 'govuk-link') %>
-              </div>
+        <p class="govuk-heading-m">Select a country<p>
+        <%= f.hidden_field :render_errors, value: false %>
+        <%= f.hidden_field :anchor, value: nil %>
+        <%= f.label :country, country_picker_text %>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <%= f.select :country, GeographicalArea.country_options, { include_blank: 'All countries' }, class: 'custom-select js-country-picker-select', "aria-label": "Filter measures by country" %>
             </div>
+            <div class="govuk-grid-column-one-third govuk-!-padding-top-2">
+              <%= link_to('Reset to all countries', goods_nomenclature_path(country: nil), class: 'govuk-link') %>
+            </div>
+          </div>
       </div>
     </div>
     <%= f.button 'Set country', class: 'button search-submit govuk-button' %>

--- a/app/views/shared/_country_picker.html.erb
+++ b/app/views/shared/_country_picker.html.erb
@@ -1,21 +1,19 @@
 <%= form_for TradingPartner.new(country: params['country']), method: :patch, url: trading_partners_path,  html: { class: 'govuk-!-margin-bottom-7' } do |f| %>
   <fieldset class="govuk-fieldset country-picker js-country-picker govuk-!-font-size-16">
-    <div class="govuk-width-container">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-heading-m">Select a country<p>
-            <%= f.hidden_field :render_errors, value: false %>
-            <%= f.hidden_field :anchor, value: nil %>
-            <%= f.label :country, country_picker_text %>
-              <div class="govuk-grid-row">
-                <div class="govuk-grid-column-two-thirds">
-                  <%= f.select :country, GeographicalArea.country_options, { include_blank: 'All countries' }, class: 'custom-select js-country-picker-select', "aria-label": "Filter measures by country" %>
-                </div>
-                <div class="govuk-grid-column-one-third govuk-!-padding-top-2">
-                  <%= link_to('Reset to all countries', goods_nomenclature_path(country: nil), class: 'govuk-link') %>
-                </div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+          <p class="govuk-heading-m">Select a country<p>
+          <%= f.hidden_field :render_errors, value: false %>
+          <%= f.hidden_field :anchor, value: nil %>
+          <%= f.label :country, country_picker_text %>
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-two-thirds">
+                <%= f.select :country, GeographicalArea.country_options, { include_blank: 'All countries' }, class: 'custom-select js-country-picker-select', "aria-label": "Filter measures by country" %>
               </div>
-        </div>
+              <div class="govuk-grid-column-one-third govuk-!-padding-top-2">
+                <%= link_to('Reset to all countries', goods_nomenclature_path(country: nil), class: 'govuk-link') %>
+              </div>
+            </div>
       </div>
     </div>
     <%= f.button 'Set country', class: 'button search-submit govuk-button' %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-254

### What?

I have removed

- [x] govuk-width-container div from Country Picker

### Why?

I am doing this because:

- It was causing a padding layout issue in mobile (small screen) mode.

### Have you? (optional)

- [x] Validated mobile responsive behaviour of view changes

BEFORE
![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/127106895/0a0d59f9-3399-45eb-a9b0-e21137b42752)

AFTER
![image](https://github.com/trade-tariff/trade-tariff-frontend/assets/127106895/62f1e248-6465-4749-9b91-270d7d2d805f)