### PR TITLE
GL-664: Add logic to determine next question page.

### DIFF
--- a/app/controllers/green_lanes/moving_requirements_controller.rb
+++ b/app/controllers/green_lanes/moving_requirements_controller.rb
@@ -52,13 +52,23 @@ module GreenLanes
 
       @categories = @determine_categories.categories
 
-      case @categories
-      when [:cat_1], [:cat_2], [:cat_3]
+      next_page = DetermineQuestionPage.new(goods_nomenclature).next_page
+
+      case next_page
+      when :result # Result Cat1, Cat2 or Cat3
         render 'result'
+      when :cat_1_exemptions_questions
+        redirect_to cat_1_questions_green_lanes_check_moving_requirements_path
+      when :cat_2_exemptions_questions
+        redirect_to cat_2_questions_green_lanes_check_moving_requirements_path
       else
         render 'generic_result'
       end
     end
+
+    def cat_1_exemptions_questions; end
+
+    def cat_2_exemptions_questions; end
 
     private
 

--- a/app/services/green_lanes/determine_category.rb
+++ b/app/services/green_lanes/determine_category.rb
@@ -13,6 +13,8 @@ module GreenLanes
       return [:cat_3] if category_assessments.empty? # Result 3
       return [:cat_1] if cat1_without_exemptions.any? # Result 1
 
+      # cat1_without_exemptions NO
+
       if cat2_without_exemptions.any?
         if cat1_with_exemptions.any?
           %i[cat_1 cat_2] # Result 4

--- a/app/services/green_lanes/determine_question_page.rb
+++ b/app/services/green_lanes/determine_question_page.rb
@@ -1,0 +1,21 @@
+module GreenLanes
+  class DetermineQuestionPage
+    def initialize(goods_nomenclature)
+      @categories = GreenLanes::DetermineCategory.new(goods_nomenclature).categories
+    end
+
+    def next_page
+      case @categories
+      when [:cat_1], [:cat_2], [:cat_3]
+        :result
+      when %i[cat_1 cat_2],
+           %i[cat_1 cat_2 cat_3]
+        :cat_1_exemptions_questions
+      when %i[cat_2 cat_3]
+        :cat_2_exemptions_questions
+      else
+        raise 'Impossible to determine next page'
+      end
+    end
+  end
+end

--- a/app/views/green_lanes/moving_requirements/cat_1_exemptions_questions.html.erb
+++ b/app/views/green_lanes/moving_requirements/cat_1_exemptions_questions.html.erb
@@ -1,0 +1,35 @@
+<% content_for :back_link do %>
+  <% back_link home_path %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-static-margin-top-7">
+
+  <div class="govuk-grid-column-two-thirds">
+    <header>
+      <h1 class="govuk-heading-l">
+        Cat 1 exemptions questions
+      </h1>
+    </header>
+
+    <%= render '/green_lanes/shared/support_email_section' %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <div class="gem-c-related-navigation">
+      <h2 class="gem-c-related-navigation__main-heading">
+        Subsections
+      </h2>
+
+      <nav class="gem-c-related-navigation__nav-section">
+        <ul class="gem-c-related-navigation__link-list">
+          <li class="gem-c-related-navigation__link">
+            <%= link_to 'Related Link 1', 'link1' %>
+          </li>
+          <li class="gem-c-related-navigation__link">
+            <%= link_to 'Related Link 2', 'link2' %>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/app/views/green_lanes/moving_requirements/cat_2_exemptions_questions.html.erb
+++ b/app/views/green_lanes/moving_requirements/cat_2_exemptions_questions.html.erb
@@ -1,0 +1,35 @@
+<% content_for :back_link do %>
+  <% back_link home_path %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-static-margin-top-7">
+
+  <div class="govuk-grid-column-two-thirds">
+    <header>
+      <h1 class="govuk-heading-l">
+        Cat 2 exemptions questions
+      </h1>
+    </header>
+
+    <%= render '/green_lanes/shared/support_email_section' %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <div class="gem-c-related-navigation">
+      <h2 class="gem-c-related-navigation__main-heading">
+        Subsections
+      </h2>
+
+      <nav class="gem-c-related-navigation__nav-section">
+        <ul class="gem-c-related-navigation__link-list">
+          <li class="gem-c-related-navigation__link">
+            <%= link_to 'Related Link 1', 'link1' %>
+          </li>
+          <li class="gem-c-related-navigation__link">
+            <%= link_to 'Related Link 2', 'link2' %>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,8 @@ Rails.application.routes.draw do
       resource :check_moving_requirements, controller: 'moving_requirements', only: %i[update edit] do
         get 'start'
         get 'result'
