### PR TITLE
Add Rack::Deflater for compression

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,7 @@ module TradeTariffFrontend
     config.guide_links = config_for(:guide_links)
     # Prevent invalid queries from causing an error, e.g., `/api/v2/search_references.json?query[letter]=%`
     config.middleware.use TradeTariffFrontend::FilterBadURLEncoding
+    config.middleware.insert_before ActionDispatch::Static, Rack::Deflater
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
I've noticed that we have no compression from the frontend which means we're using a bunch more bandwidth than needed.  (CloudFront doesn't seem to be doing it either even though it's turned on).

This PR adds Rack::Deflater to allow that GZip fun.

Running 10 users for 10 seconds on a static asset:

Before:

```
Transactions:		     5954    hits
Availability:		      100.00 %
Elapsed time:		       10.28 secs
Data transferred:	    14674.97 MB
Response time:		       17.19 ms
Transaction rate:	      579.18 trans/sec
Throughput:		     1427.53 MB/sec
Concurrency:		        9.96
Successful transactions:     5954
Failed transactions:	        0
Longest transaction:	       60.00 ms
Shortest transaction:	       10.00 ms
```

After:
```
Transactions:		      503    hits
Availability:		      100.00 %
Elapsed time:		       10.73 secs
Data transferred:	      218.30 MB
Response time:		      211.11 ms
Transaction rate:	       46.88 trans/sec
Throughput:		       20.34 MB/sec
Concurrency:		        9.90
Successful transactions:      503
Failed transactions:	        0
Longest transaction:	      280.00 ms
Shortest transaction:	       80.00 ms
```

So when we benchmark the raw speed of compressing static assets, it’s around 10 times slower. The benefit, though, is that application.js in this instance is around 5-6 times smaller - 433KB instead of 2,464KB.  Given we CDN the hell out of things, the performance drop isn't an issue, but we should see lower bandwidth use and a faster front-end.

