### PR TITLE
Gl596, GL-629 - Result pages Cat1 and Cat 2

### DIFF
--- a/app/controllers/green_lanes/moving_requirements_controller.rb
+++ b/app/controllers/green_lanes/moving_requirements_controller.rb
@@ -38,23 +38,24 @@ module GreenLanes
     end
 
     def result
-      @goods_nomenclature = GreenLanes::GoodsNomenclature.find(
+      goods_nomenclature = GreenLanes::GoodsNomenclature.find(
         moving_requirements_params[:commodity_code],
         { filter: { geographical_area_id: moving_requirements_params[:country_of_origin] } },
         { authorization: TradeTariffFrontend.green_lanes_api_token },
       )
 
-      @commodity_code = @goods_nomenclature.goods_nomenclature_item_id
-      @country_of_origin = moving_requirements_params[:country_of_origin]
+      @commodity_code = goods_nomenclature.goods_nomenclature_item_id
+      @country_of_origin = moving_requirements_params[:country_of_origin] || GeographicalArea::ERGA_OMNES
       @country_description = GeographicalArea.find(@country_of_origin).description
       @moving_date = moving_requirements_params[:moving_date]
+      @determine_categories = GreenLanes::DetermineCategory.new(goods_nomenclature)
 
-      categories = GreenLanes::DetermineCategory.new(@goods_nomenclature).call
+      @categories = @determine_categories.call
 
-      if categories == [:cat_3]
+      if @categories == [:cat_1] || @categories == [:cat_3]
         render 'result'
       else
-        render 'generic_result', locals: { categories: }
+        render 'generic_result'
       end
     end
 

--- a/app/controllers/green_lanes/moving_requirements_controller.rb
+++ b/app/controllers/green_lanes/moving_requirements_controller.rb
@@ -50,9 +50,10 @@ module GreenLanes
       @moving_date = moving_requirements_params[:moving_date]
       @determine_categories = GreenLanes::DetermineCategory.new(goods_nomenclature)
 
-      @categories = @determine_categories.call
+      @categories = @determine_categories.categories
 
-      if @categories == [:cat_1] || @categories == [:cat_3]
+      case @categories
+      when [:cat_1], [:cat_2], [:cat_3]
         render 'result'
       else
         render 'generic_result'

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -13,8 +13,6 @@ class GeographicalArea
     european_union: '1013',
   }
 
-  enum :status, { draft: 0, published: 1, archived: 2, trashed: 3 }
-
   set_collection_path '/geographical_areas/countries'
 
   attr_accessor :id, :geographical_area_id

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -3,6 +3,7 @@ require 'api_entity'
 class GeographicalArea
   EUROPEAN_UNION_ID = '1013'.freeze
   REFERENCING_EUROPEAN_UNION_ID = 'EU'.freeze
+  ERGA_OMNES = '1011'.freeze
 
   include ApiEntity
 
@@ -11,6 +12,8 @@ class GeographicalArea
     erga_omnes: '1011',
     european_union: '1013',
   }
+
+  enum :status, { draft: 0, published: 1, archived: 2, trashed: 3 }
 
   set_collection_path '/geographical_areas/countries'
 

--- a/app/services/green_lanes/determine_category.rb
+++ b/app/services/green_lanes/determine_category.rb
@@ -25,6 +25,10 @@ module GreenLanes
       end
     end
 
+    def cat1_without_exemptions
+      cat1_assessments.select { |ca| ca.exemptions.empty? }
+    end
+
     private
 
     def cat1_assessments
@@ -37,10 +41,6 @@ module GreenLanes
 
     def category_assessments
       goods_nomenclature.applicable_category_assessments
-    end
-
-    def cat1_without_exemptions
-      cat1_assessments.select { |ca| ca.exemptions.empty? }
     end
 
     def cat2_without_exemptions

--- a/app/services/green_lanes/determine_category.rb
+++ b/app/services/green_lanes/determine_category.rb
@@ -1,5 +1,8 @@
 module GreenLanes
   class DetermineCategory
+    CAT_1 = 1
+    CAT_2 = 2
+
     attr_reader :goods_nomenclature
 
     def initialize(goods_nomenclature)
@@ -26,33 +29,39 @@ module GreenLanes
     end
 
     def cat1_without_exemptions
