### PR TITLE
Switch to small_3_0 Lightsail bundle and improve secret management

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -30,6 +30,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - run: touch .env # To prevent preevy from failing due to missing .env file
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/preview-down.yml
+++ b/.github/workflows/preview-down.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: touch .env # To prevent preevy from failing due to missing .env file
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -42,7 +42,6 @@ jobs:
       - uses: livecycle/preevy-up-action@v2.4.0
         id: preevy_up
         with:
-          args: "--debug"
           install: gh-release
           profile-url: "${{ env.PREEVY_PROFILE_URL }}"
         env:

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Fetch rontend configuration secrets and mask values 
+      - name: Fetch frontend-configuration secrets and mask values
         run: |
           set -euo pipefail
 

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -30,14 +30,17 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Parse frontend configuration secrets
-        id: parse-secrets
+      - name: Fetch rontend configuration secrets and mask values 
         run: |
-          aws secretsmanager get-secret-value \
+          set -euo pipefail
+
+          SECRET_JSON=$(aws secretsmanager get-secret-value \
             --secret-id "${{ env.SECRET_NAME }}" \
             --query "SecretString" \
-            --output text \
-            | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
+            --output text)
+
+          echo "$SECRET_JSON" | jq -r 'to_entries[] | "::add-mask::\(.value)"'
+          echo "$SECRET_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env
 
       - uses: livecycle/preevy-up-action@v2.4.0
         id: preevy_up

--- a/compose.yml
+++ b/compose.yml
@@ -8,22 +8,13 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
+    env_file:
+      - .env 
     environment:
       - ENVIRONMENT=review
-      - API_SERVICE_BACKEND_URL_OPTIONS=${API_SERVICE_BACKEND_URL_OPTIONS}
       - BACKEND_BASE_DOMAIN=https://dev.trade-tariff.service.gov.uk/
-      - DUTY_CALCULATOR_BASE_URL=${DUTY_CALCULATOR_BASE_URL}
-      - GOVUK_APP_DOMAIN="localhost"
-      - GOVUK_WEBSITE_ROOT=http://localhost/
-      - RAILS_ENV=production
       - MYOTT_ENABLED=true
-      - AWS_REGION=eu-west-2
-      - TARIFF_FROM_EMAIL=${TARIFF_FROM_EMAIL}
-      - TARIFF_SUPPORT_EMAIL=${TARIFF_SUPPORT_EMAIL}
-      - TARIFF_TO_EMAIL=${TARIFF_TO_EMAIL}
       - USE_SMTP=true
-      - SMTP_USERNAME=${SMTP_USERNAME}
-      - SMTP_PASSWORD=${SMTP_PASSWORD}
     extra_hosts:
       - "telemetry.preevy.dev:127.0.0.1" # Disables telemetry
 volumes:

--- a/compose.yml
+++ b/compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "8080:8080"
     env_file:
-      - .env 
+      - .env
     environment:
       - ENVIRONMENT=review
       - BACKEND_BASE_DOMAIN=https://dev.trade-tariff.service.gov.uk/
@@ -25,4 +25,4 @@ x-preevy:
   driver: lightsail
   drivers:
     lightsail:
-      bundle-id: small_3_0  # change to medium_3_0 if you see preevy up failing 
+      bundle-id: small_3_0  # change to medium_3_0 if you see preevy up failing

--- a/compose.yml
+++ b/compose.yml
@@ -1,3 +1,5 @@
+name: trade-tariff-frontend
+
 services:
   frontend:
     container_name: frontend
@@ -27,3 +29,9 @@ services:
 volumes:
   hmrc-redis:
     driver: local
+
+x-preevy:
+  driver: lightsail
+  drivers:
+    lightsail:
+      bundle-id: small_3_0  # change to medium_3_0 if you see preevy up failing 


### PR DESCRIPTION
### Jira link

[HMRC-<TODO>](https://transformuk.atlassian.net/browse/HMRC-<TODO>)

### What?

- Downgraded the default AWS Lightsail instance type used in Preevy preview environments from the default medium_2_0 to small_3_0 

- Refactored secret handling logic to prevent value exposure in GitHub Actions logs

- Injected secrets into containers using .env + env_file: instead of embedding them directly in the Compose file

### Why?

- small_3_0 provides 2 GB RAM, 2 vCPUs, and 60 GB SSD, which should be sufficient for our Rails-based frontend preview workloads ->This change cuts the cost per preview environment from ~$24/month to ~$12/month

- Secret values were previously visible in workflow logs. Now, all secrets are securely handled by masking them using ::add-mask:: to prevent log exposure and injecting them into the container via a temporary .env file referenced by env_file: in docker-compose.yml. This improves both workflow security and runtime configuration hygiene.

