### PR TITLE
HMRC-271 Disable V1 API routing

### DIFF
--- a/app/controllers/out_of_service_controller.rb
+++ b/app/controllers/out_of_service_controller.rb
@@ -1,0 +1,8 @@
+class OutOfServiceController < ApplicationController
+  def index
+    render json: {
+      "error": 'api-disabled',
+      "message": 'The v1 API is deprecated. Please use the v2 API instead. https://api.trade-tariff.service.gov.uk/#gov-uk-trade-tariff-api',
+    }, status: :service_unavailable
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -241,6 +241,8 @@ Rails.application.routes.draw do
 
   get '/', to: redirect(TradeTariffFrontend.production? ? 'https://www.gov.uk/trade-tariff' : '/find_commodity', status: 302)
 
+  match '/api/v1/:path', to: 'out_of_service#index', via: :all
+
   get '/robots.:format', to: 'pages#robots'
   match '/400', to: 'errors#bad_request', via: :all
   match '/404', to: 'errors#not_found', via: :all, as: :not_found

--- a/spec/requests/out_of_service_controller_spec.rb
+++ b/spec/requests/out_of_service_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe OutOfServiceController, type: :request do
+  subject(:rendered) { make_request && response }
+
+  let(:json_response) { JSON.parse(rendered.body) }
+
+  shared_examples 'a json error response' do |status_code, message|
+    it { is_expected.to have_http_status status_code }
+    it { is_expected.to have_attributes media_type: 'application/json' }
+    it { expect(json_response).to include 'error' => message }
+  end
+
+  describe 'GET /api/v1/foo' do
+    let(:make_request) { get '/api/v1/foo' }
+
+    it_behaves_like 'a json error response', 503, 'api-disabled'
+  end
+end


### PR DESCRIPTION
### Jira link

HMRC-271

### What?

Disable routing for the v1 API on a temporary basis.  This PR is intended to be used for brown-out, and can be revert'ed or superseded by another PR to make the disabling permanent.