### PR TITLE
HMRC-986 Add CTA Link for SPIMM from OTT Homepage

### DIFF
--- a/app/views/find_commodities/show.html.erb
+++ b/app/views/find_commodities/show.html.erb
@@ -2,6 +2,8 @@
 
 <%= render 'news_items/hero_story', news_item: @hero_story if @hero_story %>
 
+<%= render 'news_items/hero_spimm'%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-form-group feature-panel no-bottom-border govuk-!-margin-0 govuk-!-padding-0">

--- a/app/views/news_items/_hero_spimm.html.erb
+++ b/app/views/news_items/_hero_spimm.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-notification-banner govuk-notification-banner--success" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      New process for moving goods from Great Britain to Northern Ireland
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    Check if you are eligible for the simplified process for internal market movements (SPIMM), available to UKIMS authorised traders from 1st May 2025.
+    <p><a class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-1" href="<%=green_lanes_start_path%>">Check eligibility</a></p>
+  </div>
+</div>


### PR DESCRIPTION
### Jira link

[HMRC-986](https://transformuk.atlassian.net/browse/HMRC-986)

### What?

I have added _hero_spimm for a CTA link.

### Why?

I am doing this because it was requested.  Re-used the latest news hero banner with `--success` to update border colours as specified.

**RESULT**
![image](https://github.com/user-attachments/assets/e01bb95c-073e-4c14-a3fc-269f2c65cb79)
