### PR TITLE
GL-1040: Fixes sequence handling of moving date form params

### DIFF
--- a/app/controllers/green_lanes/applicable_exemptions_controller.rb
+++ b/app/controllers/green_lanes/applicable_exemptions_controller.rb
@@ -66,7 +66,6 @@ module GreenLanes
 
     # Goods nomenclature methods
     def goods_nomenclature
-      # goods_nomenclature_params[:moving_date] = Date.parse(goods_nomenclature_params[:moving_date])
       @goods_nomenclature ||= FetchGoodsNomenclature.new(goods_nomenclature_params).call
     end
 

--- a/app/controllers/green_lanes/moving_requirements_controller.rb
+++ b/app/controllers/green_lanes/moving_requirements_controller.rb
@@ -15,9 +15,8 @@ module GreenLanes
 
     def create
       @moving_requirements_form = MovingRequirementsForm.new(moving_requirements_params)
-      form = @moving_requirements_form
 
-      if form.valid?
+      if @moving_requirements_form.valid?
         next_page = DetermineNextPage
           .new(goods_nomenclature)
           .next
@@ -39,7 +38,15 @@ module GreenLanes
     end
 
     def goods_nomenclature
-      @goods_nomenclature ||= FetchGoodsNomenclature.new(moving_requirements_params).call
+      @goods_nomenclature ||= FetchGoodsNomenclature.new(goods_nomenclature_params).call
+    end
+
+    def goods_nomenclature_params
+      {
+        commodity_code: moving_requirements_params[:commodity_code],
+        country_of_origin: moving_requirements_params[:country_of_origin],
+        moving_date: @moving_requirements_form.moving_date,
+      }
     end
 
     def handle_next_page(next_page)


### PR DESCRIPTION
### Jira link

GL-1040

### What?

I have added/removed/altered:

- [x] Fixes parsing of the moving date params

### Why?

I am doing this because:

- Before we were fetching the goods nomenclature with unparsed moving date params. The net effect of this is we were determining the next page with today's version of the goods nomenclature. This is distinct from determinations that come in subsequent controllers which were using the correct date and thus showing no data. The fix was to adjust the params handling and to just use params for the moving date that had been parsed by the form object using ActiveRecord::AttributeAssignment.
