### PR TITLE
OTT-498 Configure bullet style to lower-alpha on GIRS

### DIFF
--- a/app/webpacker/src/stylesheets/tariff-custom.scss
+++ b/app/webpacker/src/stylesheets/tariff-custom.scss
@@ -6,6 +6,7 @@
   .mobile-only {
     display: none;
   }
+
   .desktop-only {
     display: block;
   }
@@ -18,11 +19,17 @@
   }
 }
 
-.govuk-list + .govuk-list + .govuk-list--number {
+.govuk-list+.govuk-list+.govuk-list--number {
   list-style-type: lower-alpha;
 }
 
-.govuk-back-link + .govuk-main-wrapper {
+.govuk-list--number,
+.tariff-markdown ol {
+  list-style-type: lower-alpha;
+}
+
+
+.govuk-back-link+.govuk-main-wrapper {
   padding-top: 20px !important;
 
   header h1 {
@@ -37,9 +44,11 @@
 
 .govuk-heading-l a {
   text-decoration: none;
+
   &:hover {
     text-decoration: underline;
   }
+
   @include govuk-link-style-text;
 }
 


### PR DESCRIPTION
### Jira link

OTT-498

### What?

Swaps out bullet points on GIR to lower-alpha instead of decimal

Before:

![Screenshot 2024-09-10 at 16 09 03](https://github.com/user-attachments/assets/cda7884b-133b-4e6c-8574-8ae708f9c91e)

After:

![Screenshot 2024-09-10 at 16 07 02](https://github.com/user-attachments/assets/5071d0d3-0802-4071-843b-e7ee966152bf)
