### PR TITLE
HMRC-1054: Investigate and fix how we're rendering footnote DS528

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -148,8 +148,9 @@ module CommoditiesHelper
   end
 
   def sanitize_quotes(text)
-    text.gsub(/[\u2018\u2019]/, "'") # Replace left and right single quotes
-        .gsub(/[\u201C\u201D]/, '"') # Replace left and right double quotes
+    CGI.unescapeHTML(text)
+       .gsub(/[\u2018\u2019]/, "'") # Replace left and right single quotes
+       .gsub(/[\u201C\u201D]/, '"') # Replace left and right double quotes
   end
 
   private


### PR DESCRIPTION
### Jira link

[HMRC-1054](https://transformuk.atlassian.net/browse/HMRC-1054)

### What?

I have unescaped HTML characters into into their proper characters in footnotes.

### Why?

I am doing this to fix rendering error of "'"
