### PR TITLE
GL-925: Fix GL check eligibility start links.

### DIFF
--- a/app/helpers/green_lanes_helper.rb
+++ b/app/helpers/green_lanes_helper.rb
@@ -63,6 +63,10 @@ module GreenLanesHelper
     [OpenStruct.new(id: 'yes', name: 'Yes'), OpenStruct.new(id: 'no', name: 'No'), OpenStruct.new(id: 'not_sure', name: 'Not sure')]
   end
 
+  def green_lanes_eligibility_start_path
+    '/green_lanes/start/new'
+  end
+
   private
 
   def category_assessments_checked(category_assessment_id)

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -34,7 +34,10 @@
     <strong> New process for moving goods from Great Britain to Northern Ireland</strong>
   </div>
 
-  <p class="govuk-!-margin-bottom-6"><%= link_to 'Check eligibility for the simplified process for internal market movements (SPIMM)', new_green_lanes_start_path %>, available to UKIMS authorised traders from 30th September 2024.</p>
+  <p class="govuk-!-margin-bottom-6">
+    <%= link_to 'Check eligibility for the simplified process for internal market movements (SPIMM)', green_lanes_eligibility_start_path %>
+    , available to UKIMS authorised traders from 30th September 2024.
+  </p>
 <% end %>
 
 

--- a/app/views/find_commodities/show.html.erb
+++ b/app/views/find_commodities/show.html.erb
@@ -128,7 +128,10 @@
               <strong> New process for moving goods from Great Britain to Northern Ireland</strong>
             </div>
 
-            <p class="govuk-!-margin-bottom-6"><%= link_to 'Check eligibility for the simplified process for internal market movements (SPIMM)',new_green_lanes_start_path %>, available to UKIMS authorised traders from 30th September 2024.</p>
+            <p class="govuk-!-margin-bottom-6">
+              <%= link_to 'Check eligibility for the simplified process for internal market movements (SPIMM)',green_lanes_eligibility_start_path %>
+              , available to UKIMS authorised traders from 30th September 2024.
+            </p>
           <% end %>
         </div>
       </div>

--- a/app/views/pages/_howto_sidebar_links.html.erb
+++ b/app/views/pages/_howto_sidebar_links.html.erb
@@ -30,8 +30,10 @@
 
         <% if TradeTariffFrontend.green_lanes_enabled? %>
           <li class="gem-c-related-navigation__link">
-            <%= link_to 'Check if you are eligible for the simplified process for internal market movements from Great Britain to Northern Ireland (SPIMM).', new_green_lanes_start_path, class: 'govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar govuk-link gem-c-related-navigation__section-link--other' %>
-
+            <%= link_to 'Check if you are eligible for the simplified process for internal market movements from Great Britain to Northern Ireland (SPIMM).',
+              green_lanes_eligibility_start_path,
+              class: 'govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar govuk-link gem-c-related-navigation__section-link--other'
+            %>
           </li>
         <% end %>
       </ul>

--- a/spec/helpers/green_lanes_helper_spec.rb
+++ b/spec/helpers/green_lanes_helper_spec.rb
@@ -145,6 +145,11 @@ RSpec.describe GreenLanesHelper, type: :helper do
         expect(helper).to have_received(:render_exemptions_or_no_card).with(2, assessments, '2')
       end
     end
+
+    describe '#green_lanes_eligibility_start_path' do
+      it { expect(helper.green_lanes_eligibility_start_path).to eq('/green_lanes/start/new') }
+    end
+
     # rubocop:enable RSpec/InstanceVariable
   end
 end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/GL-925

### What?
Fix GL check eligibility start links.
The XI of the GL link does not exist.

### Why?
To fix broken links
