### PR TITLE
GL-979: This adds the expiry in some urls in the green lanes (SPIMM).

### DIFF
--- a/app/controllers/green_lanes/applicable_exemptions_controller.rb
+++ b/app/controllers/green_lanes/applicable_exemptions_controller.rb
@@ -2,9 +2,13 @@ module GreenLanes
   class ApplicableExemptionsController < ApplicationController
     include GreenLanesHelper
 
+    include Concerns::ExpirableUrl
+
     before_action :check_green_lanes_enabled,
                   :disable_switch_service_banner,
                   :disable_search_form
+
+    before_action :page_has_not_expired, only: %i[new]
 
     def new
       @exemptions_form = build_exemptions_form
@@ -118,6 +122,7 @@ module GreenLanes
         country_of_origin: params[:country_of_origin],
         c1ex: params[:c1ex].present? ? params[:c1ex] == 'true' : nil,
         ans: passed_exemption_answers[:ans],
+        t: Time.zone.now.to_i,
       )
     end
 
@@ -155,6 +160,7 @@ module GreenLanes
         .merge(exemptions_results_params)
         .merge(next_page_query)
         .merge(passed_exemption_answers)
+        .merge(t: Time.zone.now.to_i)
         .deep_symbolize_keys
 
       "#{path}?#{query.to_query}"

--- a/app/controllers/green_lanes/check_your_answers_controller.rb
+++ b/app/controllers/green_lanes/check_your_answers_controller.rb
@@ -1,8 +1,10 @@
 module GreenLanes
   class CheckYourAnswersController < ApplicationController
     include GreenLanesHelper
+    include Concerns::ExpirableUrl
 
     before_action :check_green_lanes_enabled,
+                  :page_has_not_expired,
                   :disable_switch_service_banner,
                   :disable_search_form
 

--- a/app/controllers/green_lanes/concerns/expirable_url.rb
+++ b/app/controllers/green_lanes/concerns/expirable_url.rb
@@ -1,0 +1,19 @@
+module GreenLanes
+  module Concerns
+    module ExpirableUrl
+      extend ActiveSupport::Concern
+
+      URL_EXPIRATION_TIME = 10.hours
+
+      def page_has_not_expired
+        return unless params[:t]
+
+        url_initial_time = Time.strptime(params[:t], '%s')
+
+        if url_initial_time < Time.zone.now - URL_EXPIRATION_TIME
+          redirect_to green_lanes_start_path
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/green_lanes/eligibilities_controller.rb
+++ b/app/controllers/green_lanes/eligibilities_controller.rb
@@ -18,7 +18,9 @@ module GreenLanes
       @eligibility_form = EligibilityForm.new(eligibility_params)
 
       if @eligibility_form.valid?
-        redirect_to green_lanes_eligibility_result_path(eligibility_params)
+        redirect_to green_lanes_eligibility_result_path(
+          eligibility_params.merge(t: Time.zone.now.to_i),
+        )
       else
         render 'new'
       end

--- a/app/controllers/green_lanes/eligibility_results_controller.rb
+++ b/app/controllers/green_lanes/eligibility_results_controller.rb
@@ -2,7 +2,10 @@ module GreenLanes
   class EligibilityResultsController < ApplicationController
     include GreenLanesHelper
 
+    include Concerns::ExpirableUrl
+
     before_action :check_green_lanes_enabled,
+                  :page_has_not_expired,
                   :disable_switch_service_banner,
                   :disable_search_form
 

--- a/app/controllers/green_lanes/moving_requirements_controller.rb
+++ b/app/controllers/green_lanes/moving_requirements_controller.rb
@@ -55,9 +55,9 @@ module GreenLanes
         commodity_code: moving_requirements_params[:commodity_code],
         country_of_origin: moving_requirements_params[:country_of_origin],
         moving_date: @moving_requirements_form.moving_date.iso8601,
-      }
-        .merge(next_page_query)
-        .deep_symbolize_keys
+      }.merge(next_page_query)
+       .merge(t: Time.zone.now.to_i)
+       .deep_symbolize_keys
 
       "#{path}?#{query.to_query}"
     end

--- a/spec/requests/green_lanes/applicable_exemptions_controller_spec.rb
+++ b/spec/requests/green_lanes/applicable_exemptions_controller_spec.rb
@@ -1,41 +1,56 @@
 require 'spec_helper'
 
-RSpec.describe GreenLanes::ApplicableExemptionsController, type: :request,
-                                                           vcr: { cassette_name: 'green_lanes/applicable_exemptions', record: :new_episodes } do
+RSpec.describe GreenLanes::ApplicableExemptionsController,
+               type: :request,
+               vcr: { cassette_name: 'green_lanes/applicable_exemptions' } do
   subject { make_request && response }
 
-  let(:category) { '1' }
   let(:commodity_code) { '4114109000' }
   let(:country_of_origin) { 'UA' }
   let(:moving_date) { '2024-05-29' }
 
   describe 'GET #new' do
     let(:make_request) do
-      get green_lanes_applicable_exemptions_path(category:,
+      get green_lanes_applicable_exemptions_path(category: '1',
                                                  commodity_code:,
                                                  country_of_origin:,
-                                                 moving_date:)
+                                                 moving_date:,
+                                                 t: timestamp)
     end
+
+    let(:timestamp) { Time.zone.now.to_i }
 
     it { is_expected.to have_http_status :ok }
     it { is_expected.to have_attributes content_type: %r{text/html} }
 
     it { is_expected.to render_template(:cat_1_exemptions_questions) }
