### PR TITLE
Add more components to the cache_key

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   include TradeTariffFrontend::ViewContext::Controller
   include ApplicationHelper
   include BasicSessionAuth
+  include CacheHelper
 
   before_action :maintenance_mode_if_active
 

--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -18,11 +18,11 @@ class CommoditiesController < GoodsNomenclaturesController
     end
 
     if params[:country].present? && @search.geographical_area
-      @rules_of_origin_schemes = Rails.cache.fetch([@tariff_last_updated, 'declarable.rules_of_origin', params[:country]]) do
+      @rules_of_origin_schemes = Rails.cache.fetch([cache_key, 'declarable.rules_of_origin', params[:country]]) do
         declarable.rules_of_origin(params[:country])
       end
     else
-      @roo_all_schemes = Rails.cache.fetch(['RulesOfOrigin::Scheme.all', @tariff_last_updated]) do
+      @roo_all_schemes = Rails.cache.fetch(['RulesOfOrigin::Scheme.all', cache_key]) do
         RulesOfOrigin::Scheme.all
       end
     end
@@ -73,7 +73,7 @@ class CommoditiesController < GoodsNomenclaturesController
   end
 
   def uk_heading
-    @uk_heading ||= Rails.cache.fetch([@tariff_last_updated, heading_id, query_params]) do
+    @uk_heading ||= Rails.cache.fetch([cache_key, heading_id, query_params]) do
       TradeTariffFrontend::ServiceChooser.with_source(:uk) do
         HeadingPresenter.new(Heading.find(heading_id, query_params))
       end
@@ -81,7 +81,7 @@ class CommoditiesController < GoodsNomenclaturesController
   end
 
   def xi_heading
-    @xi_heading ||= Rails.cache.fetch([@tariff_last_updated, heading_id, query_params]) do
+    @xi_heading ||= Rails.cache.fetch([cache_key, heading_id, query_params]) do
       TradeTariffFrontend::ServiceChooser.with_source(:xi) do
         HeadingPresenter.new(Heading.find(heading_id, query_params))
       end
@@ -89,7 +89,7 @@ class CommoditiesController < GoodsNomenclaturesController
   end
 
   def uk_commodity
-    @uk_commodity ||= Rails.cache.fetch([@tariff_last_updated, params[:id], query_params]) do
+    @uk_commodity ||= Rails.cache.fetch([cache_key, params[:id], query_params]) do
       TradeTariffFrontend::ServiceChooser.with_source(:uk) do
         CommodityPresenter.new(Commodity.find(params[:id], query_params))
       end
@@ -97,7 +97,7 @@ class CommoditiesController < GoodsNomenclaturesController
   end
 
   def xi_commodity
-    @xi_commodity ||= Rails.cache.fetch([@tariff_last_updated, params[:id], query_params]) do
+    @xi_commodity ||= Rails.cache.fetch([cache_key, params[:id], query_params]) do
       TradeTariffFrontend::ServiceChooser.with_source(:xi) do
         CommodityPresenter.new(Commodity.find(params[:id], query_params))
       end

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -1,0 +1,5 @@
+module CacheHelper
+  def cache_key
+    [TradeTariffFrontend::ServiceChooser.cache_prefix, @tariff_last_updated, TradeTariffFrontend.revision].join('/')
+  end
+end

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -1,4 +1,4 @@
-<%= cache [@tariff_last_updated, params.to_json] do %>
+<%= cache [cache_key, params.to_json] do %>
   <% content_for :head do %>
     <meta name="description" content="<%= declarable.description_plain %>">
   <% end %>


### PR DESCRIPTION
It seems our caching isn't specific enough.  This change ensures that we are using the code revision/service choice and date of last import as keys