### PR TITLE
HMRC-1146 HMRC-1215 MyOTT Unsubscribe Screens and Functionality

### DIFF
--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -85,7 +85,27 @@ module Myott
     end
 
     def subscription_confirmation
-      @email = current_user&.email
+      @header = 'You have updated your subscription'
+      @message = "When Stop Press updates are published by the UK Trade Tariff Service which relate to the chapters you have chosen, an email will be sent to <strong>#{current_user&.email}</strong>"
+      render :confirmation
+    end
+
+    def unsubscribe_confirmation
+      @header = 'You have unsubscribed'
+      @message = 'You will no longer receive any Stop Press emails from the UK Trade Tariff Service.'
+      render :confirmation
+    end
+
+    def unsubscribe; end
+
+    def unsubscribe_action
+      success = User.delete(cookies[:id_token])
+      if success
+        redirect_to myott_unsubscribe_confirmation_path
+      else
+        flash.now[:error] = 'There was an error unsubscribing you. Please try again.'
+        render :unsubscribe
+      end
     end
 
     private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,18 @@ class User
     nil
   end
 
+  def self.delete(token)
+    return nil if token.nil? && !Rails.env.development?
+
+    response = super(headers(token))
+    response.status == 200
+  rescue Faraday::UnauthorizedError
+    false
+  rescue Faraday::Error => e
+    Rails.logger.error("Failed to delete user: #{e.message}")
+    false
+  end
+
   def self.headers(token)
     {
       authorization: "Bearer #{token}",

--- a/app/views/myott/subscriptions/confirmation.html.erb
+++ b/app/views/myott/subscriptions/confirmation.html.erb
@@ -4,12 +4,12 @@
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-panel govuk-panel--confirmation">
           <h1 class="govuk-panel__title">
-            You have updated your subscription
+            <%= @header %>
           </h1>
         </div>
         <h2 class="govuk-heading-m">What happens next</h2>
         <p class="govuk-body">
-          When Stop Press updates are published by the UK Trade Tariff Service which relate to the chapters you have chosen, an email will be sent to <strong><%= @email %></strong>
+          <%= @message.html_safe %>
         </p>
         <p class="govuk-body">
           You can now close this window.

--- a/app/views/myott/subscriptions/dashboard.html.erb
+++ b/app/views/myott/subscriptions/dashboard.html.erb
@@ -14,6 +14,6 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m">Unsubscribe</h2>
-    <p class="govuk-body"><a href="">Unsubscribe from all updates</a></p>
+    <p class="govuk-body"><a href=<%= myott_unsubscribe_path%>>Unsubscribe from all updates</a></p>
   </div>
 </div>

--- a/app/views/myott/subscriptions/unsubscribe.html.erb
+++ b/app/views/myott/subscriptions/unsubscribe.html.erb
@@ -1,0 +1,20 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-body">
+    <%= render 'error' if flash.now[:error] %>
+    <h1 class="govuk-heading-l">Are you sure you want to unsubscribe?</h1>
+
+    <p>
+      You are about to unsubscribe from all Stop Press updates from the UK Trade Tariff Service.
+    </p>
+    <p>
+      It can take up to 24 hours to remove this email address from our system.
+    </p>
+     <p>
+      If you do not want to unsubscribe, close this page.
+    </p>
+
+    <a href="<%= myott_unsubscribe_action_path %>" role="button" draggable="false" class="govuk-button govuk-button--warning" data-module="govuk-button">
+      Unsubscribe
+    </a>
+  </div>
+</div>

--- a/app/views/myott/subscriptions/unsubscribe.html.erb
+++ b/app/views/myott/subscriptions/unsubscribe.html.erb
@@ -12,9 +12,8 @@
      <p>
       If you do not want to unsubscribe, close this page.
     </p>
-
-    <a href="<%= myott_unsubscribe_action_path %>" role="button" draggable="false" class="govuk-button govuk-button--warning" data-module="govuk-button">
-      Unsubscribe
-    </a>
+    <%= form_with url: myott_unsubscribe_action_path, method: :post, local: true do %>
+      <%= submit_tag "Unsubscribe", class: "govuk-button govuk-button--warning govuk-!-margin-top-4" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/myott/subscriptions/unsubscribe.html.erb
+++ b/app/views/myott/subscriptions/unsubscribe.html.erb
@@ -12,7 +12,7 @@
      <p>
       If you do not want to unsubscribe, close this page.
     </p>
-    <%= form_with url: myott_unsubscribe_action_path, method: :post, local: true do %>
+    <%= form_with url: myott_unsubscribe_path, method: :post, local: true do %>
       <%= submit_tag "Unsubscribe", class: "govuk-button govuk-button--warning govuk-!-margin-top-4" %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
       get '/subscription_confirmation', to: 'subscriptions#subscription_confirmation'
       get '/unsubscribe_confirmation', to: 'subscriptions#unsubscribe_confirmation'
       get '/unsubscribe', to: 'subscriptions#unsubscribe'
-      get '/unsubscribe_action', to: 'subscriptions#unsubscribe_action'
+      post '/unsubscribe_action', to: 'subscriptions#unsubscribe_action'
       post '/check_your_answers', to: 'subscriptions#check_your_answers'
       post '/set_preferences', to: 'subscriptions#set_preferences'
       post '/subscribe', to: 'subscriptions#subscribe'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,9 @@ Rails.application.routes.draw do
       get '/chapter_selection', to: 'subscriptions#chapter_selection'
       get '/check_your_answers', to: 'subscriptions#check_your_answers' # for when user selects all chapters
       get '/subscription_confirmation', to: 'subscriptions#subscription_confirmation'
+      get '/unsubscribe_confirmation', to: 'subscriptions#unsubscribe_confirmation'
+      get '/unsubscribe', to: 'subscriptions#unsubscribe'
+      get '/unsubscribe_action', to: 'subscriptions#unsubscribe_action'
       post '/check_your_answers', to: 'subscriptions#check_your_answers'
       post '/set_preferences', to: 'subscriptions#set_preferences'
       post '/subscribe', to: 'subscriptions#subscribe'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
       get '/subscription_confirmation', to: 'subscriptions#subscription_confirmation'
       get '/unsubscribe_confirmation', to: 'subscriptions#unsubscribe_confirmation'
       get '/unsubscribe', to: 'subscriptions#unsubscribe'
-      post '/unsubscribe_action', to: 'subscriptions#unsubscribe_action'
+      post '/unsubscribe', to: 'subscriptions#unsubscribe_action'
       post '/check_your_answers', to: 'subscriptions#check_your_answers'
       post '/set_preferences', to: 'subscriptions#set_preferences'
       post '/subscribe', to: 'subscriptions#subscribe'

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -92,6 +92,12 @@ private
       new parse_jsonapi(response)
     end
 
+    def delete(headers = {})
+      api.delete(singular_path) do |req|
+        req.headers = headers
+      end
+    end
+
     def relationships
       @relationships ||= superclass.include?(ApiEntity) ? superclass.relationships.dup : []
     end

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -334,11 +334,11 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
     end
   end
 
-  describe 'GET #unsubscribe_action' do
+  describe 'POST #unsubscribe_action' do
     context 'when current_user is not valid' do
       before do
         allow(controller).to receive(:current_user).and_return(nil)
-        get :dashboard
+        post :dashboard
       end
 
       it { is_expected.to redirect_to 'http://localhost:3005/myott' }
@@ -348,7 +348,7 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
       before do
         allow(controller).to receive(:current_user).and_return(user)
         allow(User).to receive(:delete).and_return(false)
-        get :unsubscribe_action
+        post :unsubscribe_action
       end
 
       it { is_expected.to render_template(:unsubscribe) }
@@ -362,7 +362,7 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
       before do
         allow(controller).to receive(:current_user).and_return(user)
         allow(User).to receive(:delete).and_return(true)
-        get :unsubscribe_action
+        post :unsubscribe_action
       end
 
       it { is_expected.to redirect_to(myott_unsubscribe_confirmation_path) }

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -333,5 +333,40 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
       end
     end
   end
+
+  describe 'GET #unsubscribe_action' do
+    context 'when current_user is not valid' do
+      before do
+        allow(controller).to receive(:current_user).and_return(nil)
+        get :dashboard
+      end
+
+      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
+    end
+
+    context 'when the delete request fails' do
+      before do
+        allow(controller).to receive(:current_user).and_return(user)
+        allow(User).to receive(:delete).and_return(false)
+        get :unsubscribe_action
+      end
+
+      it { is_expected.to render_template(:unsubscribe) }
+
+      it 'sets a flash error message' do
+        expect(flash.now[:error]).to eq('There was an error unsubscribing you. Please try again.')
+      end
+    end
+
+    context 'when the delete request is successful' do
+      before do
+        allow(controller).to receive(:current_user).and_return(user)
+        allow(User).to receive(:delete).and_return(true)
+        get :unsubscribe_action
+      end
+
+      it { is_expected.to redirect_to(myott_unsubscribe_confirmation_path) }
+    end
+  end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -462,4 +462,60 @@ RSpec.describe ApiEntity do
       expect(result.age).to eq(111)
     end
   end
+
+  describe '#delete' do
+    subject(:result) do
+      mock_entity.delete(
+        { 'Authorization' => 'Bearer abc123' },
+      )
+    end
+
+    let(:mock_response) { instance_double(Faraday::Response, status: 200, body: nil) }
+    let(:api_double) { instance_double(Faraday::Connection, delete: mock_response) }
+
+    before do
+      allow(mock_entity).to receive_messages(
+        api: api_double,
+        singular_path: '/api/v2/mock_entities/1',
+      )
+    end
+
+    context 'when the delete request is successful' do
+      it 'calls the delete endpoint with headers' do
+        allow(api_double).to receive(:delete)
+          .with('/api/v2/mock_entities/1', { 'Authorization' => 'Bearer abc123' })
+          .and_return(mock_response)
+
+        result
+      end
+
+      it 'returns a 200 OK response' do
+        expect(result.status).to eq(200)
+      end
+
+      it 'returns an empty body' do
+        expect(result.body).to be_nil
+      end
+    end
+
+    context 'when the delete request fails' do
+      let(:mock_response) { instance_double(Faraday::Response, status: 500, body: nil) }
+
+      it 'calls the delete endpoint with no headers' do
+        allow(api_double).to receive(:delete)
+          .with('/api/v2/mock_entities/1')
+          .and_return(mock_response)
+
+        result
+      end
+
+      it 'returns a 500 OK response' do
+        expect(result.status).to eq(500)
+      end
+
+      it 'returns an empty body' do
+        expect(result.body).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,5 +54,57 @@ RSpec.describe User do
       it { expect(response.chapter_ids).to eq('01,02') }
       it { expect(response.stop_press_subscription).to eq('true') }
     end
+
+    context 'when response is unauthorised' do
+      before do
+        stub_api_request('/user/users', :put)
+        .with(body: {
+          data: {
+            attributes: attributes,
+          },
+        }).and_return(jsonapi_error_response(401))
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '.delete' do
+    subject(:response) { described_class.delete(token) }
+
+    let(:token) { 'valid-jwt-token' }
+
+    context 'when token is nil' do
+      let(:token) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the request is successful' do
+      before do
+        stub_api_request('/user/users', :delete)
+          .and_return(status: 200)
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when response is unauthorised' do
+      before do
+        stub_api_request('/user/users', :delete)
+        .and_return(status: 401)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when response errors' do
+      before do
+        stub_api_request('/user/users', :delete)
+        .and_return(status: 500)
+      end
+
+      it { is_expected.to be false }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-1146](https://transformuk.atlassian.net/browse/HMRC-1146)
[HMRC-1215](https://transformuk.atlassian.net/browse/HMRC-1215)

### What?

I have: 

- [x] Added unsubscribe screens and flow
- [x] Added delete API for integration to backend
- [x] Refactored confirmation screen so it can be re-used for subscribe/unsubscribe

### Why?

I am doing this because it's in the ticket

Unsubscribe:
![image](https://github.com/user-attachments/assets/c1ffa233-34c6-474a-a439-a6424794a388)

Unsubscribe Confirmation
![image](https://github.com/user-attachments/assets/7f87d810-d234-48e9-a264-a0ae33883aa5)
