### PR TITLE
GL-962: Fix applicable exemptions form bug

### DIFF
--- a/app/helpers/green_lanes_helper.rb
+++ b/app/helpers/green_lanes_helper.rb
@@ -72,8 +72,4 @@ module GreenLanesHelper
   def category_assessments_checked(category_assessment_id)
     params.dig(:exemptions, :category_assessments_checked, category_assessment_id.to_s)
   end
-
-  def dig_category_answer(answers, category, category_assessment_id)
-    answers.dig(category.to_s, category_assessment_id.to_s)
-  end
 end

--- a/app/helpers/green_lanes_helper.rb
+++ b/app/helpers/green_lanes_helper.rb
@@ -10,7 +10,7 @@ module GreenLanesHelper
   def render_exemptions_or_no_card(category, assessments, result)
     no_exemptions = assessments.send("no_cat#{category}_exemptions")
     assessments_met = assessments.send("cat_#{category}_assessments_met")
-    total_assessments = assessments.send("cat_#{category}_assessments").pluck(:category_assessment_id).map(&:to_s)
+    total_assessments = assessments.send("cat_#{category}_assessments").pluck(:resource_id).map(&:to_s)
 
     all_assessments_met = total_assessments.count == assessments_met.count
 
@@ -71,5 +71,9 @@ module GreenLanesHelper
 
   def category_assessments_checked(category_assessment_id)
     params.dig(:exemptions, :category_assessments_checked, category_assessment_id.to_s)
+  end
+
+  def dig_category_answer(answers, category, category_assessment_id)
+    answers.dig(category.to_s, category_assessment_id.to_s)
   end
 end

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -28,8 +28,10 @@ class GreenLanes::CategoryAssessment
   end
 
   def answered_exemptions(answers)
+    applicable_answers = answers.dig(category.to_s, resource_id.to_s) || []
+
     exemptions.select do |exemption|
-      answers.dig(category.to_s, category_assessment_id.to_s).include?(exemption.code)
+      applicable_answers.include?(exemption.code)
     end
   end
 end

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -17,14 +17,19 @@ class GreenLanes::CategoryAssessment
   }
 
   delegate :category, to: :theme
+  delegate :regulation_url, to: :regulation
 
   def id
-    "category_assessment_#{category_assessment_id}"
+    "category_assessment_#{resource_id}"
   end
 
   def find(_id, _opts = {})
     raise NoMethodError, 'This method is not implemented'
   end
 
-  delegate :regulation_url, to: :regulation
+  def answered_exemptions(answers)
+    exemptions.select do |exemption|
+      answers.dig(category.to_s, category_assessment_id.to_s).include?(exemption.code)
+    end
+  end
 end

--- a/app/views/green_lanes/check_your_answers/_category_exemptions.html.erb
+++ b/app/views/green_lanes/check_your_answers/_category_exemptions.html.erb
@@ -1,4 +1,4 @@
-<% unless assessments.flat_map(&:exemptions).empty? %>
+<% if assessments.flat_map(&:exemptions).any? %>
   <div class="govuk-summary-card">
     <div class="govuk-summary-card__title-wrapper">
       <h2 class="govuk-summary-card__title"><%= title %></h2>

--- a/app/views/green_lanes/check_your_answers/show.html.erb
+++ b/app/views/green_lanes/check_your_answers/show.html.erb
@@ -8,8 +8,7 @@
 
     <%= render 'green_lanes/shared/about_your_goods_card',
                title: 'About your goods',
-               edit_path: 'EDIT GOOD DETAILS PAGE'
-    %>
+               edit_path: 'EDIT GOOD DETAILS PAGE' %>
 
     <% unless @category_one_assessments.empty? || @answers.nil? %>
       <h2 class="govuk-heading-m">Category exemptions</h2>
@@ -18,8 +17,7 @@
                  title: 'Category 1 exemptions',
                  category: '1',
                  assessments: @category_one_assessments,
-                 edit_path: 'EDIT PATH HERE CAT 1 questions'
-      %>
+                 edit_path: 'EDIT PATH HERE CAT 1 questions' %>
     <% end %>
 
     <% if all_exemptions_met?(1, @category_one_assessments, @answers) && @category_two_assessments_without_exemptions.empty? %>
