### PR TITLE
HMRC-948: Enable a simple user-agent header

### DIFF
--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -33,6 +33,7 @@ class ClientBuilder
         conn.response :raise_error
         conn.adapter :net_http_persistent
         conn.response :json, content_type: /\bjson$/
+        conn.headers['User-Agent'] = user_agent
       end
     end
   end
@@ -41,5 +42,9 @@ class ClientBuilder
 
   def host
     TradeTariffFrontend::ServiceChooser.public_send("#{@service}_host")
+  end
+
+  def user_agent
+    @user_agent ||= "TradeTariffFrontend/#{TradeTariffFrontend.revision}"
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-948](https://transformuk.atlassian.net/browse/HMRC-948)

### What?

I have a...

- Enables a simple user-agent header to differentiate the frontend

### Why?

I am doing this because...

- This will be useful when reviewing logs and differentiating frontend traffic to the backend
