### PR TITLE
Potential fix for code scanning alert no. 3: Reflected server-side cross-site scripting

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -55,7 +55,7 @@ class SearchController < ApplicationController
       raise TradeTariffFrontend::FeatureUnavailable
     end
 
-    form = QuotaSearchForm.new(params.permit(*QuotaSearchForm::PERMITTED_PARAMS))
+    form = QuotaSearchForm.new(quota_search_params)
     @result = QuotaSearchPresenter.new(form)
 
     # Test the search date to check if it's valid
@@ -106,6 +106,6 @@ class SearchController < ApplicationController
   end
 
   def quota_search_params
-    params.permit(:day, :month, :year, :order_number, :goods_nomenclature_item_id, :geographical_area_id, :critical, :status)
+    params.permit(QuotaSearchForm::PERMITTED_PARAMS)
   end
 end

--- a/app/helpers/quota_search_helper.rb
+++ b/app/helpers/quota_search_helper.rb
@@ -1,0 +1,24 @@
+module QuotaSearchHelper
+  def quota_search_today_params(order_number)
+    all_quota_search_params(order_number).to_h.each_with_object({}) do |(key, value), params|
+      next if value.blank?
+
+      params[key] = h(value)
+    end
+  end
+
+  private
+
+  def all_quota_search_params(order_number)
+    quota_search_params.merge(
+      day: Time.zone.today.day,
+      month: Time.zone.today.month,
+      year: Time.zone.today.year,
+      anchor: "order-number-#{order_number.number}",
+    )
+  end
+
+  def quota_search_params
+    params.permit(QuotaSearchForm::PERMITTED_PARAMS)
+  end
+end

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -30,12 +30,8 @@
               <%= quota_definition.measurement_unit %>
               <% unless @search.date.today? %>
                 <br>
-                <%= link_to params.permit(QuotaSearchForm::PERMITTED_PARAMS)
-                                  .merge(day: Date.today.day,
-                                         month: Date.today.month,
-                                         year: Date.today.year,
-                                         anchor: "order-number-#{order_number.number}") do %>
-                  View balance for <%= Date.today.to_formatted_s :short %>
+                <%= link_to quota_search_today_params(order_number) do %>
+                  View balance for <%= Time.zone.today.to_formatted_s :short %>
                 <% end %>
               <% end %>
             </td>


### PR DESCRIPTION
Potential fix for [https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/3](https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/3)

To fix the problem, we need to ensure that any user input used in the `link_to` helper is properly escaped to prevent XSS attacks. The best way to do this is to use the `h` method (alias for `html_escape`) to escape the user input before it is used in the URL. This will ensure that any potentially dangerous characters are converted to their HTML-safe equivalents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