-      cat1_assessments.select { |ca| ca.exemptions.empty? }
+      without_exemptions(
+        category_assessments(CAT_1),
+      )
     end
 
     def cat2_without_exemptions
-      cat2_assessments.select { |ca| ca.exemptions.empty? }
+      without_exemptions(
+        category_assessments(CAT_2),
+      )
     end
 
     private
 
-    def cat1_assessments
-      category_assessments.select { |ca| ca.theme.category == 1 }
+    def without_exemptions(cat_assessments)
+      cat_assessments.select { |ca| ca.exemptions.empty? }
     end
 
-    def cat2_assessments
-      category_assessments.select { |ca| ca.theme.category == 2 }
-    end
+    def category_assessments(category = nil)
+      ca_assessments = goods_nomenclature.applicable_category_assessments
 
-    def category_assessments
-      goods_nomenclature.applicable_category_assessments
+      return ca_assessments unless category
+
+      category_assessments.select { |ca| ca.theme.category == category }
     end
 
     def cat1_with_exemptions
-      cat1_assessments.select { |ca| ca.exemptions.any? }
+      category_assessments(CAT_1)
+        .select { |ca| ca.exemptions.any? }
     end
 
     def cat2_with_exemptions
-      cat2_assessments.select { |ca| ca.exemptions.any? }
+      category_assessments(CAT_2)
+        .select { |ca| ca.exemptions.any? }
     end
   end
 end

--- a/app/services/green_lanes/determine_category.rb
+++ b/app/services/green_lanes/determine_category.rb
@@ -6,8 +6,8 @@ module GreenLanes
       @goods_nomenclature = goods_nomenclature
     end
 
-    def call
-      return [:cat_3] if category_assessments.empty?  # Result 3
+    def categories
+      return [:cat_3] if category_assessments.empty? # Result 3
       return [:cat_1] if cat1_without_exemptions.any? # Result 1
 
       if cat2_without_exemptions.any?
@@ -29,6 +29,10 @@ module GreenLanes
       cat1_assessments.select { |ca| ca.exemptions.empty? }
     end
 
+    def cat2_without_exemptions
+      cat2_assessments.select { |ca| ca.exemptions.empty? }
+    end
+
     private
 
     def cat1_assessments
@@ -41,10 +45,6 @@ module GreenLanes
 
     def category_assessments
       goods_nomenclature.applicable_category_assessments
-    end
-
-    def cat2_without_exemptions
-      cat2_assessments.select { |ca| ca.exemptions.empty? }
     end
 
     def cat1_with_exemptions

--- a/app/views/green_lanes/moving_requirements/generic_result.erb
+++ b/app/views/green_lanes/moving_requirements/generic_result.erb
@@ -22,7 +22,7 @@
     <div class="govuk-notification-banner govuk-notification-banner--success" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
       <div class="govuk-notification-banner__content">
         <h2 class="govuk-notification-banner__heading">
-          Your goods may be in the categories: <%= categories.join(', ') %>
+          Your goods may be in the categories: <%= @categories.join(', ') %>
         </h2>
       </div>
     </div>

--- a/app/views/green_lanes/moving_requirements/result.html.erb
+++ b/app/views/green_lanes/moving_requirements/result.html.erb
@@ -36,6 +36,8 @@
 
     <% if @categories == [:cat_1] %>
     <%= render '/green_lanes/shared/result_category_1'%>
+    <% elsif @categories == [:cat_2] %>
+    <%= render '/green_lanes/shared/result_category_2' %>
     <% elsif @categories == [:cat_3] %>
     <%= render '/green_lanes/shared/result_standard_category_3' %>
     <% end %>
@@ -87,30 +89,19 @@
 
     <% if @categories == [:cat_1] %>
     <%= render '/green_lanes/shared/category_1_criteria_and_exemptions' %>
+    <% elsif @categories == [:cat_2] %>
+    <%= render '/green_lanes/shared/category_2_criteria_and_exemptions' %>
     <% end %>
 
     <h2 class="govuk-heading-m">
       Next steps
     </h2>
 
-    <% if @categories == [:cat_1] %>
+    <% case @categories %>
+    <% when [:cat_1] %>
     <%= render '/green_lanes/shared/category_1_next_step' %>
