### PR TITLE
HMRC-497 | add commodity code instructions for GL moving requirements

### DIFF
--- a/app/views/green_lanes/moving_requirements/new.html.erb
+++ b/app/views/green_lanes/moving_requirements/new.html.erb
@@ -15,7 +15,13 @@
       </h1>
       <%= f.govuk_text_field :commodity_code, maxlength: 10,
                              label: { text: "What is the commodity code?", size: 'm'},
-                             hint: { text: "Commodity codes are internationally recognised reference numbers that describe specific goods. You can use the Online Tariff to " \
+                             hint: { text: "Commodity codes are internationally recognised reference numbers that describe specific goods.
+                                            You must enter the full 10-digit code, including any zeros at the end.
+                                            <br><br/> For example: <br><br/>
+                                              <li> If your code is '010121', enter it as '0101210000' </li>
+                                              <li> If your code is '01012100', enter it as '0101210000' </li>
+                                            <br><br/>
+                                            You can use the Online Tariff to " \
                                            "<a href='https://www.gov.uk/trade-tariff' target='_blank' rel='noopener noreferrer'>search for a commodity (opens in a new tab).</a>".html_safe
                                    },
                              style: "width:330px" %>


### PR DESCRIPTION
### Jira link

[HMRC-497](https://transformuk.atlassian.net/browse/HMRC-497)

### What?

I have added/removed/altered:

- [x] Added instructions for users to enter a 10 digit commodity code 

### Why?

I am doing this because:

- Prevent users from using less digits in the provided commodity code
