### PR TITLE
HMRC-635 Add Rack Attack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'faraday-retry'
 gem 'multi_json'
 gem 'net-http-persistent'
 gem 'newrelic_rpm'
+gem 'rack-attack'
 gem 'routing-filter', github: 'trade-tariff/routing-filter'
 gem 'yajl-ruby'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,6 +578,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.10)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-proxy (0.7.7)
@@ -814,6 +816,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma
+  rack-attack
   rack-cors
   rack-test
   rails (~> 8.0)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,5 @@
 if Rails.env.production?
-  Rack::Attack.throttle('requests by ip', limit: 200, period: 60, &:ip)
+  Rack::Attack.throttle('requests by ip', limit: 500, period: 60, &:ip)
 else
   Rails.logger.info 'Rack::Attack is disabled in Dev env.'
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,5 @@
+if Rails.env.production?
+  Rack::Attack.throttle('requests by ip', limit: 10_000, period: 600, &:ip)
+else
+  Rails.logger.info 'Rack::Attack is disabled in Dev env.'
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,5 @@
 if Rails.env.production?
-  Rack::Attack.throttle('requests by ip', limit: 10_000, period: 600, &:ip)
+  Rack::Attack.throttle('requests by ip', limit: 200, period: 60, &:ip)
 else
   Rails.logger.info 'Rack::Attack is disabled in Dev env.'
 end


### PR DESCRIPTION
### Jira link

HMRC-635

### What?

This PR adds a rule to Rack::Attack to throttle users to 10k requests every 10 mins on a leaky bucket system.

There are only a couple of users way above this amount which we are looking to cut. Whilst this is a limit, it's still way about what should be considered reasonable.

[logs-insights-results.csv](https://github.com/user-attachments/files/18655944/logs-insights-results.csv)