-    <% else %>
-    <ol class="govuk-list govuk-list--number">
-      <li>
-        <%= link_to "Apply to become an authorised trader under the UK Internal Market Scheme (UKIMS)",
-                    "https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland",
-                    target: "_blank"
-        %>
-      </li>
-      <li>
-        Prepare a submission for your internal market movement through services provided by
-        the Trader Goods Profile (TGP), Trader Support Service (TSS) or individual customs agents.
-      </li>
-      <li>
-        Complete the submission to HMRC, including the category of your goods and any exemption or additional codes that apply.
-      </li>
-    </ol>
+    <% when [:cat_2], [:cat_3] %>
+    <%= render '/green_lanes/shared/category_2_and_3_next_step' %>
     <% end %>
 
     <%= render '/green_lanes/shared/support_email_section' %>

--- a/app/views/green_lanes/moving_requirements/result.html.erb
+++ b/app/views/green_lanes/moving_requirements/result.html.erb
@@ -34,17 +34,11 @@
       </ul>
     </p>
 
-    <div class="govuk-notification-banner govuk-notification-banner--success" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-      <div class="govuk-notification-banner__content">
-        <h2 class="govuk-notification-banner__heading">
-          Your goods are Standard Category
-        </h2>
-
-        <p class="govuk-body">
-          Your goods are eligible for the simplified process for internal market movements.
-        </p>
-      </div>
-    </div>
+    <% if @categories == [:cat_1] %>
+    <%= render '/green_lanes/shared/result_category_1'%>
+    <% elsif @categories == [:cat_3] %>
+    <%= render '/green_lanes/shared/result_standard_category_3' %>
+    <% end %>
 
     <div class="govuk-summary-card">
       <div class="govuk-summary-card__title-wrapper">
@@ -91,10 +85,17 @@
       </div>
     </div>
 
+    <% if @categories == [:cat_1] %>
+    <%= render '/green_lanes/shared/category_1_criteria_and_exemptions' %>
+    <% end %>
+
     <h2 class="govuk-heading-m">
       Next steps
     </h2>
 
+    <% if @categories == [:cat_1] %>
+    <%= render '/green_lanes/shared/category_1_next_step' %>
+    <% else %>
     <ol class="govuk-list govuk-list--number">
       <li>
         <%= link_to "Apply to become an authorised trader under the UK Internal Market Scheme (UKIMS)",
@@ -110,6 +111,7 @@
         Complete the submission to HMRC, including the category of your goods and any exemption or additional codes that apply.
       </li>
     </ol>
+    <% end %>
 
     <%= render '/green_lanes/shared/support_email_section' %>
   </div>

--- a/app/views/green_lanes/shared/_category_1_criteria_and_exemptions.html.erb
+++ b/app/views/green_lanes/shared/_category_1_criteria_and_exemptions.html.erb
@@ -1,0 +1,32 @@
+<h3 class="govuk-heading-m">Category 1 criteria and exemptions</h3>
+
+
+<p class="govuk-body govuk-!-font-weight-bold">
+  Your goods will be Category 1 if you do not meet an exemption for each category 1 assessment shown.
+  You only need to check further categories if you meet exemptions for all assessments.
+</p>
+
+<div class="govuk-summary-card">
+  <div class="govuk-summary-card__content">
+    <% @determine_categories.cat1_without_exemptions.each do |category_assessment| %>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Category 1 assessment
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= category_assessment.theme.theme %>          
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Exemption
+        </dt>
+        <dd class="govuk-summary-list__value">
+          No exemption available
+        </dd>
+      </div>
+    </dl>
+    <% end %>
+  </div>
+</div>

--- a/app/views/green_lanes/shared/_category_1_next_step.html.erb
+++ b/app/views/green_lanes/shared/_category_1_next_step.html.erb
@@ -1,0 +1,11 @@
+<p class="govuk-body">
+Category 1 goods are not eligible for the simplified process for internal market movements.
+</p>
+
+<p class="govuk-body">
+You may be able to follow particular processes and procedures, such as completing a full customs declaration, to continue with the movement of goods from Great Britain to Northern Ireland.
+</p>
+
+<%= link_to "Find out more about trading and moving goods in and out of Northern Ireland <br> (opens in a new tab)".html_safe,
+  "https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland", target: "_blank", class: "govuk-link"
+%>

