### PR TITLE
HMRC-405 SPIMM Copy changes

### DIFF
--- a/app/views/green_lanes/applicable_exemptions/_form.html.erb
+++ b/app/views/green_lanes/applicable_exemptions/_form.html.erb
@@ -25,7 +25,7 @@
 
           <% if category_assessment.regulation_url.present? %>
           <p>
-            <%= link_to 'View EU Regulation document',
+            <%= link_to 'View Regulation document',
                         category_assessment.regulation_url,
                         class: 'govuk-link', target: '_blank', rel: 'noopener noreferrer'
             %>

--- a/app/views/green_lanes/eligibilities/new.html.erb
+++ b/app/views/green_lanes/eligibilities/new.html.erb
@@ -15,35 +15,35 @@
       </h1>
 
       <p>
-        The simplified process for internal market movements (SPIMM) can only be used by traders in certain circumstances.
+        The simplified processes for Internal Market Movements can only be used by traders in certain circumstances.
       <p>
 
       <%= f.govuk_collection_radio_buttons :moving_goods_gb_to_ni,
         yes_no_options,
         :id, :name,
         legend: { text: "Are you moving goods from Great Britain to Northern Ireland?", size: "m" },
-        hint: { text: "SPIMM can only be used for the movement of goods from Great Britain to Northern Ireland." }
+        hint: { text: "Simplified processes can only be used for the movement of goods from Great Britain to Northern Ireland." }
       %>
 
       <%= f.govuk_collection_radio_buttons :free_circulation_in_uk,
         yes_no_options,
         :id, :name,
         legend: { text: "Are your goods in free circulation in the UK (England, Wales, Scotland and Northern Ireland)?", size: "m" },
-        hint: { text: "Goods in free circulation have already been imported into the UK with duties paid. SPIMM can only be used for goods that are in free circulation in Great Britain and moving into free circulation in Northern Ireland." } %>
+        hint: { text: "Goods in free circulation have already been imported into the UK with duties paid. Simplified processes can only be used for goods that are in free circulation in Great Britain and moving into free circulation in Northern Ireland." } %>
 
 
       <%= f.govuk_collection_radio_buttons :end_consumers_in_uk,
         yes_no_not_sure_options,
         :id, :name,
         legend: { text: "Are your goods intended to be sold to, or used by, end consumers in the UK (England, Wales, Scotland and Northern Ireland)?", size: "m" },
-        hint: { text: "SPIMM can only be used for the movement of goods that are 'not at risk' of onward movement into the European Union, including Republic of Ireland." } %>
+        hint: { text: "Simplified processes can only be used for the movement of goods that are 'not at risk' of onward movement into the European Union, including Republic of Ireland." } %>
 
 
       <%= f.govuk_collection_radio_buttons :ukims,
         yes_no_options,
         :id, :name,
         legend: { text: "Are you authorised to trade under the UK Internal Market Scheme (UKIMS)?", size: "m" },
-        hint: { text: "The simplified process for internal market movements is only available to UKIMS authorised traders." } %>
+        hint: { text: "Simplified processes are only available to UKIMS authorised traders." } %>
 
       <%= f.govuk_submit "Continue", class: "govuk-button" %>
     <% end %>

--- a/app/views/green_lanes/eligibility_results/_not_eligible.html.erb
+++ b/app/views/green_lanes/eligibility_results/_not_eligible.html.erb
@@ -1,22 +1,22 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      You are not eligible for the simplified process for internal market movements
+      You are not eligible for the simplified processes for Internal Market Movements
     </h1>
 
     <p class="govuk-body">
-      The simplified process for internal market movements (SPIMM) is only available for:
+      The simplified processes for Internal Market Movements are only available for:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>goods in direct transport from Great Britain to Northern Ireland</li>
       <li>goods in free circulation in the United Kingdom</li>
-      <li>goods intended to be sold to, or used by, end consumers in the UK, and therefore deemed not “at risk” of onward movement to the EU</li>
+      <li>goods intended to be sold to, or used by, end consumers in the UK, and therefore deemed 'not at risk' of onward movement to the EU</li>
       <li>UK internal market scheme (UKIMS) authorised traders</li>
     </ul>
 
     <p class="govuk-body">
