### PR TITLE
OTT-287 Fix Trading Partners to persist variety of commodity IDs over multiple tabs

### DIFF
--- a/app/controllers/trading_partners_controller.rb
+++ b/app/controllers/trading_partners_controller.rb
@@ -7,17 +7,27 @@ class TradingPartnersController < ApplicationController
 
   def show
     @trading_partner = TradingPartner.new(country: params[:country])
+    @goods_nomenclature_code = params[:goods_nomenclature_code]
   end
 
   def update
     @trading_partner = TradingPartner.new(country: trading_partner_params[:country])
 
     if @trading_partner.valid?
-      redirect_to goods_nomenclature_path(
-        country: @trading_partner.country,
-        anchor: trading_partner_params[:anchor],
-        id: referer_goods_nomenclature_code(request.referer),
-      )
+      referer_commodity_code = referer_goods_nomenclature_code(request.referer)
+      if referer_commodity_code.nil?
+        redirect_to goods_nomenclature_path(
+          country: @trading_partner.country,
+          anchor: trading_partner_params[:anchor],
+          id: trading_partner_params[:goods_nomenclature_code],
+        )
+      else
+        redirect_to goods_nomenclature_path(
+          country: @trading_partner.country,
+          anchor: trading_partner_params[:anchor],
+          id: referer_commodity_code,
+        )
+      end
     elsif should_not_render_errors?
       redirect_to goods_nomenclature_path
     else
@@ -32,6 +42,6 @@ class TradingPartnersController < ApplicationController
   end
 
   def trading_partner_params
-    params.fetch(:trading_partner, {}).permit(:country, :anchor)
+    params.fetch(:trading_partner, {}).permit(:country, :anchor, :goods_nomenclature_code)
   end
 end

--- a/app/views/trading_partners/show.html.erb
+++ b/app/views/trading_partners/show.html.erb
@@ -16,6 +16,7 @@
         </legend>
 
         <%= f.hidden_field :render_errors, value: true %>
+        <%= f.hidden_field :goods_nomenclature_code, value: referer_goods_nomenclature_code(request.referer) %>
 
         <%= f.govuk_error_summary %>
 
@@ -29,7 +30,7 @@
 
         <div class="govuk-button-group">
           <%= f.govuk_submit(t('trading_partner.form.submit')) %>
-          <%= link_to('Reset to all countries', goods_nomenclature_path(country: nil), class: 'govuk-link') %>
+          <%= link_to('Reset to all countries', goods_nomenclature_path(country: nil, id: referer_goods_nomenclature_code(request.referer)), class: 'govuk-link') %>
         </div>
       <% end %>
       </fieldset>

--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -287,7 +287,7 @@
         });
 
         $('form').on('click', 'button[type=submit]', function(e) {
-          this.closest('form').trigger('submit');
+          $(this).closest('form').trigger('submit');
         });
 
         this.responsivePlaceholder.initialize();


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-287

### What?

I have altered:

- [x] Trading Partners Controller and View to persist commodity ID on submit.
- [x] Trading Partners 'Reset all countries' link to use request.referer for commodity id
- [x] Fix syntax error in commodities.js

### Why?

I am doing this because:

- Request.Referer wasn't persisting with the current tab's commodity id on submit to the trading partners controller
- 'Reset all countries' was defaulting to the session commodity id and not the 'tabs' (ie the one from request.referer)
- Javascript kept on breaking in debug so syntax fix applied

Tested locally but QA Required to test over multiple tabs as per the Jira.