### PR TITLE
Add es-module-shims

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,7 @@
 
   <%= yield :head %>
 
+  <script async src="https://ga.jspm.io/npm:es-module-shims@1.8.2/dist/es-module-shims.js" data-turbo-track="reload"></script>
   <%= javascript_importmap_tags %>
 </head>
 


### PR DESCRIPTION
It turns out import-maps has limited support over older browser versions:

https://caniuse.com/import-maps

From what I can see, errors in NR are showing as slightly older versions of browsers so this is likely the culprit.  Instead of backing the change out though we can add [es-module-shims](https://github.com/guybedford/es-module-shims?tab=readme-ov-file#import-maps) which should resolve this across the board.