### PR TITLE
HMRC-694: Fixes broken titles

### DIFF
--- a/app/controllers/duty_calculator/steps/base_controller.rb
+++ b/app/controllers/duty_calculator/steps/base_controller.rb
@@ -67,12 +67,14 @@ module DutyCalculator
       end
 
       def title
-        t("page_titles.#{@step.class.try(:id)}", default: super)
+        t("page_titles.#{@step.class.try(:id)}", default: t("title.#{service_name}"))
       end
 
       def with_session_tracking
         yield
       end
+
+      delegate :service_name, to: ::TradeTariffFrontend::ServiceChooser
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,13 @@
 <head>
   <%= render 'shared/gtm', part: 'head' if analytics_allowed? %>
   <meta charset="utf-8">
-  <title><%= yield :pageTitle %></title>
+  <title>
+    <% if respond_to?(:title) %>
+      <%= title %>
+    <% else %>
+      <%= yield :pageTitle %>
+    <% end %>
+  </title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">
 


### PR DESCRIPTION
### Jira link

[HMRC-694](https://transformuk.atlassian.net/browse/HMRC-694)

### What?

I have a...

- Fixed an issue with broken titles in the Duty Calculator

### Why?

I am doing this because...

- These weren't displaying properly after merging the DC