@@ -27,8 +25,7 @@
                  title: 'Category 2 exemptions',
                  category: '2',
                  assessments: @category_two_assessments,
-                 edit_path: 'EDIT PATH HERE CAT 2 questions'
-      %>
+                 edit_path: 'EDIT PATH HERE CAT 2 questions' %>
     <% end %>
 
     <div class="govuk-button-group">

--- a/app/views/green_lanes/results/_exemptions_card.html.erb
+++ b/app/views/green_lanes/results/_exemptions_card.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-summary-card__content">
     <div class="govuk-summary-list">
       <% @assessments.public_send("cat#{category}_with_exemptions").each do |category_assessment| %>
-        <% category_assessment.exemptions.select { |exemption| dig_category_answer(@answers, category, category_assessment.category_assessment_id).include?(exemption.code) }.each do |exemption| %>
+        <% category_assessment.answered_exemptions(@answers).each do |exemption| %>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
               <%= exemption.code %>

--- a/app/views/green_lanes/results/_result_category_2.html.erb
+++ b/app/views/green_lanes/results/_result_category_2.html.erb
@@ -30,15 +30,13 @@
   <li>
     <%= link_to 'Become an authorised trader under the UK Internal Market Scheme (UKIMS) (opens in a new tab)',
                 'https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland',
-                target: '_blank', rel: 'noopener noreferrer'
-    %> if you are not already.
+                target: '_blank', rel: 'noopener noreferrer' %> if you are not already.
   </li>
   <li>Prepare an Internal Market Movement Information (IMMI) submission either pre-movement or post-movement, depending on your preference.</li>
   <li>Submit the IMMI using a customs agent, or free-to-use services provided by the
       <%= link_to 'Trader Support Service (TSS) (opens in a new tab).',
                 'https://www.gov.uk/guidance/trader-support-service',
-                target: '_blank', rel: 'noopener noreferrer'
-      %>
+                target: '_blank', rel: 'noopener noreferrer' %>
   </li>
 </ol>
 
@@ -64,7 +62,6 @@
 <%= render 'green_lanes/shared/about_your_goods_card',
             title: 'Your goods',
             optional_rows: [:category],
-            edit_path: 'EDIT GOOD DETAILS PAGE'
-%>
+            edit_path: 'EDIT GOOD DETAILS PAGE' %>
 
 <%= render_exemptions(@assessments, @category) %>

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
       category { 2 }
     end
 
+    resource_id  { '37f58c7ec2982bf82ab238d33b376b4f' }
     theme        { attributes_for :green_lanes_theme, category: }
     measure_type { attributes_for :measure_type }
     regulation   { attributes_for :legal_act }

--- a/spec/features/green_lanes_category_assessments_spec.rb
+++ b/spec/features/green_lanes_category_assessments_spec.rb
@@ -6,17 +6,6 @@ RSpec.describe 'Green lanes category assessments',
                  record: :new_episodes,
                },
                js: true do
-  # 1 - direct to cat 1 (no exemptions) "6912002310", "USA"
-  # 2 - direct to cat 2 (no exemptions) "2402209000", "Italy"
-  # 3 - direct to cat 3 "3926200000", "Bangladesh"
-  # 4 - cat 1 with exemptions, exemptions don't apply "0808108090" "Ukraine"
-  # 5 - 2204101500 Ukraine
-  # 6 - 0808108090 Ukraine
-
-  # 7 - 3926909790 Iran
-  # 8 - 3926909790 Iran
-  # 9 - 1904901000 China
-  # 10 - 1904901000 China
   scenario 'direct to category 1' do
     visit new_green_lanes_moving_requirements_path
 
@@ -96,16 +85,14 @@ RSpec.describe 'Green lanes category assessments',
 
     click_on 'Continue'
 
-    check 'exemptions-category-assessment-34-none-field'
-    check 'exemptions-category-assessment-82-none-field'
+    check 'exemptions-category-assessment-a6b633a7b098132ec45c036d0e14713a-none-field'
+    check 'exemptions-category-assessment-18fcbb5b75781f8a676bd84dae9c170e-none-field'
 
     click_on 'Continue'
 
     expect(page).to have_current_path(green_lanes_check_your_answers_path, ignore_query: true)
 
     click_on 'Continue'
