### PR TITLE
Cache the commodity page

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -18,9 +18,13 @@ class CommoditiesController < GoodsNomenclaturesController
     end
 
     if params[:country].present? && @search.geographical_area
-      @rules_of_origin_schemes = declarable.rules_of_origin(params[:country])
+      @rules_of_origin_schemes = Rails.cache.fetch([@tariff_last_updated, 'declarable.rules_of_origin', params[:country]]) do
+        declarable.rules_of_origin(params[:country])
+      end
     else
-      @roo_all_schemes = RulesOfOrigin::Scheme.all
+      @roo_all_schemes = Rails.cache.fetch(['RulesOfOrigin::Scheme.all', @tariff_last_updated]) do
+        RulesOfOrigin::Scheme.all
+      end
     end
   end
 
@@ -69,26 +73,34 @@ class CommoditiesController < GoodsNomenclaturesController
   end
 
   def uk_heading
-    @uk_heading ||= TradeTariffFrontend::ServiceChooser.with_source(:uk) do
-      HeadingPresenter.new(Heading.find(heading_id, query_params))
+    @uk_heading ||= Rails.cache.fetch([@tariff_last_updated, heading_id, query_params]) do
+      TradeTariffFrontend::ServiceChooser.with_source(:uk) do
+        HeadingPresenter.new(Heading.find(heading_id, query_params))
+      end
     end
   end
 
   def xi_heading
-    @xi_heading ||= TradeTariffFrontend::ServiceChooser.with_source(:xi) do
-      HeadingPresenter.new(Heading.find(heading_id, query_params))
+    @xi_heading ||= Rails.cache.fetch([@tariff_last_updated, heading_id, query_params]) do
+      TradeTariffFrontend::ServiceChooser.with_source(:xi) do
+        HeadingPresenter.new(Heading.find(heading_id, query_params))
+      end
     end
   end
 
   def uk_commodity
-    @uk_commodity ||= TradeTariffFrontend::ServiceChooser.with_source(:uk) do
-      CommodityPresenter.new(Commodity.find(params[:id], query_params))
+    @uk_commodity ||= Rails.cache.fetch([@tariff_last_updated, params[:id], query_params]) do
+      TradeTariffFrontend::ServiceChooser.with_source(:uk) do
+        CommodityPresenter.new(Commodity.find(params[:id], query_params))
+      end
     end
   end
 
   def xi_commodity
-    @xi_commodity ||= TradeTariffFrontend::ServiceChooser.with_source(:xi) do
-      CommodityPresenter.new(Commodity.find(params[:id], query_params))
+    @xi_commodity ||= Rails.cache.fetch([@tariff_last_updated, params[:id], query_params]) do
+      TradeTariffFrontend::ServiceChooser.with_source(:xi) do
+        CommodityPresenter.new(Commodity.find(params[:id], query_params))
+      end
     end
   end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -43,11 +43,11 @@ class Search
   end
 
   def countries
-    @countries ||= GeographicalArea.all.compact
+    @countries ||= Rails.cache.fetch([@tariff_last_updated, 'GeographicalArea.all']) { GeographicalArea.all.compact }
   end
 
   def geographical_area
-    @geographical_area ||= GeographicalArea.find(country) if country.present?
+    @geographical_area ||= Rails.cache.fetch([@tariff_last_updated, country]) { GeographicalArea.find(country) } if country.present?
   end
 
   def country_description

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -1,38 +1,40 @@
-<% content_for :head do %>
-  <meta name="description" content="<%= declarable.description_plain %>">
+<%= cache [@tariff_last_updated, params.to_json] do %>
+  <% content_for :head do %>
+    <meta name="description" content="<%= declarable.description_plain %>">
+  <% end %>
+
+  <% content_for :bodyClasses, "page--wide" %>
+
+  <%= render 'commodities/header', commodity_code: declarable.code %>
+
+  <% declarable.critical_footnotes.each do |footnote| %>
+    <%= render 'footnotes/critical_warning', footnote: footnote %>
+  <% end %>
+
+  <%= render 'goods_nomenclatures/ancestors', goods_nomenclature: declarable %>
+
+  <%= render 'shared/context_tables/commodity' %>
+
+  <strong class="govuk-tag govuk-tag--green--wide">
+    You are currently using the <%= service_name %>
+  </strong>
+
+  <p class="govuk-body govuk-!-margin-top-6">
+    Use this page to find:
+  </p>
+
+  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+    <li>import and export measures, conditions and exemptions</li>
+    <li>reduced or zero duty rates based on preferential rules of origin</li>
+    <li>chapter notes and references</li>
+  </ul>
+
+  <%= render 'declarables/declarable',
+            declarable: declarable,
+            xi_declarable: xi_declarable,
+            uk_declarable: uk_declarable,
+            rules_of_origin_schemes: @rules_of_origin_schemes,
+            roo_all_schemes: @roo_all_schemes %>
+
+  <%= render 'commodities/help_popup' %>
 <% end %>
-
-<% content_for :bodyClasses, "page--wide" %>
-
-<%= render 'commodities/header', commodity_code: declarable.code %>
-
-<% declarable.critical_footnotes.each do |footnote| %>
-  <%= render 'footnotes/critical_warning', footnote: footnote %>
-<% end %>
-
-<%= render 'goods_nomenclatures/ancestors', goods_nomenclature: declarable %>
-
-<%= render 'shared/context_tables/commodity' %>
-
-<strong class="govuk-tag govuk-tag--green--wide">
-  You are currently using the <%= service_name %>
-</strong>
-
-<p class="govuk-body govuk-!-margin-top-6">
-  Use this page to find:
-</p>
-
-<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-  <li>import and export measures, conditions and exemptions</li>
-  <li>reduced or zero duty rates based on preferential rules of origin</li>
-  <li>chapter notes and references</li>
-</ul>
-
-<%= render 'declarables/declarable',
-           declarable: declarable,
-           xi_declarable: xi_declarable,
-           uk_declarable: uk_declarable,
-           rules_of_origin_schemes: @rules_of_origin_schemes,
-           roo_all_schemes: @roo_all_schemes %>
-
-<%= render 'commodities/help_popup' %>

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Commodity page', type: :request do
 
   shared_examples_for 'loads the correct xi declarables' do
     it { expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:xi) }
-    it { expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:uk) }
+    it { expect(TradeTariffFrontend::ServiceChooser).not_to have_received(:with_source).with(:uk) }
   end
 
   it_behaves_like 'loads the correct uk declarables' do


### PR DESCRIPTION
This is an experiment in fragment caching on one of the heaviest pages we have.

We're adding a bunch of caching here, all centered around the date that `/uk/api/v2/updates/latest` returns.

* The page content itself is cached as much as possible.  Once we've rendered it once, we use it as much as we can
* We cache things like ROO as much as possible for the day for use across different codes
* We cache individual headings/commodities for the day
* We cache geographical areas/countries for the day for re-use in multiple places.

Initial testing locally drops performance from 100-200ms+ to sub 10ms on a warm cache.