### PR TITLE
HMRC-715: Fixes integration with green lanes apis

### DIFF
--- a/app/models/green_lanes/faq_feedback.rb
+++ b/app/models/green_lanes/faq_feedback.rb
@@ -5,7 +5,7 @@ module GreenLanes
 
     def send_feedback_to_backend(feedback_params, session_id)
       response = self.class.post(
-        'green_lanes/faq_feedback',
+        '/api/v2/green_lanes/faq_feedback',
         data: {
           attributes: {
             session_id:,
@@ -14,7 +14,10 @@ module GreenLanes
             useful: feedback_params[:useful],
           },
         },
-        headers: { 'Content-Type' => 'application/json' },
+        headers: {
+          'Content-Type' => 'application/json',
+          'Authorization' => TradeTariffFrontend.green_lanes_api_token,
+        },
       )
 
       if response.success?
@@ -30,7 +33,7 @@ module GreenLanes
 
     def get_faq_feedback
       response = self.class.get(
-        'green_lanes/faq_feedback',
+        '/api/v2/green_lanes/faq_feedback',
       )
 
       if response.success?


### PR DESCRIPTION
### Jira link

HMRC-715

### What?

I have added/removed/altered:

- [x] Fixes integrations with v2 apis

### Why?

I am doing this because:

- This is required to migrate the admin-scoped apis to v2 and uses the standard authentication of our green lanes integrations
