### PR TITLE
WIP(work in progress) OTT-225-269: Multiple commodity pages bug fix

### DIFF
--- a/app/controllers/import_export_dates_controller.rb
+++ b/app/controllers/import_export_dates_controller.rb
@@ -17,6 +17,7 @@ class ImportExportDatesController < ApplicationController
         day: @import_export_date.day,
         month: @import_export_date.month,
         year: @import_export_date.year,
+        id: referer_goods_nomenclature_code(params['previous_page_referer']),
       )
     else
       render 'show'

--- a/app/controllers/trading_partners_controller.rb
+++ b/app/controllers/trading_partners_controller.rb
@@ -16,7 +16,7 @@ class TradingPartnersController < ApplicationController
       redirect_to goods_nomenclature_path(
         country: @trading_partner.country,
         anchor: trading_partner_params[:anchor],
-        id: referer_goods_nomenclature_code,
+        id: referer_goods_nomenclature_code(request.referer),
       )
     elsif should_not_render_errors?
       redirect_to goods_nomenclature_path

--- a/app/controllers/trading_partners_controller.rb
+++ b/app/controllers/trading_partners_controller.rb
@@ -16,6 +16,7 @@ class TradingPartnersController < ApplicationController
       redirect_to goods_nomenclature_path(
         country: @trading_partner.country,
         anchor: trading_partner_params[:anchor],
+        id: referer_goods_nomenclature_code,
       )
     elsif should_not_render_errors?
       redirect_to goods_nomenclature_path

--- a/app/helpers/goods_nomenclature_helper.rb
+++ b/app/helpers/goods_nomenclature_helper.rb
@@ -32,8 +32,8 @@ module GoodsNomenclatureHelper
     session[:goods_nomenclature_code]
   end
 
-  def referer_goods_nomenclature_code
-    referer.path.match(%r{/commodities/(\d+)})[1] if referer.present? && referer.path.present?
+  def referer_goods_nomenclature_code(referer_link)
+    referer_link.match(%r{/commodities/(\d+)})[1] if referer_link.present?
   end
 
   private

--- a/app/helpers/goods_nomenclature_helper.rb
+++ b/app/helpers/goods_nomenclature_helper.rb
@@ -1,6 +1,6 @@
 module GoodsNomenclatureHelper
   def goods_nomenclature_back_link
-    link_to('Back', goods_nomenclature_path, class: 'govuk-back-link')
+    link_to('Back', goods_nomenclature_path(id: referer_goods_nomenclature_code(request.referer)), class: 'govuk-back-link')
   end
 
   def goods_nomenclature_path(path_opts = {})

--- a/app/helpers/goods_nomenclature_helper.rb
+++ b/app/helpers/goods_nomenclature_helper.rb
@@ -33,7 +33,7 @@ module GoodsNomenclatureHelper
   end
 
   def referer_goods_nomenclature_code(referer_link)
-    referer_link.match(%r{/commodities/(\d+)})[1] if referer_link.present?
+    referer_link.match(%r{/commodities/(\d+)})[1] if referer_link.present? && referer_link.match(%r{/commodities/(\d+)}).present?
   end
 
   private

--- a/app/helpers/goods_nomenclature_helper.rb
+++ b/app/helpers/goods_nomenclature_helper.rb
@@ -4,7 +4,7 @@ module GoodsNomenclatureHelper
   end
 
   def goods_nomenclature_path(path_opts = {})
-    path_opts = goods_nomenclature_path_opts.merge(path_opts) if current_goods_nomenclature_code.present?
+    path_opts = goods_nomenclature_path_opts.merge(path_opts.reject { |k, v| (k == :id && v.blank?) }) if current_goods_nomenclature_code.present?
 
     case current_goods_nomenclature_code&.size
     when nil
@@ -30,6 +30,10 @@ module GoodsNomenclatureHelper
 
   def current_goods_nomenclature_code
     session[:goods_nomenclature_code]
