### PR TITLE
HMRC-747 trade-tariff redirect for Headings

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,9 +170,11 @@ Rails.application.routes.draw do
       as: :pending_quota_balance,
       defaults: { format: :json }
 
-  # The following two routes are how gov.uk links to the trade tariff
+  # The following routes are how gov.uk links to the trade tariff
   get '/', to: redirect(TradeTariffFrontend.production? ? 'https://www.gov.uk/trade-tariff' : '/find_commodity', status: 302)
   get '/trade-tariff/sections', to: redirect('/find_commodity', status: 301)
+  get '/trade-tariff/headings', to: redirect('/find_commodity', status: 301)
+  get '/trade-tariff/headings/:heading_id', to: redirect('/headings/%{heading_id}', status: 301), constraints: { heading_id: /\d+/ }
 
   get '/robots.:format', to: 'pages#robots'
   match '/400', to: 'errors#bad_request', via: :all


### PR DESCRIPTION
### Jira link

[HMRC-747](https://transformuk.atlassian.net/browse/HMRC-747)

### What?

I have added extra routes for trade-tariff/headings to redirect to /headings

### Why?

I am doing this because there seems to be users that use the trade-tariff route in their URLs as per the gov.uk website, see this [PR](https://github.com/trade-tariff/trade-tariff-frontend/pull/2195) 
