### PR TITLE
Fix - Cache the commodity page

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -18,9 +18,13 @@ class CommoditiesController < GoodsNomenclaturesController
     end
 
     if params[:country].present? && @search.geographical_area
-      @rules_of_origin_schemes = declarable.rules_of_origin(params[:country])
+      @rules_of_origin_schemes = Rails.cache.fetch([@tariff_last_updated, 'declarable.rules_of_origin', params[:country]]) do
+        declarable.rules_of_origin(params[:country])
+      end
     else
-      @roo_all_schemes = RulesOfOrigin::Scheme.all
+      @roo_all_schemes = Rails.cache.fetch(['RulesOfOrigin::Scheme.all', @tariff_last_updated]) do
+        RulesOfOrigin::Scheme.all
+      end
     end
   end
 
@@ -69,26 +73,34 @@ class CommoditiesController < GoodsNomenclaturesController
   end
 
   def uk_heading
-    @uk_heading ||= TradeTariffFrontend::ServiceChooser.with_source(:uk) do
-      HeadingPresenter.new(Heading.find(heading_id, query_params))
+    @uk_heading ||= Rails.cache.fetch([@tariff_last_updated, heading_id, query_params]) do
+      TradeTariffFrontend::ServiceChooser.with_source(:uk) do
+        HeadingPresenter.new(Heading.find(heading_id, query_params))
+      end
     end
   end
 
   def xi_heading
-    @xi_heading ||= TradeTariffFrontend::ServiceChooser.with_source(:xi) do
-      HeadingPresenter.new(Heading.find(heading_id, query_params))
+    @xi_heading ||= Rails.cache.fetch([@tariff_last_updated, heading_id, query_params]) do
+      TradeTariffFrontend::ServiceChooser.with_source(:xi) do
+        HeadingPresenter.new(Heading.find(heading_id, query_params))
+      end
     end
   end
 
   def uk_commodity
-    @uk_commodity ||= TradeTariffFrontend::ServiceChooser.with_source(:uk) do
-      CommodityPresenter.new(Commodity.find(params[:id], query_params))
+    @uk_commodity ||= Rails.cache.fetch([@tariff_last_updated, params[:id], query_params]) do
+      TradeTariffFrontend::ServiceChooser.with_source(:uk) do
+        CommodityPresenter.new(Commodity.find(params[:id], query_params))
+      end
     end
   end
 
   def xi_commodity
-    @xi_commodity ||= TradeTariffFrontend::ServiceChooser.with_source(:xi) do
-      CommodityPresenter.new(Commodity.find(params[:id], query_params))
+    @xi_commodity ||= Rails.cache.fetch([@tariff_last_updated, params[:id], query_params]) do
+      TradeTariffFrontend::ServiceChooser.with_source(:xi) do
+        CommodityPresenter.new(Commodity.find(params[:id], query_params))
+      end
     end
   end
 

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -6,4 +6,8 @@ const application = Application.start()
 application.debug = false
 window.Stimulus   = application
 
+document.addEventListener('DOMContentLoaded', function () {
+  jQuery('input[name=authenticity_token]').val($('meta[name=csrf-token]').attr('content'))
+});
+
 export { application }

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -43,11 +43,11 @@ class Search
   end
 
   def countries
-    @countries ||= GeographicalArea.all.compact
+    @countries ||= Rails.cache.fetch([@tariff_last_updated, 'GeographicalArea.all']) { GeographicalArea.all.compact }
   end
 
   def geographical_area
