### PR TITLE
HMRC-1092 Redirect to login if user is not valid

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
-require:
+plugins:
   - rubocop-rspec
   - rubocop-capybara
 

--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -6,6 +6,12 @@ module Myott
 
   private
 
+    def authenticate
+      if current_user.nil?
+        redirect_to(URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s, allow_other_host: true)
+      end
+    end
+
     def current_user
       @current_user ||= User.find(cookies[:id_token])
     end

--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -5,16 +5,17 @@ module Myott
                   :disable_last_updated_footnote
 
     before_action :all_sections_chapters, only: %i[chapter_selection check_your_answers]
+    before_action :authenticate, except: %i[start]
 
     def start; end
 
     def dashboard
-      subscribed_to_stop_press = current_user&.stop_press_subscription || false
+      subscribed_to_stop_press = current_user.stop_press_subscription
 
       return redirect_to myott_preference_selection_path unless subscribed_to_stop_press
 
-      session[:chapter_ids] = if current_user&.chapter_ids&.split(',')&.any?
-                                current_user&.chapter_ids&.split(',')
+      session[:chapter_ids] = if current_user.chapter_ids&.split(',')&.any?
+                                current_user.chapter_ids&.split(',')
                               else
                                 all_chapters.map(&:to_param)
                               end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User
   attr_accessor :email, :chapter_ids, :stop_press_subscription
 
   def self.find(token)
-    return nil if token.nil?
+    return nil if token.nil? && !Rails.env.development?
 
     super(nil, {}, headers(token))
   rescue Faraday::UnauthorizedError
@@ -14,7 +14,7 @@ class User
   end
 
   def self.update(token, attributes)
