### PR TITLE
HMRC-635 Remove Rack::Timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'multi_json'
 gem 'net-http-persistent'
 gem 'newrelic_rpm'
 gem 'rack-attack'
-gem 'rack-timeout'
 gem 'routing-filter', github: 'trade-tariff/routing-filter'
 gem 'yajl-ruby'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -588,7 +588,6 @@ GEM
       rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rack-timeout (0.7.0)
     rackup (1.0.0)
       rack (< 3)
       webrick
@@ -820,7 +819,6 @@ DEPENDENCIES
   rack-attack
   rack-cors
   rack-test
-  rack-timeout
   rails (~> 8.0)
   rails-controller-testing!
   redis

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,0 @@
-Rails.application.config.middleware.insert_before Rack::Runtime, Rack::Timeout, service_timeout: ENV.fetch('RACK_TIMEOUT_SERVICE_TIMEOUT', 5).to_i


### PR DESCRIPTION
### Jira link

HMRC-635

### What?

Removing Rack Timeout as it's causing 500s we can avoid