### PR TITLE
Handle production domain correctly when removing cookie

### DIFF
--- a/app/controllers/myott/unsubscribes_controller.rb
+++ b/app/controllers/myott/unsubscribes_controller.rb
@@ -15,7 +15,8 @@ module Myott
     end
 
     def confirmation
-      cookies.delete(:id_token, domain: ".#{request.host}")
+      domain = ".#{request.host.sub(/^www\./, '')}"
+      cookies.delete(:id_token, domain:)
       @header = 'You have unsubscribed'
       @message = 'You will no longer receive any Stop Press emails from the UK Trade Tariff Service.'
     end

--- a/spec/controllers/myott/unsubscribes_controller_spec.rb
+++ b/spec/controllers/myott/unsubscribes_controller_spec.rb
@@ -60,6 +60,18 @@ RSpec.describe Myott::UnsubscribesController, type: :controller do
         get :confirmation
         expect(assigns(:message)).to eq('You will no longer receive any Stop Press emails from the UK Trade Tariff Service.')
       end
+
+      context 'when request host contains www' do
+        before do
+          request.host = 'www.example.com'
+          allow(cookies).to receive(:delete).and_call_original
+        end
+
+        it 'deletes the id_token cookie with the correct domain' do
+          expect_any_instance_of(ActionDispatch::Cookies::CookieJar).to receive(:delete).with(:id_token, hash_including(domain: '.example.com')) # rubocop:disable RSpec/AnyInstance
+          get :confirmation
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### What?

The id_token in production is stored with the domain excluding "www" so it can be set in the Identity service.
The "www" needs to be removed from the domain when deleting the cookie when a user unsubscribes.

### Why?

I am doing this so the user's JWT is deleted when the unsubscribe so that they are logged out of the service.
