### PR TITLE
GL-483 Add Pseudo Exemption support

### DIFF
--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -8,7 +8,11 @@ class GreenLanes::CategoryAssessment
   has_one :regulation, class_name: 'LegalAct'
   has_one :geographical_area
   has_many :excluded_geographical_areas, class_name: 'GeographicalArea'
-  has_many :exemptions, polymorphic: true
+  has_many :exemptions, polymorphic: {
+    'exemption' => 'GreenLanes::Exemption',
+    'certificate' => 'Certificate',
+    'additional_code' => 'AdditionalCode',
+  }
 
   delegate :category, to: :theme
 

--- a/app/models/green_lanes/exemption.rb
+++ b/app/models/green_lanes/exemption.rb
@@ -1,0 +1,7 @@
+module GreenLanes
+  class Exemption
+    include XiOnlyApiEntity
+
+    attr_accessor :code, :description, :formatted_description
+  end
+end

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -132,7 +132,9 @@ private
         entity = if attributes.nil?
                    nil
                  else
-                   class_name = if options[:polymorphic]
+                   class_name = if options[:polymorphic].is_a?(Hash)
+                                  options[:polymorphic][attributes['resource_type']] || raise('Unspecified polymorphic resource type')
+                                elsif options[:polymorphic]
                                   attributes['resource_type'].classify
                                 else
                                   options[:class_name]
@@ -167,7 +169,9 @@ private
         data = data.presence || []
 
         collection = data.map do |attributes|
-          class_name = if options[:polymorphic]
+          class_name = if options[:polymorphic].is_a?(Hash)
+                         options[:polymorphic][attributes['resource_type']] || raise('Unspecified polymorphic resource type')
+                       elsif options[:polymorphic]
                          attributes['resource_type'].classify
                        else
                          options[:class_name]

--- a/spec/factories/green_lanes/exemption_factory.rb
+++ b/spec/factories/green_lanes/exemption_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :green_lanes_exemption, class: 'GreenLanes::Exemption' do
+    sequence(:code)        { |n| sprintf 'E%03d', n }
+    sequence(:description) { |n| "Green Lanes Exemption #{n}" }
+    formatted_description  { description }
+  end
+end

--- a/spec/models/green_lanes/exemption_spec.rb
+++ b/spec/models/green_lanes/exemption_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe GreenLanes::Exemption do
+  subject { build :green_lanes_exemption }
+
+  it { is_expected.to respond_to :code }
+  it { is_expected.to respond_to :description }
+  it { is_expected.to respond_to :formatted_description }
+end


### PR DESCRIPTION
Also adds support for manually specifying polymorphic mapping to ApiEntity

### Jira link

GL-483

### What?

I have added/removed/altered:

- [x] Added an ApiEntity class for Psuedo Exemptions
- [x] Extended the ApiEntity base class to support manually specifying the polymorphic mapping

### Why?

I am doing this because:

- We need to deserialize pseudo exemptions
- Our ApiEntity didn't know how to deserialize into namespaced models

### Deployment risks (optional)

- Some, makes changes to ApiEntity but they should be safe - I cannot find anywhere setting the polymorphic attribute to anything other than true, and the code change only has impact when there is a Hash value for `polymorphic:`.
- There aren't any specs around the polymorphic behaviour
