### PR TITLE
HMRC-1297 MyOTT Reset Session Chapter IDs On Arrival to the preference selection page

### DIFF
--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -7,7 +7,6 @@ module Myott
     def invalid; end
 
     def dashboard
-      session.delete(:chapter_ids)
       return redirect_to myott_preference_selection_path unless current_user.stop_press_subscription
 
       session[:chapter_ids] = if current_user.chapter_ids&.split(',')&.any?
@@ -55,7 +54,9 @@ module Myott
       @selected_sections_chapters = get_selected_sections_chapters(Array(session[:chapter_ids]))
     end
 
-    def preference_selection; end
+    def preference_selection
+      session.delete(:chapter_ids)
+    end
 
     def subscribe
       if params[:all_tariff_updates] == 'true'

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -84,10 +84,6 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
         it 'redirects to sign up page' do
           expect(response).to redirect_to(myott_preference_selection_path)
         end
-
-        it 'clears the session chapter ids' do
-          expect(session[:chapter_ids]).to be_nil
-        end
       end
     end
   end
@@ -334,6 +330,21 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
 
         it { is_expected.to redirect_to(myott_check_your_answers_path(all_tariff_updates: true)) }
       end
+    end
+  end
+
+  describe 'GET #preference_selection' do
+    context 'when current_user is not valid' do
+      before do
+        allow(controller).to receive(:current_user).and_return(nil)
+        get :dashboard
+      end
+
+      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
+    end
+
+    it 'clears the session chapter ids' do
+      expect(session[:chapter_ids]).to be_nil
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-1297](https://transformuk.atlassian.net/browse/HMRC-1297)

### What?

I have cleared session chapter IDs upon arrival to the preference selection page

### Why?

I am doing this because the session KV pair was causing a leak for unsubscribe/re-subscribe process
