### PR TITLE
HMRC-1128 Fix legacy browsers and add fallback search

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
       "noLoadEventRetriggers": true
     }
   </script>
+
   <%= javascript_importmap_tags %>
 </head>
 

--- a/app/views/shared/search/_autocomplete.html.erb
+++ b/app/views/shared/search/_autocomplete.html.erb
@@ -1,43 +1,48 @@
 <div class="govuk-fieldset" id='autocomplete' aria-describedby='q'>
   <script>
-    window.onload = function() {
-      let tempQuery = '';
-      window.GOVUK.accessibleAutocomplete({
-        element: document.querySelector('#autocomplete'),
-        id: 'q',
-        name: 'q',
-        required: 'true',
-        className: 'govuk-input',
-        placeholder: 'Enter the name of the goods or commodity code',
-        confirmOnBlur: false,
-        autoselect: true,
-        minLength: 2,
-        tNoResults: () => 'Searching...',
-        templates: {
-          inputValue: function(result) {
-            return result;
+    document.addEventListener('DOMContentLoaded', function() {
+      try {
+        let tempQuery = '';
+        window.GOVUK.accessibleAutocomplete({
+          element: document.querySelector('#autocomplete'),
+          id: 'q',
+          name: 'q',
+          required: 'true',
+          className: 'govuk-input',
+          placeholder: 'Enter the name of the goods or commodity code',
+          confirmOnBlur: false,
+          autoselect: true,
+          minLength: 2,
+          tNoResults: () => 'Searching...',
+          templates: {
+            inputValue: function(result) {
+              return result;
+            },
+            suggestion: function(result) {
+              return result.replace(tempQuery, '<strong>$&</strong>');
+            },
           },
-          suggestion: function(result) {
-            return result.replace(tempQuery, '<strong>$&</strong>');
-          },
-        },
-        source: window.GOVUK.debounce((query, populateResults) => {
-          tempQuery = query;
-          const searchSuggestionsPath = document.querySelector('.path_info').dataset.searchSuggestionsPath;
-          window.GOVUK.Utility.fetchCommoditySearchSuggestions(query, searchSuggestionsPath, [], populateResults);
-        }, 200, false),
-        onConfirm: (suggestion) => {
-          if (suggestion) {
-            document.querySelector('#q').value = suggestion
-            document.querySelector("#new_search").submit()
+          source: window.GOVUK.debounce((query, populateResults) => {
+            tempQuery = query;
+            const searchSuggestionsPath = document.querySelector('.path_info').dataset.searchSuggestionsPath;
+            window.GOVUK.Utility.fetchCommoditySearchSuggestions(query, searchSuggestionsPath, [], populateResults);
+          }, 200, false),
+          onConfirm: (suggestion) => {
+            if (suggestion) {
+              document.querySelector('#q').value = suggestion
+              document.querySelector("#new_search").submit()
+            }
           }
-        }
-      });
+        });
 
-      window.addEventListener('pageshow', (event) => {
-        event.persisted ? document.querySelector('#autocomplete input').value = '' : () => {}
-      });
-    }
+        window.addEventListener('pageshow', (event) => {
+          event.persisted ? document.querySelector('#autocomplete input').value = '' : () => {}
+        });
+      } catch(e) {
+        var node = document.getElementById('autocomplete');
+        node.innerHTML = '<div class="autocomplete__wrapper"><input autocomplete="off" class="autocomplete__input autocomplete__input--default" id="q" name="q" placeholder="Enter the name of the goods or commodity code" type="text" role="combobox" required=""></div>'
+      }
+    })
   </script>
 
   <noscript>


### PR DESCRIPTION
### Jira link

HMRC-1128

### What?

Fixes search in new and old browsers, whilst also showing a search box should JS fail

Chrome/Brave
![Brave](https://github.com/user-attachments/assets/e3141aad-c36d-48f7-86c4-36b858e680f9)
Safari
![Safari](https://github.com/user-attachments/assets/5482bb31-ca46-43b5-9d53-9591bad60fcb)
Firefox
![Firefox](https://github.com/user-attachments/assets/309ef4cd-a4f5-4657-b6e1-8b5e229b6f87)
Chrome 87
![Chrome 87](https://github.com/user-attachments/assets/9c7a7901-66c5-4c1f-9561-3ca67df87e0e)