+        get 'cat_1_exemptions_questions', as: :cat_1_questions
+        get 'cat_2_exemptions_questions', as: :cat_2_questions
       end
     end
   end

--- a/spec/services/green_lanes/determine_question_page_spec.rb
+++ b/spec/services/green_lanes/determine_question_page_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+RSpec.describe ::GreenLanes::DetermineQuestionPage do
+  describe '#next_page' do
+    # [cat_3]
+    context 'when there are no category assessments' do
+      let(:goods_nomenclature) do
+        build(:green_lanes_goods_nomenclature, applicable_category_assessments: [])
+      end
+
+      it 'next page is result' do
+        expect(described_class.new(goods_nomenclature).next_page).to eq(:result)
+      end
+    end
+
+    # [cat_1]
+    context 'when there are category assessments' do
+      context 'when there are Cat1 without exemptions' do
+        let(:goods_nomenclature) do
+          build(:green_lanes_goods_nomenclature, applicable_category_assessments: assessments)
+        end
+
+        let(:assessments) { [attributes_for(:category_assessment, category: 1)] }
+
+        it 'next page is result' do
+          expect(described_class.new(goods_nomenclature).next_page).to eq(:result)
+        end
+      end
+
+      # [cat_2]
+      context 'when there are not Cat1 AND there are Cat2 without exemptions' do
+        let(:goods_nomenclature) do
+          build(:green_lanes_goods_nomenclature, applicable_category_assessments: assessments)
+        end
+
+        let(:assessments) { [attributes_for(:category_assessment, category: 2)] }
+
+        it 'next page is result' do
+          expect(described_class.new(goods_nomenclature).next_page).to eq(:result)
+        end
+      end
+
+      # [cat_1, cat_2]
+      context 'when there are Cat1 with exemptions AND Cat2 without exemptions' do
+        let(:goods_nomenclature) do
+          build(:green_lanes_goods_nomenclature, applicable_category_assessments: assessments)
+        end
+
+        let(:assessments) do
+          [
+            attributes_for(:category_assessment, :with_exemptions, category: 1),
+            attributes_for(:category_assessment, category: 2),
+          ]
+        end
+
+        it 'next page is cat_1_exemptions_questions' do
+          expect(described_class.new(goods_nomenclature).next_page).to eq(:cat_1_exemptions_questions)
+        end
+      end
+
+      # [cat_1 cat_2 cat_3]
+      context 'when there are Cat1 with exemptions AND there are Cat2 with exemptions' do
+        let(:goods_nomenclature) do
+          build(:green_lanes_goods_nomenclature, applicable_category_assessments: assessments)
+        end
+
+        let(:assessments) do
+          [
+            attributes_for(:category_assessment, :with_exemptions, category: 1),
+            attributes_for(:category_assessment, :with_exemptions, category: 2),
+          ]
+        end
+
+        it 'next page is cat_1_exemptions_questions' do
+          expect(described_class.new(goods_nomenclature).next_page).to eq(:cat_1_exemptions_questions)
+        end
+      end
+
+      # [cat1, cat_2, cat_3] + cat_1 question assessment
+      # context 'when there are Cat1 with exemptions AND Cat2 with exemptions' \
+      #         'and NOT Cat1 without exemptions AND NOT Cat2 without exemptions' do
+      #   let(:goods_nomenclature) do
+      #     build(:green_lanes_goods_nomenclature, applicable_category_assessments: assessments)
+      #   end
+
+      #   let(:assessments) do
+      #     [
+      #       attributes_for(:category_assessment, :with_exemptions, category: 1),
+      #       attributes_for(:category_assessment, :with_exemptions, category: 2)
+      #     ]
+      #   end
+
+      #   it 'next page is cat_2_exemptions_questions' do
+      #     expect(
+      #       described_class.new(goods_nomenclature).next_page(no_cat_1_exemptions_apply: true)
+      #     ).to eq(:cat_2_exemptions_questions)
+      #   end
+      # end
+
+      # [cat_2, cat_3]
+      context 'when there are not Cat1 AND there are only Cat2 with exemptions' do
+        let(:goods_nomenclature) do
+          build(:green_lanes_goods_nomenclature, applicable_category_assessments: assessments)
+        end
+
+        let(:assessments) { [attributes_for(:category_assessment, :with_exemptions, category: 2)] }
+
+        it 'next page is cat_1_exemptions_questions' do
+          expect(described_class.new(goods_nomenclature).next_page).to eq(:cat_2_exemptions_questions)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What?
Add logic to determine the next question page.
Add placeholder for Cat 1 and Cat 2 exemptions question pages.

### Jira link
https://transformuk.atlassian.net/browse/GL-664

### Why?
To iterate towards the final user journey to assess the goods to Cat 1, 2 or 3 
