### PR TITLE
OTT-BAU: Fixes issues with automatic showing of re-rendered modals

### DIFF
--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="anchor">
   <%= link_to order_number.number, "#", class: 'reference numerical', data: { action: "click->anchor#launchModal", modal_ref: "order-number-#{order_number.number}" }, "aria-label": "Opens in a popup", role: "button" %>&nbsp;
-  <div id="modal" class="modal tariff-info" data-controller="modal" data-anchor-target="modal"></div>
+  <div id="modal" class="modal tariff-info" data-controller="modal" data-anchor-target="modal" data-order-number="#order-number-#{order_number.number}"></div>
 </div>
 <div class="govuk-visually-hidden" data-popup="order-number-<%= order_number.number %>">
   <article>

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="anchor">
   <%= link_to order_number.number, "#", class: 'reference numerical', data: { action: "click->anchor#launchModal", modal_ref: "order-number-#{order_number.number}" }, "aria-label": "Opens in a popup", role: "button" %>&nbsp;
-  <div id="modal" class="modal tariff-info" data-controller="modal" data-anchor-target="modal" data-order-number="#order-number-#{order_number.number}"></div>
+  <div id="modal" class="modal tariff-info" data-controller="modal" data-anchor-target="modal"></div>
 </div>
 <div class="govuk-visually-hidden" data-popup="order-number-<%= order_number.number %>">
   <article>

--- a/app/webpacker/controllers/anchor_controller.js
+++ b/app/webpacker/controllers/anchor_controller.js
@@ -18,23 +18,23 @@ export default class extends Controller {
     this.isModalOpen = false;
   }
 
