### PR TITLE
Implement accessibility checks for quota search feature

### DIFF
--- a/spec/javascript/accessibility/find_commodity.spec.js
+++ b/spec/javascript/accessibility/find_commodity.spec.js
@@ -1,10 +1,10 @@
 const { test, expect } = require("@playwright/test");
 const { LoginPage } = require("./pages/loginPage");
-const AxeBuilder = require('@axe-core/playwright').default;
+const AxeBuilder = require("@axe-core/playwright").default;
 
 test.describe("Find Commodity Page", () => {
   test("Validating accessibility", async ({ page }) => {
-    await new LoginPage("/", page).login()
+    await new LoginPage("/", page).login();
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 

--- a/spec/javascript/accessibility/pages/loginPage.js
+++ b/spec/javascript/accessibility/pages/loginPage.js
@@ -2,7 +2,7 @@ class LoginPage {
   constructor(relativeUrl, page) {
     this.page = page;
     this.url = relativeUrl;
-    this.password = process.env.BASIC_PASSWORD
+    this.password = process.env.BASIC_PASSWORD;
   }
 
   async login() {

--- a/spec/javascript/accessibility/quota_search.spec.js
+++ b/spec/javascript/accessibility/quota_search.spec.js
@@ -1,0 +1,40 @@
+const { test, expect } = require("@playwright/test");
+const { LoginPage } = require("./pages/loginPage");
+const AxeBuilder = require("@axe-core/playwright").default;
+
+test.describe("Search for quotas", () => {
+  test("Validate UK quota Search Results", async ({ page }, testInfo) => {
+    await new LoginPage("/quota_search", page, testInfo).login();
+
+    await expect(
+      page.getByRole("heading", { name: "Search for quotas" })
+    ).toBeVisible();
+    await page
+      .getByRole("textbox", { name: "Enter the 6-digit quota order" })
+      .fill("052016");
+
+    //Select a country to which the quota applies
+    await page
+      .getByRole("combobox", { name: "Select a country to which the" })
+      .click();
+    await page.getByRole("option", { name: "Albania (AL)" }).click();
+
+    //search for quotas
+    await page.getByRole("button", { name: "Search for quotas" }).click();
+
+    //Validation
+    await expect(
+      page.getByRole("heading", { name: "Quota search results" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Order number" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Opens in a popup" })
+    ).toHaveText("052016");
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    expect(accessibilityScanResults.violations.length).toBeLessThan(5);
+  });
+});

--- a/spec/javascript/accessibility/quota_search.spec.js
+++ b/spec/javascript/accessibility/quota_search.spec.js
@@ -4,34 +4,7 @@ const AxeBuilder = require("@axe-core/playwright").default;
 
 test.describe("Search for quotas", () => {
   test("Validate UK quota Search Results", async ({ page }, testInfo) => {
-    await new LoginPage("/quota_search", page, testInfo).login();
-
-    await expect(
-      page.getByRole("heading", { name: "Search for quotas" })
-    ).toBeVisible();
-    await page
-      .getByRole("textbox", { name: "Enter the 6-digit quota order" })
-      .fill("052016");
-
-    //Select a country to which the quota applies
-    await page
-      .getByRole("combobox", { name: "Select a country to which the" })
-      .click();
-    await page.getByRole("option", { name: "Albania (AL)" }).click();
-
-    //search for quotas
-    await page.getByRole("button", { name: "Search for quotas" }).click();
-
-    //Validation
-    await expect(
-      page.getByRole("heading", { name: "Quota search results" })
-    ).toBeVisible();
-    await expect(
-      page.getByRole("columnheader", { name: "Order number" })
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Opens in a popup" })
-    ).toHaveText("052016");
+    await new LoginPage("/quota_search?order_number=052012", page, testInfo).login();
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 


### PR DESCRIPTION
### Jira link

[HMRC-<1090> <https://transformuk.atlassian.net/browse/HMRC-1090>)]

### What?
This PR adds an automated accessibility test for the quota search functionality. The test ensures that the user interface for this feature is compliant with accessibility standards, particularly focusing on:

- Proper use of ARIA roles and attributes
- Keyboard navigation and focus handling
- Screen reader compatibility and semantic structure

The test helps identify any accessibility barriers in the quota search screen, ensuring it's usable for all users, including those relying on assistive technologies.

### Why?

I am doing this because it complies with WCAG accessibility standards.
- Improves usability for users with disabilities
- Supports broader accessibility efforts across the application
- Prevents regressions as UI evolves
