### PR TITLE
BAU: Fix search button CSS

### DIFF
--- a/app/webpacker/src/stylesheets/_header.scss
+++ b/app/webpacker/src/stylesheets/_header.scss
@@ -5,7 +5,7 @@
   bottom: 0;
   left: -30px;
   right: 0;
-  height: 39px;
+  height: 40px;
   width: 40px;
   overflow: visible;
   -webkit-box-shadow: none;


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [x] Aligned search button

### Why?

I am doing this because:

Before:
![Screenshot 2025-02-26 at 16 45 04](https://github.com/user-attachments/assets/0a33410b-cb2e-43c3-ba6b-3ffd399c926d)

After:
![Screenshot 2025-02-26 at 16 44 55](https://github.com/user-attachments/assets/53192f43-c718-46ec-b710-28d24cbf664f)
