### PR TITLE
Locked Docker Compose to v2.36.0

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -30,6 +30,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Lock Docker Compose to v2.36.0 manually
+        run: |
+          mkdir -p ~/.docker/cli-plugins/
+          curl -sSL https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
+          chmod +x ~/.docker/cli-plugins/docker-compose
       - run: touch .env # To prevent preevy from failing due to missing .env file
 
       - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -30,6 +30,12 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Lock Docker Compose to v2.36.0 manually
+        run: |
+          mkdir -p ~/.docker/cli-plugins/
+          curl -sSL https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
+          chmod +x ~/.docker/cli-plugins/docker-compose
+
       - name: Fetch frontend-configuration secrets and mask values
         run: |
           set -euo pipefail


### PR DESCRIPTION
### Jira link

[HMRC-<TODO>](https://transformuk.atlassian.net/browse/HMRC-<TODO>)

### What?

I have locked Docker Compose to v2.36.0 as a temporary compatibility fix until Preevy supports newer versions

### Why?

I am doing this because...

Preevy currently breaks with newer versions of Docker Compose.  
To prevent CI failures and maintain stability, we're pinning Compose to a known-working version (`v2.36.0`).


### What’s next?

- Monitor Preevy’s updates and remove this workaround once compatibility is restored.