-  connect(){
+  connect() {
     // This will check the anchor tag in the URL and launch the modal automatically if it matches the order number
     const anchorOrderNumber = window.location.hash && window.location.hash.slice(1);
     const anchorLink = this.element.querySelector('a');
     if (anchorLink) {
       const modalOrderNumber = anchorLink.dataset.modalRef;
       if (modalOrderNumber === anchorOrderNumber) {
-        this.launchModal({ currentTarget: anchorLink });
+        this.launchModal({currentTarget: anchorLink});
       }
     }
   }
 
   launchModal(event) {
     const modalRef = event.currentTarget.dataset.modalRef;
-console.log('modalRef: ',modalRef);
+
     // this stops the page scrolling to the top when the modal is closed
-    if (event.isTrusted){
+    if (event.isTrusted) {
       event.preventDefault();
     }
 
@@ -47,20 +47,18 @@ console.log('modalRef: ',modalRef);
     }
 
     // ensure all modals are loaded before opening
-   // setTimeout(() => {
-      this.modalController = this.application.getControllerForElementAndIdentifier(
+    // setTimeout(() => {
+    this.modalController = this.application.getControllerForElementAndIdentifier(
         this.modalTarget,
-        'modal'
-      );
-      console.log('modalController: ', this.modalController);
-      if (this.modalController) {
-        this.isModalOpen = true;
-        console.log('opening modal now!');
-        this.modalController.open(popupContent.innerHTML);
-      } else {
-        console.error('Modal controller could not be found');
-      }
-    //}, 0);
+        'modal',
+    );
+    if (this.modalController) {
+      this.isModalOpen = true;
+      this.modalController.open(popupContent.innerHTML);
+    } else {
+      console.error('Modal controller could not be found');
+    }
+    // }, 0);
   }
 
   handleClickOutsideOpenModal(event) {

--- a/app/webpacker/controllers/anchor_controller.js
+++ b/app/webpacker/controllers/anchor_controller.js
@@ -21,18 +21,18 @@ export default class extends Controller {
   connect(){
     // This will check the anchor tag in the URL and launch the modal automatically if it matches the order number
     const anchorOrderNumber = window.location.hash && window.location.hash.slice(1);
-    const myModal = this.element.querySelector('a');
-    if (myModal) {
-      const modalOrderNumber = myModal.dataset.modalRef;
+    const anchorLink = this.element.querySelector('a');
+    if (anchorLink) {
+      const modalOrderNumber = anchorLink.dataset.modalRef;
       if (modalOrderNumber === anchorOrderNumber) {
-        this.launchModal({ currentTarget: myModal });
+        this.launchModal({ currentTarget: anchorLink });
       }
     }
   }
 
   launchModal(event) {
     const modalRef = event.currentTarget.dataset.modalRef;
-
+console.log('modalRef: ',modalRef);
     // this stops the page scrolling to the top when the modal is closed
     if (event.isTrusted){
       event.preventDefault();
@@ -40,7 +40,6 @@ export default class extends Controller {
 
     // Find the hidden HTML element with the corresponding data-popup value
     const popupContent = document.querySelector(`[data-popup='${modalRef}']`);
-    console.log('popupContent: ', popupContent);
 
     if (!popupContent) {
       console.error(`No content found for modal reference: ${modalRef}`);
@@ -48,19 +47,20 @@ export default class extends Controller {
     }
 
     // ensure all modals are loaded before opening
-    setTimeout(() => {
+   // setTimeout(() => {
       this.modalController = this.application.getControllerForElementAndIdentifier(
         this.modalTarget,
         'modal'
       );
-
+      console.log('modalController: ', this.modalController);
       if (this.modalController) {
         this.isModalOpen = true;
+        console.log('opening modal now!');
         this.modalController.open(popupContent.innerHTML);
       } else {
         console.error('Modal controller could not be found');
       }
-    }, 0);
+    //}, 0);
   }
 
   handleClickOutsideOpenModal(event) {

--- a/app/webpacker/controllers/anchor_controller.js
+++ b/app/webpacker/controllers/anchor_controller.js
@@ -16,33 +16,51 @@ export default class extends Controller {
     document.addEventListener('click', this.handleClickOutsideOpenModal.bind(this));
     document.addEventListener('keydown', this.handleEscapePressWithOpenModal.bind(this));
     this.isModalOpen = false;
+  }
 
-    const anchorOrderNumber = window.location.hash;
-    const modalOrderNumber = this.modalTarget.data.get('order-number');
-
-    if (modalOrderNumber === anchorOrderNumber) {
-      const event = new Event('click');
-      this.launchModal(event);
+  connect(){
+    // This will check the anchor tag in the URL and launch the modal automatically if it matches the order number
+    const anchorOrderNumber = window.location.hash && window.location.hash.slice(1);
+    const myModal = this.element.querySelector('a');
+    if (myModal) {
+      const modalOrderNumber = myModal.dataset.modalRef;
+      if (modalOrderNumber === anchorOrderNumber) {
+        this.launchModal({ currentTarget: myModal });
+      }
     }
   }
 
   launchModal(event) {
-    event.preventDefault();
     const modalRef = event.currentTarget.dataset.modalRef;
+
+    // this stops the page scrolling to the top when the modal is closed
+    if (event.isTrusted){
+      event.preventDefault();
+    }
+
     // Find the hidden HTML element with the corresponding data-popup value
     const popupContent = document.querySelector(`[data-popup='${modalRef}']`);
+    console.log('popupContent: ', popupContent);
 
     if (!popupContent) {
       console.error(`No content found for modal reference: ${modalRef}`);
       return;
     }
 
-    this.modalController = this.application.getControllerForElementAndIdentifier(
+    // ensure all modals are loaded before opening
+    setTimeout(() => {
+      this.modalController = this.application.getControllerForElementAndIdentifier(
         this.modalTarget,
-        'modal');
+        'modal'
+      );
 
-    this.isModalOpen = true;
-    this.modalController.open(popupContent.innerHTML);
+      if (this.modalController) {
+        this.isModalOpen = true;
+        this.modalController.open(popupContent.innerHTML);
+      } else {
+        console.error('Modal controller could not be found');
+      }
+    }, 0);
   }
 
   handleClickOutsideOpenModal(event) {

--- a/app/webpacker/controllers/anchor_controller.js
+++ b/app/webpacker/controllers/anchor_controller.js
@@ -13,9 +13,17 @@ export default class extends Controller {
   initialize() {
     // All the HTML for modal pop-ups are generated already and need to be hidden on the page
     $('#import-measure-references, #export-measure-references').hide();
-    this.isModalOpen = false;
     document.addEventListener('click', this.handleClickOutsideOpenModal.bind(this));
     document.addEventListener('keydown', this.handleEscapePressWithOpenModal.bind(this));
+    this.isModalOpen = false;
+
+    const anchorOrderNumber = window.location.hash;
+    const modalOrderNumber = this.modalTarget.data.get('order-number');
+
+    if (modalOrderNumber === anchorOrderNumber) {
+      const event = new Event('click');
+      this.launchModal(event);
+    }
   }
 
   launchModal(event) {

--- a/app/webpacker/controllers/anchor_controller.js
+++ b/app/webpacker/controllers/anchor_controller.js
@@ -47,18 +47,18 @@ export default class extends Controller {
     }
 
     // ensure all modals are loaded before opening
-    // setTimeout(() => {
-    this.modalController = this.application.getControllerForElementAndIdentifier(
-        this.modalTarget,
-        'modal',
-    );
-    if (this.modalController) {
-      this.isModalOpen = true;
-      this.modalController.open(popupContent.innerHTML);
-    } else {
-      console.error('Modal controller could not be found');
-    }
-    // }, 0);
+    setTimeout(() => {
+      this.modalController = this.application.getControllerForElementAndIdentifier(
+          this.modalTarget,
+          'modal',
+      );
+      if (this.modalController) {
+        this.isModalOpen = true;
+        this.modalController.open(popupContent.innerHTML);
+      } else {
+        console.error('Modal controller could not be found');
+      }
+    }, 0);
   }
 
   handleClickOutsideOpenModal(event) {

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -31,12 +31,6 @@ require('jquery-roving-tabindex/jquery.rovingtabindex');
 require('jquery-tabs/jquery.tabs');
 require('mark.js/dist/jquery.mark');
 
-// console.log('popup');
-// console.log(BetaPopup);
-// BetaPopup.popup('title', 'tariff-info');
-// require('./node_modules/jquery-history/dist/jquery.history');
-// require('../../../node_modules/jquery-history/dist/jquery.history');
-// require('jquery-history/dist/jquery.history');
 require('../src/javascripts/datepicker-day.js');
 require('../src/javascripts/calendar-button.js');
 require('../src/javascripts/datepicker.js');

--- a/app/webpacker/src/javascripts/utility.js
+++ b/app/webpacker/src/javascripts/utility.js
@@ -65,7 +65,6 @@ export default class Utility {
 
   static commoditySelectorOnConfirm(text, options, resourceIdHidden, inputElement) {
     let selectedOption = null;
-    console.log(options);
     options.forEach((option) => {
       if (option.text === text.id || option.text === text) {
         selectedOption = option;

--- a/spec/javascript/controllers/anchor_controller_spec.js
+++ b/spec/javascript/controllers/anchor_controller_spec.js
@@ -28,7 +28,7 @@ describe('AnchorController', () => {
     application.stop();
   });
 
-  it.only('launchModal method opens the modal with the correct content', () => {
+  it('launchModal method opens the modal with the correct content', async () => {
     const anchorController = application.getControllerForElementAndIdentifier(anchorElement, 'anchor');
     const modalController = application.getControllerForElementAndIdentifier(modalElement, 'modal');
 
@@ -42,20 +42,25 @@ describe('AnchorController', () => {
 
     anchorController.launchModal(event);
 
+    // Wait for the modal to be opened
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(event.preventDefault).toHaveBeenCalled();
     expect(modalController.open).toHaveBeenCalledWith('Modal Content for Test');
     expect(modalElement.classList.contains('show')).toEqual(true);
   });
 
-  it('handleClickOutsideOpenModal method closes the modal when clicking outside', () => {
+  it('handleClickOutsideOpenModal method closes the modal when clicking outside', async () => {
     const anchorController = application.getControllerForElementAndIdentifier(anchorElement, 'anchor');
     const modalController = application.getControllerForElementAndIdentifier(modalElement, 'modal');
 
     const event = {
       preventDefault: jest.fn(),
       currentTarget: anchorElement.querySelector('a'),
+      isTrusted: true,
     };
     anchorController.launchModal(event);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     jest.spyOn(modalController, 'close');
 
@@ -73,15 +78,17 @@ describe('AnchorController', () => {
     expect(modalElement.classList.contains('show')).toEqual(false);
   });
 
-  it('handleEscapePressWithOpenModal method closes the modal on Escape key press', () => {
+  it('handleEscapePressWithOpenModal method closes the modal on Escape key press', async () => {
     const anchorController = application.getControllerForElementAndIdentifier(anchorElement, 'anchor');
     const modalController = application.getControllerForElementAndIdentifier(modalElement, 'modal');
 
     const event = {
       preventDefault: jest.fn(),
       currentTarget: anchorElement.querySelector('a'),
+      isTrusted: true,
     };
     anchorController.launchModal(event);
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     jest.spyOn(modalController, 'close');
 

--- a/spec/javascript/controllers/anchor_controller_spec.js
+++ b/spec/javascript/controllers/anchor_controller_spec.js
@@ -29,7 +29,6 @@ describe('AnchorController', () => {
   });
 
   it.only('launchModal method opens the modal with the correct content', () => {
-    console.log(window.location.hash);
     const anchorController = application.getControllerForElementAndIdentifier(anchorElement, 'anchor');
     const modalController = application.getControllerForElementAndIdentifier(modalElement, 'modal');
 
@@ -40,7 +39,7 @@ describe('AnchorController', () => {
       currentTarget: anchorElement.querySelector('a'),
       isTrusted: true,
     };
-console.log(event);
+
     anchorController.launchModal(event);
 
     expect(event.preventDefault).toHaveBeenCalled();

--- a/spec/javascript/controllers/anchor_controller_spec.js
+++ b/spec/javascript/controllers/anchor_controller_spec.js
@@ -28,7 +28,8 @@ describe('AnchorController', () => {
     application.stop();
   });
 
-  it('launchModal method opens the modal with the correct content', () => {
+  it.only('launchModal method opens the modal with the correct content', () => {
+    console.log(window.location.hash);
     const anchorController = application.getControllerForElementAndIdentifier(anchorElement, 'anchor');
     const modalController = application.getControllerForElementAndIdentifier(modalElement, 'modal');
 
@@ -37,8 +38,9 @@ describe('AnchorController', () => {
     const event = {
       preventDefault: jest.fn(),
       currentTarget: anchorElement.querySelector('a'),
+      isTrusted: true,
     };
-
+console.log(event);
     anchorController.launchModal(event);
 
     expect(event.preventDefault).toHaveBeenCalled();


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-488

### What?

I have added/removed/altered:

- [x] Added handling in the anchor controller for modals that have already been rendered with different data

### Why?

I am doing this because:

- This was previously working and has stopped working with the stimulus migration
