### PR TITLE
HMRC-635 Commodity Fragment Caching

### DIFF
--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -1,6 +1,7 @@
+<% cache [TradeTariffFrontend::ServiceChooser.service_name, params[:id], params[:year], params[:month], params[:day], params[:country]], expires_in: 3.hours do %>
 <% content_for :head do %>
-  <meta name="description" content="<%= declarable.description_plain %>">
-  <link rel='alternate' type='application/json' href='<%= declarable_path_json(declarable) %>' title='Commodity information page in JSON format' />
+<meta name="description" content="<%= declarable.description_plain %>">
+<link rel='alternate' type='application/json' href='<%= declarable_path_json(declarable) %>' title='Commodity information page in JSON format' />
 <% end %>
 
 <% content_for :bodyClasses, "page--wide" %>
@@ -8,7 +9,7 @@
 <%= render 'commodities/header', commodity_code: declarable.code %>
 
 <% declarable.critical_footnotes.each do |footnote| %>
-  <%= render 'footnotes/critical_warning', footnote: footnote %>
+<%= render 'footnotes/critical_warning', footnote: footnote %>
 <% end %>
 
 <%= render 'goods_nomenclatures/ancestors', goods_nomenclature: declarable %>
@@ -37,3 +38,4 @@
            roo_all_schemes: @roo_all_schemes %>
 
 <%= render 'commodities/help_popup' %>
+<% end %>


### PR DESCRIPTION
### Jira link

HMRC-635

### What?

I have added very simplistic fragment caching to the commodity#show page in an effort to establish the impact of such caching and whether we want to roll out a more aggressive caching scheme site wide.

Expiry is 3.hours which will add a little latency on updates, but the impact of this is expected to be low.