-      <a href="http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland" target="_blank" class="govuk-link">Find out more about SPIMM (opens in new tab)</a>
+      <a href="http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland" target="_blank" class="govuk-link">Find out more about Internal Market Movements (opens in new tab)</a>
     </p>
 
     <p class="govuk-body">

--- a/app/views/green_lanes/eligibility_results/_not_yet_eligible.html.erb
+++ b/app/views/green_lanes/eligibility_results/_not_yet_eligible.html.erb
@@ -6,7 +6,7 @@
     </h1>
 
     <p>
-      To use the simplified process for internal market movements (SPIMM) you must:
+      To use the simplified processes for Internal Market Movements you must:
     </p>
 
 
@@ -23,13 +23,13 @@
     </p>
 
     <p>
-      As categorisation is complex, this tool will help determine if your specific goods are:
+      This tool will help determine if your specific goods are:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>Category 1: not eligible for SPIMM and subject to full customs processes</li>
-      <li>Category 2: eligible for SPIMM but must meet certain requirements and conditions, including document controls</li>
-      <li>Standard goods: eligible for SPIMM</li>
+      <li>Category 1: not eligible for simplified processes and subject to full customs processes</li>
+      <li>Category 2: eligible for simplified processes but must meet certain requirements and conditions, including document controls</li>
+      <li>Standard goods: eligible for simplified processes</li>
     </ul>
 
     <p>

--- a/app/views/green_lanes/eligibility_results/_you_may_be_eligible.html.erb
+++ b/app/views/green_lanes/eligibility_results/_you_may_be_eligible.html.erb
@@ -6,7 +6,7 @@
     </h1>
 
     <p>
-      To use the simplified process for internal market movements (SPIMM) you must:
+      To use the simplified processes for Internal Market Movements you must:
     </p>
 
 
@@ -23,13 +23,13 @@
     </p>
 
     <p>
-      As categorisation is complex, this tool will help determine if your specific goods are:
+      This tool will help determine if your specific goods are:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>Category 1: not eligible for SPIMM and subject to full customs processes</li>
-      <li>Category 2: eligible for SPIMM but must meet certain requirements and conditions, including document controls</li>
-      <li>Standard goods: eligible for SPIMM</li>
+      <li>Category 1: not eligible for simplified processes and subject to full customs processes</li>
+      <li>Category 2: eligible for simplified processes but must meet certain requirements and conditions, including document controls</li>
+      <li>Standard goods: eligible for simplified processes</li>
     </ul>
 
     <p>

--- a/app/views/green_lanes/results/_category_assessments_card.erb
+++ b/app/views/green_lanes/results/_category_assessments_card.erb
@@ -1,7 +1,7 @@
 <div class="govuk-summary-card">
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title">
-      Your Category <%= category %> result is based on EU regulations
+      Your Category <%= category %> result is based on the following regulations
     </h2>
   </div>
 
@@ -17,7 +17,7 @@
             </p>
 
             <% if category_assessment.regulation_url.present? %>
-              <%= link_to 'View EU Regulation document', category_assessment.regulation_url, class: 'govuk-link' %>
+              <%= link_to 'View Regulation document', category_assessment.regulation_url, class: 'govuk-link' %>
             <% end %>
 
             <p class='govuk-!-margin-top-4'>

--- a/app/views/green_lanes/results/_result_category_1.html.erb
+++ b/app/views/green_lanes/results/_result_category_1.html.erb
@@ -3,7 +3,7 @@
     Category 1
   </h1>
   <div class="govuk-panel__body">
-    Goods are not eligible to move through the simplified process for internal market movements (SPIMM)
+    Goods are not eligible to move using the simplified processes for Internal Market Movements
   </div>
 </div>
 
@@ -11,7 +11,7 @@
   Based on the information you have provided, your goods are determined to be Category 1.
 </p>
 
-<p>Category 1 goods are not eligible for SPIMM as they are subject to one or more of the following:</p>
+<p>Category 1 goods are not eligible for the simplified processes for Internal Market Movements as they are subject to one or more of the following:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>restrictions enforced by Article 215 of The Treaty of the Functioning of the European Union (TFEU)</li>
@@ -22,7 +22,7 @@
 </ul>
 
 <p>
