### PR TITLE
HMRC-1150: Add workflow to recycle Lightsail instances

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,124 @@
+name: Nightly Preview Cleanup
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Every day at midnight UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run only (true/false)'
+        required: false
+        default: 'true'  
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: eu-west-2
+  IAM_ROLE_ARN: arn:aws:iam::844815912454:role/GithubActions-Preview-App-Role
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    outputs:
+      destroyed_envs: ${{ steps.set-outputs.outputs.destroyed_envs }}
+      dry_run: ${{ steps.set-outputs.outputs.dry_run }}
+      run_mode: ${{ steps.set-outputs.outputs.run_mode }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.IAM_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - run: npm install -g preevy
+
+      - name: Clean up preview environments
+        id: cleanup-step
+        run: |
+          set -euo pipefail
+          PROFILE_URL="s3://preevy-profile-store?region=eu-west-2"
+          destroyed_envs="[]"
+          
+          # Simplified dry-run logic
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            DRY_RUN="false"
+            RUN_MODE="scheduled"
+          else
+            DRY_RUN="${{ github.event.inputs.dry_run || 'true' }}"
+            RUN_MODE="manual"
+          fi
+
+          echo "Run mode: $RUN_MODE"
+          echo "Dry run: $DRY_RUN"
+
+          envs_json=$(preevy ls --json --profile "$PROFILE_URL") || {
+            echo "⚠️ Failed to list environments"
+            echo "DESTROYED_ENVS=[]" >> "$GITHUB_ENV"
+            echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+            echo "run_mode=$RUN_MODE" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          if [[ -z "$envs_json" || "$envs_json" == "null" ]]; then
+            echo "⚠️ No environments found"
+            echo "DESTROYED_ENVS=[]" >> "$GITHUB_ENV"
+            echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+            echo "run_mode=$RUN_MODE" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          while IFS= read -r env_id; do
+            [[ -z "$env_id" || "$env_id" == "null" ]] && continue
+            [[ "$env_id" == *keep* ]] && {
+              echo "🛑 Skipping: $env_id (exclusion rule)"
+              continue
+            }
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "✅ [DRY RUN] Would destroy: $env_id"
+              destroyed_envs=$(jq -n --argjson arr "$destroyed_envs" --arg id "$env_id" '$arr + [$id + " (DRY RUN)"]')
+            else
+              echo "🔥 Destroying: $env_id"
+              if preevy down --force "$env_id" --profile "$PROFILE_URL"; then
+                destroyed_envs=$(jq -n --argjson arr "$destroyed_envs" --arg id "$env_id" '$arr + [$id]')
+              else
+                echo "❌ Failed to destroy: $env_id"
+                destroyed_envs=$(jq -n --argjson arr "$destroyed_envs" --arg id "$env_id" '$arr + [$id + " (FAILED)"]')
+              fi
+            fi
+          done < <(echo "$envs_json" | jq -r '.[].envId')
+
+          echo "DESTROYED_ENVS='$destroyed_envs'" >> "$GITHUB_ENV"
+          echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+          echo "run_mode=$RUN_MODE" >> "$GITHUB_OUTPUT"
+
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          {
+            echo "destroyed_envs=$DESTROYED_ENVS" 
+            echo "dry_run=$DRY_RUN" 
+            echo "run_mode=$RUN_MODE" 
+          }>> "$GITHUB_OUTPUT"
+
+  notifications:
+    if: always()
+    needs: cleanup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: 'deployments'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: 'Preevy Cleanup Report'
+          SLACK_MESSAGE: |
+            :recycle: *Preevy Cleanup finished*
+            *Run Mode:* `${{ needs.cleanup.outputs.run_mode }}`
+            *Dry Run:* `${{ needs.cleanup.outputs.dry_run }}`
+            *Cleaned Environments:*
+            ${{ join(fromJson(needs.cleanup.outputs.destroyed_envs || '["None"]'), '\n') }}

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -8,7 +8,7 @@ on:
       dry_run:
         description: 'Dry run only (true/false)'
         required: false
-        default: 'true'  
+        default: 'true'
 
 permissions:
   contents: read
@@ -41,7 +41,7 @@ jobs:
           set -euo pipefail
           PROFILE_URL="s3://preevy-profile-store?region=eu-west-2"
           destroyed_envs="[]"
-          
+
           # Simplified dry-run logic
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             DRY_RUN="false"
@@ -99,9 +99,9 @@ jobs:
         id: set-outputs
         run: |
           {
-            echo "destroyed_envs=$DESTROYED_ENVS" 
-            echo "dry_run=$DRY_RUN" 
-            echo "run_mode=$RUN_MODE" 
+            echo "destroyed_envs=$DESTROYED_ENVS"
+            echo "dry_run=$DRY_RUN"
+            echo "run_mode=$RUN_MODE"
           }>> "$GITHUB_OUTPUT"
 
   notifications:

--- a/.github/workflows/preview-down.yml
+++ b/.github/workflows/preview-down.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [closed, unlabeled]
 
-
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/preview-down.yml
+++ b/.github/workflows/preview-down.yml
@@ -12,7 +12,7 @@ concurrency: preevy-${{ github.event.number }}
 
 env:
   AWS_REGION: eu-west-2
-  IAM_ROLE_ARN: arn:aws:iam::844815912454:role/GithubActions-ECS-Deployments-Role
+  IAM_ROLE_ARN: arn:aws:iam::844815912454:role/GithubActions-Preview-App-Role
   PREEVY_PROFILE_URL: s3://preevy-profile-store?region=eu-west-2
 
 jobs:

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   AWS_REGION: eu-west-2
-  IAM_ROLE_ARN: arn:aws:iam::844815912454:role/GithubActions-ECS-Deployments-Role
+  IAM_ROLE_ARN: arn:aws:iam::844815912454:role/GithubActions-Preview-App-Role
   PREEVY_PROFILE_URL: s3://preevy-profile-store?region=eu-west-2
   ENVIRONMENT: development
   SECRET_NAME: frontend-configuration


### PR DESCRIPTION
### Jira link

[HMRC-1150](https://transformuk.atlassian.net/browse/HMRC-1150)

### What?

I have added a nightly preview cleanup workflow
Key Features
- Runs nightly at midnight UTC
- Supports manual dispatch with dry_run mode for safe testing
- Excludes environments whose envId (branch name) includes the word "keep" 
- Sends a Slack notification to the #deployments channel summarising the cleanup operation and listing affected environments

### Why?

I am doing this because...
To automatically remove stale preview environments and free up resources.
