### PR TITLE
HMRC-971: Remove http-cache middleware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ end
 gem 'rails', '~> 8.0'
 
 gem 'faraday'
-gem 'faraday-http-cache'
 gem 'faraday-net_http_persistent'
 gem 'faraday-retry'
 gem 'multi_json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,8 +165,6 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-http-cache (2.5.1)
-      faraday (>= 0.8)
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     faraday-net_http_persistent (2.3.0)
@@ -788,7 +786,6 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faraday
-  faraday-http-cache
   faraday-net_http_persistent
   faraday-retry
   forgery

--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -29,11 +29,9 @@ class ClientBuilder
       Faraday.new(host) do |conn|
         conn.request :url_encoded
         conn.request :retry, RETRY_DEFAULTS.merge(Rails.configuration.x.http.retry_options)
-        conn.use :http_cache, store: @cache, logger: Rails.logger if @cache
         conn.response :raise_error
         conn.adapter :net_http_persistent
         conn.response :json, content_type: /\bjson$/
-        conn.headers['User-Agent'] = user_agent
       end
     end
   end
@@ -42,9 +40,5 @@ class ClientBuilder
 
   def host
     TradeTariffFrontend::ServiceChooser.public_send("#{@service}_host")
-  end
-
-  def user_agent
-    @user_agent ||= "TradeTariffFrontend/#{TradeTariffFrontend.revision}"
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-971](https://transformuk.atlassian.net/browse/HMRC-971)

### What?

I have a...

- Removes etag caching behaviour

### Why?

I am doing this because...

- This is part of a drive for simplification around caching where all of our cache configuration is controlled by the CDN

