### PR TITLE
HMRC-821 handle undefined method 'goods_nomenclature_label' for nil

### DIFF
--- a/app/services/simplified_procedural_code_measure_fetcher_service.rb
+++ b/app/services/simplified_procedural_code_measure_fetcher_service.rb
@@ -36,8 +36,10 @@ class SimplifiedProceduralCodeMeasureFetcherService
 
   def by_code
     result.measures = SimplifiedProceduralCodeMeasure.by_code(simplified_procedural_code)
-    result.goods_nomenclature_label = result.measures.first.goods_nomenclature_label
-    result.goods_nomenclature_item_ids = result.measures.first.goods_nomenclature_item_ids
+    first_measure = result.measures.first
+
+    result.goods_nomenclature_label = first_measure&.goods_nomenclature_label
+    result.goods_nomenclature_item_ids = first_measure&.goods_nomenclature_item_ids
     result.by_code = true
     result.no_data = result.measures.all?(&:no_data?)
     result.simplified_procedural_code = simplified_procedural_code

--- a/spec/services/simplified_procedural_code_measure_fetcher_service_spec.rb
+++ b/spec/services/simplified_procedural_code_measure_fetcher_service_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe SimplifiedProceduralCodeMeasureFetcherService do
       let(:params) { { simplified_procedural_code: '2.120.1' } }
 
       it { expect(result.measures).to all(be_a(SimplifiedProceduralCodeMeasure)) }
-      it { expect(result.goods_nomenclature_label).to eq('Apples') }
-      it { expect(result.goods_nomenclature_item_ids).to eq('0808108010, 0808108020, 0808108090') }
+      it { expect(result.goods_nomenclature_label).to eq('Plums') }
+      it { expect(result.goods_nomenclature_item_ids).to eq('0809400500') }
       it { expect(result.validity_start_date).to be_nil }
       it { expect(result.validity_end_date).to be_nil }
       it { expect(result.validity_start_dates).to be_nil }
@@ -47,6 +47,18 @@ RSpec.describe SimplifiedProceduralCodeMeasureFetcherService do
       it { expect(result.by_code).to be(false) }
       it { expect(result.simplified_procedural_code).to be_nil }
       it { expect(result.no_data).to be_nil }
+    end
+
+    context 'when no measures are returned by code' do
+      let(:params) { { simplified_procedural_code: 'nonexistent-code' } }
+
+      before do
+        allow(SimplifiedProceduralCodeMeasure).to receive(:by_code).and_return([])
+      end
+
+      it 'does not raise an error' do
+        expect { result }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-821](https://transformuk.atlassian.net/browse/HMRC-821)

### What?

I have handled nothing returned from simplified procedural code measures by code

### Why?

I am doing this because when the backend doesn't return a `Goods_Nomenclature_Label_ID` when calling the `simplified_procedural_code_fetcher_service` an unhandled error was being thrown and logged in New Relic.