### PR TITLE
OTT-295 Added more responsiveness styling for other and older devices

### DIFF
--- a/app/webpacker/src/stylesheets/_feedback_useful_banner.scss
+++ b/app/webpacker/src/stylesheets/_feedback_useful_banner.scss
@@ -35,6 +35,9 @@
     .govuk-footer__meta-item {
       margin-right: 0 !important;
     }
+    .govuk-footer__inline-list-item{
+      margin-right: 0 !important;
+    }
   }
 }
 
@@ -46,6 +49,25 @@
 
     .govuk-button {
       min-width: 3.5em;
+    }
+  }
+}
+
+// for the older devices with smaller screens show the buttons as a block
+@media (max-width: 384px) {
+  .feedback-useful-banner {
+    .feedback-useful-container {
+      height: auto;
+      padding-bottom: 20px;
+    }
+
+    .govuk-footer__inline-list-item {
+      display: block;
+      margin-bottom: 10px;
+    }
+
+    .govuk-button {
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-295

### What?

I have added

- [x] media query for smaller devices to show the buttons in a block and removed padding from buttons for devices where we still show buttons side by side.

### Why?

I am doing this because:

- It looks better on smaller devices.

### Have you? (optional)

- [x ] Validated mobile responsive behaviour of view changes (on all devices available in chrome dev tools)

BEFORE
<img width="420" alt="image" src="https://github.com/user-attachments/assets/c4838124-21de-4374-880b-dc02bb75cfd1">

AFTER
<img width="405" alt="image" src="https://github.com/user-attachments/assets/61427a55-c0ee-47e0-8646-382f347305a3">
