### PR TITLE
This allow the segments of the date (year, month and day)

### DIFF
--- a/app/controllers/green_lanes/applicable_exemptions_controller.rb
+++ b/app/controllers/green_lanes/applicable_exemptions_controller.rb
@@ -102,14 +102,6 @@ module GreenLanes
       params.permit(:commodity_code, :country_of_origin, :moving_date)
     end
 
-    def moving_requirements_params
-      params.require(:green_lanes_moving_requirements_form).permit(
-        :commodity_code,
-        :country_of_origin,
-        :moving_date,
-      )
-    end
-
     def category
       @category ||= params[:category].to_i
     end

--- a/app/forms/green_lanes/moving_requirements_form.rb
+++ b/app/forms/green_lanes/moving_requirements_form.rb
@@ -10,16 +10,13 @@ module GreenLanes
 
     attribute :commodity_code, :string
     attribute :country_of_origin, :string
+    attr_reader :moving_date
 
     def moving_date=(date)
       date ||= {}
 
-      @moving_date = if valid_moving_date?(date)
-                       Date.new(date[YEAR], date[MONTH], date[DAY])
-                     end
+      @moving_date = valid_moving_date?(date) ? convert_to_date(date) : nil
     end
-
-    attr_reader :moving_date
 
     validates :commodity_code, length: { is: 10 },
                                format: { with: /\A\d+\z/, message: :only_numbers }
@@ -38,13 +35,25 @@ module GreenLanes
     private
 
     def valid_moving_date?(date)
-      Date.new(date[YEAR], date[MONTH], date[DAY])
-
       raise ArgumentError unless date[YEAR].to_s.length == 4
+
+      unless only_digits?(date[YEAR]) && only_digits?(date[MONTH]) && only_digits?(date[DAY])
+        raise ArgumentError
+      end
+
+      convert_to_date(date)
 
       true
     rescue ArgumentError, TypeError
       false
+    end
+
+    def only_digits?(str)
+      /^\d+$/.match?(str)
+    end
+
+    def convert_to_date(date)
+      Date.new(date[YEAR].to_i, date[MONTH].to_i, date[DAY].to_i)
     end
   end
 end

--- a/app/views/green_lanes/moving_requirements/new.html.erb
+++ b/app/views/green_lanes/moving_requirements/new.html.erb
@@ -33,14 +33,16 @@
                               style: "width:330px" %>
 
       <%= f.label :commodity_code, "When is the internal movement of goods taking place?", class: 'govuk-heading-m',
-                  for: 'green_lanes_moving_requirements_form_moving_date_3i' %>
+                  for: 'green_lanes_moving_requirements_form_moving_date_3' %>
 
       <%= f.govuk_date_field :moving_date,
         maxlength_enabled: true,
         hint: { text: "Arrangements can change over time. If you do not know the date of movement and want to check arrangements currently in place, enter today's date.",
                       class: 'govuk-body-l'
               },
-        legend: nil %>
+        legend: nil,
+        segments: { day: '3', month: '2', year: '1' } # This prevents casting the segments to Integer (3i, 2i, 1i)
+        %>
 
         <%= f.submit "Continue", class: "govuk-button" %>
     <% end %>

--- a/spec/features/green_lanes_category_assessments_spec.rb
+++ b/spec/features/green_lanes_category_assessments_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe 'Green lanes category assessments',
 
     select 'United States (US)', from: 'green-lanes-moving-requirements-form-country-of-origin-field'
 
-    fill_in 'green_lanes_moving_requirements_form_moving_date_3i', with: '12'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_2i', with: '8'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_1i', with: '2024'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_3', with: '12'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_2', with: '8'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_1', with: '2024'
 
     click_on 'Continue'
 
@@ -46,9 +46,9 @@ RSpec.describe 'Green lanes category assessments',
 
     select 'Morocco (MA)', from: 'green-lanes-moving-requirements-form-country-of-origin-field'
 
-    fill_in 'green_lanes_moving_requirements_form_moving_date_3i', with: '12'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_2i', with: '8'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_1i', with: '2024'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_3', with: '12'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_2', with: '8'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_1', with: '2024'
 
     click_on 'Continue'
 
@@ -67,9 +67,9 @@ RSpec.describe 'Green lanes category assessments',
 
     select 'Bangladesh (BD)', from: 'green-lanes-moving-requirements-form-country-of-origin-field'
 
-    fill_in 'green_lanes_moving_requirements_form_moving_date_3i', with: '12'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_2i', with: '8'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_1i', with: '2024'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_3', with: '12'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_2', with: '8'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_1', with: '2024'
 
     click_on 'Continue'
 
@@ -90,9 +90,9 @@ RSpec.describe 'Green lanes category assessments',
 
     select 'Ukraine (UA)', from: 'green-lanes-moving-requirements-form-country-of-origin-field'
 
-    fill_in 'green_lanes_moving_requirements_form_moving_date_3i', with: '12'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_2i', with: '8'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_1i', with: '2024'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_3', with: '12'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_2', with: '8'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_1', with: '2024'
 
     click_on 'Continue'
 
