### PR TITLE
HMRC-1210: set up preview monitoring

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -30,17 +30,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Lock Docker Compose to v2.36.0 manually
-        run: |
-          mkdir -p ~/.docker/cli-plugins/
-          curl -sSL https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
-          chmod +x ~/.docker/cli-plugins/docker-compose
       - run: touch .env # To prevent preevy from failing due to missing .env file
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.IAM_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+
+      - name: Lock Docker Compose to v2.36.0
+        uses: trade-tariff/trade-tariff-tools/.github/actions/lock-docker-compose@main
 
       - run: npm install -g preevy
 

--- a/.github/workflows/preview-down.yml
+++ b/.github/workflows/preview-down.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: touch .env # To prevent preevy from failing due to missing .env file
+      - name: Lock Docker Compose to v2.36.0
+        run: |
+          mkdir -p ~/.docker/cli-plugins/
+          curl -sSL https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
+          chmod +x ~/.docker/cli-plugins/docker-compose
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/preview-down.yml
+++ b/.github/workflows/preview-down.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   teardown:
-    if: github.event.action == 'closed' || (github.event.action == 'unlabeled' && github.event.label.name == 'needs-preview')
+    if: github.event.action == 'closed' || (github.event.action == 'unlabeled' && (github.event.label.name == 'needs-preview' || github.event.label.name == 'keep-preview'))
     permissions: write-all
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/preview-down.yml
+++ b/.github/workflows/preview-down.yml
@@ -23,11 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: touch .env # To prevent preevy from failing due to missing .env file
+
       - name: Lock Docker Compose to v2.36.0
-        run: |
-          mkdir -p ~/.docker/cli-plugins/
-          curl -sSL https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
-          chmod +x ~/.docker/cli-plugins/docker-compose
+        uses: trade-tariff/trade-tariff-tools/.github/actions/lock-docker-compose@main
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Lock Docker Compose to v2.36.0 manually
+      - name: Lock Docker Compose to v2.36.0
         run: |
           mkdir -p ~/.docker/cli-plugins/
           curl -sSL https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -56,3 +56,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           BUILDX_BAKE_ENTITLEMENTS_FS: 0
+
+      - name: Capture frontend logs
+        if: always()
+        run: .github/workflows/scripts/capture-log.sh
+        env:
+          PREEVY_PROFILE_URL: ${{ env.PREEVY_PROFILE_URL }}
+
+      - name: Upload logs as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: preevy-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -30,12 +30,6 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Lock Docker Compose to v2.36.0
-        run: |
-          mkdir -p ~/.docker/cli-plugins/
-          curl -sSL https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
-          chmod +x ~/.docker/cli-plugins/docker-compose
-
       - name: Fetch frontend-configuration secrets and mask values
         run: |
           set -euo pipefail
@@ -47,6 +41,9 @@ jobs:
 
           echo "$SECRET_JSON" | jq -r 'to_entries[] | "::add-mask::\(.value)"'
           echo "$SECRET_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env
+
+      - name: Lock Docker Compose to v2.36.0
+        uses: trade-tariff/trade-tariff-tools/.github/actions/lock-docker-compose@main
 
       - uses: livecycle/preevy-up-action@v2.4.0
         id: preevy_up

--- a/.github/workflows/scripts/capture-log
+++ b/.github/workflows/scripts/capture-log
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "📄 Starting log capture process..."
-LOG_DIR="logs"
+LOG_DIR="log"
 SERVICE_NAME="frontend"
 DRIVER="lightsail"
 mkdir -p "$LOG_DIR"

--- a/.github/workflows/scripts/capture-log.sh
+++ b/.github/workflows/scripts/capture-log.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "📄 Starting log capture process..."
+LOG_DIR="logs"
+SERVICE_NAME="frontend"
+DRIVER="lightsail"
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date +%s)
+LOG_FILE="$LOG_DIR/${SERVICE_NAME}-${TIMESTAMP}.log"
+ERROR_LOG_FILE="$LOG_DIR/preevy-error.log"
+
+echo "🔍 Checking Preevy version..."
+if ! npx preevy --version; then
+  echo "❌ Preevy is not available. Exiting log capture early."
+  exit 1
+fi
+
+echo "🔄 Attempting to capture logs for service: $SERVICE_NAME"
+if npx preevy logs "$SERVICE_NAME" \
+  --driver="$DRIVER" \
+  --profile="${PREEVY_PROFILE_URL}" \
+  --timestamps 2> "$ERROR_LOG_FILE" | tee "$LOG_FILE"; then
+
+  if [ -s "$LOG_FILE" ]; then
+    echo "✅ Logs captured and saved to: $LOG_FILE"
+    exit 0
+  else
+    echo "⚠️ Log file was created but is empty: $LOG_FILE"
+  fi
+else
+  echo "⚠️ Log capture failed for service: $SERVICE_NAME"
+fi
+
+echo "❌ Log capture failed or returned empty log. Writing fallback file."
+echo "No logs captured" > "$LOG_DIR/no-logs-captured.log"
+
+echo "🔚 Last error log (if any):"
+if [ -s "$ERROR_LOG_FILE" ]; then
+  cat "$ERROR_LOG_FILE"
+else
+  echo "No error log available"
+fi
+
+echo "📂 Final list of log files:"
+ls -la "$LOG_DIR" || echo "⚠️ Could not list log directory"