-    return nil if token.nil?
+    return nil if token.nil? && !Rails.env.development?
 
     json_api_params = {
       data: {

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -43,6 +43,10 @@ module TradeTariffFrontend
     ENV.fetch('FRONTEND_HOST', 'http://localhost')
   end
 
+  def identity_base_url
+    ENV.fetch('IDENTITY_BASE_URL', 'http://localhost:3005')
+  end
+
   def backend_base_domain
     ENV['BACKEND_BASE_DOMAIN']
   end

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Myott::SubscriptionsController, type: :controller do
   let(:section) { instance_double(Section, title: 'Section 1', resource_id: 1) }
   let(:chapter1) { instance_double(Chapter, to_param: '01', short_code: '01', to_s: 'Live animals') }
   let(:chapter2) { instance_double(Chapter, to_param: '02', short_code: '02', to_s: 'Meat') }
   let(:chapter3) { instance_double(Chapter, to_param: '03', short_code: '03', to_s: 'Fish and crustaceans, molluscs and other aquatic invertebrates') }
+  let(:user) { build(:user, chapter_ids: '', stop_press_subscription: true) }
 
   before do
     allow(Rails.cache).to receive(:fetch).with('all_sections_chapters', expires_in: 1.day)
@@ -12,217 +14,292 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
   end
 
   describe 'GET #dashboard' do
-    before do
-      allow(controller).to receive(:current_user).and_return(user)
-      get :dashboard
-    end
-
-    context 'with user subscribed to all chapters' do
-      let(:user) { build(:user, chapter_ids: '', stop_press_subscription: true) }
-
-      it { is_expected.to respond_with(:success) }
-
-      it 'assigns the correct amount of selected chapters' do
-        expect(assigns(:amount_of_selected_chapters)).to eq('all')
-      end
-
-      it 'assigns selected sections and chapters' do
-        expect(assigns(:selected_sections_chapters)).to eq(
-          section => [chapter1, chapter2, chapter3],
-        )
-      end
-    end
-
-    context 'with subscribed user to some chapters' do
-      let(:user) { build(:user, stop_press_subscription: true, chapter_ids: '01,03') }
-
+    context 'when current_user is not valid' do
       before do
-        session[:chapter_ids] = %w[01,03]
+        allow(controller).to receive(:current_user).and_return(nil)
+        get :dashboard
       end
 
-      it 'assigns the correct amount of selected chapters' do
-        expect(assigns(:amount_of_selected_chapters)).to eq(2)
-      end
-
-      it 'assigns selected sections and chapters' do
-        expect(assigns(:selected_sections_chapters)).to eq(
-          section => [chapter1, chapter3],
-        )
-      end
+      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
     end
 
-    context 'with unsubscribed user' do
-      let(:user) { build(:user, stop_press_subscription: false) }
+    context 'when current_user is valid' do
+      before do
+        allow(controller).to receive(:current_user).and_return(user)
+        get :dashboard
+      end
 
-      it 'redirects to sign up page' do
-        expect(response).to redirect_to(myott_preference_selection_path)
+      context 'with user subscribed to all chapters' do
+        it { is_expected.to respond_with(:success) }
+
+        it 'assigns the correct amount of selected chapters' do
+          expect(assigns(:amount_of_selected_chapters)).to eq('all')
+        end
+
+        it 'assigns selected sections and chapters' do
+          expect(assigns(:selected_sections_chapters)).to eq(
+            section => [chapter1, chapter2, chapter3],
+          )
+        end
+      end
+
+      context 'with subscribed user to some chapters' do
+        let(:user) { build(:user, stop_press_subscription: true, chapter_ids: '01,03') }
+
+        before do
+          session[:chapter_ids] = %w[01,03]
+        end
+
+        it 'assigns the correct amount of selected chapters' do
+          expect(assigns(:amount_of_selected_chapters)).to eq(2)
+        end
+
+        it 'assigns selected sections and chapters' do
+          expect(assigns(:selected_sections_chapters)).to eq(
+            section => [chapter1, chapter3],
+          )
+        end
+      end
+
+      context 'with unsubscribed user' do
+        let(:user) { build(:user, stop_press_subscription: false) }
+
+        it 'redirects to sign up page' do
+          expect(response).to redirect_to(myott_preference_selection_path)
+        end
       end
     end
   end
 
   describe 'GET #chapter_selection' do
-    before do
-      session[:chapter_ids] = %w[01]
-      get :chapter_selection
+    context 'when current_user is not valid' do
+      before do
+        allow(controller).to receive(:current_user).and_return(nil)
+        get :chapter_selection
+      end
+
+      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
     end
 
-    it { is_expected.to respond_with(:success) }
+    context 'when current_user is valid' do
+      before do
+        allow(controller).to receive(:current_user).and_return(user)
+        session[:chapter_ids] = %w[01]
+        get :chapter_selection
+      end
 
-    it 'assigns the selected chapters' do
-      expect(assigns(:selected_chapters)).to eq([chapter1])
+      it { is_expected.to respond_with(:success) }
+
+      it 'assigns the selected chapters' do
+        expect(assigns(:selected_chapters)).to eq([chapter1])
+      end
     end
   end
 
   describe 'POST #check_your_answers' do
-    context 'when some chapters are selected' do
+    context 'when current_user is not valid' do
       before do
-        session[:chapter_ids] = %w[01 03]
+        allow(controller).to receive(:current_user).and_return(nil)
         post :check_your_answers, params: { chapter_ids: %w[01 03] }
       end
 
-      it { expect(flash.now[:error]).to be_nil }
-
-      it { is_expected.to respond_with(:success) }
-
-      it 'assigns the correct amount of selected chapters' do
-        expect(assigns(:amount_of_selected_chapters)).to eq(2)
-      end
-
-      it 'assigns selected sections and chapters' do
-        expect(assigns(:selected_sections_chapters)).to eq(
-          section => [chapter1, chapter3],
-        )
-      end
+      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
     end
 
-    context 'when no chapters are selected' do
+    context 'when current_user is valid' do
       before do
-        session[:chapter_ids] = %w[01]
-        post :check_your_answers, params: {}
+        allow(controller).to receive(:current_user).and_return(user)
       end
 
-      it 'renders the chapter_selection template again' do
-        expect(response).to render_template(:chapter_selection)
+      context 'when some chapters are selected' do
+        before do
+          session[:chapter_ids] = %w[01 03]
+          post :check_your_answers, params: { chapter_ids: %w[01 03] }
+        end
+
+        it { expect(flash.now[:error]).to be_nil }
+
+        it { is_expected.to respond_with(:success) }
+
+        it 'assigns the correct amount of selected chapters' do
+          expect(assigns(:amount_of_selected_chapters)).to eq(2)
+        end
+
+        it 'assigns selected sections and chapters' do
+          expect(assigns(:selected_sections_chapters)).to eq(
+            section => [chapter1, chapter3],
+          )
+        end
       end
 
-      it 'sets a flash error message' do
-        expect(flash.now[:error]).to eq('Select the chapters you want tariff updates about.')
+      context 'when no chapters are selected' do
+        before do
+          session[:chapter_ids] = %w[01]
+          post :check_your_answers, params: {}
+        end
+
+        it 'renders the chapter_selection template again' do
+          expect(response).to render_template(:chapter_selection)
+        end
+
+        it 'sets a flash error message' do
+          expect(flash.now[:error]).to eq('Select the chapters you want tariff updates about.')
+        end
       end
     end
   end
 
   describe 'GET #check_your_answers' do
-    context 'when all chapters are selected' do
+    context 'when current_user is not valid' do
       before do
+        allow(controller).to receive(:current_user).and_return(nil)
+        get :check_your_answers, params: { all_tariff_updates: 'true' }
+      end
+
+      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
+    end
+
+    context 'when current_user is valid' do
+      before do
+        allow(controller).to receive(:current_user).and_return(user)
         session[:chapter_ids] = %w[01]
         get :check_your_answers, params: { all_tariff_updates: 'true' }
       end
 
-      it { expect(flash.now[:error]).to be_nil }
+      context 'when all chapters are selected' do
+        it { expect(flash.now[:error]).to be_nil }
 
-      it { is_expected.to respond_with(:success) }
+        it { is_expected.to respond_with(:success) }
 
-      it 'assigns the correct amount of selected chapters' do
-        expect(assigns(:amount_of_selected_chapters)).to eq('all')
-      end
+        it 'assigns the correct amount of selected chapters' do
+          expect(assigns(:amount_of_selected_chapters)).to eq('all')
+        end
 
-      it 'assigns selected sections and chapters' do
-        expect(assigns(:selected_sections_chapters)).to eq(
-          section => [chapter1, chapter2, chapter3],
-        )
+        it 'assigns selected sections and chapters' do
+          expect(assigns(:selected_sections_chapters)).to eq(
+            section => [chapter1, chapter2, chapter3],
+          )
+        end
       end
     end
   end
 
   describe 'POST #set_preferences' do
-    context 'when selectChapters is selected' do
+    context 'when current_user is not valid' do
       before do
+        allow(controller).to receive(:current_user).and_return(nil)
         post :set_preferences, params: { preference: 'selectChapters' }
       end
 
-      it { is_expected.to redirect_to(myott_chapter_selection_path) }
+      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
     end
 
-    context 'when allChapters is selected' do
+    context 'when current_user is valid' do
       before do
-        post :set_preferences, params: { preference: 'allChapters' }
+        allow(controller).to receive(:current_user).and_return(user)
       end
 
-      it { is_expected.to redirect_to(myott_check_your_answers_path(all_tariff_updates: true)) }
-    end
+      context 'when selectChapters is selected' do
+        before do
+          post :set_preferences, params: { preference: 'selectChapters' }
+        end
 
-    context 'when no option is selected' do
-      before do
-        post :set_preferences, params: {}
+        it { is_expected.to redirect_to(myott_chapter_selection_path) }
       end
 
-      it 'renders the chapter_selection template again' do
-        expect(response).to render_template(:preference_selection)
+      context 'when allChapters is selected' do
+        before do
+          post :set_preferences, params: { preference: 'allChapters' }
+        end
+
+        it { is_expected.to redirect_to(myott_check_your_answers_path(all_tariff_updates: true)) }
       end
 
-      it 'sets a flash error message' do
-        expect(flash.now[:error]).to eq('Select a subscription preference to continue')
-      end
+      context 'when no option is selected' do
+        before do
+          post :set_preferences, params: {}
+        end
 
-      it 'sets a flash select_error message' do
-        expect(flash.now[:select_error]).to eq('Select an option to continue')
+        it 'renders the chapter_selection template again' do
+          expect(response).to render_template(:preference_selection)
+        end
+
+        it 'sets a flash error message' do
+          expect(flash.now[:error]).to eq('Select a subscription preference to continue')
+        end
+
+        it 'sets a flash select_error message' do
+          expect(flash.now[:select_error]).to eq('Select an option to continue')
+        end
       end
     end
   end
 
   describe 'POST #subscribe' do
-    let(:attributes) { { chapter_ids: '01,03', stop_press_subscription: 'true' } }
-
-    before do
-      token = 'valid-jwt-token'
-      cookies[:id_token] = token
-      session[:chapter_ids] = %w[01 03]
-    end
-
-    context 'when the update is successful' do
+    context 'when current_user is not valid' do
       before do
-        stub_api_request('/user/users', :put)
-          .with(body: {
-            data: {
-              attributes: attributes,
-            },
-          })
-          .and_return(jsonapi_response(:user, attributes))
-
+        allow(controller).to receive(:current_user).and_return(nil)
         post :subscribe
       end
 
-      it { is_expected.to respond_with(:redirect) }
-
-      it { is_expected.to redirect_to(myott_subscription_confirmation_path) }
-
-      it 'clears the session chapter ids' do
-        expect(session[:chapter_ids]).to be_nil
-      end
-
-      it 'clears the session all_tariff_updates flag' do
-        expect(session[:all_tariff_updates]).to be_nil
-      end
+      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
     end
 
-    context 'when the update fails' do
+    context 'when current_user is valid' do
+      let(:attributes) { { chapter_ids: '01,03', stop_press_subscription: 'true' } }
+
       before do
-        stub_api_request('/user/users', :put)
-          .and_return(jsonapi_error_response(401))
-
-        post :subscribe
+        allow(controller).to receive(:current_user).and_return(user)
+        token = 'valid-jwt-token'
+        cookies[:id_token] = token
+        session[:chapter_ids] = %w[01 03]
       end
 
-      it 'does not render confirmation' do
-        expect(response).not_to render_template(:subscription_confirmation)
+      context 'when the update is successful' do
+        before do
+          stub_api_request('/user/users', :put)
+            .with(body: {
+              data: {
+                attributes: attributes,
+              },
+            })
+            .and_return(jsonapi_response(:user, attributes))
+
+          post :subscribe
+        end
+
+        it { is_expected.to respond_with(:redirect) }
+
+        it { is_expected.to redirect_to(myott_subscription_confirmation_path) }
+
+        it 'clears the session chapter ids' do
+          expect(session[:chapter_ids]).to be_nil
+        end
+
+        it 'clears the session all_tariff_updates flag' do
+          expect(session[:all_tariff_updates]).to be_nil
+        end
       end
 
-      it 'does not clear the session chapter ids' do
-        expect(session[:chapter_ids]).to eq(%w[01 03])
-      end
+      context 'when the update fails' do
+        before do
+          stub_api_request('/user/users', :put)
+            .and_return(jsonapi_error_response(401))
 
-      it 'sets a flash error message' do
-        expect(flash[:error]).to eq('There was an error updating your subscription. Please try again.')
+          post :subscribe
+        end
+
+        it 'does not render confirmation' do
+          expect(response).not_to render_template(:subscription_confirmation)
+        end
+
+        it 'does not clear the session chapter ids' do
+          expect(session[:chapter_ids]).to eq(%w[01 03])
+        end
+
+        it 'sets a flash error message' do
+          expect(flash[:error]).to eq('There was an error updating your subscription. Please try again.')
+        end
       end
 
       context 'when all chapters are selected' do
@@ -239,3 +316,4 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
     end
   end
 end
+# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
### Jira link

[HMRC-1092](https://transformuk.atlassian.net/browse/HMRC-1092)

### What?

The user is taken to the login page if their session is not valid. This is disabled in the development environment.

### Why?

Users need to be authenticated to login
