### PR TITLE
GL-1000: Fixes bug in check your answers page

### DIFF
--- a/app/helpers/green_lanes_helper.rb
+++ b/app/helpers/green_lanes_helper.rb
@@ -1,10 +1,10 @@
 module GreenLanesHelper
-  def exemption_checkbox_checked?(category_assessment_id, exemption_code)
-    category_assessments_checked(category_assessment_id)&.include?(exemption_code)
+  def exemption_checkbox_checked?(resource_id, exemption_code)
+    category_assessments_checked(resource_id)&.include?(exemption_code)
   end
 
-  def exemption_checkbox_none?(category_assessment_id)
-    exemption_checkbox_checked?(category_assessment_id, 'none')
+  def exemption_checkbox_none?(resource_id)
+    exemption_checkbox_checked?(resource_id, 'none')
   end
 
   def render_exemptions_or_no_card(category, assessments, result)
@@ -25,7 +25,7 @@ module GreenLanesHelper
   def exemption_met?(exemption_code, category, category_assessment, answers)
     return false if answers.blank?
 
-    category_assessment_answer = dig_category_answer(answers, category, category_assessment.category_assessment_id)
+    category_assessment_answer = dig_category_answer(answers, category, category_assessment.resource_id)
     category_assessment_answer.present? && category_assessment_answer != %w[none] && category_assessment_answer.include?(exemption_code)
   end
 
@@ -33,7 +33,7 @@ module GreenLanesHelper
     return false if answers.blank?
 
     category_assessments.all? do |ca|
-      category_assessment_answer = dig_category_answer(answers, category, ca.category_assessment_id)
+      category_assessment_answer = dig_category_answer(answers, category, ca.resource_id)
       category_assessment_answer.present? && category_assessment_answer != %w[none]
     end
   end
@@ -69,11 +69,11 @@ module GreenLanesHelper
 
   private
 
-  def category_assessments_checked(category_assessment_id)
-    params.dig(:exemptions, :category_assessments_checked, category_assessment_id.to_s)
+  def category_assessments_checked(resource_id)
+    params.dig(:exemptions, :category_assessments_checked, resource_id.to_s)
   end
 
-  def dig_category_answer(answers, category, category_assessment_id)
-    answers.dig(category.to_s, category_assessment_id.to_s)
+  def dig_category_answer(answers, category, resource_id)
+    answers.dig(category.to_s, resource_id.to_s)
   end
 end

--- a/spec/helpers/green_lanes_helper_spec.rb
+++ b/spec/helpers/green_lanes_helper_spec.rb
@@ -1,21 +1,19 @@
 require 'spec_helper'
 
 RSpec.describe GreenLanesHelper, type: :helper do
-  let(:assessment_1) { OpenStruct.new(category_assessment_id: 1) }
-  let(:assessment_2) { OpenStruct.new(category_assessment_id: 2) }
-
-  let(:assessments) do
-    instance_double('Assessments',
-                    no_cat1_exemptions: false,
-                    cat_1_assessments_met: [1],
-                    cat_1_assessments: [assessment_1, assessment_2])
-  end
-
-  before do
-    allow(helper).to receive(:render)
-  end
+  before { allow(helper).to receive(:render) }
 
   describe '#render_exemptions_or_no_card' do
+    let(:assessments) do
+      instance_double('Assessments',
+                      no_cat1_exemptions: false,
+                      cat_1_assessments_met: [1],
+                      cat_1_assessments: [assessment_1, assessment_2])
+    end
+
+    let(:assessment_1) { OpenStruct.new(category_assessment_id: 1) }
+    let(:assessment_2) { OpenStruct.new(category_assessment_id: 2) }
+
     context 'when result is "3"' do
       it 'renders exemptions_card' do
         helper.render_exemptions_or_no_card(1, assessments, '3')
@@ -150,6 +148,38 @@ RSpec.describe GreenLanesHelper, type: :helper do
 
     describe '#green_lanes_eligibility_start_path' do
       it { expect(helper.green_lanes_eligibility_start_path).to eq('/green_lanes/start/new') }
+    end
+
+    describe '#exemption_met?' do
+      subject(:exemption_met?) { helper.exemption_met?(category_assessment.exemptions.first.code, 2, category_assessment, answers) }
+
+      let(:category_assessment) { build(:category_assessment, :with_exemptions) }
+
+      context 'when there are answers given and the answers include our exemption code' do
+        let(:answers) do
+          {
+            '2' => {
+              category_assessment.resource_id => [category_assessment.exemptions.first.code],
+            },
+          }
+        end
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'when there are answers given and the answers include none' do
+        let(:answers) do
+          { '2' => { category_assessment.id => %w[none] } }
+        end
+
+        it { is_expected.to be(false) }
+      end
+
+      context 'when there are no answers given' do
+        let(:answers) { {} }
+
+        it { is_expected.to be(false) }
+      end
     end
 
     # rubocop:enable RSpec/InstanceVariable


### PR DESCRIPTION
### Jira link

GL-1000

### What?

I have added/removed/altered:

- [x] Altered the use of category_assessment_id to be resource_id when looking up answers in the check your answers page
- [x] Adds rspec coverage for the affected methods 

### Why?

I am doing this because:

- This fixes a bug in highlighting met exemptions