### PR TITLE
Unescape id_token to enable decryption

### DIFF
--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -19,7 +19,7 @@ module Myott
         raw_token = cookies[:id_token]
         return nil if raw_token.blank?
 
-        EncryptionService.decrypt_string(raw_token)
+        EncryptionService.decrypt_string(CGI.unescape(raw_token))
       end
     end
   end

--- a/spec/controllers/myott/myott_controller_spec.rb
+++ b/spec/controllers/myott/myott_controller_spec.rb
@@ -2,19 +2,17 @@ require 'spec_helper'
 
 RSpec.describe Myott::MyottController, type: :controller do
   describe '#current_user' do
-    let(:id_token) { 'encrypted_token' }
+    let(:id_token) { 'encrypted+token' }
     let(:decrypted_token) { 'decrypted_token' }
 
     before do
       allow(controller).to receive(:cookies).and_return(id_token: id_token)
-      allow(EncryptionService).to receive(:decrypt_string).with(id_token).and_return(decrypted_token)
+      allow(EncryptionService).to receive(:decrypt_string).with(CGI.unescape(id_token)).and_return(decrypted_token)
+      allow(JWT).to receive(:decode).with(decrypted_token, nil, false).and_return('user_data')
     end
 
     it 'decodes the ID token and returns the current user' do
-      allow(JWT).to receive(:decode).with(decrypted_token, nil, false).and_return('user_data')
-
       result = controller.send(:current_user)
-
       expect(result).to eq('user_data')
     end
   end


### PR DESCRIPTION
### Jira link

[HMRC-1073](https://transformuk.atlassian.net/browse/HMRC-1073)

### What?

The id_token set in the cookie is URL encoded, so this needs to be reversed before it can be decrypted.

### Why?

To enable logging in to MyOTT
