### PR TITLE
OTT-509 Remove /geographical_areas/countries page

### DIFF
--- a/app/controllers/geographical_areas_controller.rb
+++ b/app/controllers/geographical_areas_controller.rb
@@ -5,6 +5,7 @@ class GeographicalAreasController < ApplicationController
                 :set_goods_nomenclature_code
 
   def show
+    render 'errors/not_found', status: :not_found if params[:id] == 'countries'
     @geographical_area = GeographicalArea.find(params[:id], query_params)
   end
 


### PR DESCRIPTION
### Jira link

[OTT-509](https://transformuk.atlassian.net/browse/OTT-509)

### What?

This removes the unintended `/geographical_areas/countries` page