### PR TITLE
HMRC-837: Adds an id to the duty calculator link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -184,7 +184,7 @@ module ApplicationHelper
       link_url += "?#{query}" if query.present?
     end
 
-    link_to link_description, link_url
+    link_to link_description, link_url, id: 'duty-calculator-link'
   end
 
   def month_name_and_year(month, year)


### PR DESCRIPTION
### Jira link

[HMRC-837](https://transformuk.atlassian.net/browse/HMRC-837)

### What?

I have a...

- Added an id to the duty calculator link on the commodity pages

### Why?

I am doing this because...

- This simplifies our e2e test suite and reduces brittle tests