-
-    expect(page).to have_css('h1', text: 'Category 1')
   end
 
   scenario 'Given the commodity has Cat1 exemptions \
@@ -126,8 +113,8 @@ RSpec.describe 'Green lanes category assessments',
 
     expect(page).to have_text('Your goods may be Category 1')
 
-    check 'exemptions-category-assessment-34-y997-field'
-    check 'exemptions-category-assessment-82-y984-field'
+    check 'exemptions-category-assessment-a6b633a7b098132ec45c036d0e14713a-y997-field'
+    check 'exemptions-category-assessment-18fcbb5b75781f8a676bd84dae9c170e-y984-field'
 
     click_on 'Continue'
 
@@ -156,8 +143,8 @@ RSpec.describe 'Green lanes category assessments',
 
     expect(page).to have_text('Your goods may be Category 1')
 
-    check 'exemptions-category-assessment-34-y997-field'
-    check 'exemptions-category-assessment-82-y984-field'
+    check 'exemptions-category-assessment-a6b633a7b098132ec45c036d0e14713a-y997-field'
+    check 'exemptions-category-assessment-18fcbb5b75781f8a676bd84dae9c170e-y984-field'
 
     click_on 'Continue'
 
@@ -188,15 +175,15 @@ RSpec.describe 'Green lanes category assessments',
 
     expect(page).to have_text('Your goods may be Category 1')
 
-    check 'exemptions-category-assessment-838-y160-field'
-    check 'exemptions-category-assessment-30-y966-field'
+    check 'exemptions-category-assessment-b75355747789bdbc8e3d63cf2d91d214-y160-field'
+    check 'exemptions-category-assessment-e562118c58fdbb9ac68bb82c4593f98e-y966-field'
 
     click_on 'Continue'
 
     expect(page).to have_text('Your goods may be Category 2')
 
-    check 'exemptions-category-assessment-23-none-field'
-    check 'exemptions-category-assessment-92-none-field'
+    check 'exemptions-category-assessment-b8e061e4ddb9e4d99cbec41195277304-none-field'
+    check 'exemptions-category-assessment-34aad1bc2c330cd7635ef3fdacef2de7-none-field'
 
     click_on 'Continue'
 
@@ -226,15 +213,15 @@ RSpec.describe 'Green lanes category assessments',
 
     expect(page).to have_text('Your goods may be Category 1')
 
-    check 'exemptions-category-assessment-838-y160-field'
-    check 'exemptions-category-assessment-30-y966-field'
+    check 'exemptions-category-assessment-b75355747789bdbc8e3d63cf2d91d214-y160-field'
+    check 'exemptions-category-assessment-e562118c58fdbb9ac68bb82c4593f98e-y966-field'
 
     click_on 'Continue'
 
     expect(page).to have_text('Your goods may be Category 2')
 
-    check 'exemptions-category-assessment-23-y058-field'
-    check 'exemptions-category-assessment-92-y904-field'
+    check 'exemptions-category-assessment-b8e061e4ddb9e4d99cbec41195277304-y058-field'
+    check 'exemptions-category-assessment-34aad1bc2c330cd7635ef3fdacef2de7-y904-field'
 
     click_on 'Continue'
 
@@ -264,15 +251,9 @@ RSpec.describe 'Green lanes category assessments',
 
     expect(page).to have_text('Your goods may be Category 2')
 
-    # Check the first 'exemptions-category-assessment-23-none-field'
-    all('#exemptions-category-assessment-23-none-field').first.set(true)
-
-    # find(:css, 'input[name="exemptions-category-assessment-23-none-field"]:nth-of-type(1)').set(true)
-
-    # This checkbox has the same ID as previouse "none" in a different Cat Assessment
-    # TODO: check Back End API
-    # check 'exemptions-category-assessment-23-none-field'
-    check 'exemptions-category-assessment-818-none-field'
+    check 'exemptions-category-assessment-37f58c7ec2982bf82ab238d33b376b4f-none-field'
+    check 'exemptions-category-assessment-abed84f406002f0d36f8660d9f80884e-none-field'
+    check 'exemptions-category-assessment-5667f4515c310042a7349c3aa31bd57e-none-field'
 
     click_on 'Continue'
 
