### PR TITLE
HMRC-1222 Unsubscribe controller with new authentication

### DIFF
--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -15,5 +15,10 @@ module Myott
     def current_user
       @current_user ||= User.find(cookies[:id_token])
     end
+    helper_method :current_user
+
+    def current_subscription
+      @current_subscription ||= Subscription.find(params[:id])
+    end
   end
 end

--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -1,20 +1,13 @@
 module Myott
   class SubscriptionsController < MyottController
-    before_action :disable_search_form,
-                  :disable_switch_service_banner,
-                  :disable_last_updated_footnote
-
     before_action :all_sections_chapters, only: %i[chapter_selection check_your_answers]
     before_action :authenticate, except: %i[start invalid]
 
     def start; end
-
     def invalid; end
 
     def dashboard
-      subscribed_to_stop_press = current_user.stop_press_subscription
-
-      return redirect_to myott_preference_selection_path unless subscribed_to_stop_press
+      return redirect_to myott_preference_selection_path unless current_user.stop_press_subscription
 
       session[:chapter_ids] = if current_user.chapter_ids&.split(',')&.any?
                                 current_user.chapter_ids&.split(',')
@@ -88,24 +81,6 @@ module Myott
       @header = 'You have updated your subscription'
       @message = "When Stop Press updates are published by the UK Trade Tariff Service which relate to the chapters you have chosen, an email will be sent to <strong>#{current_user&.email}</strong>"
       render :confirmation
-    end
-
-    def unsubscribe_confirmation
-      @header = 'You have unsubscribed'
-      @message = 'You will no longer receive any Stop Press emails from the UK Trade Tariff Service.'
-      render :confirmation
-    end
-
-    def unsubscribe; end
-
-    def unsubscribe_action
-      success = User.delete(cookies[:id_token])
-      if success
-        redirect_to myott_unsubscribe_confirmation_path
-      else
-        flash.now[:error] = 'There was an error unsubscribing you. Please try again.'
-        render :unsubscribe
-      end
     end
 
     private

--- a/app/controllers/myott/unsubscribes_controller.rb
+++ b/app/controllers/myott/unsubscribes_controller.rb
@@ -1,0 +1,31 @@
+module Myott
+  class UnsubscribesController < MyottController
+    before_action :authentication, except: :confirmation
+
+    def show; end
+
+    def destroy
+      success = Subscription.delete(params[:id])
+      if success
+        redirect_to confirmation_myott_unsubscribes_path
+      else
+        flash.now[:error] = 'There was an error unsubscribing you. Please try again.'
+        render :show
+      end
+    end
+
+    def confirmation
+      cookies.delete(:id_token)
+      @header = 'You have unsubscribed'
+      @message = 'You will no longer receive any Stop Press emails from the UK Trade Tariff Service.'
+    end
+
+  private
+
+    def authentication
+      if params[:id].nil? || current_subscription.nil?
+        redirect_to myott_start_path
+      end
+    end
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,7 @@
+class Subscription
+  include ApiEntity
+
+  set_singular_path 'user/subscriptions/:id'
+
+  attr_accessor :active, :uuid
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,18 +26,6 @@ class User
     nil
   end
 
