### PR TITLE
BAU: Fixes category assessment fieldset inputs

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -27,8 +27,10 @@ Terraform to deploy the service into AWS.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.emails](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_document.emails](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.secretsmanager_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_lb_target_group.beta](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |

--- a/terraform/beta.tf
+++ b/terraform/beta.tf
@@ -29,8 +29,11 @@ module "beta_service" {
   ]
 
   task_role_policy_arns = [
+    aws_iam_policy.exec.arn,
     aws_iam_policy.emails.arn
   ]
+
+  enable_ecs_exec = true
 
   service_environment_config = [
     {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -52,3 +52,24 @@ resource "aws_iam_policy" "emails" {
   name   = "frontend-task-role-emails-policy"
   policy = data.aws_iam_policy_document.emails.json
 }
+
+data "aws_iam_policy_document" "exec" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "exec" {
+  name   = "frontend-task-role-exec-policy"
+  policy = data.aws_iam_policy_document.exec.json
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,8 +29,11 @@ module "service" {
   ]
 
   task_role_policy_arns = [
+    aws_iam_policy.exec.arn,
     aws_iam_policy.emails.arn
   ]
+
+  enable_ecs_exec = true
 
   service_environment_config = [
     {


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Enable ecs-exec
- [x] Fixes issue with fieldset input not showing category assessment id

### Why?

I am doing this because:

- This is broken
- ECS exec was used to debug the live service
