### PR TITLE
refactor: use keep-preview label for skipping preview cleanup

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -85,10 +85,31 @@ jobs:
 
           while IFS= read -r env_id; do
             [[ -z "$env_id" || "$env_id" == "null" ]] && continue
-            [[ "$env_id" == *keep* ]] && {
-              echo "🛑 Skipping: $env_id (exclusion rule)"
+
+            # Match envId to PR branch
+            branch_name="${env_id#trade-tariff-frontend-}"
+            branch_name="${branch_name,,}"  # Lowercase
+            should_skip="false"
+
+            for pr in $(gh pr list --state open --json number,headRefName -q '.[] | "\(.number)::\(.headRefName)"'); do
+              pr_number="${pr%%::*}"
+              head_branch="${pr##*::}"
+              head_branch_lower="${head_branch,,}"
+
+              echo "🔍 Checking PR #$pr_number (branch: $head_branch_lower) against env branch: $branch_name"
+
+              if [[ "$head_branch_lower" == "$branch_name" ]]; then
+                if gh pr view "$pr_number" --json labels -q '.labels[].name' | grep -q "^keep-preview$"; then
+                  echo "🛑 Skipping: $env_id (PR #$pr_number is labeled keep-preview)"
+                  should_skip="true"
+                fi
+                break
+              fi
+            done
+
+            if [[ "$should_skip" == "true" ]]; then
               continue
-            }
+            fi
 
             if [ "$DRY_RUN" = "true" ]; then
               echo "✅ [DRY RUN] Would destroy: $env_id"
@@ -98,22 +119,17 @@ jobs:
               if preevy down --id "$env_id" --force --wait --profile "$PROFILE_URL"; then
                 destroyed_envs=$(jq -n --argjson arr "$destroyed_envs" --arg id "$env_id" '$arr + [$id]')
 
-                # Try to find the related PR by matching the env_id to PR branch names
-                branch_name="${env_id#trade-tariff-frontend-}"
-                branch_name="${branch_name,,}"  # Lowercase
-
-                for pr in $(gh pr list --state open --json number,headRefName -q '.[].number'); do
-                head_branch=$(gh pr view "$pr" --json headRefName -q '.headRefName')
-                head_branch_lower="${head_branch,,}"  # Lowercase
-
-                echo "🔍 Checking PR #$pr (branch: $head_branch_lower) against env branch: $branch_name"
-
-                if [[ "$head_branch_lower" == "$branch_name" ]]; then
-                  echo "✅ Match found. Removing 'needs-preview' label from PR #$pr"
-                  gh pr edit "$pr" --remove-label "needs-preview" || echo "⚠️ Failed to remove label"
-                  break
-                fi
-              done
+                # Remove 'needs-preview' label if matching PR exists
+                for pr in $(gh pr list --state open --json number,headRefName -q '.[] | "\(.number)::\(.headRefName)"'); do
+                  pr_number="${pr%%::*}"
+                  head_branch="${pr##*::}"
+                  head_branch_lower="${head_branch,,}"
+                  if [[ "$head_branch_lower" == "$branch_name" ]]; then
+                    echo "✅ Match found. Removing 'needs-preview' label from PR #$pr_number"
+                    gh pr edit "$pr_number" --remove-label "needs-preview" || echo "⚠️ Failed to remove label"
+                    break
+                  fi
+                done
               else
                 echo "❌ Failed to destroy: $env_id"
                 destroyed_envs=$(jq -n --argjson arr "$destroyed_envs" --arg id "$env_id" '$arr + [$id + " (FAILED)"]')
@@ -138,9 +154,10 @@ jobs:
         env:
           SLACK_CHANNEL: 'deployments'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_ICON_EMOJI: ':recycle:'
           SLACK_TITLE: 'Preview Cleanup Report'
           SLACK_MESSAGE: |
-            :recycle: *Cleanup finished*
+            *Cleanup finished*
             *Run Mode:* `${{ needs.cleanup.outputs.run_mode }}`
             *Dry Run:* `${{ needs.cleanup.outputs.dry_run }}`
             *Cleaned Environments:*

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -20,7 +20,7 @@ concurrency: preevy-${{ github.event.number }}
 
 jobs:
   deploy:
-    if: contains(github.event.pull_request.labels.*.name, 'needs-preview')
+    if: contains(github.event.pull_request.labels.*.name, 'needs-preview') || contains(github.event.pull_request.labels.*.name, 'keep-preview')
     runs-on: ubuntu-latest
     steps:
       - uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
### Jira link

BAU

### What?

I have updated the preview cleanup workflow to skip environments based on a `keep-preview` PR label instead of checking if the branch name contains `keep`.

### Why?

I am doing this because using the branch name for exclusion requires closing and recreating PRs. Switching to a label makes it simpler and avoids unnecessary git work.