@@ -118,9 +118,9 @@ RSpec.describe 'Green lanes category assessments',
 
     select 'Ukraine (UA)', from: 'green-lanes-moving-requirements-form-country-of-origin-field'
 
-    fill_in 'green_lanes_moving_requirements_form_moving_date_3i', with: '12'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_2i', with: '8'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_1i', with: '2024'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_3', with: '12'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_2', with: '8'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_1', with: '2024'
 
     click_on 'Continue'
 
@@ -148,9 +148,9 @@ RSpec.describe 'Green lanes category assessments',
 
     select 'Ukraine (UA)', from: 'green-lanes-moving-requirements-form-country-of-origin-field'
 
-    fill_in 'green_lanes_moving_requirements_form_moving_date_3i', with: '12'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_2i', with: '8'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_1i', with: '2024'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_3', with: '12'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_2', with: '8'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_1', with: '2024'
 
     click_on 'Continue'
 
@@ -180,9 +180,9 @@ RSpec.describe 'Green lanes category assessments',
 
     select 'Iran, Islamic Republic of (IR)', from: 'green-lanes-moving-requirements-form-country-of-origin-field'
 
-    fill_in 'green_lanes_moving_requirements_form_moving_date_3i', with: '12'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_2i', with: '8'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_1i', with: '2024'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_3', with: '12'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_2', with: '8'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_1', with: '2024'
 
     click_on 'Continue'
 
@@ -218,9 +218,9 @@ RSpec.describe 'Green lanes category assessments',
 
     select 'Iran, Islamic Republic of (IR)', from: 'green-lanes-moving-requirements-form-country-of-origin-field'
 
-    fill_in 'green_lanes_moving_requirements_form_moving_date_3i', with: '12'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_2i', with: '8'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_1i', with: '2024'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_3', with: '12'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_2', with: '8'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_1', with: '2024'
 
     click_on 'Continue'
 
@@ -256,9 +256,9 @@ RSpec.describe 'Green lanes category assessments',
 
     select 'Greenland (GL)', from: 'green-lanes-moving-requirements-form-country-of-origin-field'
 
-    fill_in 'green_lanes_moving_requirements_form_moving_date_3i', with: '12'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_2i', with: '8'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_1i', with: '2024'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_3', with: '12'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_2', with: '8'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_1', with: '2024'
 
     click_on 'Continue'
 
@@ -294,9 +294,9 @@ RSpec.describe 'Green lanes category assessments',
 
     select 'Greenland (GL)', from: 'green-lanes-moving-requirements-form-country-of-origin-field'
 
-    fill_in 'green_lanes_moving_requirements_form_moving_date_3i', with: '12'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_2i', with: '8'
-    fill_in 'green_lanes_moving_requirements_form_moving_date_1i', with: '2024'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_3', with: '12'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_2', with: '8'
+    fill_in 'green_lanes_moving_requirements_form_moving_date_1', with: '2024'
 
     click_on 'Continue'
 

--- a/spec/forms/green_lanes/moving_requirements_form_spec.rb
+++ b/spec/forms/green_lanes/moving_requirements_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe GreenLanes::MovingRequirementsForm, type: :model do
         {
           commodity_code: '6203000000',
           country_of_origin: 'IT',
-          moving_date: { year => 2022, month => 2, day => 3 },
+          moving_date: { year => '2022', month => '2', day => '3' },
         }
       end
 
@@ -27,7 +27,7 @@ RSpec.describe GreenLanes::MovingRequirementsForm, type: :model do
         {
           commodity_code: '1234567890',
           country_of_origin: 'IT',
-          moving_date: { year => 2022, month => 2, day => 3 },
+          moving_date: { year => '2022', month => '2', day => '3' },
         }
       end
 
@@ -56,7 +56,7 @@ RSpec.describe GreenLanes::MovingRequirementsForm, type: :model do
     describe 'date validation' do
       context 'when day is empty' do
         let(:params) do
-          { moving_date: { year => 1998, month => 12, day => nil } }
+          { moving_date: { year => '1998', month => '12', day => '' } }
         end
 
         it { expect(form.errors[:moving_date]).to eq(['Enter a valid date, for example, 01 02 2024']) }
@@ -64,7 +64,7 @@ RSpec.describe GreenLanes::MovingRequirementsForm, type: :model do
 
       context 'when year is 2 digit instead of 4' do
         let(:params) do
-          { moving_date: { year => 24, month => 12, day => 20 } }
+          { moving_date: { year => '24', month => '12', day => '20' } }
         end
 
         it { expect(form.errors[:moving_date]).to eq(['Enter a valid date, for example, 01 02 2024']) }
@@ -72,7 +72,7 @@ RSpec.describe GreenLanes::MovingRequirementsForm, type: :model do
 
       context 'when date is correct' do
         let(:params) do
-          { moving_date: { year => 2024, month => 12, day => 20 } }
+          { moving_date: { year => '2024', month => '12', day => '20' } }
         end
 
         it { expect(form.errors[:moving_date]).to be_empty }


### PR DESCRIPTION
### What?
This allows the segments of the date (year, month and day)
to be passed inside the Form Validation as strings and not being casted to integer (allowing a fine-grained validation)

### Why?
to reckon as invalid, date like this one:  "1! 12 2024"
