### PR TITLE
GL-978: Add new redirections to start SPIMM

### DIFF
--- a/app/controllers/green_lanes/results_controller.rb
+++ b/app/controllers/green_lanes/results_controller.rb
@@ -7,6 +7,11 @@ module GreenLanes
                   :disable_search_form,
                   only: :create
 
+    def show
+      # Restart the Wizard
+      redirect_to green_lanes_start_path
+    end
+
     def create
       @commodity_code = goods_nomenclature.goods_nomenclature_item_id
       @country_of_origin = results_params[:country_of_origin] || GeographicalArea::ERGA_OMNES

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,8 @@ Rails.application.routes.draw do
 
   resolve('GreenLanes::CategoryAssessmentSearch') { [:category_assessments] }
 
+  get 'green_lanes' => 'green_lanes/results#show' # Old path. Now "check_spimm_eligibility".
+
   namespace :green_lanes, path: 'check_spimm_eligibility' do
     get '/', to: 'starts#new', as: 'start'
 
@@ -125,7 +127,9 @@ Rails.application.routes.draw do
 
     resource :check_your_answers, only: %i[show]
 
-    resources :results, param: :category, only: %i[create], path: 'results'
+    get 'result' => 'results#show'
+
+    resources :results, param: :category, only: %i[create], path: 'result'
   end
 
   match '/search', as: :perform_search, via: %i[get post], to: 'search#search'

--- a/spec/requests/green_lanes/results_controller_spec.rb
+++ b/spec/requests/green_lanes/results_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe GreenLanes::ResultsController, type: :request do
+  subject { make_request && response }
+
+  before do
+    allow(TradeTariffFrontend).to receive(:green_lanes_enabled?).and_return true
+  end
+
+  describe 'when users try to directly access the result page it redirects to the start page' do
+    let(:make_request) { get green_lanes_result_path }
+
+    it { is_expected.to have_http_status :redirect }
+    it { is_expected.to redirect_to(green_lanes_start_path) }
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/GL-978

### What?

Add new redirections, GET /results and GET /green_lanes, to the start of the SPIMM journey.