+
+    context 'when the page has expired' do
+      let(:timestamp) { Time.zone.now.to_i - 11.hours }
+
+      it { is_expected.to redirect_to green_lanes_start_path }
+    end
   end
 
   describe 'POST #create' do
+    before do
+      allow(Time).to receive(:now).and_return(fixed_now)
+    end
+
     let(:make_request) do
       post green_lanes_applicable_exemptions_path, params: {
         exemptions: {
           category_assessment_a6b633a7b098132ec45c036d0e14713a: ['', 'Y997'],
           category_assessment_18fcbb5b75781f8a676bd84dae9c170e: ['', 'none'],
         },
-        category:,
+        category: '1',
         commodity_code:,
         country_of_origin:,
         moving_date:,
       }
     end
+
+    let(:fixed_now) { Time.zone.now }
 
     it { is_expected.to have_http_status :redirect }
 
@@ -53,6 +68,7 @@ RSpec.describe GreenLanes::ApplicableExemptionsController, type: :request,
           commodity_code: '4114109000',
           country_of_origin: 'UA',
           moving_date: '2024-05-29',
+          t: fixed_now.to_i,
         }),
       )
     end

--- a/spec/requests/green_lanes/check_your_answers_controller_spec.rb
+++ b/spec/requests/green_lanes/check_your_answers_controller_spec.rb
@@ -1,7 +1,6 @@
-RSpec.describe GreenLanes::CheckYourAnswersController, type: :request, vcr: {
-  cassette_name: 'green_lanes/check_your_answers',
-  record: :new_episodes,
-} do
+RSpec.describe GreenLanes::CheckYourAnswersController,
+               type: :request,
+               vcr: { cassette_name: 'green_lanes/check_your_answers' } do
   describe 'GET #new' do
     before { make_request }
 
@@ -22,8 +21,11 @@ RSpec.describe GreenLanes::CheckYourAnswersController, type: :request, vcr: {
         category: 2,
         c1ex: true,
         c2ex: false,
+        t: timestamp,
       )
     end
+
+    let(:timestamp) { Time.zone.now.to_i }
 
     it 'responds with status code :ok' do
       expect(response).to have_http_status(:ok), "Response body: #{response.body}"
@@ -44,6 +46,14 @@ RSpec.describe GreenLanes::CheckYourAnswersController, type: :request, vcr: {
       expect(response).to render_template('green_lanes/check_your_answers/show')
       expect(response).to render_template('green_lanes/shared/_about_your_goods_card')
       expect(response).to render_template('green_lanes/check_your_answers/_category_exemptions')
+    end
+
+    context 'when the page has expired' do
+      let(:timestamp) { Time.zone.now.to_i - 11.hours }
+
+      it 'redirects to the start page' do
+        expect(make_request).to redirect_to green_lanes_start_path
+      end
     end
   end
 end

--- a/spec/requests/green_lanes/eligibilities_controller_spec.rb
+++ b/spec/requests/green_lanes/eligibilities_controller_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe GreenLanes::EligibilitiesController, type: :request do
 
   describe 'POST #create' do
     context 'with valid params' do
+      before do
+        allow(Time.zone).to receive(:now).and_return(
+          instance_double(Time, to_i: timestamp),
+        )
+      end
+
       let(:valid_params) do
         {
           green_lanes_eligibility_form: {
@@ -32,12 +38,22 @@ RSpec.describe GreenLanes::EligibilitiesController, type: :request do
         }
       end
 
+      let(:timestamp) { Time.zone.now.to_i }
+
       let(:make_request) { post green_lanes_eligibility_path, params: valid_params }
 
       it 'redirects to the result path' do
         make_request
 
-        expect(response).to redirect_to(green_lanes_eligibility_result_path(valid_params[:green_lanes_eligibility_form]))
+        expect(response).to redirect_to(green_lanes_eligibility_result_path(
+                                          {
+                                            moving_goods_gb_to_ni: 'yes',
+                                            free_circulation_in_uk: 'yes',
+                                            end_consumers_in_uk: 'yes',
+                                            ukims: 'yes',
+                                            t: timestamp,
+                                          },
+                                        ))
       end
     end
 

--- a/spec/requests/green_lanes/eligibility_results_controller_spec.rb
+++ b/spec/requests/green_lanes/eligibility_results_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe GreenLanes::EligibilityResultsController, type: :request do
+  subject { make_request && response }
+
+  before do
+    allow(TradeTariffFrontend).to receive(:green_lanes_enabled?).and_return true
+  end
+
+  describe 'GET #new' do
+    let(:make_request) do
+      get green_lanes_eligibility_result_path,
+          params: {
+            moving_goods_gb_to_ni: 'yes',
+            free_circulation_in_uk: 'yes',
+            end_consumers_in_uk: 'yes',
+            ukims: 'yes',
+            t: timestamp,
+          }
+    end
+
+    let(:timestamp) { Time.zone.now.to_i }
+
+    it { is_expected.to have_http_status :ok }
+
+    context 'when the page has expired' do
+      let(:timestamp) { 11.hours.ago.to_i }
+
+      it { is_expected.to redirect_to(green_lanes_start_path) }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/GL-979

### Why
If the user bookmarks the page, and it reloads the page after 10 hours, they must restart the journey from the beginning
(/check_spimm_eligibility).