--- a/app/views/green_lanes/shared/_category_2_and_3_next_step.html.erb
+++ b/app/views/green_lanes/shared/_category_2_and_3_next_step.html.erb
@@ -1,0 +1,15 @@
+<ol class="govuk-list govuk-list--number">
+  <li>
+    <%= link_to "Apply to become an authorised trader under the UK Internal Market Scheme (UKIMS)",
+                "https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland",
+                target: "_blank"
+    %>
+  </li>
+  <li>
+    Prepare a submission for your internal market movement through services provided by
+    the Trader Goods Profile (TGP), Trader Support Service (TSS) or individual customs agents.
+  </li>
+  <li>
+    Complete the submission to HMRC, including the category of your goods and any exemption or additional codes that apply.
+  </li>
+</ol>

--- a/app/views/green_lanes/shared/_category_2_criteria_and_exemptions.html.erb
+++ b/app/views/green_lanes/shared/_category_2_criteria_and_exemptions.html.erb
@@ -1,18 +1,17 @@
-<h3 class="govuk-heading-m">Category 1 criteria and exemptions</h3>
+<h3 class="govuk-heading-m">Category 2 criteria and exemptions</h3>
 
 
 <p class="govuk-body govuk-!-font-weight-bold">
-  Your goods will be Category 1 if you do not meet an exemption for each category 1 assessment shown.
-  You only need to check further categories if you meet exemptions for all assessments.
+  Your goods will be Category 2 if you do not meet an exemption for each Category 2 assessment shown.
 </p>
 
-<% @determine_categories.cat1_without_exemptions.each do |category_assessment| %>
+<% @determine_categories.cat2_without_exemptions.each do |category_assessment| %>
 <div class="govuk-summary-card">
   <div class="govuk-summary-card__content">
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Category 1 assessment
+          Category 2 assessment
         </dt>
         <dd class="govuk-summary-list__value">
           <%= category_assessment.theme.theme %>

--- a/app/views/green_lanes/shared/_result_category_1.html.erb
+++ b/app/views/green_lanes/shared/_result_category_1.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-notification-banner govuk-notification-banner--error" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__content">
+    <h2 class="govuk-notification-banner__heading">
+        Your goods are Category 1
+    </h2>
+
+    <p class="govuk-body">
+        You cannot continue through the simplified process for internal market movements.
+    </p>
+    </div>
+</div>

--- a/app/views/green_lanes/shared/_result_category_2.html.erb
+++ b/app/views/green_lanes/shared/_result_category_2.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-notification-banner govuk-notification-banner--success" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__content">
+    <h2 class="govuk-notification-banner__heading">
+        Your goods are Category 2
+    </h2>
+
+    <p class="govuk-body">
+        Your goods are eligible for the Simplified Process for Internal Market Movements
+    </p>
+    </div>
+</div>

--- a/app/views/green_lanes/shared/_result_standard_category_3.html.erb
+++ b/app/views/green_lanes/shared/_result_standard_category_3.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-notification-banner govuk-notification-banner--success" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__content">
+    <h2 class="govuk-notification-banner__heading">
+        Your goods are Standard Category
+    </h2>
+
+    <p class="govuk-body">
+        Your goods are eligible for the simplified process for internal market movements.
+    </p>
+    </div>
+</div>

--- a/app/views/green_lanes/shared/_support_email_section.html.erb
+++ b/app/views/green_lanes/shared/_support_email_section.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m">
+<h2 class="govuk-heading-m govuk-!-static-margin-top-5">
   If you need help using this tool
 </h2>
 <p class="govuk-body">

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -71,3 +71,4 @@ $govuk-images-path: '~govuk-frontend/dist/govuk/assets/images/';
 @import '../src/stylesheets/exchange_rates';
 @import '../src/stylesheets/feedback_useful_banner';
 @import '../src/stylesheets/feedback_banner';
+@import '../src/stylesheets/notification_banner';