+  end
+
+  def referer_goods_nomenclature_code
+    referer.path.match(%r{/commodities/(\d+)})[1] if referer.present? && referer.path.present?
   end
 
   private

--- a/app/helpers/goods_nomenclature_helper.rb
+++ b/app/helpers/goods_nomenclature_helper.rb
@@ -25,7 +25,11 @@ module GoodsNomenclatureHelper
   end
 
   def goods_nomenclature_back_to_commodity_link
-    link_to("Back to commodity #{current_goods_nomenclature_code}", goods_nomenclature_path, class: 'govuk-back-link')
+    if referer_goods_nomenclature_code(request.referer).present?
+      link_to("Back to commodity #{referer_goods_nomenclature_code(request.referer)}", goods_nomenclature_path(id: referer_goods_nomenclature_code(request.referer)), class: 'govuk-back-link')
+    else
+      link_to("Back to commodity #{current_goods_nomenclature_code}", goods_nomenclature_path, class: 'govuk-back-link')
+    end
   end
 
   def current_goods_nomenclature_code

--- a/app/models/import_export_date.rb
+++ b/app/models/import_export_date.rb
@@ -4,6 +4,7 @@ class ImportExportDate
   include ActiveRecord::AttributeAssignment
 
   attribute :import_date, :tariff_date
+  attribute :previous_page_referer
 
   delegate :day, :month, :year, to: :import_date, allow_nil: true
 

--- a/app/views/import_export_dates/show.html.erb
+++ b/app/views/import_export_dates/show.html.erb
@@ -10,6 +10,9 @@
   <div class="govuk-grid-column-three-quarters">
     <%= form_for @import_export_date, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: 'patch' do |f| %>
       <%= f.govuk_error_summary %>
+
+      <%= hidden_field_tag :previous_page_referer, request.referer %>
+      
       <%= f.govuk_date_field :import_date,
         legend: { text: t('import_export_date.form.legend_text'), size: 'xl', tag: 'h1' },
         hint: { text: t('import_export_date.form.hint_text_html') } %>

--- a/spec/helpers/goods_nomenclature_helper_spec.rb
+++ b/spec/helpers/goods_nomenclature_helper_spec.rb
@@ -96,5 +96,11 @@ RSpec.describe GoodsNomenclatureHelper, type: :helper do
     context 'when there is a referer' do
       it { expect(helper.referer_goods_nomenclature_code(helper.request.referer)).to eq('2402201000') }
     end
+
+    context 'when there is non commodity code referer' do
+      before { allow(helper.request).to receive(:referer).and_return('http://example.com/something/else') }
+
+      it { expect(helper.referer_goods_nomenclature_code(helper.request.referer)).to eq(nil) }
+    end
   end
 end

--- a/spec/helpers/goods_nomenclature_helper_spec.rb
+++ b/spec/helpers/goods_nomenclature_helper_spec.rb
@@ -90,11 +90,11 @@ RSpec.describe GoodsNomenclatureHelper, type: :helper do
     context 'when there is no referer' do
       before { allow(helper.request).to receive(:referer).and_return(nil) }
 
-      it { expect(helper.referer_goods_nomenclature_code).to eq(nil) }
+      it { expect(helper.referer_goods_nomenclature_code(helper.request.referer)).to eq(nil) }
     end
 
     context 'when there is a referer' do
-      it { expect(helper.referer_goods_nomenclature_code).to eq('2402201000') }
+      it { expect(helper.referer_goods_nomenclature_code(helper.request.referer)).to eq('2402201000') }
     end
   end
 end

--- a/spec/helpers/goods_nomenclature_helper_spec.rb
+++ b/spec/helpers/goods_nomenclature_helper_spec.rb
@@ -11,10 +11,8 @@ RSpec.describe GoodsNomenclatureHelper, type: :helper do
   let(:url_options) { { country: 'AR', year: '2021', month: '01', day: '01' } }
 
   describe '#goods_nomenclature_back_link' do
