### PR TITLE
OTT-296 Unwonky styling

### DIFF
--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -62,10 +62,10 @@
       </table>
     <% end %>
   <% else %>
-    <h2 class="govuk-heading-l">There are no results matching your query.</h2>
+    <h2 class="govuk-heading-m">There are no results matching your query.</h2>
     <div class="panel govuk-panel">
       <p><strong>Please search again and consider:</strong></p>
-      <ul class="list list-bullet">
+      <ul class="govuk-list govuk-list--bullet">
         <li>Searching what the item is used for or made from</li>
         <li>Broadening your search criteria</li>
         <li>Checking your spelling</li>


### PR DESCRIPTION
### Jira link

OTT-296

### What?

I have unwonkied the styling and fonts of the search results "no results" page to be more inline with correct styling/typeface

Before:

![Untitled](https://github.com/user-attachments/assets/f44998a3-8ea0-4a55-8d49-39bb0eadb60d)


After:

![Screenshot 2024-09-10 at 11 47 32](https://github.com/user-attachments/assets/9507db66-a55e-4532-91e0-9159061e203d)

