### PR TITLE
HMRC-1048: Support path prefixing via configuration

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 ALLOW_SEARCH=true
-API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3000","xi":"http://localhost:3000"}
+API_SERVICE_BACKEND_URL_OPTIONS={"uk":"https://dev.trade-tariff.service.gov.uk","xi":"https://dev.trade-tariff.service.gov.uk/xi"}
 AWS_ACCESS_KEY_ID=aws_access_key_id
 AWS_BUCKET_NAME=trade-tariff-frontend
 AWS_REGION=us-east-1

--- a/app/models/exchange_rate_collection.rb
+++ b/app/models/exchange_rate_collection.rb
@@ -3,7 +3,7 @@ require 'api_entity'
 class ExchangeRateCollection
   include ApiEntity
 
-  set_singular_path '/api/v2/exchange_rates/:id'
+  set_singular_path 'api/v2/exchange_rates/:id'
 
   attr_accessor :month, :year, :type
 

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -13,7 +13,7 @@ class GeographicalArea
     european_union: '1013',
   }
 
-  set_collection_path '/api/v2/geographical_areas/countries'
+  set_collection_path 'api/v2/geographical_areas/countries'
 
   attr_accessor :id, :geographical_area_id
 

--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -4,7 +4,7 @@ module News
   class Collection
     include UkOnlyApiEntity
 
-    set_collection_path '/api/v2/news/collections'
+    set_collection_path 'api/v2/news/collections'
 
     attr_writer   :id
     attr_accessor :name,

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -6,7 +6,7 @@ module News
 
     DISPLAY_STYLE_REGULAR = 0
 
-    set_collection_path '/api/v2/news/items'
+    set_collection_path 'api/v2/news/items'
 
     attr_accessor :id,
                   :slug,

--- a/app/models/news/year.rb
+++ b/app/models/news/year.rb
@@ -4,7 +4,7 @@ module News
   class Year
     include UkOnlyApiEntity
 
-    set_collection_path '/api/v2/news/years'
+    set_collection_path 'api/v2/news/years'
 
     attr_accessor :year
   end

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -6,7 +6,7 @@ class OrderNumber
     include ApiEntity
     include HasGoodsNomenclature
 
-    set_collection_path '/api/v2/quotas'
+    set_collection_path 'api/v2/quotas'
 
     DATE_FIELDS = %w[
       blocking_period_start_date

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -3,7 +3,7 @@ require 'api_entity'
 class RulesOfOrigin::Scheme
   include ApiEntity
 
-  set_collection_path '/api/v2/rules_of_origin_schemes'
+  set_collection_path 'api/v2/rules_of_origin_schemes'
 
   attr_accessor :scheme_code,
                 :title,

--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -9,7 +9,7 @@ class TariffUpdate
 
   attr_writer :applied_at
 
-  set_collection_path '/api/v2/updates/latest'
+  set_collection_path 'api/v2/updates/latest'
 
   def applied_at
     Date.parse(@applied_at)

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -34,7 +34,7 @@ module ApiEntity
     end
 
     def resource_path
-      "/api/v2/#{self.class.name.underscore.pluralize}/#{to_param}"
+      "api/v2/#{self.class.name.underscore.pluralize}/#{to_param}"
     end
 
     def to_param
@@ -226,7 +226,7 @@ private
     end
 
     def singular_path
-      @singular_path ||= "/api/v2/#{name.pluralize.underscore}/:id"
+      @singular_path ||= "api/v2/#{name.pluralize.underscore}/:id"
     end
 
     def set_singular_path(path)
@@ -234,7 +234,7 @@ private
     end
 
     def collection_path
-      @collection_path ||= "/api/v2/#{name.pluralize.underscore}"
+      @collection_path ||= "api/v2/#{name.pluralize.underscore}"
     end
 
     def set_collection_path(path)

--- a/spec/models/rules_of_origin/scheme_spec.rb
+++ b/spec/models/rules_of_origin/scheme_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe RulesOfOrigin::Scheme do
         schemes # trigger the query
 
         expect(api_instance).to have_received(:get)
-          .with('/api/v2/rules_of_origin_schemes',
+          .with('api/v2/rules_of_origin_schemes',
                 heading_code: '190531',
                 country_code: 'FR',
                 page: 1)


### PR DESCRIPTION
### Jira link

[HMRC-1048](https://transformuk.atlassian.net/browse/HMRC-1048)

### What?

I have a...

- Removes leading `/` from the api entity path methods
- Sets the default environment in development to just speak to the backend in dev

### Why?

I am doing this because...

- This means we can let the service chooser just pick the XI client and
concatenate the correct path and have the Application Load Balancer
route the path to the XI app correctly
- Without this change we would always route to the UK because the path
prefix of the XI client wasn't doing concatenation
