### PR TITLE
Fix some broken logic with at least one exemption not showing for a CA

### DIFF
--- a/app/controllers/green_lanes/check_your_answers_controller.rb
+++ b/app/controllers/green_lanes/check_your_answers_controller.rb
@@ -21,34 +21,27 @@ module GreenLanes
     private
 
     def determine_back_link_path(permitted_params)
-      cat_2_questions_exist = !permitted_params[:ans]['2'].nil?
-      cat_1_questions_dont_exist = permitted_params[:ans]['1'].nil?
+      ans = permitted_params[:ans]
+      category = if ans.nil?
+                   1
+                 elsif ans['2'].present?
+                   2
+                 else
+                   1
+                 end
 
-      if cat_2_questions_exist
-        new_green_lanes_applicable_exemptions_path(
-          category: 2,
-          commodity_code: permitted_params[:commodity_code],
-          country_of_origin: permitted_params[:country_of_origin],
-          moving_date: permitted_params[:moving_date],
-          ans: permitted_params[:ans],
-          c1ex: permitted_params[:c1ex],
-          c2ex: permitted_params[:c2ex],
-        )
-      elsif cat_1_questions_dont_exist
-        new_green_lanes_moving_requirements_path(
-          commodity_code: permitted_params[:commodity_code],
-          country_of_origin: permitted_params[:country_of_origin],
-          moving_date: permitted_params[:moving_date],
-        )
+      base_params = {
+        commodity_code: permitted_params[:commodity_code],
+        country_of_origin: permitted_params[:country_of_origin],
+        moving_date: permitted_params[:moving_date],
+      }
+
+      if category == 2
+        new_green_lanes_applicable_exemptions_path(base_params.merge(category:, ans:, c1ex: permitted_params[:c1ex], c2ex: permitted_params[:c2ex]))
+      elsif ans.nil? || ans['1'].nil?
+        new_green_lanes_moving_requirements_path(base_params)
       else
-        new_green_lanes_applicable_exemptions_path(
-          category: 1,
-          commodity_code: permitted_params[:commodity_code],
-          country_of_origin: permitted_params[:country_of_origin],
-          moving_date: permitted_params[:moving_date],
-          ans: permitted_params[:ans],
-          c1ex: permitted_params[:c1ex],
-        )
+        new_green_lanes_applicable_exemptions_path(base_params.merge(category:, ans:, c1ex: permitted_params[:c1ex]))
       end
     end
 

--- a/app/controllers/green_lanes/results_controller.rb
+++ b/app/controllers/green_lanes/results_controller.rb
@@ -14,6 +14,7 @@ module GreenLanes
       @category = category
       @answers = JSON.parse(results_params[:ans].presence || '{}')
       @assessments = AssessmentsPresenter.new(determine_category, @answers)
+      @cas_without_exemptions = cas_without_exemptions
     end
 
     private
@@ -27,6 +28,12 @@ module GreenLanes
         :c2ex,
         :ans,
       )
+    end
+
+    def cas_without_exemptions
+      return [] if @category == '3'
+
+      determine_category.public_send("cat#{category}_without_exemptions")
     end
 
     def determine_category

--- a/app/presenters/green_lanes/assessments_presenter.rb
+++ b/app/presenters/green_lanes/assessments_presenter.rb
@@ -27,10 +27,14 @@ module GreenLanes
     end
 
     def cat_1_exemptions_met
+      return [] if @answers.nil?
+
       process_exemptions(@answers['1'])
     end
 
     def cat_2_exemptions_met
+      return [] if @answers.nil?
+
       process_exemptions(@answers['2'])
     end
 

--- a/app/services/green_lanes/determine_next_page.rb
+++ b/app/services/green_lanes/determine_next_page.rb
@@ -31,6 +31,7 @@ module GreenLanes
     end
 
     def handle_cat1_cat2(cat_1_exemptions_apply)
+      return check_your_answers if @determine_category.cat1_without_exemptions.present?
       return new_exemptions_path(1) if question_unanswered?(cat_1_exemptions_apply) && @determine_category.cat1_with_exemptions.present?
 
       check_your_answers

--- a/app/views/green_lanes/check_your_answers/show.html.erb
+++ b/app/views/green_lanes/check_your_answers/show.html.erb
@@ -11,14 +11,16 @@
                edit_path: 'EDIT GOOD DETAILS PAGE'
     %>
 
-    <h2 class="govuk-heading-m">Category exemptions</h2>
+    <% unless @category_one_assessments.empty? || @answers.nil? %>
+      <h2 class="govuk-heading-m">Category exemptions</h2>
 
-    <%= render 'category_exemptions',
-               title: 'Category 1 exemptions',
-               category: '1',
-               assessments: @category_one_assessments,
-               edit_path: 'EDIT PATH HERE CAT 1 questions'
-    %>
+      <%= render 'category_exemptions',
+                 title: 'Category 1 exemptions',
+                 category: '1',
+                 assessments: @category_one_assessments,
+                 edit_path: 'EDIT PATH HERE CAT 1 questions'
+      %>
+    <% end %>
 
     <% if all_exemptions_met?(1, @category_one_assessments, @answers) %>
       <%= render 'category_exemptions',

--- a/app/views/green_lanes/results/_category_assessments_card.erb
+++ b/app/views/green_lanes/results/_category_assessments_card.erb
@@ -7,13 +7,14 @@
 
   <div class="govuk-summary-card__content">
     <dl class="govuk-summary-list">
-      <% @assessments.public_send("cat_#{category}_exemptions_not_met").each do |category_assessment| %>
+      <% assessments = @cas_without_exemptions.present? ? @cas_without_exemptions : @assessments.public_send("cat_#{category}_exemptions_not_met") %>
+
+      <% assessments.each do |category_assessment| %>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
             <p>
               Annex IV of the Windsor Framework: "<%= category_assessment.theme.to_s %>"
             </p>
-
 
             <p><%= category_assessment.regulation.description %></p>
 
@@ -21,11 +22,9 @@
               <%= link_to 'View EU Regulation document', category_assessment.regulation_url, class: 'govuk-link' %>
             <% end %>
 
-            <% if category_assessment.exemptions.none? %>
-              <p class='govuk-!-margin-top-4'>No exemptions available</p>
-            <% else %>
-              <p class='govuk-!-margin-top-4'>Exemptions not met</p>
-            <% end %>
+            <p class='govuk-!-margin-top-4'>
+              <%= @cas_without_exemptions.present? ? 'No exemptions available' : (category_assessment.exemptions.none? ? 'No exemptions available' : 'Exemptions not met') %>
+            </p>
           </dd>
         </div>
       <% end %>

--- a/app/views/green_lanes/results/_result_category_3.html.erb
+++ b/app/views/green_lanes/results/_result_category_3.html.erb
@@ -64,4 +64,6 @@
 
 <%= render 'green_lanes/shared/about_your_goods_card', title: 'Your movement of goods', edit_path: 'EDIT GOOD DETAILS PAGE' %>
 
-<%= render_exemptions(@assessments, @category) %>
+<% unless @answers.nil? %>
+  <%= render_exemptions(@assessments, @category) %>
+<% end %>


### PR DESCRIPTION
https://transformuk.atlassian.net/browse/GL-923

This PR handles some of the broken logic when if a commodity returns at least one Ca without an exemption the user should be skipped to the CYA page and not the exemption questions page.

Also fixes an error where no answers are provided in the exemptions questionaire
