### PR TITLE
OTT-348 Fix for quota definition modal

### DIFF
--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -1,6 +1,8 @@
-<%= link_to order_number.number, "#order-number-#{order_number.number}", class: 'reference numerical', title: 'Opens in a popup', 'data-popup-ref' => "order-number-#{order_number.number}" %>&nbsp;
-
-<div class="popup govuk-visually-hidden" data-popup="order-number-<%= order_number.number %>">
+<div data-controller="anchor">
+  <%= link_to order_number.number, "#", class: 'reference numerical', data: { action: "click->anchor#launchModal", modal_ref: "order-number-#{order_number.number}" }, "aria-label": "Opens in a popup", role: "button" %>&nbsp;
+  <div id="modal" class="modal tariff-info" data-controller="modal" data-anchor-target="modal"></div>
+</div>
+<div class="govuk-visually-hidden" data-popup="order-number-<%= order_number.number %>">
   <article>
     <% if order_number.definition.present? %>
       <table class="govuk-table govuk-table-m">

--- a/app/webpacker/controllers/modal_controller.js
+++ b/app/webpacker/controllers/modal_controller.js
@@ -26,7 +26,6 @@ export default class extends Controller {
     // Display the modal
     this.element.style.display = 'block';
     this.element.classList.add('show');
-    this.element.classList.add('modal-border');
 
     // Create and append the backdrop
     const backdrop = document.createElement('div');
@@ -45,7 +44,6 @@ export default class extends Controller {
     // Hide the modal
     this.element.style.display = 'none';
     this.element.classList.remove('show');
-    this.element.classList.remove('modal-border');
 
     // Remove the backdrop
     const backdrop = document.querySelector('.modal-backdrop');

--- a/app/webpacker/src/stylesheets/_modal.scss
+++ b/app/webpacker/src/stylesheets/_modal.scss
@@ -27,12 +27,6 @@
   opacity: 1;
 }
 
-.modal-border{
-  border-style: solid;
-  border-color: black;
-  border-width: 3px;
-}
-
 /* styling for the modal */
 .modal {
   position: fixed;


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-348

### What?

I have

- [x] Added Anchor and Modal stimulus controllers for quota definitions
- [x] Removed border from modal styling

### Why?

I am doing this because:

- popup has been replaced by modal as part of stimulus pop up migration
- quota definition was missed in test

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

screenshot after fix applied
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/acacd9f9-6a68-4eb8-aad4-086600e5dd79">
 
