### PR TITLE
HMRC-1293 hide original feedback link from subscription confirmation page

### DIFF
--- a/app/views/myott/subscriptions/confirmation.html.erb
+++ b/app/views/myott/subscriptions/confirmation.html.erb
@@ -14,7 +14,7 @@
         <p class="govuk-body">
           You can now close this window.
         </p>
-        <p class="govuk-body">
+        <p class="govuk-body govuk-!-display-none">
           <%= link_to 'What did you think of this service?', feedback_path, class: 'govuk-link' %>
           (takes 30 seconds)
         </p>

--- a/app/views/myott/subscriptions/confirmation.html.erb
+++ b/app/views/myott/subscriptions/confirmation.html.erb
@@ -14,7 +14,7 @@
         <p class="govuk-body">
           You can now close this window.
         </p>
-        <p class="govuk-body govuk-!-display-none">
+        <p class="govuk-body govuk-!-display-none"><!-- remove govuk-!-display-none for MyOTT public beta -->
           <%= link_to 'What did you think of this service?', feedback_path, class: 'govuk-link' %>
           (takes 30 seconds)
         </p>


### PR DESCRIPTION
### Jira link

[HMRC-1293](https://transformuk.atlassian.net/browse/HMRC-1293)

### What?

I have hidden original feedback link and accompanying text

### Why?

I am doing this because there is a private beta link to a survey

THIS SHOULD BE UNHIDDEN AS PART OF [HMRC-1230](https://transformuk.atlassian.net/browse/HMRC-1230)
