### PR TITLE
Allow search to work without JS

### DIFF
--- a/app/views/shared/search/_autocomplete.html.erb
+++ b/app/views/shared/search/_autocomplete.html.erb
@@ -39,4 +39,10 @@
       });
     }
   </script>
+
+  <noscript>
+    <div class="autocomplete__wrapper">
+      <input autocomplete="off" class="autocomplete__input autocomplete__input--default" id="q" name="q" placeholder="Enter the name of the goods or commodity code" type="text" role="combobox" required="">
+    </div>
+  </noscript>
 </div>


### PR DESCRIPTION
Currently, a JS error (or a client with no JS) renders search unusable.  This PR allows the user to still search without JS