### PR TITLE
HMRC-633 Add VAT column to /headings and /subheadings pages on XI

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -78,9 +78,7 @@ module CommoditiesHelper
 
   def overview_measure_duty_amounts_for(commodity)
     content_tag(:div, data: { tree_target: 'commodityInfo' }, class: 'commodity__info') do
-      if TradeTariffFrontend::ServiceChooser.uk?
-        concat(content_tag(:div, vat_overview_measure_duty_amounts(commodity), class: 'vat', aria: { describedby: 'commodity-vat-title' }))
-      end
+      concat(content_tag(:div, vat_overview_measure_duty_amounts(commodity), class: 'vat', aria: { describedby: 'commodity-vat-title' }))
 
       concat(
         content_tag(

--- a/app/views/shared/_commodity_tree.html.erb
+++ b/app/views/shared/_commodity_tree.html.erb
@@ -8,9 +8,7 @@
       <span>The number following each commodity's description is its commodity code.</span>
       <em class="description">Description</em>
       <div class="commodity-tree__additional-info">
-        <% if TradeTariffFrontend::ServiceChooser.uk? %>
-          <em class="vat" id="commodity-vat-title">VAT</em>
-        <% end %>
+        <em class="vat" id="commodity-vat-title">VAT</em>
         <em class="duty" id="commodity-duty-title">Third country duty</em>
         <em class="supplementary-units" id="commodity-supplementary-title">Supplementary unit</em>
         <em class="commcode">Commodity code</em>

--- a/app/webpacker/src/stylesheets/_variables.scss
+++ b/app/webpacker/src/stylesheets/_variables.scss
@@ -39,7 +39,7 @@ $supplementary-units-width-desktop: 120px;
 $identifier-width: $chapter-code-width+$heading-code-width+$commodity-code-width + 10px;
 $identifier-width-desktop: $chapter-code-width+$heading-code-width+$commodity-code-width-desktop+$vat-width-desktop+$duty-width-desktop+$supplementary-units-width-desktop;
 $identifier-width-desktop-uk: 130px;
-$identifier-width-desktop-xi: 220px;
+$identifier-width-desktop-xi: 130px;
 
 $table-row-standard-height: 1.31579em;
 $small-table-breakpoint: 840px;

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe CommoditiesHelper, type: :helper do
         allow(TradeTariffFrontend::ServiceChooser).to receive(:uk?).and_return(false)
       end
 
-      it { is_expected.not_to have_css('div.vat') }
+      it { is_expected.to have_css('div.vat') }
     end
 
     it { is_expected.to have_css('div.duty') }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-633

### What?

I have added/removed/altered:

- [x] Added VAT Column for XI in commodity tree

### Why?

I am doing this because:

- It's been requested by the customer.

VAT Column Added
<img width="944" alt="image" src="https://github.com/user-attachments/assets/9e67b75f-78cc-426c-8714-00f48a619e26" />
