### PR TITLE
HMRC-1297 MyOTT Reset Session Chapter IDs On Arrival

### DIFF
--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -7,6 +7,7 @@ module Myott
     def invalid; end
 
     def dashboard
+      session.delete(:chapter_ids)
       return redirect_to myott_preference_selection_path unless current_user.stop_press_subscription
 
       session[:chapter_ids] = if current_user.chapter_ids&.split(',')&.any?

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -84,6 +84,10 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
         it 'redirects to sign up page' do
           expect(response).to redirect_to(myott_preference_selection_path)
         end
+
+        it 'clears the session chapter ids' do
+          expect(session[:chapter_ids]).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
### Jira link

[HMRC-1297](https://transformuk.atlassian.net/browse/HMRC-1297)

### What?

I have cleared session chapter IDs upon arrival to the service

### Why?

I am doing this because the session KV pair was causing a leak for unsubscribe/re-subscribe process
