### PR TITLE
OTT-275: Pass the import date to the duty calculator

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -168,11 +168,23 @@ module ApplicationHelper
     end
   end
 
-  def duty_calculator_url(dc_path)
-    dc_base_url = ENV.fetch('DUTY_CALCULATOR_BASE_URL', '/duty-calculator')
-    normalised_dc_path = dc_path.gsub(/\A\//, '')
+  def duty_calculator_link(service_choice, declarable_code)
+    url = ENV.fetch('DUTY_CALCULATOR_BASE_URL', '/duty-calculator')
+    code = divide_commodity_code(declarable_code).join(' ')
 
-    "#{dc_base_url}/#{normalised_dc_path}"
+    link_description = "work out the duties and taxes applicable to the import of commodity #{code}"
+    link_url = File.join(
+      url,
+      service_choice,
+      declarable_code,
+      'import-date',
+    )
+
+    params.slice(:day, :month, :year).to_unsafe_hash.to_query.tap do |query|
+      link_url += "?#{query}" if query.present?
+    end
+
+    link_to link_description, link_url
   end
 
   def month_name_and_year(month, year)

--- a/app/views/measures/grouped/_tariff_duty_calculator_link.html.erb
+++ b/app/views/measures/grouped/_tariff_duty_calculator_link.html.erb
@@ -8,10 +8,8 @@
 
     <p>
       Use our <strong>tariff duty calculator</strong> to
-      <%= link_to duty_calculator_url "/#{service_choice}/#{declarable_code}/import-date" do %>
-        work out the duties and taxes applicable to the import of commodity
-        <%= divide_commodity_code(declarable_code).join ' ' %>.
-      <% end %>
+
+      <%= duty_calculator_link(service_choice, declarable_code) %>
     </p>
 
     <p><%= I18n.t("measure_type_message")%></p>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -445,29 +445,10 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#duty_calculator_url' do
-    context 'with default' do
-      subject { duty_calculator_url '/some/test?path=1' }
+  describe '#duty_calculator_link' do
+    subject { helper.duty_calculator_link 'uk', '1704909991' }
 
-      it { is_expected.to eq '/duty-calculator/some/test?path=1' }
-    end
-
-    context 'with override' do
-      subject { duty_calculator_url '/some/test?path=1' }
-
-      before do
-        allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:fetch).with('/some/test?path=1')
-                                     .and_return 'http://localhost:3002'
-      end
-
-      it { is_expected.to eq '/duty-calculator/some/test?path=1' }
-    end
-
-    context 'without leading slash' do
-      subject { duty_calculator_url 'some/test?path=1' }
-
-      it { is_expected.to eq '/duty-calculator/some/test?path=1' }
-    end
+    it { is_expected.to have_css 'a', text: 'work out the duties and taxes applicable to the import of commodity 1704 9099 91' }
+    it { is_expected.to have_css 'a[href="/duty-calculator/uk/1704909991/import-date"]' }
   end
 end


### PR DESCRIPTION
### Jira link

OTT-275

### What?

I have added/removed/altered:

- [x] Added handling of the import date when calling the duty calculator

### Why?

I am doing this because:

- This enables calculations on expired commodities
