### PR TITLE
HMRC-1306: Adds workflow to stop development services on a schedule

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -21,6 +21,7 @@ jobs:
     with:
       app-name: tariff-frontend
       environment: development
+      test-flavour: none
     secrets:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/stop-development-services.yml
+++ b/.github/workflows/stop-development-services.yml
@@ -1,0 +1,19 @@
+name: Stop Development Services
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 17 * * *'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  stop-services:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: trade-tariff/trade-tariff-tools/.github/actions/stop-services@main
+        with:
+          service-names: frontend
+          environment: development

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,7 +19,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.13.1 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.17.0 |
 
 ## Resources
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,6 +1,7 @@
 locals {
-  secret_value = try(data.aws_secretsmanager_secret_version.this.secret_string, "{}")
-  secret_map   = jsondecode(local.secret_value)
+  has_autoscaler = var.environment == "development" ? false : true
+  secret_value   = try(data.aws_secretsmanager_secret_version.this.secret_string, "{}")
+  secret_map     = jsondecode(local.secret_value)
   secret_env_vars = [
     for key, value in local.secret_map : {
       name  = key

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.13.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.17.0"
 
   region = var.region
 
@@ -11,9 +11,6 @@ module "service" {
   security_groups           = [data.aws_security_group.this.id]
   target_group_arn          = data.aws_lb_target_group.this.arn
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
-
-  min_capacity = var.min_capacity
-  max_capacity = var.max_capacity
 
   docker_image = "382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-frontend-production"
   docker_tag   = var.docker_tag
@@ -28,4 +25,8 @@ module "service" {
   enable_ecs_exec       = true
 
   service_environment_config = local.secret_env_vars
+
+  has_autoscaler = local.has_autoscaler
+  min_capacity   = var.min_capacity
+  max_capacity   = var.max_capacity
 }


### PR DESCRIPTION
### Jira link

[HMRC-1306](https://transformuk.atlassian.net/browse/HMRC-1306)

### What?

I have added/removed/altered:

- [x] Added stop service workflow only in development

### Why?

I am doing this because:

- This will let developers deploy the service using `needs-deployment` on an ad hoc basis and cut costs for the tax payer
