### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/app/webpacker/src/javascripts/step-by-step-nav.js
+++ b/app/webpacker/src/javascripts/step-by-step-nav.js
@@ -334,7 +334,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         $stepElement.toggleClass('step-is-shown', isShown)
         $stepContent.toggleClass('js-hidden', !isShown)
         $titleLink.attr('aria-expanded', isShown)
-        $stepElement.find('.js-toggle-link').html(isShown ? actions.hideText : actions.showText)
+        $stepElement.find('.js-toggle-link').text(isShown ? actions.hideText : actions.showText)
       }
 
       function isShown () {


### PR DESCRIPTION
Potential fix for [https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/12](https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/12)

To fix the problem, we need to ensure that the text extracted from the DOM attributes is properly escaped before being inserted into the HTML. This can be achieved by using a method that safely sets the text content without interpreting it as HTML.

- In general terms, we should use `.text()` instead of `.html()` to set the text content of an element, as `.text()` will escape any HTML characters.
- Specifically, we will replace the use of `.html()` with `.text()` in the `setIsShown` function.
- The changes will be made in the file `app/webpacker/src/javascripts/step-by-step-nav.js` on line 337.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
