### PR TITLE
OTT-288  Updates to Country Selector on Commodity Code page

### DIFF
--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -36,12 +36,18 @@ class GeographicalArea
     end
 
     def country_options
-      all.compact.map do |geographical_area|
-        [
-          geographical_area.long_description,
-          geographical_area.id,
-        ]
-      end
+      options = all.compact
+                   .sort_by(&:long_description)
+                   .map do |geographical_area|
+                     [
+                       geographical_area.long_description,
+                       geographical_area.id,
+                     ]
+                   end
+
+      options.unshift(['All countries', ' '])
+
+      options
     end
   end
 

--- a/app/views/shared/_country_picker.html.erb
+++ b/app/views/shared/_country_picker.html.erb
@@ -9,7 +9,7 @@
         <%= f.label :country, country_picker_text %>
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-              <%= f.select :country, GeographicalArea.country_options, { include_blank: 'All countries' }, class: 'custom-select js-country-picker-select', "aria-label": "Filter measures by country" %>
+              <%= f.select :country, GeographicalArea.country_options, {}, class: 'custom-select js-country-picker-select', "aria-label": "Filter measures by country" %>
             </div>
             <div class="govuk-grid-column-one-third govuk-!-padding-top-2">
               <%= link_to('Reset to all countries', goods_nomenclature_path(country: nil), class: 'govuk-link') %>

--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -538,21 +538,23 @@
 
         $('.js-country-picker-select').each(function() {
           (function(element) {
+            let previousValue = element.find('option:selected').text();
             accessibleAutocomplete.enhanceSelectElement({
               selectElement: element[0],
               minLength: 2,
-              autoselect: true,
+              autoselect: false,
               showAllValues: true,
-              confirmOnBlur: true,
+              confirmOnBlur: false,
               alwaysDisplayArrow: true,
               displayMenu: 'overlay',
+              placeholder: previousValue, // in case the user clicks away without selecting anything
               dropdownArrow: function() {
                 return '<span class=\'autocomplete__arrow\'></span>';
               },
               onConfirm: function(confirmed) {
                 const commodityCode = $('.commodity-header').data('comm-code');
                 // Handle the "All countries" case
-                if (confirmed === ' ' || confirmed === 'All countries') {
+                if (confirmed === 'All countries') {
                   const selectedTab = window.location.hash.substring(1);  //to maintain the tab
                   const url = `/commodities/${commodityCode}#${selectedTab}`;
                   window.location.href = url;
@@ -565,13 +567,11 @@
                 }
               },
             });
-
             $('#' + element[0].id.replace('-select', '')).on('focus', function(event) {
               $(event.currentTarget).val('');
             });
           })($(this));
         });
-
 
         $('.js-commodity-picker-select').each(function() {
           const debugEnabled = $(this).data('debug') || false;

--- a/app/webpacker/src/javascripts/commodities.js
+++ b/app/webpacker/src/javascripts/commodities.js
@@ -550,11 +550,19 @@
                 return '<span class=\'autocomplete__arrow\'></span>';
               },
               onConfirm: function(confirmed) {
-                const code = /\((\w\w)\)/.test(confirmed) ? /\((\w\w)\)/.exec(confirmed)[1] : null;
-                element.val(code);
-                const anchorInput = element.closest('.govuk-fieldset').find('input[name$="[anchor]"]');
-                anchorInput.val(window.location.hash.substring(1)); // maintain the tab
-                element.parents('form:first').trigger('submit');
+                const commodityCode = $('.commodity-header').data('comm-code');
+                // Handle the "All countries" case
+                if (confirmed === ' ' || confirmed === 'All countries') {
+                  const selectedTab = window.location.hash.substring(1);  //to maintain the tab
+                  const url = `/commodities/${commodityCode}#${selectedTab}`;
+                  window.location.href = url;
+                } else {
+                    const code = /\((\w\w)\)/.test(confirmed) ? /\((\w\w)\)/.exec(confirmed)[1] : null;
+                    element.val(code);
+                    const anchorInput = element.closest('.govuk-fieldset').find('input[name$="[anchor]"]');
+                    anchorInput.val(window.location.hash.substring(1)); // maintain the tab
+                    element.parents('form:first').trigger('submit');
+                }
               },
             });
 
@@ -563,6 +571,7 @@
             });
           })($(this));
         });
+
 
         $('.js-commodity-picker-select').each(function() {
           const debugEnabled = $(this).data('debug') || false;

--- a/app/webpacker/src/stylesheets/_form_customisations.scss
+++ b/app/webpacker/src/stylesheets/_form_customisations.scss
@@ -101,6 +101,7 @@
     position: absolute;
     top: 10px;
     right: 0.5em;
+    pointer-events: none; // HW allows element behind arrow (ie select element) to react to pointer events
 
     @media (max-width: 640px) {
       top: 8px;

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -69,10 +69,14 @@ RSpec.describe GeographicalArea do
     let(:expected_countries) do
       countries = file_fixture('geographical_areas/countries.json').read
 
-      JSON.parse(countries)
+      sorted_countries = JSON.parse(countries).sort_by { |country| country[0] }
+
+      [['All countries', ' ']] + sorted_countries
     end
 
-    it { is_expected.to eq(expected_countries) }
+    it 'returns countries in alphabetical order with "All countries" first' do
+      expect(country_options).to eq(expected_countries)
+    end
   end
 
   describe '#eu_member?', vcr: { cassette_name: 'geographical_areas#1013' } do


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-285
https://transformuk.atlassian.net/browse/OTT-288

### What?

I have added/removed/altered:

- [x] Updated js-country-picker-select javascript function for described UX Changes
- [x] Updated GeographicalArea>CountryOptions to sort list of countries and relevant spec
- [x]  Updated the .autocomplete__arrow scss class

### Why?

I am doing this because:

- The UX Changes were to add 'All countries' as an available option and to sort the remaining options into alphabetical order
- The country selector was triggering an onConfirm event onBlur which was causing an error if the user clicked away from the select options without making a selection
- The pointer was missing the select element when hovering over the custom arrow

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes


