### PR TITLE
HMRC-669 | Remove CHIEF guidance from export conditions and certificate search

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -7,8 +7,7 @@ class Certificate
                 :certificate_code,
                 :description,
                 :formatted_description,
-                :guidance_cds,
-                :guidance_chief
+                :guidance_cds
 
   has_many :goods_nomenclatures, polymorphic: true
 

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -17,7 +17,6 @@ class MeasureCondition
                 :duty_expression,
                 :certificate_description,
                 :guidance_cds,
-                :guidance_chief,
                 :threshold_unit_type,
                 :requirement_operator
 
@@ -36,7 +35,7 @@ class MeasureCondition
   end
 
   def has_guidance?
-    guidance_cds.present? || guidance_chief.present?
+    guidance_cds.present?
   end
 
   def presented_action

--- a/app/views/measures/_guidance_table.html.erb
+++ b/app/views/measures/_guidance_table.html.erb
@@ -10,9 +10,6 @@
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Document code</th>
             <th scope="col" class="govuk-table__header">CDS guidance</th>
-            <% if include_chief_guidance %>
-              <th scope="col" class="govuk-table__header">CHIEF guidance</th>
-            <% end %>
           </tr>
         </thead>
 
@@ -25,12 +22,6 @@
               <td class="govuk-table__cell tariff-markdown">
                 <%= govspeak mc.guidance_cds %>
               </td>
-
-              <% if include_chief_guidance %>
-                <td class="govuk-table__cell tariff-markdown">
-                  <%= govspeak mc.guidance_chief %>
-                </td>
-              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/measures/_measure_condition_modal_default.html.erb
+++ b/app/views/measures/_measure_condition_modal_default.html.erb
@@ -16,8 +16,7 @@
   <% end %>
 
   <%= render 'measures/guidance_table',
-    measure_conditions_with_guidance: measure.measure_conditions_with_guidance,
-    include_chief_guidance: anchor == 'export'
+    measure_conditions_with_guidance: measure.measure_conditions_with_guidance
   %>
 <% end %>
 

--- a/app/views/search/certificate_search.html.erb
+++ b/app/views/search/certificate_search.html.erb
@@ -38,7 +38,7 @@
         <details class="govuk-details govuk-!-margin-top-2" data-module="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
-              Using this certificate on CDS or CHIEF
+              Using this certificate on CDS
             </span>
           </summary>
 
@@ -52,14 +52,7 @@
                 <%= govspeak(certificate.guidance_cds) %>
                 </dd>
               </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                <strong>CHIEF guidance:</strong>
-                </dt>
-                <dd class="govuk-summary-list__value">
-                <%= govspeak(certificate.guidance_chief) %>
-                </dd>
-              </div>
+
             </dl>
           </div>
         </details>

--- a/spec/factories/measure_condition_factory.rb
+++ b/spec/factories/measure_condition_factory.rb
@@ -15,7 +15,6 @@ FactoryBot.define do
 
     trait :with_guidance do
       guidance_cds { 'Guidance CDS' }
-      guidance_chief { 'Guidance CHIEF' }
     end
 
     trait :threshold do

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe MeasureCondition do
                   duty_expression: '',
                   certificate_description: 'Foo bar',
                   guidance_cds: 'CDS guiance',
-                  guidance_chief: 'CHIEF guiance',
                   requirement: 'requirement'
 
   describe '#has_guidance?' do

--- a/spec/services/simplified_procedural_code_measure_fetcher_service_spec.rb
+++ b/spec/services/simplified_procedural_code_measure_fetcher_service_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe SimplifiedProceduralCodeMeasureFetcherService do
       let(:params) { { simplified_procedural_code: '2.120.1' } }
 
       it { expect(result.measures).to all(be_a(SimplifiedProceduralCodeMeasure)) }
-      it { expect(result.goods_nomenclature_label).to eq('Plums') }
-      it { expect(result.goods_nomenclature_item_ids).to eq('0809400500') }
+      it { expect(result.goods_nomenclature_label).to eq('Apples') }
+      it { expect(result.goods_nomenclature_item_ids).to eq('0808108010, 0808108020, 0808108090') }
       it { expect(result.validity_start_date).to be_nil }
       it { expect(result.validity_end_date).to be_nil }
       it { expect(result.validity_start_dates).to be_nil }

