### PR TITLE
HMRC-1328 Add page titles for myott

### DIFF
--- a/app/helpers/myott_helper.rb
+++ b/app/helpers/myott_helper.rb
@@ -1,0 +1,16 @@
+module MyottHelper
+  def myott_page_title(title = nil, error: false)
+    default = 'UK Online Trade Tariff'
+    base_title = "#{title} | #{default}"
+
+    if error
+      base_title = "Error: #{base_title}"
+    end
+
+    if title
+      content_for :title, base_title
+    else
+      content_for(:title) || default
+    end
+  end
+end

--- a/app/views/myott/preferences/edit.html.erb
+++ b/app/views/myott/preferences/edit.html.erb
@@ -1,3 +1,5 @@
+<% myott_page_title "Select chapters", error: flash.now[:error] %>
+
 <% content_for :back_link do %>
   <% back_link session[:all_tariff_updates] ? myott_check_your_answers_path : myott_path %>
 <% end %>

--- a/app/views/myott/preferences/new.html.erb
+++ b/app/views/myott/preferences/new.html.erb
@@ -1,3 +1,5 @@
+<% myott_page_title "Set preferences", error: flash.now[:error] %>
+
 <div class="govuk-body">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/myott/subscriptions/check_your_answers.html.erb
+++ b/app/views/myott/subscriptions/check_your_answers.html.erb
@@ -1,3 +1,5 @@
+<% myott_page_title "Review selection" %>
+
 <% content_for :back_link do %>
   <% back_link session[:all_tariff_updates] ? new_myott_preferences_path : edit_myott_preferences_path %>
 <% end %>

--- a/app/views/myott/subscriptions/confirmation.html.erb
+++ b/app/views/myott/subscriptions/confirmation.html.erb
@@ -1,3 +1,5 @@
+<% myott_page_title "Subscription updated" %>
+
 <div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/app/views/myott/subscriptions/show.html.erb
+++ b/app/views/myott/subscriptions/show.html.erb
@@ -1,3 +1,5 @@
+<% myott_page_title "Manage subscription" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Manage your subscription</h1>

--- a/app/views/myott/subscriptions/start.html.erb
+++ b/app/views/myott/subscriptions/start.html.erb
@@ -1,3 +1,5 @@
+<% myott_page_title "Subscribe and manage" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/myott/unsubscribes/confirmation.html.erb
+++ b/app/views/myott/unsubscribes/confirmation.html.erb
@@ -1,3 +1,5 @@
+<% myott_page_title "You have unsubscribed" %>
+
 <div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/app/views/myott/unsubscribes/show.html.erb
+++ b/app/views/myott/unsubscribes/show.html.erb
@@ -1,3 +1,5 @@
+<% myott_page_title "Unsubscribe" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-body">
     <%= render 'error' if flash.now[:error] %>

--- a/spec/features/myott_spec.rb
+++ b/spec/features/myott_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe 'Myott subscriptions', type: :feature do
     describe 'subscribing to all chapters' do
       it 'allows a user to subscribe to all chapters' do
         visit myott_path
+        expect(page).to have_title('Set preferences')
 
         choose 'All tariff chapter updates'
         click_button 'Continue'
 
         expect(page).to have_content('You have selected all chapters')
+        expect(page).to have_title('Review selection')
 
         find('span', text: 'Show chapters selected').click
         expect(page).to have_content(chapter1.to_s)
@@ -28,6 +30,7 @@ RSpec.describe 'Myott subscriptions', type: :feature do
 
         click_button 'Continue'
 
+        expect(page).to have_title('Subscription updated')
         expect(page).to have_content('You have updated your subscription')
       end
     end
@@ -35,6 +38,7 @@ RSpec.describe 'Myott subscriptions', type: :feature do
     describe 'subscribing to specific chapters' do
       it 'allows a user to subscribe to specific chapters' do
         visit myott_path
+        expect(page).to have_title('Set preferences')
 
         choose 'Select the tariff chapters I am interested in'
         click_button 'Continue'
@@ -67,6 +71,7 @@ RSpec.describe 'Myott subscriptions', type: :feature do
 
       it 'shows the user their current subscription' do
         visit myott_path
+        expect(page).to have_title('Manage subscription')
 
         expect(page).to have_content('Manage your subscription')
         expect(page).to have_content('You have selected 2 chapters')

--- a/spec/helpers/myott_helper_spec.rb
+++ b/spec/helpers/myott_helper_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe MyottHelper, type: :helper do
+  describe '#myott_page_title' do
+    let(:default_title) { 'UK Online Trade Tariff' }
+
+    before do
+      helper.instance_variable_set(:@content_for, {})
+    end
+
+    context 'when no title is provided' do
+      it 'returns the default title' do
+        expect(helper.myott_page_title).to eq(default_title)
+      end
+
+      it 'returns existing content_for title if set' do
+        helper.content_for :title, 'Existing Title'
+        expect(helper.myott_page_title).to eq('Existing Title')
+      end
+    end
+
+    context 'when title is provided without error boolean' do
+      it 'sets content_for to formatted title' do
+        helper.myott_page_title('Login')
+        expect(helper.content_for(:title)).to eq("Login | #{default_title}")
+      end
+    end
+
+    context 'when title is provided with error boolean' do
+      it 'sets content_for without error prefix when form has no errors' do
+        helper.myott_page_title('Login', error: false)
+        expect(helper.content_for(:title)).to eq("Login | #{default_title}")
+      end
+
+      it 'sets content_for with error prefix when form has errors' do
+        helper.myott_page_title('Login', error: true)
+        expect(helper.content_for(:title)).to eq("Error: Login | #{default_title}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[HMRC-1328](https://transformuk.atlassian.net/browse/HMRC-1328)

### What?

- Adds custom page titles for myott
- Form errors will add a "Error: " prefix to the page title
