### PR TITLE
HMRC-404 Redirect old SPIMM url to new

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,8 +108,9 @@ Rails.application.routes.draw do
   resolve('GreenLanes::CategoryAssessmentSearch') { [:category_assessments] }
 
   get 'green_lanes' => 'green_lanes/results#show' # Old path. Now "check_spimm_eligibility".
+  get '/check_spimm_eligibility(/:path)', to: redirect('/check_simplified_processes_eligibility', status: :moved_permanently)
 
-  namespace :green_lanes, path: 'check_spimm_eligibility' do
+  namespace :green_lanes, path: 'check_simplified_processes_eligibility' do
     get '/', to: 'starts#new', as: 'start'
 
     resource :category_assessments, only: %i[create show]


### PR DESCRIPTION
### Jira link

HMRC-404

### What?

I have added a redirect from old SPIMM to new:

    Current URL - https://www.trade-tariff.service.gov.uk/check_spimm_eligibility 

    New URL - https://trade-tariff.service.gov.uk/check_simplified_processes_eligibility 
    
This is done via a 301.