-  <%= link_to 'Find out more about SPIMM (opens in new tab)',
+  <%= link_to 'Find out more about Internal Market Movements (opens in a new tab)',
               'http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland',
               target: '_blank', rel: 'noopener noreferrer'
   %>
@@ -31,7 +31,7 @@
 <h2 class="govuk-heading-m">What you should do next</h2>
 
 <p>
-  Category 1 goods cannot continue through SPIMM.
+  Category 1 goods cannot move using simplified processes.
 </p>
 
 <p>

--- a/app/views/green_lanes/results/_result_category_2.html.erb
+++ b/app/views/green_lanes/results/_result_category_2.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">Category 2</h1>
   <div class="govuk-panel__body">
-    Goods are eligible to move through the simplified process for internal market movements (SPIMM)
+    Goods are eligible to move using the simplified processes for Internal Market Movements
   </div>
 </div>
 
@@ -9,48 +9,21 @@
   Based on the information you have provided, your goods are determined to be Category 2.
 </p>
 
-<p>Category 2 goods are eligible for SPIMM if they are:</p>
+<p>Category 2 goods are eligible for the simplified processes for Internal Market Movements if they are:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>in direct transport from Great Britain to Northern Ireland</li>
-  <li>intended to be sold to, or used by, end consumers in the UK, and therefore deemed not 'at risk' of onward movement to the EU, including the Republic of Ireland</li>
+  <li>intended to be sold to, or used by, end consumers in the UK, and therefore deemed 'not at risk' of onward movement to the EU, including the Republic of Ireland</li>
   <li>in free circulation in the UK</li>
   <li>excise products and goods subject to special health, licensing or environmental controls</li>
 </ul>
 
 <p>
-  <%= link_to 'Find out more about SPIMM (opens in new tab)',
+  <%= link_to 'Find out more about Internal Market Movements (opens in a new tab)',
               'http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland',
               target: '_blank', rel: 'noopener noreferrer'
   %>
 </p>
-
-<!--
-
-<h2 class="govuk-heading-m">What you should do next</h2>
-
-<p>To move your goods through SPIMM, you'll need to submit an Internal Market Movement Information (IMMI). This will allow you to submit a reduced data set requiring significantly less information.
-  <%# <a href="" target="_blank" class="govuk-link">Find out more about what you need to submit an IMMI (opens in a new tab).</a> %>
-</p>
-
-<ol class="govuk-list govuk-list--number">
-  <li>
-    If you are not already,
-    <%= link_to 'Become an authorised trader under the UK Internal Market Scheme (UKIMS) (opens in a new tab)',
-                'https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland',
-                target: '_blank', rel: 'noopener noreferrer' %>
-  </li>
-  <li>You may wish to access your <%= link_to 'Trader Goods Profile (opens in new tab)',
-                'https://www.gov.uk/guidance/manage-your-trader-goods-profile',
-                target: '_blank', rel: 'noopener noreferrer' %> which will be automatically created when you register for UKIMS. Information about your business's commonly transported goods can be used to automatically fill in the IMMI.
-  </li>
-  <li>Contact a customs agent, or access the free-to-use <%= link_to 'Trader Support Service (TSS) (opens in a new tab).',
-                'https://www.gov.uk/guidance/trader-support-service',
-                target: '_blank', rel: 'noopener noreferrer' %> to prepare the IMMI. Depending on your preference, submit an IMMI either pre-movement or post-movement.
-  </li>
-</ol>
--->
-
 
 <h2 class="govuk-heading-m">About the categorisation of your goods</h2>
 

--- a/app/views/green_lanes/results/_result_category_3.html.erb
+++ b/app/views/green_lanes/results/_result_category_3.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">Standard goods</h1>
   <div class="govuk-panel__body">
-    Goods are eligible to move through the simplified process for internal market movements (SPIMM)
+    Goods are eligible to move using the simplified processes for Internal Market Movements
   </div>
 </div>
 
