### PR TITLE
HMRC-1093 Remove 'print this page' from bottom of news items

### DIFF
--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -77,15 +77,6 @@
           <%= format_news_item_content @news_collection.description %>
         </div>
       <% end %>
-
-      <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-bottom-6">
-        <button onclick="javascript:window.print()"
-                class="govuk-link govuk-body-s gem-c-print-link__button"
-                data-module="print-link"
-                data-print-link-module-started="true">
-          Print this page
-        </button>
-      </div>
     </article>
   </div>
 


### PR DESCRIPTION
### Jira link

[HMRC-1093](https://transformuk.atlassian.net/browse/HMRC-1093)

### What?

I have removed 'print this page' from the bottom of news items

### Why?

I am doing this because it is in the way of the SP CTA button and should be removed from other news collection types for consistency.
