### PR TITLE
HMRC-968 Add region and accept input ref for deploy marker

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -72,9 +72,10 @@ jobs:
         uses: newrelic/deployment-marker-action@v2.5.1
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "EU"
           guid: ${{ secrets.NEW_RELIC_APPLICATION_GUID }}
-          version: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
-          user: ${{ github.actor }}
+          version: ${{ inputs.ref || steps.docker-tag.outputs.DOCKER_TAG }}
+          user: "${{ github.actor }}"
 
   post-deploy:
     uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main


### PR DESCRIPTION
### Jira link

[HMRC-968](https://transformuk.atlassian.net/browse/HMRC-968)

### What?

Fixed issue where version is blank and new relic region is wrong.
