### PR TITLE
HMRC-541 Update GTM implementation (to follow Google recommendation)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,8 @@
 </head>
 
 <body class="govuk-template__body <%= service_choice || service_default %>-service">
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= TradeTariffFrontend.google_tag_manager_container_id %>"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <%= content_tag :div, class: 'path_info', data: @path_info do %>
   <% end %>
 

--- a/app/webpacker/src/javascripts/google-tag-manager-loader.js
+++ b/app/webpacker/src/javascripts/google-tag-manager-loader.js
@@ -6,7 +6,6 @@ if (cookieManager.usage()) {
   (function(w, d, s, l, i) {
     w[l] = w[l] || [];
     w[l].push({'gtm.start': new Date().getTime(), 'event': 'gtm.js'});
-    const f = d.getElementsByTagName(s)[0];
     const j = d.createElement(s);
     const dl = l != 'dataLayer' ? '&l=' + l : '';
     j.async = true;

--- a/app/webpacker/src/javascripts/google-tag-manager-loader.js
+++ b/app/webpacker/src/javascripts/google-tag-manager-loader.js
@@ -11,6 +11,6 @@ if (cookieManager.usage()) {
     const dl = l != 'dataLayer' ? '&l=' + l : '';
     j.async = true;
     j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-    f.parentNode.insertBefore(j, f);
+    document.head.insertBefore(j, document.head.firstChild);
   })(window, document, 'script', 'dataLayer', window.googleTagManagerContainerId);
 }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-541

### What?

I have prepended GTM tag script to top of `<head>` and added `noscript` to top of `<body>` in `application.html.erb`

### Why?

I am doing this because:

- The GTM script must be at the top of `<head>` for it to work and a `<noscript>` is required for basic tracking of users who have disabled javascript