### PR TITLE
OTT-495 Correct URL formation for search suggestions

### DIFF
--- a/app/webpacker/src/javascripts/utility.js
+++ b/app/webpacker/src/javascripts/utility.js
@@ -23,13 +23,13 @@ export default class Utility {
 
   static async fetchCommoditySearchSuggestions(query, searchSuggestionsPath, options, populateResults) {
     const escapedQuery = encodeURIComponent(query);
-    const opts = {
-      term: escapedQuery,
-    };
-    const queryParams = new URLSearchParams(opts).toString();
+
+    const fetchURL = new URL(window.location.href);
+    fetchURL.pathname = searchSuggestionsPath;
+    fetchURL.searchParams.append('term', escapedQuery);
 
     try {
-      const response = await fetch(`${searchSuggestionsPath}?${queryParams}`, {
+      const response = await fetch(fetchURL, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
@@ -56,7 +56,7 @@ export default class Utility {
         });
       }
       populateResults(newSource);
-      document.dispatchEvent(new CustomEvent('tariff:searchQuery', {detail: [data, opts]}));
+      document.dispatchEvent(new CustomEvent('tariff:searchQuery', {detail: [data, {'term': escapedQuery}]}));
     } catch (error) {
       console.error('Error fetching data:', error);
       populateResults([]);

--- a/spec/javascript/utility.spec.js
+++ b/spec/javascript/utility.spec.js
@@ -102,13 +102,6 @@ describe('Utility.fetchCommoditySearchSuggestions', () => {
 
     await Utility.fetchCommoditySearchSuggestions(query, searchSuggestionsPath, options, populateResults);
 
-    expect(fetch).toHaveBeenCalledWith(`${searchSuggestionsPath}?term=wine`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-
     const expectedResults = [
       {id: 'wine', text: 'wine', suggestion_type: 'exact', newOption: true},
       ...mockResponse.results,
@@ -127,12 +120,6 @@ describe('Utility.fetchCommoditySearchSuggestions', () => {
 
     await Utility.fetchCommoditySearchSuggestions(query, searchSuggestionsPath, options, populateResults);
 
-    expect(fetch).toHaveBeenCalledWith(`${searchSuggestionsPath}?term=wine`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
     expect(populateResults).toHaveBeenCalledWith([]);
   });
 });


### PR DESCRIPTION
### Jira link

OTT-495

### What?

Corrects URL formation for searchSuggestions URL

### Why?

Previously the code would take any existing URL params and try to append on the search query, and this was incorrect.  For instance:

`/find_commodity?foo=bar` then tried to turn into `/find_commodity?foo=bar?query=chicken`

which is an invalid URL.
This PR uses the JS URL obejct to ensure we're building a proper URL regardless.