### PR TITLE
BAU: Fixes redirecting to the main site

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,7 +170,9 @@ Rails.application.routes.draw do
       as: :pending_quota_balance,
       defaults: { format: :json }
 
+  # The following two routes are how gov.uk links to the trade tariff
   get '/', to: redirect(TradeTariffFrontend.production? ? 'https://www.gov.uk/trade-tariff' : '/find_commodity', status: 302)
+  get '/trade-tariff/sections', to: redirect('/find_commodity', status: 301)
 
   get '/robots.:format', to: 'pages#robots'
   match '/400', to: 'errors#bad_request', via: :all


### PR DESCRIPTION
### Jira link

The gov.uk page for the trade-tariff expects all of our links to support a /trade-tariff/sections path

![image](https://github.com/user-attachments/assets/2cc90907-04af-417b-8ae2-3bf0a3972637)


BAU

### What?

I have added/removed/altered:

- [x] Fixes redirects from gov.uk

### Why?

I am doing this because:

- They use a very old path to the application that we should coordinate them moving off of
