### PR TITLE
BAU: Speed up headings spec

### DIFF
--- a/spec/features/headings_spec.rb
+++ b/spec/features/headings_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe 'JS behaviour', js: true, vcr: { cassette_name: 'headings#8501' }
 
     page.find_all('.tree-controls')[1].first('a').click # hide all
 
-    expect(page.find_all(".has_children ul[aria-hidden='true']").length).to eq(0)
+    expect(page.find_all(".has_children ul[aria-hidden='true']", wait: false).length).to eq(0)
 
     page.find_all('.tree-controls')[0].find('a:nth-child(2)').click # reshow all
 
-    expect(page.find_all(".has_children ul[aria-hidden='false']").length).to eq(0)
+    expect(page.find_all(".has_children ul[aria-hidden='false']", wait: false).length).to eq(0)
   end
 
   it 'is able to open close specific headings' do
@@ -35,10 +35,10 @@ RSpec.describe 'JS behaviour', js: true, vcr: { cassette_name: 'headings#8501' }
 
     within parent do
       find(:xpath, "./span[contains(concat(' ',normalize-space(@class),' '), ' description ')]").click
-      expect(parent.find_all(:xpath, "./span[contains(concat(' ',normalize-space(@class),' '), ' open ')]").length).to eq(1)
+      expect(parent.find_all(:xpath, "./span[contains(concat(' ',normalize-space(@class),' '), ' open ')]", wait: false).length).to eq(1)
 
       find(:xpath, "./span[contains(concat(' ',normalize-space(@class),' '), ' description ')]").click
-      expect(parent.find_all(:xpath, "./span[contains(concat(' ',normalize-space(@class),' '), ' open ')]").length).to eq(0)
+      expect(parent.find_all(:xpath, "./span[contains(concat(' ',normalize-space(@class),' '), ' open ')]", wait: false).length).to eq(0)
     end
   end
 end


### PR DESCRIPTION
### Jira link

BAU

### What?

Small test change to speed things up.  

Before:
```
Top 10 slowest examples (62.08 seconds, 34.5% of total time):
  JS behaviour render table tools on the top and bottom
    11.94 seconds ./spec/features/headings_spec.rb:4
  JS behaviour is able to open close specific headings
    6.95 seconds ./spec/features/headings_spec.rb:25
```

After:

```
Top 2 slowest examples (4.02 seconds, 99.7% of total time):
  JS behaviour is able to open close specific headings
    2.01 seconds ./spec/features/headings_spec.rb:25
  JS behaviour render table tools on the top and bottom
    2 seconds ./spec/features/headings_spec.rb:4
```

### Why?

This makes the test suite about 15% faster.