### PR TITLE
HMRC-1025 Fix bug with Chapter Selection Error Handling

### DIFF
--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -4,7 +4,7 @@ module Myott
                   :disable_switch_service_banner,
                   :disable_last_updated_footnote
 
-    before_action :sections_chapters, only: %i[chapter_selection]
+    before_action :sections_chapters, only: %i[chapter_selection check_your_answers]
 
     def dashboard
       @email = current_user&.fetch('email') || 'not_logged_in@email.com'


### PR DESCRIPTION
### Jira link

[HMRC-1025](https://transformuk.atlassian.net/browse/HMRC-1025)

### What?

Added check your answers before_action to ensure chapter_selection is available in case theres an error in selection.

### Why?

I am doing this because error was being produced from chapter_selection being unavailable.

**bug**
<img width="774" alt="image" src="https://github.com/user-attachments/assets/96159fa9-5c2d-4cf1-b1ca-b7f516e1e30a" />

**after fix** 
![image](https://github.com/user-attachments/assets/4e489a7f-cab8-44e1-b730-d5614067e207)