### PR TITLE
MYOTT-43 Add private beta notification banner

### DIFF
--- a/app/views/myott/subscriptions/start.html.erb
+++ b/app/views/myott/subscriptions/start.html.erb
@@ -2,6 +2,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          Important
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        This service is in the private beta phase. All information in this service is accurate, but some aspects might change during this phase.
+      </div>
+    </div>
 
     <h1 class="govuk-heading-l">Subscribe and manage tariff updates</h1>
 


### PR DESCRIPTION
### Jira link

[MYOTT-43](https://transformuk.atlassian.net/browse/MYOTT-43)

### What?

Adds a banner to the stop press subscriptions start page to inform users this service is in private beta

<img width="710" height="397" alt="Screenshot 2025-07-17 at 15 12 04" src="https://github.com/user-attachments/assets/02749bdc-3c40-49a8-98e1-a42bb7626825" />
