### PR TITLE
HMRC-1008 Separate Deploy To Development CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: ci
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches-ignore:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: eu-west-2
+  ECR_URL: 382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-frontend-production
+  ENVIRONMENT: development
+  IAM_ROLE_ARN: arn:aws:iam::844815912454:role/GithubActions-ECS-Deployments-Role
+  SKIP: terraform_docs,actionlint-docker
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3'
+      - id: ruby-version
+        run: echo "RUBY_VERSION=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ steps.ruby-version.outputs.RUBY_VERSION }}
+          bundler-cache: true
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.11.0
+      - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-tflint@main
+      - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-ssh@main
+        with:
+          ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
+      - run: bundle exec brakeman
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: ruby-version
+        run: echo "RUBY_VERSION=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ steps.ruby-version.outputs.RUBY_VERSION }}
+          bundler-cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+
+      - run: bundle exec rspec
+
+      - run: yarn run test

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -1,4 +1,5 @@
 name: Deploy to development
+
 on:
   workflow_dispatch:
 
@@ -14,55 +15,6 @@ env:
   SKIP: terraform_docs,actionlint-docker
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3'
-      - id: ruby-version
-        run: echo "RUBY_VERSION=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ steps.ruby-version.outputs.RUBY_VERSION }}
-          bundler-cache: true
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.11.0
-      - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-tflint@main
-      - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-ssh@main
-        with:
-          ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
-      - run: bundle exec brakeman
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - id: ruby-version
-        run: echo "RUBY_VERSION=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ steps.ruby-version.outputs.RUBY_VERSION }}
-          bundler-cache: true
-
-      - uses: actions/setup-node@v4
-        with:
-          cache: yarn
-      - run: yarn install --frozen-lockfile
-
-      - run: bundle exec rspec
-
-      - run: yarn run test
 
   build:
     runs-on: ubuntu-latest
@@ -87,7 +39,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - test
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### Jira link

[HMRC-1008](https://transformuk.atlassian.net/browse/HMRC-1008)

### What?

I have a separated out CI and build/deploy workflows for development

### Why?

I am doing this because CI HAS to run so tests/linting run before a PR can be merged
