### PR TITLE
HMRC-820 Namespace objects and functions on window to avoid being overwritten

### DIFF
--- a/app/views/shared/search/_autocomplete.html.erb
+++ b/app/views/shared/search/_autocomplete.html.erb
@@ -2,7 +2,7 @@
   <script>
     window.onload = function() {
       let tempQuery = '';
-      window.accessibleAutocomplete({
+      window.GOVUK.accessibleAutocomplete({
         element: document.querySelector('#autocomplete'),
         id: 'q',
         name: 'q',
@@ -21,10 +21,10 @@
             return result.replace(tempQuery, '<strong>$&</strong>');
           },
         },
-        source: window.debounce((query, populateResults) => {
+        source: window.GOVUK.debounce((query, populateResults) => {
           tempQuery = query;
           const searchSuggestionsPath = document.querySelector('.path_info').dataset.searchSuggestionsPath;
-          window.Utility.fetchCommoditySearchSuggestions(query, searchSuggestionsPath, [], populateResults);
+          window.GOVUK.Utility.fetchCommoditySearchSuggestions(query, searchSuggestionsPath, [], populateResults);
         }, 200, false),
         onConfirm: (suggestion) => {
           if (suggestion) {

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -45,9 +45,10 @@ import debounce from '../src/javascripts/debounce.js';
 import Utility from '../src/javascripts/utility.js';
 import accessibleAutocomplete from 'accessible-autocomplete';
 
-window.Utility = Utility;
-window.debounce = debounce;
-window.accessibleAutocomplete = accessibleAutocomplete;
+window.GOVUK = window.GOVUK || {};
+window.GOVUK.Utility = Utility;
+window.GOVUK.debounce = debounce;
+window.GOVUK.accessibleAutocomplete = accessibleAutocomplete;
 
 require.context('govuk-frontend/dist/govuk/assets');
 import {initAll} from 'govuk-frontend/dist/govuk/govuk-frontend.min.js';
@@ -60,6 +61,4 @@ import 'controllers';
 $(function() {
   // eslint-disable-next-line no-undef
   GOVUK.tariff.onLoad();
-  window.Utility = Utility;
-  window.debounce = debounce;
 });


### PR DESCRIPTION
### Jira link

[HMRC-820](https://transformuk.atlassian.net/browse/HMRC-820)

### What?

Namespace the objects and functions being put on the window object.

### Why?

There are multiple "window.debounce is not a function" errors being reported. These errors could be caused by window.debounce being overwritten by something external to the application. 
Adding a namespace should reduce the chances of this happening.