-    @geographical_area ||= GeographicalArea.find(country) if country.present?
+    @geographical_area ||= Rails.cache.fetch([@tariff_last_updated, country]) { GeographicalArea.find(country) } if country.present?
   end
 
   def country_description

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -1,38 +1,40 @@
-<% content_for :head do %>
-  <meta name="description" content="<%= declarable.description_plain %>">
+<%= cache [@tariff_last_updated, params.to_json] do %>
+  <% content_for :head do %>
+    <meta name="description" content="<%= declarable.description_plain %>">
+  <% end %>
+
+  <% content_for :bodyClasses, "page--wide" %>
+
+  <%= render 'commodities/header', commodity_code: declarable.code %>
+
+  <% declarable.critical_footnotes.each do |footnote| %>
+    <%= render 'footnotes/critical_warning', footnote: footnote %>
+  <% end %>
+
+  <%= render 'goods_nomenclatures/ancestors', goods_nomenclature: declarable %>
+
+  <%= render 'shared/context_tables/commodity' %>
+
+  <strong class="govuk-tag govuk-tag--green--wide">
+    You are currently using the <%= service_name %>
+  </strong>
+
+  <p class="govuk-body govuk-!-margin-top-6">
+    Use this page to find:
+  </p>
+
+  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+    <li>import and export measures, conditions and exemptions</li>
+    <li>reduced or zero duty rates based on preferential rules of origin</li>
+    <li>chapter notes and references</li>
+  </ul>
+
+  <%= render 'declarables/declarable',
+            declarable: declarable,
+            xi_declarable: xi_declarable,
+            uk_declarable: uk_declarable,
+            rules_of_origin_schemes: @rules_of_origin_schemes,
+            roo_all_schemes: @roo_all_schemes %>
+
+  <%= render 'commodities/help_popup' %>
 <% end %>
-
-<% content_for :bodyClasses, "page--wide" %>
-
-<%= render 'commodities/header', commodity_code: declarable.code %>
-
-<% declarable.critical_footnotes.each do |footnote| %>
-  <%= render 'footnotes/critical_warning', footnote: footnote %>
-<% end %>
-
-<%= render 'goods_nomenclatures/ancestors', goods_nomenclature: declarable %>
-
-<%= render 'shared/context_tables/commodity' %>
-
-<strong class="govuk-tag govuk-tag--green--wide">
-  You are currently using the <%= service_name %>
-</strong>
-
-<p class="govuk-body govuk-!-margin-top-6">
-  Use this page to find:
-</p>
-
-<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-  <li>import and export measures, conditions and exemptions</li>
-  <li>reduced or zero duty rates based on preferential rules of origin</li>
-  <li>chapter notes and references</li>
-</ul>
-
-<%= render 'declarables/declarable',
-           declarable: declarable,
-           xi_declarable: xi_declarable,
-           uk_declarable: uk_declarable,
-           rules_of_origin_schemes: @rules_of_origin_schemes,
-           roo_all_schemes: @roo_all_schemes %>
-
-<%= render 'commodities/help_popup' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,6 +61,7 @@
     </div>
     <%= render 'news_items/header_banner', news_item: News::Item.latest_banner unless @skip_news_banner %>
     <%= render 'shared/feedback_banner' %>
+    <%= csrf_meta_tags %>
   </header>
 
   <div class="tariff service govuk-width-container">
@@ -77,7 +78,6 @@
       <%= yield %>
 
       <%= render 'shared/switch_banner_bottom' if is_switch_service_banner_enabled? %>
-
       <%= render 'shared/webchat_message/footer' if webchat_visible_in_footer? %>
 
       <% if @tariff_last_updated %>

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Commodity page', type: :request do
 
   shared_examples_for 'loads the correct xi declarables' do
     it { expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:xi) }
-    it { expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:uk) }
+    it { expect(TradeTariffFrontend::ServiceChooser).not_to have_received(:with_source).with(:uk) }
   end
 
   it_behaves_like 'loads the correct uk declarables' do


### PR DESCRIPTION
Another go at page caching without the previous issues.

The initial problem was that the CSRF token was cached in the form around country select.  This caused an invalid token to be posted, resulting in an error.  This made it through testing as the environment was fresh when tested and the token hadn't expired.

This PR ensures that any CSRF token is up-to-date as it comes from the header (not cached) and is inserted into any `authenticity_token` field which may be cached.