### PR TITLE
Increase permissions on staging workflow

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  pull-requests: write
 
 env:
   AWS_REGION: eu-west-2


### PR DESCRIPTION
For whatever reason we're seeing this error on `deploy-to-staging`:

```
The workflow is not valid. .github/workflows/deploy-to-staging.yml (Line: 49, Col: 3): Error calling workflow 'trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main'. The workflow is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.
```

From reading https://www.kenmuse.com/blog/github-actions-workflow-permissions/ this change might fix that.