### PR TITLE
HMRC-1183 Invalid verification link page

### DIFF
--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -5,7 +5,7 @@ module Myott
                   :disable_last_updated_footnote
 
     before_action :all_sections_chapters, only: %i[chapter_selection check_your_answers]
-    before_action :authenticate, except: %i[start]
+    before_action :authenticate, except: %i[start invalid]
 
     def start; end
 

--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -9,6 +9,8 @@ module Myott
 
     def start; end
 
+    def invalid; end
+
     def dashboard
       subscribed_to_stop_press = current_user.stop_press_subscription
 

--- a/app/views/myott/subscriptions/invalid.html.erb
+++ b/app/views/myott/subscriptions/invalid.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Verification link invalid</h1>
+
+    <p class="govuk-body">This could be because:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the verification link has expired</li>
+      <li>you have switched web browser</li>
+    </ul>
+
+    <p class="govuk-body">
+      To resend the verification email for Stop Press updates from the
+      UK Trade Tariff Service, continue to subscribe and manage updates.
+    </p>
+
+    <a href="<%= myott_start_path %>" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+      Continue
+    </a>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
   if TradeTariffFrontend.myott?
     namespace :myott, path: 'subscriptions' do
       get '/start', to: 'subscriptions#start'
+      get '/invalid', to: 'subscriptions#invalid'
       get '/', to: 'subscriptions#dashboard'
       get '/preference_selection', to: 'subscriptions#preference_selection'
       get '/chapter_selection', to: 'subscriptions#chapter_selection'

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -13,6 +13,24 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
       .and_return({ section => [chapter1, chapter2, chapter3] })
   end
 
+  describe 'GET #start' do
+    it 'does not authenticate the user' do
+      allow(controller).to receive(:authenticate)
+
+      get :start
+      expect(controller).not_to have_received(:authenticate)
+    end
+  end
+
+  describe 'GET #invalid' do
+    it 'does not authenticate the user' do
+      allow(controller).to receive(:authenticate)
+
+      get :invalid
+      expect(controller).not_to have_received(:authenticate)
+    end
+  end
+
   describe 'GET #dashboard' do
     context 'when current_user is not valid' do
       before do


### PR DESCRIPTION
### Jira link

[HMRC-1183](https://transformuk.atlassian.net/browse/HMRC-1183)

### What?

Static page for when a user's verification link is invalid.

### Why?

To inform user what has gone wrong when they use a verification link after expiry or with the wrong browser.