--- a/app/webpacker/src/stylesheets/_notification_banner.scss
+++ b/app/webpacker/src/stylesheets/_notification_banner.scss
@@ -1,0 +1,3 @@
+.govuk-notification-banner--error {
+  border-color: $govuk-error-colour;
+}

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -22,7 +22,7 @@ namespace :green_lanes do
       commodity_code = row[0]
 
       goods_nomenclature = GreenLanes::GoodsNomenclature.find(commodity_code)
-      cat = GreenLanes::DetermineCategory.new(goods_nomenclature).call
+      cat = GreenLanes::DetermineCategory.new(goods_nomenclature).categories
 
       puts "#{commodity_code}, #{cat}"
     end

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -1,0 +1,30 @@
+require 'csv'
+
+namespace :green_lanes do
+  desc 'Find out the categories of a list of goods.'
+
+  task :determine_categories, [:filename] => :environment do |_, args|
+    filename = args[:filename]
+
+    if filename.nil?
+      puts 'Usage: bundle exec rake green_lanes:determine_categories[filename]'
+      puts 'filename is the path to a CSV file with a list of goods.'
+      puts 'Important notes:'
+      puts '- The CSV file must have a header row.'
+      puts '- The first column of the CSV file must be the commodity code.'
+      puts '- The other columns of the CSV file will be ignored.'
+      exit
+    end
+
+    puts 'GoodsNomenclature, Categories'
+
+    CSV.foreach(filename, headers: true) do |row|
+      commodity_code = row[0]
+
+      goods_nomenclature = GreenLanes::GoodsNomenclature.find(commodity_code)
+      cat = GreenLanes::DetermineCategory.new(goods_nomenclature).call
+
+      puts "#{commodity_code}, #{cat}"
+    end
+  end
+end

--- a/spec/services/green_lanes/determine_category_spec.rb
+++ b/spec/services/green_lanes/determine_category_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe ::GreenLanes::DetermineCategory do
-  describe '.call' do
-    subject { described_class.new(goods_nomenclature).call }
+  describe '.categories' do
+    subject { described_class.new(goods_nomenclature).categories }
 
     # Result 3
     context 'when there are no category assessments' do
@@ -94,6 +94,54 @@ RSpec.describe ::GreenLanes::DetermineCategory do
 
         it { is_expected.to eq(%i[cat_2 cat_3]) }
       end
+    end
+  end
+
+  describe '#cat1_without_exemptions' do
+    subject(:cat1_without_exemptions) do
+      described_class.new(goods_nomenclature).cat1_without_exemptions
+    end
+
+    let(:goods_nomenclature) do
+      build(:green_lanes_goods_nomenclature, applicable_category_assessments: assessments)
+    end
+
+    let(:assessments) do
+      [
+        attributes_for(:category_assessment, category: 1),
+        attributes_for(:category_assessment, :with_exemptions, category: 1),
+        attributes_for(:category_assessment, category: 2),
+        attributes_for(:category_assessment, category: 2),
+        attributes_for(:category_assessment, :with_exemptions, category: 2),
+      ]
+    end
+
+    it 'returns only Cat1 assessments without exemptions' do
+      expect(cat1_without_exemptions.count).to eq(1)
+    end
+  end
+
+  describe '#cat2_without_exemptions' do
+    subject(:cat2_without_exemptions) do
+      described_class.new(goods_nomenclature).cat2_without_exemptions
+    end
+
+    let(:goods_nomenclature) do
+      build(:green_lanes_goods_nomenclature, applicable_category_assessments: assessments)
+    end
+
+    let(:assessments) do
+      [
+        attributes_for(:category_assessment, category: 1),
+        attributes_for(:category_assessment, :with_exemptions, category: 1),
+        attributes_for(:category_assessment, category: 2),
+        attributes_for(:category_assessment, category: 2),
+        attributes_for(:category_assessment, :with_exemptions, category: 2),
+      ]
+    end
+
+    it 'returns only Cat2 assessments without exemptions' do
+      expect(cat2_without_exemptions.count).to eq(2)
     end
   end
 end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/GL-596
https://transformuk.atlassian.net/browse/GL-629

### What?
- I have added two new pages for the result when the result is only Cat1 and only Cat2
- Refactor the DetermineCategory class
 
### Why?
I am doing this because:
The user needs to know what are the categories of their goods before moving them to Northern Ireland

### Deployment risks (optional)
Very low risk.
Those pages are under Feature Flag, wich is disabled on prod.
