### PR TITLE
Ensure NR notices all errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -172,6 +172,7 @@ class ApplicationController < ActionController::Base
   alias_method :handle_params_parse_error, :bad_request
 
   def raise_internal_server_error(exception)
+    NewRelic::Agent.notice_error(exception)
     Rails.logger.error(exception.message)
     redirect_to '/500', status: :internal_server_error
   end


### PR DESCRIPTION
There's a few instances where errors are not appearing in NewRelic.  This PR ensures all errors are logged.