-    let(:session_goods_nomenclature_code) { '1901200000' }
-
     it 'returns the correct link html' do
-      expected_link = '<a class="govuk-back-link" href="/commodities/1901200000?country=AR&amp;day=01&amp;month=01&amp;year=2021#export">Back</a>'
+      expected_link = '<a class="govuk-back-link" href="/commodities/2402201000?country=AR&amp;day=01&amp;month=01&amp;year=2021#export">Back</a>'
 
       expect(helper.goods_nomenclature_back_link).to eq(expected_link)
     end

--- a/spec/helpers/goods_nomenclature_helper_spec.rb
+++ b/spec/helpers/goods_nomenclature_helper_spec.rb
@@ -85,4 +85,16 @@ RSpec.describe GoodsNomenclatureHelper, type: :helper do
 
     it { expect(helper.current_goods_nomenclature_code).to eq('1901200000') }
   end
+
+  describe '#referer_goods_nomenclature_code' do
+    context 'when there is no referer' do
+      before { allow(helper.request).to receive(:referer).and_return(nil) }
+
+      it { expect(helper.referer_goods_nomenclature_code).to eq(nil) }
+    end
+
+    context 'when there is a referer' do
+      it { expect(helper.referer_goods_nomenclature_code).to eq('2402201000') }
+    end
+  end
 end

--- a/spec/helpers/goods_nomenclature_helper_spec.rb
+++ b/spec/helpers/goods_nomenclature_helper_spec.rb
@@ -42,10 +42,8 @@ RSpec.describe GoodsNomenclatureHelper, type: :helper do
 
   describe '#goods_nomenclature_link_back_link' do
     context 'when the session goods_nomenclature_code is a commodity code' do
-      let(:session_goods_nomenclature_code) { '1901200000' }
-
       it 'returns a return link for the commodity' do
-        expected_link = '<a class="govuk-back-link" href="/commodities/1901200000?country=AR&amp;day=01&amp;month=01&amp;year=2021#export">Back to commodity 1901200000</a>'
+        expected_link = '<a class="govuk-back-link" href="/commodities/2402201000?country=AR&amp;day=01&amp;month=01&amp;year=2021#export">Back to commodity 2402201000</a>'
 
         expect(helper.goods_nomenclature_back_to_commodity_link).to eq(expected_link)
       end
@@ -54,8 +52,10 @@ RSpec.describe GoodsNomenclatureHelper, type: :helper do
     context 'when the session goods_nomenclature_code is a heading code' do
       let(:session_goods_nomenclature_code) { '1901' }
 
+      before { allow(helper.request).to receive(:referer).and_return('http://example.com/headings/1901') }
+
       it 'returns a return link for the heading' do
-        expected_link = '<a class="govuk-back-link" href="/headings/1901?country=AR&amp;day=01&amp;month=01&amp;year=2021#export">Back to commodity 1901</a>'
+        expected_link = '<a class="govuk-back-link" href="/headings/1901?country=AR&amp;day=01&amp;month=01&amp;year=2021">Back to commodity 1901</a>'
 
         expect(helper.goods_nomenclature_back_to_commodity_link).to eq(expected_link)
       end


### PR DESCRIPTION
WIP(work in progress): This ticket requires a total refactor of the sessions code and still needs to be done on Headings, Chapters, Subheadings. I was only able to do Commodities with the limited time I had before going on holiday.

### Jira link

https://transformuk.atlassian.net/browse/OTT-225
https://transformuk.atlassian.net/browse/OTT-269

### What?

I have added/removed/altered:

- [ ] used request referrer instead of sessions to fix country selection bug
- [ ] pass request referrer as a hidden field to fix date selection bug
- [ ] used request referrer in back links
- [ ] use request referrer in back to commodity links

### Why?

I am doing this because:

- Sessions contained the wrong commodity code

<img width="1084" alt="Screenshot 2024-05-08 at 14 03 03" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/c037d15a-8e63-4337-8330-8de1e71f7ca8">

