### PR TITLE
BAU: Fix running cuprite specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,9 +189,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get update
-      - browser-tools/install-chrome:
-          chrome-version: 114.0.5735.90 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
-      - browser-tools/install-chromedriver
+      - browser-tools/install-chrome
       - ruby/install-deps
       - node/install-packages:
           pkg-manager: yarn


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixed running feature specs via browser

### Why?

I am doing this because:

- Previously it was installing an old chrome version

### Deployment risks (optional)

- Low, spec only changes