@@ -9,48 +9,22 @@
   Based on the information you have provided, your goods are determined to be Standard goods.
 </p>
 
-<p>Standard goods are eligible for SPIMM if they are:</p>
+<p>Standard goods are eligible for the simplified processes for Internal Market Movements if they are:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>in direct transport from Great Britain to Northern Ireland</li>
-  <li>intended to be sold to, or used by, end consumers in the UK, and therefore deemed not 'at risk' of onward movement to the EU, including the Republic of Ireland</li>
+  <li>intended to be sold to, or used by, end consumers in the UK, and therefore deemed 'not at risk' of onward movement to the EU, including the Republic of Ireland</li>
   <li>free of import or licensing requirements</li>
   <li>in free circulation in the UK</li>
   <li>not entering a customs duty suspense procedure</li>
 </ul>
 
 <p>
-  <%= link_to 'Find out more about SPIMM (opens in new tab)',
+   <%= link_to 'Find out more about Internal Market Movements (opens in a new tab)',
               'http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland',
               target: '_blank', rel: 'noopener noreferrer'
   %>
 </p>
-
-<!--
-
-<h2 class="govuk-heading-m">What you should do next</h2>
-
-<p>To move your goods through SPIMM, you'll need to submit an Internal Market Movement Information (IMMI). This will allow you to submit a reduced data set requiring significantly less information.
-<a href="" target="_blank" class="govuk-link">Find out more about what you need to submit an IMMI (opens in a new tab).</a></p>
-
-<ol class="govuk-list govuk-list--number">
-  <li>
-    If you are not already,
-    <%= link_to 'Become an authorised trader under the UK Internal Market Scheme (UKIMS) (opens in a new tab)',
-                'https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland',
-                target: '_blank', rel: 'noopener noreferrer' %>
-  </li>
-  <li>You may wish to access your <%= link_to 'Trader Goods Profile (opens in new tab)',
-                'https://www.gov.uk/guidance/manage-your-trader-goods-profile',
-                target: '_blank', rel: 'noopener noreferrer' %> which will be automatically created when you register for UKIMS. Information about your business's commonly transported goods can be used to automatically fill in the IMMI.
-  </li>
-  <li>Contact a customs agent, or access the free-to-use <%= link_to 'Trader Support Service (TSS) (opens in a new tab).',
-                'https://www.gov.uk/guidance/trader-support-service',
-                target: '_blank', rel: 'noopener noreferrer' %> to prepare the IMMI. Depending on your preference, submit an IMMI either pre-movement or post-movement.
-  </li>
-</ol>
--->
-
 
 <h2 class="govuk-heading-m">About the categorisation of your goods</h2>
 

--- a/app/views/green_lanes/shared/_about_spimm_link.html.erb
+++ b/app/views/green_lanes/shared/_about_spimm_link.html.erb
@@ -1,6 +1,0 @@
-<p>
-  <%= link_to 'Find out more about SPIMM',
-              '',
-              class: 'govuk-link'
-  %>
-</p>

--- a/app/views/green_lanes/starts/new.html.erb
+++ b/app/views/green_lanes/starts/new.html.erb
@@ -7,19 +7,20 @@
   <div class="govuk-grid-column-two-thirds">
     <header>
       <h1 class="govuk-heading-l">
-        Check if you are eligible for the simplified process for internal market movements from Great Britain to Northern Ireland (SPIMM)
+        Check if you are eligible for the simplified processes for Internal Market Movements from Great Britain to Northern Ireland
       </h1>
     </header>
 
     <p>
-      Traders may be able to use the simplified process for internal market movements (SPIMM) under the Windsor Framework.
-      <a href='http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland' target='_blank' rel='noopener noreferrer'>Find out more about SPIMM (opens in new tab).</a>
+      Traders may be able to use the simplified processes for Internal Market Movements when moving goods within the UK's internal market. This applies to goods moving from a business in Great Britain (England, Scotland, or Wales) to a business in Northern Ireland.
+    </p>
+    <p>
+     These simplified processes will be introduced when the new arrangements for parcels and freight under the Windsor Framework come into effect no earlier than 31 March 2025.
+     <a href='http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland' target='_blank' rel='noopener noreferrer'> Find out more about Internal Market Movements (opens in new tab)</a>.
     <p>
 
     <p>
