### PR TITLE
Fix when blank code shows

### DIFF
--- a/app/helpers/green_lanes_helper.rb
+++ b/app/helpers/green_lanes_helper.rb
@@ -77,6 +77,10 @@ module GreenLanesHelper
     code.start_with?('WFE') ? '' : code
   end
 
+  def format_pseudo_code_for_exemption(exemption)
+    exemption.code.start_with?('WFE') ? exemption.formatted_description.to_s : "#{exemption.code} #{exemption.formatted_description}"
+  end
+
   def unique_exemptions(assessments)
     exemptions = []
     displayed_exemptions = Set.new

--- a/app/views/green_lanes/applicable_exemptions/_form.html.erb
+++ b/app/views/green_lanes/applicable_exemptions/_form.html.erb
@@ -33,12 +33,12 @@
 
           <% category_assessment.exemptions.each_with_index do |exemption, exem_index| %>
             <%= f.govuk_check_box category_assessment.id,
-                                  exemption.code,
-                                  link_errors: (exem_index == 0),
-                                  label: { text: hide_pseudo_code(exemption.code) },
-                                  hint: { text: exemption.formatted_description },
-                                  checked: exemption_checkbox_checked?(category_assessment.id, exemption.code)
+                  exemption.code,
+                  link_errors: (exem_index == 0),
+                  label: { text: format_pseudo_code_for_exemption(exemption) },
+                  checked: exemption_checkbox_checked?(category_assessment.id, exemption.code)
             %>
+
 
           <% end %>
 

--- a/spec/helpers/green_lanes_helper_spec.rb
+++ b/spec/helpers/green_lanes_helper_spec.rb
@@ -3,6 +3,19 @@ require 'spec_helper'
 RSpec.describe GreenLanesHelper, type: :helper do
   before { allow(helper).to receive(:render) }
 
+  describe '#format_pseudo_code_for_exemption' do
+    let(:exemption_with_wfe_code) { instance_double('Exemption', code: 'WFE001', formatted_description: 'Ukraine exemption') }
+    let(:exemption_without_wfe_code) { instance_double('Exemption', code: 'Y171', formatted_description: 'Food Exemption') }
+
+    it 'returns the formatted description for codes starting with WFE' do
+      expect(format_pseudo_code_for_exemption(exemption_with_wfe_code)).to eq('Ukraine exemption')
+    end
+
+    it 'returns the code and formatted description for codes not starting with WFE' do
+      expect(format_pseudo_code_for_exemption(exemption_without_wfe_code)).to eq('Y171 Food Exemption')
+    end
+  end
+
   describe '#hide_pseudo_code' do
     it 'returns an empty string for codes starting with WFE' do
       expect(hide_pseudo_code('WFE001')).to eq('')


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/GL-823

### What?

Amendments to when a blank code shows it creates an ID based on the object as we need a label on the checkbox. This change puts all the content into the label and hides the code when needed.

See new design of the exemption questions below:

![Screenshot 2024-09-20 at 15 23 34](https://github.com/user-attachments/assets/922a527f-4f04-4f97-9e66-0fee63007a12)
