### PR TITLE
HMRC-1093 Add subscribe links to Stop Press News Collection Items

### DIFF
--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -12,6 +12,13 @@ module News
                   :description,
                   :priority
 
+    enum :id, {
+      trade_news: [1],
+      tariff_notices: [2],
+      tariff_stop_press: [3],
+      service_updates: [4],
+    }
+
     def id
       @id ||= resource_id.presence&.to_i
     end
@@ -28,10 +35,6 @@ module News
       else
         false
       end
-    end
-
-    def stop_press?
-      slug == 'tariff_stop_press'
     end
   end
 end

--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -29,5 +29,9 @@ module News
         false
       end
     end
+
+    def stop_press?
+      slug == 'tariff_stop_press'
+    end
   end
 end

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -70,7 +70,7 @@
         <%= link_to t('navigation.back_to_top'), '#content', class: 'govuk-!-display-none-print' %>
       </p>
 
-      <% if TradeTariffFrontend.myott? && @news_collection.stop_press?%>
+      <% if TradeTariffFrontend.myott? && @news_collection.tariff_stop_press?%>
         <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-2" />
         <%= format_news_item_content "## Subscribe and manage Stop Press alerts\n\nSubscribe to Stop Press alerts to stay up-to-date with the latest tariff updates, or manage your existing subscription.\n" %>
         <%= link_to 'Start now', myott_start_path, class: 'govuk-button govuk-button--secondary' %>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -70,12 +70,18 @@
         <%= link_to t('navigation.back_to_top'), '#content', class: 'govuk-!-display-none-print' %>
       </p>
 
-      <% if @news_collection.description.present? %>
+      <% if TradeTariffFrontend.myott? && @news_collection.stop_press?%>
         <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-2" />
+        <%= format_news_item_content "## Subscribe and manage Stop Press alerts\n\nSubscribe to Stop Press alerts to stay up-to-date with the latest tariff updates, or manage your existing subscription.\n" %>
+        <%= link_to 'Start now', myott_start_path, class: 'govuk-button govuk-button--secondary' %>
+      <% else %>
+        <% if @news_collection.description.present? %>
+          <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-2" />
 
-        <div class="tariff-markdown">
-          <%= format_news_item_content @news_collection.description %>
-        </div>
+          <div class="tariff-markdown">
+            <%= format_news_item_content @news_collection.description %>
+          </div>
+        <% end %>
       <% end %>
 
       <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-bottom-6">

--- a/spec/models/news/collection_spec.rb
+++ b/spec/models/news/collection_spec.rb
@@ -89,4 +89,20 @@ RSpec.describe News::Collection do
       it { is_expected.to be false }
     end
   end
+
+  describe '#stop_press?' do
+    subject { collection.stop_press? }
+
+    let(:collection) { build :news_collection, slug: 'tariff_stop_press' }
+
+    context 'when slug is tariff_stop_press' do
+      it { is_expected.to be true }
+    end
+
+    context 'when slug is not tariff_stop_press' do
+      let(:collection) { build :news_collection, slug: 'other_slug' }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/news/collection_spec.rb
+++ b/spec/models/news/collection_spec.rb
@@ -89,20 +89,4 @@ RSpec.describe News::Collection do
       it { is_expected.to be false }
     end
   end
-
-  describe '#stop_press?' do
-    subject { collection.stop_press? }
-
-    let(:collection) { build :news_collection, slug: 'tariff_stop_press' }
-
-    context 'when slug is tariff_stop_press' do
-      it { is_expected.to be true }
-    end
-
-    context 'when slug is not tariff_stop_press' do
-      let(:collection) { build :news_collection, slug: 'other_slug' }
-
-      it { is_expected.to be false }
-    end
-  end
 end


### PR DESCRIPTION
### IMPORTANT DO NOT MERGE THIS UNTIL MYOTT PRIVATE BETA TESTING STARTS!

### Jira link

[HMRC-1093](https://transformuk.atlassian.net/browse/HMRC-1093)

### What?

I have added subscribe links for stop press news collection type

### Why?

I am doing this because it is required for MyOTT when Public Beta Testing Starts

This means the Stop Press News Collection Description can be set to nil in the database by a backend data migration with this PR:
https://github.com/trade-tariff/trade-tariff-backend/pull/2293

**Change to Stop Press News** 
![image](https://github.com/user-attachments/assets/8f044806-1dcf-4fba-934c-57d7479a9256)