-      UK Internal Market Scheme (UKIMS) authorised traders that move goods from Great Britain
-      to Northern Ireland through SPIMM can submit a simplified data set rather than a full declaration,
-      as well as benefitting from zero customs duties and reduced checks.
+      UK Internal Market Scheme (UKIMS) authorised traders that move goods from Great Britain to Northern Ireland using the simplified processes can submit a simplified data set rather than a full declaration, as well as benefitting from zero customs duties.
     </p>
 
     <p>
@@ -27,7 +28,7 @@
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>what is required for SPIMM</li>
+      <li>what is required to use the simplified processes for Internal Market Movements</li>
       <li>the category of your goods</li>
       <li>what to do next</li>
     </ul>
@@ -39,23 +40,23 @@
     <h3 class="govuk-heading-m">Categorisation of goods</h3>
 
     <p>
-      Categorisation is a complex process based on legal regulations, and the specific composition and origin of goods.
+      Categorisation is based on legal regulations and the specific composition and origin of goods.
     </p>
 
     <p>
-      Traders must check the category of their goods to determine if they are eligible to move through SPIMM.
+      Traders must check the category of their goods to determine if they are eligible to use the simplified processes for Internal Market Movements.
     </p>
 
     <p>Goods can be:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
         <span class="govuk-!-font-weight-bold">Category 1:</span>
-        not eligible for SPIMM and subject to full customs processes
+        not eligible for simplified processes and subject to full customs duties and checks
       </li>
       <li>
         <span class="govuk-!-font-weight-bold">Category 2</span> or
         <span class="govuk-!-font-weight-bold">Standard goods:</span>
-        eligible for SPIMM
+        eligible for simplified processes
       </li>
     </ul>
 

--- a/spec/features/green_lanes_category_assessments_spec.rb
+++ b/spec/features/green_lanes_category_assessments_spec.rb
@@ -281,14 +281,14 @@ RSpec.describe 'Green lanes category assessments',
     expect(page).to have_css('h1', text: 'Category 1')
     expect(page).to have_css('.govuk-summary-list__value', text: 'Category 1')
 
-    expect(page).to have_css('h2', text: 'Your Category 1 result is based on EU regulations')
+    expect(page).to have_css('h2', text: 'Your Category 1 result is based on the following regulations')
   end
 
   def category_2_result_screen
     expect(page).to have_css('h1', text: 'Category 2')
     expect(page).to have_css('.govuk-summary-list__value', text: 'Category 2')
 
-    expect(page).to have_css('h2', text: 'Your Category 2 result is based on EU regulations')
+    expect(page).to have_css('h2', text: 'Your Category 2 result is based on the following regulations')
   end
 
   def standard_category_result_screen


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-405

### What?

I have altered:

- [x] Views for GL categorisation eligibility checks 

### Why?

I am doing this because:

- An urgent HMRC request to make copy changes where the SPIMM acronym was used and some other minor changes in the journey


START PAGE
![image](https://github.com/user-attachments/assets/35a36046-2f91-4774-abf6-397ddbfa5a76)

ELIGIBILITY QUESTIONS PAGE
![image](https://github.com/user-attachments/assets/c3e3bccf-f85b-4f5e-a30f-65e630e69c2f)

NOT ELIGIBLE PAGE
![image](https://github.com/user-attachments/assets/bbce04a7-6a91-4407-9d22-ddb431eaad2a)

CHECK THE CATEGORY OF YOUR GOODS PAGE
![image](https://github.com/user-attachments/assets/47e8644f-3fa8-43dc-9890-0cbd401bb776)

CATEGORY 1
![image](https://github.com/user-attachments/assets/f4f6e33c-7c9d-4e99-bc7a-30ac1771b056)

CATEGORY 2
![image](https://github.com/user-attachments/assets/b70453d0-10fe-4d20-9ac9-26e478704758)

STANDARD GOODS (CATEGORY 3)
![image](https://github.com/user-attachments/assets/eefdc08a-45d2-430e-a41c-b0cab6a4dc1f)