### PR TITLE
HMRC-1327 Adds space around links

### DIFF
--- a/app/views/myott/preferences/_checkbox_toggles.html.erb
+++ b/app/views/myott/preferences/_checkbox_toggles.html.erb
@@ -2,10 +2,14 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
-        <button class="link_button" data-action="click->chapter-selection#toggleAllChapterCheckboxes" value="true" >Select all chapters</button>
+        <p>
+          <button class="link_button" data-action="click->chapter-selection#toggleAllChapterCheckboxes" value="true" >Select all chapters</button>
+        </p>
       </div>
       <div class="govuk-grid-column-one-half">
-        <button class="link_button" data-action="click->chapter-selection#toggleAllChapterCheckboxes" value="false" >Unselect all chapters</button>
+        <p>
+          <button class="link_button" data-action="click->chapter-selection#toggleAllChapterCheckboxes" value="false" >Unselect all chapters</button>
+        </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Jira link

[HMRC-1327](https://transformuk.atlassian.net/browse/HMRC-1327)

### What?

<img width="471" alt="Screenshot 2025-07-01 at 10 52 22" src="https://github.com/user-attachments/assets/fc7f16bc-8dd0-4c8c-b8cc-c7c4d5cedbd3" />

### Why?

Gives mobile users more space to click links