--- a/compose.yml
+++ b/compose.yml
@@ -25,4 +25,26 @@ x-preevy:
   driver: lightsail
   drivers:
     lightsail:
-      bundle-id: small_3_0  # change to medium_3_0 if you see preevy up failing
+      bundle-id: small_3_0  # change to medium_3_0 if you see "out of memory" errors
+
+  plugins:
+    - module: '@preevy/plugin-github'
+      commentTemplate: |
+        {% if urls %}[Preevy](https://preevy.dev) has created a preview environment for this PR.
+
+        Here is how to access it:
+
+        | Service | Port | URL |
+        |---------|------|-----|
+        {% for url in urls %}| {{ url.service }} | {{ url.port }} | {{ url.url }} |
+        {% endfor %}
+        {% else %}The [Preevy](https://preevy.dev) preview environment for this PR has been deleted.
+        {% endif %}
+
+        💸 **Preview Environment Estimated Cost**: £0.50/day
+        *(AWS Lightsail small_3_0, $12/mo, eu-west-2 — 2025)*
+
+        ⚠️ **Environment Cleanup Policy**:
+        - **Nightly cleanup**: All preview environments with `needs-preview` label
+        - **Immediate cleanup**: When PR is closed or `needs-preview`/`keep-preview` label is removed
+        - **Retain environments**: Add `keep-preview` label to prevent automatic deletion

--- a/compose.yml
+++ b/compose.yml
@@ -44,7 +44,8 @@ x-preevy:
         💸 **Preview Environment Estimated Cost**: £0.50/day
         *(AWS Lightsail small_3_0, $12/mo, eu-west-2 — 2025)*
 
-        ⚠️ **Environment Cleanup Policy**:
-        - **Nightly cleanup**: All preview environments with `needs-preview` label
-        - **Immediate cleanup**: When PR is closed or `needs-preview`/`keep-preview` label is removed
-        - **Retain environments**: Add `keep-preview` label to prevent automatic deletion
+        **Environment Cleanup Policy**
+        
+        🕛 Nightly cleanup: All preview environments with the needs-preview label are removed automatically at midnight.
+        ❌ Immediate teardown: When a PR is closed or the needs-preview/keep-preview label is removed, the associated environment is destroyed immediately.
+        📌 Retention override: Add the keep-preview label to retain a preview environment beyond the nightly cleanup.

--- a/compose.yml
+++ b/compose.yml
@@ -45,7 +45,6 @@ x-preevy:
         *(AWS Lightsail small_3_0, $12/mo, eu-west-2 — 2025)*
 
         **Environment Cleanup Policy**
-        
-        🕛 Nightly cleanup: All preview environments with the needs-preview label are removed automatically at midnight.
-        ❌ Immediate teardown: When a PR is closed or the needs-preview/keep-preview label is removed, the associated environment is destroyed immediately.
-        📌 Retention override: Add the keep-preview label to retain a preview environment beyond the nightly cleanup.
+        🕛 Nightly cleanup: All preview environments with the `needs-preview` label are removed automatically at midnight.
+        ❌ Immediate teardown: When a PR is closed or the `needs-preview`/`keep-preview` label is removed, the associated environment is destroyed immediately.
+        📌 Retention override: Add the `keep-preview` label to retain a preview environment beyond the nightly cleanup.


### PR DESCRIPTION
### Jira link

[HMRC-1210](https://transformuk.atlassian.net/browse/HMRC-1210)

### What?

- Added log capture for preview envs
- Added cost estimates and cleanup behaviour in the PR comment for visibility.

### Why?

- I am doing this because failing silently is annoying, and we need the logs when things break.
Logs now auto-upload as artifacts for 7 days.
- Adding cleanup policy info helps the team understand when and how environments are removed and how to keep them around when needed.
