### PR TITLE
Updated Chapter Notes text

### DIFF
--- a/app/views/shared/_notes.html.erb
+++ b/app/views/shared/_notes.html.erb
@@ -12,7 +12,7 @@ chapter_note ||= false %>
     <%= insert_service_links(govspeak(section_note)) %>
 
   <% elsif chapter_note %>
-    <h2 class="govuk-heading-s">There are important chapter notes for this part of the tariff:</h2>
+    <h2 class="govuk-heading-s">Chapter notes</h2>
     <%= insert_service_links(govspeak(chapter_note)) %>
 
   <% elsif section_note %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-622

### What?

I have Updated Chapter Notes text

### Why?

I am doing this because it is a Jira requirement

BEFORE
![image](https://github.com/user-attachments/assets/cfc1cade-0729-4fa3-86e4-f35e8d1598a3)

AFTER
![image](https://github.com/user-attachments/assets/cc461f36-581c-43a4-9da6-4a664872aa4d)

