### PR TITLE
HMRC-1259 Verified User Bug Fix

### DIFF
--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -60,10 +60,7 @@ module Myott
       @selected_sections_chapters = get_selected_sections_chapters(Array(session[:chapter_ids]))
     end
 
-    def preference_selection
-      Rails.logger.info("cookies[:id_token]: #{cookies[:id_token].inspect}")
-      Rails.logger.info("authenticate: #{authenticate.inspect}")
-    end
+    def preference_selection; end
 
     def subscribe
       if params[:all_tariff_updates] == 'true'

--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -6,8 +6,7 @@ module Myott
     def start; end
 
     def invalid
-      # HMRC-1259 user re-using token could still be valid
-      if cookies[:id_token].present?
+      unless current_user.nil?
         redirect_to myott_path
       end
     end

--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -6,7 +6,7 @@ module Myott
     def start; end
 
     def invalid
-      unless current_user.nil?
+      if current_user.present?
         redirect_to myott_path
       end
     end

--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -4,7 +4,13 @@ module Myott
     before_action :authenticate, except: %i[start invalid]
 
     def start; end
-    def invalid; end
+
+    def invalid
+      # HMRC-1259 user re-using token could still be valid
+      if cookies[:id_token].present?
+        redirect_to myott_path
+      end
+    end
 
     def dashboard
       return redirect_to myott_preference_selection_path unless current_user.stop_press_subscription
@@ -54,7 +60,10 @@ module Myott
       @selected_sections_chapters = get_selected_sections_chapters(Array(session[:chapter_ids]))
     end
 
-    def preference_selection; end
+    def preference_selection
+      Rails.logger.info("cookies[:id_token]: #{cookies[:id_token].inspect}")
+      Rails.logger.info("authenticate: #{authenticate.inspect}")
+    end
 
     def subscribe
       if params[:all_tariff_updates] == 'true'

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
       get :invalid
       expect(controller).not_to have_received(:authenticate)
     end
+
+    context 'when a cookie with id_token exists' do
+      before do
+        cookies[:id_token] = 'valid-jwt-token'
+        get :invalid
+      end
+
+      it { is_expected.to redirect_to myott_path }
+    end
+
+    context 'when a cookie with id_token does not exist' do
+      before do
+        cookies[:id_token] = nil
+        get :invalid
+      end
+
+      it { is_expected.not_to redirect_to myott_path }
+    end
   end
 
   describe 'GET #dashboard' do

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -29,18 +29,18 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
       expect(controller).not_to have_received(:authenticate)
     end
 
-    context 'when a cookie with id_token exists' do
+    context 'when a user does exist' do
       before do
-        cookies[:id_token] = 'valid-jwt-token'
+        allow(controller).to receive(:current_user).and_return(user)
         get :invalid
       end
 
       it { is_expected.to redirect_to myott_path }
     end
 
-    context 'when a cookie with id_token does not exist' do
+    context 'when a user does not exist' do
       before do
-        cookies[:id_token] = nil
+        allow(controller).to receive(:current_user).and_return(nil)
         get :invalid
       end
 


### PR DESCRIPTION
### Jira link

[HMRC-1259](https://transformuk.atlassian.net/browse/HMRC-1259)

### What?

I have update `invalid` controller function to check for a current_user.
If there is user is redirected to dashboard or preference selection.

### Why?

I am doing this so a user can click on their password-less identity link to verify, close the window and still be authenticated.
