### PR TITLE
HMRC-988 Updated start date to 1 May 2025

### DIFF
--- a/app/views/green_lanes/starts/new.html.erb
+++ b/app/views/green_lanes/starts/new.html.erb
@@ -15,7 +15,7 @@
       Traders may be able to use the simplified processes for Internal Market Movements when moving goods within the UK's internal market. This applies to goods moving from a business in Great Britain (England, Scotland, or Wales) to a business in Northern Ireland.
     </p>
     <p>
-     These simplified processes will be introduced when the new arrangements for parcels and freight under the Windsor Framework come into effect no earlier than 31 March 2025.
+     These simplified processes will be introduced when the new arrangements for parcels and freight under the Windsor Framework come into effect no earlier than 1 May 2025.
      <a href='http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland' target='_blank' rel='noopener noreferrer'> Find out more about Internal Market Movements (opens in new tab)</a>.
     <p>
 


### PR DESCRIPTION
### Jira link

[HMRC-988](https://transformuk.atlassian.net/browse/HMRC-988)

### What?

I have updated SPIMM start date to 1 May 2025

### Why?

I am doing this because it was incorrect.

![image](https://github.com/user-attachments/assets/6fffe389-34d6-4b46-8c62-5ec0c702a423)
