### PR TITLE
OTT-496 Speed up search lookups

### DIFF
--- a/app/webpacker/controllers/commodity_select_box_controller.js
+++ b/app/webpacker/controllers/commodity_select_box_controller.js
@@ -69,7 +69,7 @@ export default class extends Controller {
       source: debounce((query, populateResults) => {
         const searchSuggestionsPath = document.querySelector('.path_info').dataset.searchSuggestionsPath;
         Utility.fetchCommoditySearchSuggestions(query, searchSuggestionsPath, this.options, populateResults);
-      }, 400, false),
+      }, 200, false),
       onConfirm: (text) => {
         Utility.commoditySelectorOnConfirm(text, this.options, this.resourceIdHidden, this.inputElement);
       },


### PR DESCRIPTION
### Jira link

OTT-496

### What?

The search box has a debounce function set to avoid hammering the API  with every key press, however, it's set to quite a slow level which is what is causing the issue in this issue.

This PR speeds up the debounce to 200ms which doesn't solve the issue, but should make it much much harder to trigger.

We _could_ fix this properly and stop the form submitting if the lookup is still running, but doing this would make the form effectively break if the API lookup is a little slow or fails.