--- a/spec/services/simplified_procedural_code_measure_fetcher_service_spec.rb
+++ b/spec/services/simplified_procedural_code_measure_fetcher_service_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe SimplifiedProceduralCodeMeasureFetcherService do
       let(:params) { { simplified_procedural_code: '2.120.1' } }
 
       it { expect(result.measures).to all(be_a(SimplifiedProceduralCodeMeasure)) }
-      it { expect(result.goods_nomenclature_label).to eq('Apples') }
-      it { expect(result.goods_nomenclature_item_ids).to eq('0808108010, 0808108020, 0808108090') }
+      it { expect(result.goods_nomenclature_label).to eq('Plums') }
+      it { expect(result.goods_nomenclature_item_ids).to eq('0809400500') }
       it { expect(result.validity_start_date).to be_nil }
       it { expect(result.validity_end_date).to be_nil }
       it { expect(result.validity_start_dates).to be_nil }

--- a/spec/views/measures/_guidance_table.html.erb_spec.rb
+++ b/spec/views/measures/_guidance_table.html.erb_spec.rb
@@ -3,39 +3,20 @@ require 'spec_helper'
 RSpec.describe 'measures/guidance_table', type: :view do
   subject { render_page && rendered }
 
-  let(:render_page) { render 'measures/guidance_table', measure_conditions_with_guidance:, include_chief_guidance: }
+  let(:render_page) { render 'measures/guidance_table', measure_conditions_with_guidance: }
 
-  context 'when the page include_chief_guidance is `true`' do
+  context 'page includes measures with conditions' do
     let(:measure_conditions_with_guidance) { build_list :measure_condition, 2, :with_guidance }
-    let(:include_chief_guidance) { true }
 
     it { is_expected.to have_css 'details summary', text: /Guidance for completing/ }
     it { is_expected.to have_css 'table tbody tr', count: 2 }
     it { is_expected.to have_css 'table tbody td', text: measure_conditions_with_guidance.first.document_code }
     it { is_expected.to have_css 'table tbody td', text: /Guidance CDS/ }
-    it { is_expected.to have_css 'table tbody td', text: /Guidance CHIEF/ }
-
-    context 'with no conditions' do
-      let(:measure_conditions_with_guidance) { [] }
-
-      it { is_expected.not_to have_css 'details' }
-    end
   end
 
-  context 'when the page include_chief_guidance is `import`' do
-    let(:measure_conditions_with_guidance) { build_list :measure_condition, 2, :with_guidance }
-    let(:include_chief_guidance) { false }
+  context 'page includes with no conditions' do
+    let(:measure_conditions_with_guidance) { [] }
 
-    it { is_expected.to have_css 'details summary', text: /Guidance for completing/ }
-    it { is_expected.to have_css 'table tbody tr', count: 2 }
-    it { is_expected.to have_css 'table tbody td', text: measure_conditions_with_guidance.first.document_code }
-    it { is_expected.to have_css 'table tbody td', text: /Guidance CDS/ }
-    it { is_expected.not_to have_css 'table tbody td', text: /Guidance CHIEF/ }
-
-    context 'with no conditions' do
-      let(:measure_conditions_with_guidance) { [] }
-
-      it { is_expected.not_to have_css 'details' }
-    end
+    it { is_expected.not_to have_css 'details' }
   end
 end

--- a/spec/views/measures/_guidance_table.html.erb_spec.rb
+++ b/spec/views/measures/_guidance_table.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'measures/guidance_table', type: :view do
 
   let(:render_page) { render 'measures/guidance_table', measure_conditions_with_guidance: }
 
-  context 'page includes measures with conditions' do
+  context 'when page includes measures with conditions' do
     let(:measure_conditions_with_guidance) { build_list :measure_condition, 2, :with_guidance }
 
     it { is_expected.to have_css 'details summary', text: /Guidance for completing/ }
@@ -14,7 +14,7 @@ RSpec.describe 'measures/guidance_table', type: :view do
     it { is_expected.to have_css 'table tbody td', text: /Guidance CDS/ }
   end
 
-  context 'page includes with no conditions' do
+  context 'when page includes measures without conditions' do
     let(:measure_conditions_with_guidance) { [] }
 
     it { is_expected.not_to have_css 'details' }


### PR DESCRIPTION
### Jira link

[HMRC-669](https://transformuk.atlassian.net/browse/HMRC-669)

### What?

I have added/removed/altered:

- [x] Removed CHIEF guidance from export conditions and certificate search

### Why?

I am doing this because:

- Service request from Scott, CHIEF guidance isn't used anymore