### PR TITLE
HMRC-635 Fix Rack Timeout timeouts to protect app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'faraday-retry'
 gem 'multi_json'
 gem 'net-http-persistent'
 gem 'newrelic_rpm'
+gem 'rack-timeout'
 gem 'routing-filter', github: 'trade-tariff/routing-filter'
 gem 'yajl-ruby'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -586,6 +586,7 @@ GEM
       rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
+    rack-timeout (0.7.0)
     rackup (1.0.0)
       rack (< 3)
       webrick
@@ -816,6 +817,7 @@ DEPENDENCIES
   puma
   rack-cors
   rack-test
+  rack-timeout
   rails (~> 8.0)
   rails-controller-testing!
   redis

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,1 @@
+Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: ENV.fetch('RACK_TIMEOUT_SERVICE_TIMEOUT', 5).to_i


### PR DESCRIPTION
### Jira link

HMRC-635

### What?

Rack timeout is set way too high to be useful.  This PR sets this to a more realistic level to provide the protection it's intended to
