### PR TITLE
OTT-302 Additional CSS to handle $LegislativeList

### DIFF
--- a/app/webpacker/src/stylesheets/_lists.scss
+++ b/app/webpacker/src/stylesheets/_lists.scss
@@ -58,8 +58,20 @@ ol.numbered-then-lettered-list {
 ol.legislative-list,
 ol.legislative-list ol {
   list-style-type: none;
+  font-size: 1.1875rem;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 ol.legislative-list {
   padding: 0;
+
+  ol li {
+    color: #0b0c0c;
+    font-weight: 400;
+  }
+
+  ol li ol {
+    margin-top: 20px;
+  }
 }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-302

### What?

Additional CSS to handle nested lists within `$LegislativeList`, particularly in cases with bullets with list content

![Screenshot 2024-09-20 at 12 00 36](https://github.com/user-attachments/assets/74595ef6-42b9-4c30-bd34-e66d993fea62)
