### PR TITLE
HMRC-1229 MyOTT Add link to survey for private beta

### DIFF
--- a/app/views/myott/subscriptions/confirmation.html.erb
+++ b/app/views/myott/subscriptions/confirmation.html.erb
@@ -20,5 +20,17 @@
         </p>
       </div>
     </div>
+    <!-- Call to action section to be deleted for MyOTT public beta-->
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="call-to-action">
+          <h2 class="govuk-heading-m">What did you think of this pilot service?</h2>
+          <a href="https://docs.google.com/forms/d/e/1FAIpQLSfNf37-MVrHE6g93JJv4xbDChcMLc81b_CAFhStINEad2ER3g/viewform" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+            Complete the survey
+            <%= render 'shared/start_arrow' %>
+          </a>
+        </div>
+      </div>
+    </div>
   </main>
 </div>


### PR DESCRIPTION
### Jira link

[HMRC-1229](https://transformuk.atlassian.net/browse/HMRC-1229)

### What?

I have added MyOTT Private Beta Survey CTA box

### Why?

I am doing this because it's required for private beta.

This must be removed before public beta (see [HMRC-1230](https://transformuk.atlassian.net/browse/HMRC-1230))

<img width="535" alt="image" src="https://github.com/user-attachments/assets/87a82b3c-58ea-4411-b0fe-9d26bf243e30" />