### PR TITLE
HMRC-962: Notify in production-alerts for production deployments

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -78,3 +78,4 @@ jobs:
           with:
             result: ${{ needs.deploy.result }}
             slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+            slack_channel: production-alerts


### PR DESCRIPTION
### Jira link

[HMRC-962](https://transformuk.atlassian.net/browse/HMRC-962)

### What?

I have a...

- Moved notifications to `production-alerts` for production deployments

### Why?

I am doing this because...

- This makes more sense/enhances signalling
