### PR TITLE
OTT-271 Fix OL legislative list styling

### DIFF
--- a/app/webpacker/src/stylesheets/_lists.scss
+++ b/app/webpacker/src/stylesheets/_lists.scss
@@ -54,3 +54,12 @@ ol.numbered-then-lettered-list {
     padding-left: govuk-spacing(3);
   }
 }
+
+ol.legislative-list,
+ol.legislative-list ol {
+  list-style-type: none;
+}
+
+ol.legislative-list {
+  padding: 0;
+}


### PR DESCRIPTION
### Jira link

[OTT-271](https://transformuk.atlassian.net/browse/OTT-271)

### What?

This PR adds additional styles to support the `govspeak` `legislative-list` markup in order to correctly display bullet points

![Screenshot 2024-09-19 at 14 14 16](https://github.com/user-attachments/assets/cdccc274-8524-4306-8010-a223395d5af7)
