### PR TITLE
BAU: Fixes GTM id

### DIFF
--- a/app/webpacker/src/javascripts/google-tag-manager-loader.js
+++ b/app/webpacker/src/javascripts/google-tag-manager-loader.js
@@ -12,5 +12,5 @@ if (cookieManager.usage()) {
     j.async = true;
     j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
     f.parentNode.insertBefore(j, f);
-  })(window, document, 'script', 'dataLayer', 'GTM-MNNT6SX');
+  })(window, document, 'script', 'dataLayer', 'GTM-KPM7NRDG');
 }


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Altered the GTM id

### Why?

I am doing this because:

- The previous id was disabled by whoever administers our GTM estate and this has caused a sudden drop in the feed