@@ -302,9 +283,9 @@ RSpec.describe 'Green lanes category assessments',
 
     expect(page).to have_text('Your goods may be Category 2')
 
-    # We check 1 checkbox instead of two because they share the same ID (there is a ticket to solve this)
-    all('#exemptions-category-assessment-23-y170-field').first.set(true)
-    check 'exemptions-category-assessment-818-y900-field'
+    check 'exemptions-category-assessment-37f58c7ec2982bf82ab238d33b376b4f-y170-field'
+    check 'exemptions-category-assessment-abed84f406002f0d36f8660d9f80884e-y058-field'
+    check 'exemptions-category-assessment-5667f4515c310042a7349c3aa31bd57e-y900-field'
 
     click_on 'Continue'
 

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -18,4 +18,36 @@ RSpec.describe GreenLanes::CategoryAssessment do
     it { is_expected.to have_attributes category: category_assessment.theme.category }
     it { is_expected.to have_attributes theme: category_assessment.theme }
   end
+
+  describe '#id' do
+    subject(:id) { build(:category_assessment).id }
+
+    it { is_expected.to eq("category_assessment_#{category_assessment.resource_id}") }
+  end
+
+  describe '#answered_exemptions' do
+    subject(:answered_exemptions) do
+      category_assessment.answered_exemptions(answers).map(&:code)
+    end
+
+    let(:category_assessment) { build(:category_assessment, :with_exemptions) }
+
+    context 'when there are no answers' do
+      let(:answers) { {} }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when there are answers' do
+      let(:answers) do
+        {
+          category_assessment.category.to_s => {
+            category_assessment.resource_id => [category_assessment.exemptions.first.code],
+          },
+        }
+      end
+
+      it { is_expected.to eq([category_assessment.exemptions.first.code]) }
+    end
+  end
 end

--- a/spec/requests/green_lanes/applicable_exemptions_controller_spec.rb
+++ b/spec/requests/green_lanes/applicable_exemptions_controller_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe GreenLanes::ApplicableExemptionsController, type: :request,
     let(:make_request) do
       post green_lanes_applicable_exemptions_path, params: {
         exemptions: {
-          category_assessment_34: ['', 'Y997'],
-          category_assessment_82: ['', 'none'],
+          category_assessment_a6b633a7b098132ec45c036d0e14713a: ['', 'Y997'],
+          category_assessment_18fcbb5b75781f8a676bd84dae9c170e: ['', 'none'],
         },
         category:,
         commodity_code:,
@@ -38,6 +38,6 @@ RSpec.describe GreenLanes::ApplicableExemptionsController, type: :request,
     end
 
     it { is_expected.to have_http_status :redirect }
-    it { is_expected.to redirect_to('http://www.example.com/green_lanes/check_your_answers?ans%5B1%5D%5B34%5D%5B%5D=Y997&ans%5B1%5D%5B82%5D%5B%5D=none&c1ex=false&category=1&commodity_code=4114109000&country_of_origin=UA&moving_date=2024-05-29') }
+    it { is_expected.to redirect_to('http://www.example.com/green_lanes/check_your_answers?ans%5B1%5D%5B18fcbb5b75781f8a676bd84dae9c170e%5D%5B%5D=none&ans%5B1%5D%5Ba6b633a7b098132ec45c036d0e14713a%5D%5B%5D=Y997&c1ex=false&category=1&commodity_code=4114109000&country_of_origin=UA&moving_date=2024-05-29') }
   end
 end


### PR DESCRIPTION
### Jira link

GL-962

### What?

I have added/removed/altered:

- [x] Altered the id of every category assessment across forms and answers to be a unique id
- [x] Added coverage for a refactored method

### Why?

I am doing this because:

- This is needed to avoid collisions across category assessments with the same category assessment id

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Makes changes to our complex routing setup that may affect apis to proxying to backend
