### PR TITLE
HMRC-1264 Fix subscriber cookie deletion

### DIFF
--- a/app/controllers/myott/unsubscribes_controller.rb
+++ b/app/controllers/myott/unsubscribes_controller.rb
@@ -15,7 +15,7 @@ module Myott
     end
 
     def confirmation
-      cookies.delete(:id_token, domain: ".#{request.domain}")
+      cookies.delete(:id_token, domain: ".#{request.host}")
       @header = 'You have unsubscribed'
       @message = 'You will no longer receive any Stop Press emails from the UK Trade Tariff Service.'
     end


### PR DESCRIPTION
### Jira link

[HMRC-1264](https://transformuk.atlassian.net/browse/HMRC-1264)

### What?

Update to use request.host to correctly match the cookie domain.

### Why?

So that the user is logged out after they unsubscribe.
