### PR TITLE
Downgrade uktt gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'net-http-persistent'
 gem 'newrelic_rpm'
 gem 'rack-attack'
 gem 'routing-filter', github: 'trade-tariff/routing-filter'
-gem 'uktt', git: 'https://github.com/trade-tariff/uktt.git'
+gem 'uktt', git: 'https://github.com/trade-tariff/uktt.git', ref: 'c0ad361f2753527fddbc72b3448553cca0ef3d57'
 
 # Assets
 gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,10 @@ GIT
 
 GIT
   remote: https://github.com/trade-tariff/uktt.git
-  revision: 5597912b1fa9ddc52e3e3611b510ac98567fe69f
+  revision: c0ad361f2753527fddbc72b3448553cca0ef3d57
+  ref: c0ad361f2753527fddbc72b3448553cca0ef3d57
   specs:
-    uktt (3.0.0)
+    uktt (2.6.0)
       faraday
       faraday-follow_redirects
       faraday-net_http_persistent


### PR DESCRIPTION
### What?

Downgrade uktt gem to version 2.6.0

### Why?

The latest version is causing an issue with duty calculator
