### PR TITLE
Delete cookie based on domain

### DIFF
--- a/app/controllers/myott/unsubscribes_controller.rb
+++ b/app/controllers/myott/unsubscribes_controller.rb
@@ -15,7 +15,7 @@ module Myott
     end
 
     def confirmation
-      cookies.delete(:id_token)
+      cookies.delete(:id_token, domain: ".#{request.domain}")
       @header = 'You have unsubscribed'
       @message = 'You will no longer receive any Stop Press emails from the UK Trade Tariff Service.'
     end


### PR DESCRIPTION
### What?

The id_token cookie is set with a specific domain. That domain needs to be specified to delete it.

### Why?

To ensure a user is logged out when they unsubscribe.
