### PR TITLE
Remove support email from all pages in SPIMM flow

### DIFF
--- a/app/views/green_lanes/applicable_exemptions/cat_1_exemptions_questions.html.erb
+++ b/app/views/green_lanes/applicable_exemptions/cat_1_exemptions_questions.html.erb
@@ -10,7 +10,5 @@
     </p>
 
     <%= render 'form', submit_form_url: applicable_exemptions_path, category: '1' %>
-
-    <%= render '/green_lanes/shared/support_email_section' %>
   </div>
 </div>

--- a/app/views/green_lanes/applicable_exemptions/cat_2_exemptions_questions.html.erb
+++ b/app/views/green_lanes/applicable_exemptions/cat_2_exemptions_questions.html.erb
@@ -10,7 +10,5 @@
     </p>
 
     <%= render 'form', submit_form_url: applicable_exemptions_path, category: '2' %>
-
-    <%= render '/green_lanes/shared/support_email_section' %>
   </div>
 </div>

--- a/app/views/green_lanes/eligibilities/new.html.erb
+++ b/app/views/green_lanes/eligibilities/new.html.erb
@@ -42,7 +42,5 @@
 
       <%= f.govuk_submit "Continue", class: "govuk-button" %>
     <% end %>
-
-    <%= render '/green_lanes/shared/support_email_section' %>
   </div>
 </div>

--- a/app/views/green_lanes/eligibility_results/_not_yet_eligible.html.erb
+++ b/app/views/green_lanes/eligibility_results/_not_yet_eligible.html.erb
@@ -33,7 +33,5 @@
     <%= form_with url: green_lanes_your_goods_path, method: :get, local: true do %>
       <%= submit_tag "Continue", class: "govuk-button" %>
     <% end %>
-
-    <%= render '/green_lanes/shared/support_email_section' %>
   </div>
 </div>

--- a/app/views/green_lanes/eligibility_results/_you_may_be_eligible.html.erb
+++ b/app/views/green_lanes/eligibility_results/_you_may_be_eligible.html.erb
@@ -33,7 +33,5 @@
     <%= form_with url: green_lanes_your_goods_path, method: :get, local: true do %>
       <%= submit_tag "Continue", class: "govuk-button" %>
     <% end %>
-
-    <%= render '/green_lanes/shared/support_email_section' %>
   </div>
 </div>

--- a/app/views/green_lanes/moving_requirements/new.html.erb
+++ b/app/views/green_lanes/moving_requirements/new.html.erb
@@ -46,7 +46,5 @@
 
         <%= f.submit "Continue", class: "govuk-button" %>
     <% end %>
-
-    <%= render '/green_lanes/shared/support_email_section' %>
   </div>
 </div>

--- a/app/views/green_lanes/results/create.html.erb
+++ b/app/views/green_lanes/results/create.html.erb
@@ -19,5 +19,3 @@
           country_of_origin: @country_of_origin,
           moving_date: @moving_date,
         ), class: 'govuk-button govuk-button--secondary' %>
-
-<%= render '/green_lanes/shared/support_email_section' %>

--- a/app/views/green_lanes/shared/_support_email_section.html.erb
+++ b/app/views/green_lanes/shared/_support_email_section.html.erb
@@ -1,6 +1,0 @@
-<h2 class="govuk-heading-m">
-  If you need help using this tool
-</h2>
-<p>
-  Email <%= mail_to 'help@hmrc.gov.uk' %> for non-legally binding advice on internal market movements.
-</p>

--- a/app/views/green_lanes/starts/new.html.erb
+++ b/app/views/green_lanes/starts/new.html.erb
@@ -83,8 +83,6 @@
       <%= render 'shared/start_arrow' %>
     <% end %>
 
-    <%= render '/green_lanes/shared/support_email_section' %>
-
     <p>This tool sits on the UK tariff due to legal requirements set out in the Windsor Framework.</p>
   </div>
 </div>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/GL-983

### What?

I have added/removed/altered:

- [ ] Remove support email from all SPIMM pages

### Why?

HMRC wont have an email to support this
