### PR TITLE
BAU: Add Guard for development CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ end
 
 group :development, :test do
   gem 'dotenv-rails'
+  gem 'guard-rspec', '~> 4.7'
+  gem 'guard-rubocop'
   gem 'pry-byebug'
   gem 'pry-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,11 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (>= 0.6, < 0.8)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     forgery (0.8.1)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (4.27.3-arm64-darwin)
@@ -244,6 +248,23 @@ GEM
       rouge
       sprockets (>= 3)
       sprockets-rails
+    guard (2.18.1)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.13.0)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    guard-rubocop (1.5.0)
+      guard (~> 2.0)
+      rubocop (< 2.0)
     hashdiff (1.0.1)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
@@ -278,6 +299,9 @@ GEM
       addressable (~> 2.8)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -290,6 +314,7 @@ GEM
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    lumberjack (1.2.10)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -303,6 +328,7 @@ GEM
     msgpack (1.7.2)
     multi_json (1.15.0)
     mutex_m (0.2.0)
+    nenv (0.3.0)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
     net-imap (0.4.14)
@@ -321,6 +347,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     opentelemetry-api (1.3.0)
     opentelemetry-common (0.21.0)
       opentelemetry-api (~> 1.0)
@@ -585,6 +614,9 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
     rbs (2.8.4)
     rdoc (6.7.0)
       psych (>= 4.0.0)
@@ -603,6 +635,10 @@ GEM
       strscan
     rinku (2.0.6)
     rouge (4.3.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -667,6 +703,7 @@ GEM
     sentry-ruby (5.17.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    shellany (0.0.1)
     shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
     simplecov (0.22.0)
@@ -755,6 +792,8 @@ DEPENDENCIES
   forgery
   govspeak
   govuk_design_system_formbuilder
+  guard-rspec (~> 4.7)
+  guard-rubocop
   kaminari
   letter_opener
   lograge

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,75 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# NOTE: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: 'bundle exec rspec' do
+  require 'guard/rspec/dsl'
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Feel free to open issues for suggestions and improvements
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+
+  # Rails files
+  rails = dsl.rails(view_extensions: %w[erb haml slim])
+  dsl.watch_spec_files_for(rails.app_files)
+  dsl.watch_spec_files_for(rails.views)
+
+  watch(rails.controllers) do |m|
+    [
+      rspec.spec.call("routing/#{m[1]}_routing"),
+      rspec.spec.call("controllers/#{m[1]}_controller"),
+      rspec.spec.call("acceptance/#{m[1]}"),
+    ]
+  end
+
+  # Rails config changes
+  watch(rails.spec_helper)     { rspec.spec_dir }
+  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+  # Capybara features specs
+  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+
+  # Turnip features and steps
+  watch(%r{^spec/acceptance/(.+)\.feature$})
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+    Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance'
+  end
+end
+
+guard :rubocop do
+  watch(%r{.+\.rb$})
+  watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
+end

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ To run the spec use the following command:
 bundle exec rspec
 ```
 
+### Guard
+
+We use [Guard](https://github.com/guard/guard) to run the test suite automatically when files are changed.
+
+To run Guard use the following command:
+
+```sh
+bundle exec guard
+``` 
+
+This will run the appropriate test suite for the file you are working on.
+
 ## Troubleshooting
 
 Sometimes, when trying to load the front page, you get the error:


### PR DESCRIPTION
### Jira link

BAU: Add Guard

### What?

Guard allows a developer locally to be running a continuous test-loop providing faster feedback.