-  def self.delete(token)
-    return nil if token.nil? && !Rails.env.development?
-
-    response = super(headers(token))
-    response.status == 200
-  rescue Faraday::UnauthorizedError
-    false
-  rescue Faraday::Error => e
-    Rails.logger.error("Failed to delete user: #{e.message}")
-    false
-  end
-
   def self.headers(token)
     {
       authorization: "Bearer #{token}",

--- a/app/views/myott/subscriptions/dashboard.html.erb
+++ b/app/views/myott/subscriptions/dashboard.html.erb
@@ -14,6 +14,6 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m">Unsubscribe</h2>
-    <p class="govuk-body"><a href=<%= myott_unsubscribe_path%>>Unsubscribe from all updates</a></p>
+    <p class="govuk-body"><a href=<%= myott_unsubscribe_path(current_user.stop_press_subscription) %>>Unsubscribe from all updates</a></p>
   </div>
 </div>

--- a/app/views/myott/unsubscribes/confirmation.html.erb
+++ b/app/views/myott/unsubscribes/confirmation.html.erb
@@ -1,0 +1,24 @@
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+          <h1 class="govuk-panel__title">
+            <%= @header %>
+          </h1>
+        </div>
+        <h2 class="govuk-heading-m">What happens next</h2>
+        <p class="govuk-body">
+          <%= @message.html_safe %>
+        </p>
+        <p class="govuk-body">
+          You can now close this window.
+        </p>
+        <p class="govuk-body">
+          <%= link_to 'What did you think of this service?', feedback_path, class: 'govuk-link' %>
+          (takes 30 seconds)
+        </p>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/myott/unsubscribes/show.html.erb
+++ b/app/views/myott/unsubscribes/show.html.erb
@@ -12,7 +12,7 @@
      <p>
       If you do not want to unsubscribe, close this page.
     </p>
-    <%= form_with url: myott_unsubscribe_path, method: :post, local: true do %>
+    <%= form_with url: myott_unsubscribe_path(params[:id]), method: :delete, local: true do %>
       <%= submit_tag "Unsubscribe", class: "govuk-button govuk-button--warning govuk-!-margin-top-4" %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,12 +68,15 @@ Rails.application.routes.draw do
       get '/chapter_selection', to: 'subscriptions#chapter_selection'
       get '/check_your_answers', to: 'subscriptions#check_your_answers' # for when user selects all chapters
       get '/subscription_confirmation', to: 'subscriptions#subscription_confirmation'
-      get '/unsubscribe_confirmation', to: 'subscriptions#unsubscribe_confirmation'
-      get '/unsubscribe', to: 'subscriptions#unsubscribe'
-      post '/unsubscribe', to: 'subscriptions#unsubscribe_action'
       post '/check_your_answers', to: 'subscriptions#check_your_answers'
       post '/set_preferences', to: 'subscriptions#set_preferences'
       post '/subscribe', to: 'subscriptions#subscribe'
+
+      resources :unsubscribes, only: %i[show destroy], path: 'unsubscribe' do
+        collection do
+          get '/confirmation', to: 'unsubscribes#confirmation'
+        end
+      end
     end
   end
 

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -92,12 +92,6 @@ private
       new parse_jsonapi(response)
     end
 
-    def delete(headers = {})
-      api.delete(singular_path) do |req|
-        req.headers = headers
-      end
-    end
-
     def relationships
       @relationships ||= superclass.include?(ApiEntity) ? superclass.relationships.dup : []
     end
@@ -109,6 +103,11 @@ private
       response = api.get(path, opts, headers)
 
       new parse_jsonapi(response)
+    end
+
+    def delete(id)
+      path = singular_path.sub(':id', id.to_s)
+      api.delete(path)
     end
 
     def all(opts = {})

--- a/spec/controllers/myott/myott_controller_spec.rb
+++ b/spec/controllers/myott/myott_controller_spec.rb
@@ -16,4 +16,18 @@ RSpec.describe Myott::MyottController, type: :controller do
       expect(result).to eq(user)
     end
   end
+
+  describe '#current_subscription' do
+    let(:subscription) { build(:subscription) }
+
+    before do
+      allow(Subscription).to receive(:find).and_return(subscription)
+      allow(controller).to receive(:params).and_return(id: subscription.uuid)
+    end
+
+    it 'returns the current subscription' do
+      result = controller.send(:current_subscription)
+      expect(result).to eq(subscription)
+    end
+  end
 end

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -332,39 +332,4 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
       end
     end
   end
-
-  describe 'POST #unsubscribe_action' do
-    context 'when current_user is not valid' do
-      before do
-        allow(controller).to receive(:current_user).and_return(nil)
-        post :dashboard
-      end
-
-      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
-    end
-
-    context 'when the delete request fails' do
-      before do
-        allow(controller).to receive(:current_user).and_return(user)
-        allow(User).to receive(:delete).and_return(false)
-        post :unsubscribe_action
-      end
-
-      it { is_expected.to render_template(:unsubscribe) }
-
-      it 'sets a flash error message' do
-        expect(flash.now[:error]).to eq('There was an error unsubscribing you. Please try again.')
-      end
-    end
-
-    context 'when the delete request is successful' do
-      before do
-        allow(controller).to receive(:current_user).and_return(user)
-        allow(User).to receive(:delete).and_return(true)
-        post :unsubscribe_action
-      end
-
-      it { is_expected.to redirect_to(myott_unsubscribe_confirmation_path) }
-    end
-  end
 end

--- a/spec/controllers/myott/unsubscribes_controller_spec.rb
+++ b/spec/controllers/myott/unsubscribes_controller_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+RSpec.describe Myott::UnsubscribesController, type: :controller do
+  let(:subscription) { build(:subscription) }
+
+  describe 'GET #show' do
+    before do
+      allow(controller).to receive(:current_subscription).and_return(subscription)
+    end
+
+    it 'renders the show template' do
+      get :show, params: { id: subscription.uuid }
+      expect(response).to render_template(:show)
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    before do
+      allow(controller).to receive(:current_subscription).and_return(subscription)
+    end
+
+    context 'when deletion is successful' do
+      it 'redirects to the confirmation page' do
+        allow(Subscription).to receive(:delete).with(subscription.uuid).and_return(true)
+        delete :destroy, params: { id: subscription.uuid }
+        expect(response).to redirect_to(confirmation_myott_unsubscribes_path)
+      end
+    end
+
+    context 'when deletion fails' do
+      it 'sets the flash error message' do
+        allow(Subscription).to receive(:delete).with(subscription.uuid).and_return(false)
+        delete :destroy, params: { id: subscription.uuid }
+        expect(flash[:error]).to eq('There was an error unsubscribing you. Please try again.')
+      end
+
+      it 'renders the show template' do
+        allow(Subscription).to receive(:delete).with(subscription.uuid).and_return(false)
+        delete :destroy, params: { id: subscription.uuid }
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe 'GET #confirmation' do
+      before do
+        cookies[:id_token] = 'test_uuid'
+      end
+
+      it 'deletes the subscription_uuid cookie' do
+        get :confirmation
+        expect(cookies[:id_token]).to be_nil
+      end
+
+      it 'assigns the correct header' do
+        get :confirmation
+        expect(assigns(:header)).to eq('You have unsubscribed')
+      end
+
+      it 'assigns the correct message' do
+        get :confirmation
+        expect(assigns(:message)).to eq('You will no longer receive any Stop Press emails from the UK Trade Tariff Service.')
+      end
+    end
+  end
+
+  describe 'before_action :authenticate' do
+    context 'when current_subscription is nil' do
+      before do
+        allow(controller).to receive(:current_subscription).and_return(nil)
+      end
+
+      it 'redirects to myott_start_path' do
+        get :show, params: { id: 1 }
+        expect(response).to redirect_to(myott_start_path)
+      end
+    end
+  end
+end

--- a/spec/factories/subscription_factory.rb
+++ b/spec/factories/subscription_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :subscription do
+    active { true }
+    uuid { SecureRandom.uuid }
+  end
+end

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -464,11 +464,7 @@ RSpec.describe ApiEntity do
   end
 
   describe '#delete' do
-    subject(:result) do
-      mock_entity.delete(
-        { 'Authorization' => 'Bearer abc123' },
-      )
-    end
+    subject(:result) { mock_entity.delete(123) }
 
     let(:mock_response) { instance_double(Faraday::Response, status: 200, body: nil) }
     let(:api_double) { instance_double(Faraday::Connection, delete: mock_response) }
@@ -482,11 +478,7 @@ RSpec.describe ApiEntity do
 
     context 'when the delete request is successful' do
       it 'calls the delete endpoint with headers' do
-        allow(api_double).to receive(:delete)
-          .with('/api/v2/mock_entities/1', { 'Authorization' => 'Bearer abc123' })
-          .and_return(mock_response)
-
-        result
+        expect(result).to eq(mock_response)
       end
 
       it 'returns a 200 OK response' do
@@ -502,11 +494,7 @@ RSpec.describe ApiEntity do
       let(:mock_response) { instance_double(Faraday::Response, status: 500, body: nil) }
 
       it 'calls the delete endpoint with no headers' do
-        allow(api_double).to receive(:delete)
-          .with('/api/v2/mock_entities/1')
-          .and_return(mock_response)
-
-        result
+        expect(result).to eq(mock_response)
       end
 
       it 'returns a 500 OK response' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,43 +68,4 @@ RSpec.describe User do
       it { is_expected.to be_nil }
     end
   end
-
-  describe '.delete' do
-    subject(:response) { described_class.delete(token) }
-
-    let(:token) { 'valid-jwt-token' }
-
-    context 'when token is nil' do
-      let(:token) { nil }
-
-      it { is_expected.to be_nil }
-    end
-
-    context 'when the request is successful' do
-      before do
-        stub_api_request('/user/users', :delete)
-          .and_return(status: 200)
-      end
-
-      it { is_expected.to be true }
-    end
-
-    context 'when response is unauthorised' do
-      before do
-        stub_api_request('/user/users', :delete)
-        .and_return(status: 401)
-      end
-
-      it { is_expected.to be false }
-    end
-
-    context 'when response errors' do
-      before do
-        stub_api_request('/user/users', :delete)
-        .and_return(status: 500)
-      end
-
-      it { is_expected.to be false }
-    end
-  end
 end


### PR DESCRIPTION
### Jira link

[HMRC-1222](https://transformuk.atlassian.net/browse/HMRC-1222)

### What?

- Moves unsubscribe actions to a new controller
- Loads subscription based on token
- Adds subscription model

### Why?

Users need to be able to unsubscribe without logging in.
