### PR TITLE
OTT-295 Fix Footer Alignment in Responsive mode

### DIFF
--- a/app/views/shared/_feedback_useful_banner.html.erb
+++ b/app/views/shared/_feedback_useful_banner.html.erb
@@ -1,5 +1,5 @@
 <div class="feedback-useful-banner govuk-width-container">
-  <div class="feedback-useful-container">
+  <div class="feedback-useful-container govuk-!-padding-4">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <p>Is this page useful?</p>

--- a/app/webpacker/src/stylesheets/_feedback_useful_banner.scss
+++ b/app/webpacker/src/stylesheets/_feedback_useful_banner.scss
@@ -3,7 +3,6 @@
 
   .feedback-useful-container {
     position: relative;
-    padding: 1em;
     background-color: govuk-colour("light-grey");
     height: 36px;
     padding-top: 17px;
@@ -32,6 +31,9 @@
   .feedback-useful-banner {
     .report-problem {
       display: none;
+    }
+    .govuk-footer__meta-item {
+      margin-right: 0 !important;
     }
   }
 }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-295

### What?

I have:

- [x] Altered Feedback Useful Banner's responsive styling

### Why?

I am doing this because:

- The 'No' button was appearing on the next line due to `.govuk-footer__meta-item` margin settings in reused code.

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

BEFORE
![image](https://github.com/user-attachments/assets/3bf60670-5dcc-442e-a698-0f755d052996)

AFTER
![image](https://github.com/user-attachments/assets/884db823-95fa-4f2e-b95a-c18260e0e240)
