### PR TITLE
HMRC-818 Fix country autocomplete

### DIFF
--- a/app/webpacker/src/javascripts/quota-search.js
+++ b/app/webpacker/src/javascripts/quota-search.js
@@ -1,4 +1,4 @@
-import debounce from "./debounce";
+import accessibleAutocomplete from 'accessible-autocomplete';
 
 (function(){
   var fieldset = $('.js-quota-country-picker');

--- a/app/webpacker/src/javascripts/quota-search.js
+++ b/app/webpacker/src/javascripts/quota-search.js
@@ -1,36 +1,34 @@
 import accessibleAutocomplete from 'accessible-autocomplete';
 
-(function(){
-  var fieldset = $('.js-quota-country-picker');
-  var autocomplete = null;
+(function(global) {
+  const $ = global.jQuery;
+  const fieldset = $('.js-quota-country-picker');
 
-  $('.js-quota-country-picker-select').each(function() {
-    (function(element) {
-      autocomplete = accessibleAutocomplete.enhanceSelectElement({
-        selectElement: element[0],
-        minLength: 2,
-        showAllValues: true,
-        confirmOnBlur: true,
-        dropdownArrow: function() {
-          return "<span class='autocomplete__arrow'></span>";
-        },
-      });
+  $('.js-quota-country-picker-select').each((_, element) => {
+    accessibleAutocomplete.enhanceSelectElement({
+      selectElement: element,
+      minLength: 2,
+      showAllValues: true,
+      confirmOnBlur: true,
+      dropdownArrow: function() {
+        return '<span class=\'autocomplete__arrow\'></span>';
+      },
+    });
 
-      $('#' + element[0].id.replace('-select', '')).on('focus', function(event) {
-        $(event.currentTarget).val('')
-      });
-
-    })($(this));
+    $('#' + element.id.replace('-select', '')).on('focus', (event) => {
+      $(event.currentTarget).val('');
+    });
   });
 
-  fieldset.on('click', 'a.reset-country-picker', function (e) {
+  fieldset.on('click', 'a.reset-country-picker', (e) => {
     $('.js-quota-country-picker-select').val('');
     $('.js-quota-country-picker-select').trigger('blur');
     $('#' + $('.js-quota-country-picker-select').attr('name')).val('All Countries');
 
     return false;
   });
-  $('form.quota-search#new_search').on("submit", function(){
-    $(this).find(':input[type=submit]').prop('disabled', true);
+
+  $('form.quota-search#new_search').on('submit', (event) => {
+    $(event.currentTarget).find(':input[type=submit]').prop('disabled', true);
   });
-})();
+})(window);

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe 'Search', :js do
           expect(page.find('#year')).to be_present
           expect(page.find('input[name="new_search"]')).to be_present
 
+          expect(page.find('.autocomplete__wrapper')).to be_present
+
           expect(page).not_to have_content('Quota search results')
         end
       end


### PR DESCRIPTION
### Jira link

[HMRC-818](https://transformuk.atlassian.net/browse/HMRC-818)

### What?

Added missing module reference which was stopping the autocomplete functionality working and causing a console error.

### Why?

https://www.trade-tariff.service.gov.uk/quota_search country dropdown is meant to have autocomplete enabled.
