### PR TITLE
HMRC-537 Handle bad news requests with a 404

### DIFF
--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -15,6 +15,8 @@ class NewsItemsController < ApplicationController
     end
 
     @news_items = News::Item.updates_page(**news_index_params)
+  rescue Faraday::ServerError
+    redirect_to not_found_path
   end
 
   def show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,7 +237,7 @@ Rails.application.routes.draw do
 
   get '/robots.:format', to: 'pages#robots'
   match '/400', to: 'errors#bad_request', via: :all
-  match '/404', to: 'errors#not_found', via: :all
+  match '/404', to: 'errors#not_found', via: :all, as: :not_found
   match '/405', to: 'errors#method_not_allowed', via: :all
   match '/406', to: 'errors#not_acceptable', via: :all
   match '/422', to: 'errors#unprocessable_entity', via: :all


### PR DESCRIPTION
### Jira link

HMRC-537

### What?

This PR means bad requests for news collections will be handled with a 404 rather than an error page.  Errors may still occur on the backend