### PR TITLE
OTT-255: Changed link for licensed quotas

### DIFF
--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -122,7 +122,7 @@
       <% id = "missing-definition-#{order_number.licenced? ? "licenced" : "non-licenced"}" %>
       <p id="<%= id %>" class="govuk-!-margin-top-4">
         <% if order_number.licenced? %>
-          Information on the availability of licenced quotas can be obtained from the <%= link_to("Rural Payments Agency (opens in new browser window)", "https://www.gov.uk/government/organisations/rural-payments-agency", target: '_blank', class: 'govuk-link') %>.
+          Information on the availability of licenced quotas can be obtained from the <%= link_to("UK tariff rate quotas (opens in new browser window)", "https://www.gov.uk/government/collections/uk-tariff-rate-quotas-allocation-of-co-efficients", target: '_blank', class: 'govuk-link') %>.
         <% else %>
           No further information for this quota can be found.
         <% end %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-255

### What?

I have added/removed/altered:

- [ ] Changed link for licensed quotas

### Why?

I am doing this because:

-  old link was outdated

<img width="1122" alt="Screenshot 2024-05-14 at 10 51 39" src="https://github.com/trade-tariff/trade-tariff-frontend/assets/12201130/b98ba02b-41f6-4555-a386-2810da7fffb8">

