### PR TITLE
HMRC-968 Mark deployments in New Relic

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -62,6 +62,20 @@ jobs:
           ecr-url: ${{ env.ECR_URL }}
           ref: ${{ inputs.ref || steps.docker-tag.outputs.DOCKER_TAG }}
 
+  newrelic:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - id: docker-tag
+        run: echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: New Relic Application Deployment Marker
+        uses: newrelic/deployment-marker-action@v2.5.1
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          guid: ${{ secrets.NEW_RELIC_APPLICATION_GUID }}
+          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          user: ${{ github.actor }}
+
   post-deploy:
     uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
     needs: deploy


### PR DESCRIPTION
### Jira link

[HMRC-968](https://transformuk.atlassian.net/browse/HMRC-968)

### What?

I have added a post production deployment step to send the commit ID to New Relic

### Why?

So New Relic can track deployments
