### PR TITLE
Fix es-shim refires

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,11 @@
   <%= yield :head %>
 
   <script async src="https://ga.jspm.io/npm:es-module-shims@2.5.1/dist/es-module-shims.js"></script>
+  <script type="esms-options">
+    {
+      "noLoadEventRetriggers": true
+    }
+  </script>
   <%= javascript_importmap_tags %>
 </head>
 

--- a/app/views/shared/search/_autocomplete.html.erb
+++ b/app/views/shared/search/_autocomplete.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-fieldset" id='autocomplete' aria-describedby='q'>
-  <script defer>
+  <script>
     window.onload = function() {
       let tempQuery = '';
       window.GOVUK.accessibleAutocomplete({


### PR DESCRIPTION
Adds the following to disable the double event refires in es module shims:
```html
<script type="esms-options">
{
  "noLoadEventRetriggers": true
}
</script>
```
This is a feature of es-module-shims that refires load events after es module shims has applied for applciations that wait on ready and load events to initiate themselves which otherwise would not get listener events if they execute late.