### PR TITLE
PRDEX 71 | Add ability to display 'None affected' for commodities under live issues

### DIFF
--- a/app/views/live_issues/_commodities.html.erb
+++ b/app/views/live_issues/_commodities.html.erb
@@ -1,0 +1,28 @@
+<% if live_issue.commodities.empty? %>
+  <p class="govuk-body">
+    None affected
+  </p>
+<% elsif live_issue.commodities.size > 1 %>
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      <%= live_issue.commodities.count %> commodities affected
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <% live_issue.commodities.each do |commodity_code| %>
+      <p class="govuk-body">
+        <a href="/commodities/<%= commodity_code %>" class="govuk-link">
+          <%= commodity_code %>
+        </a>
+      </p>
+    <% end %>
+  </div>
+</details>
+<% else %>
+<p class="govuk-body">
+  <a href="/commodities/<%= live_issue.commodities.first %>" class="govuk-link">
+    <%= live_issue.commodities.first %>
+  </a>
+</p>
+<% end %>

--- a/app/views/live_issues/index.html.erb
+++ b/app/views/live_issues/index.html.erb
@@ -47,6 +47,10 @@
             <% end %>
           </div>
         </details>
+        <% elsif live_issue.commodities.empty? %>
+          <p class="govuk-body">
+            None affected
+          </p>
         <% else %>
         <p class="govuk-body">
           <a href="/commodities/<%= live_issue.commodities.first %>" class="govuk-link">

--- a/app/views/live_issues/index.html.erb
+++ b/app/views/live_issues/index.html.erb
@@ -30,34 +30,7 @@
       </th>
       <td class="govuk-table__cell"> <%= markdown_field(live_issue.description) %> </td>
       <td class="govuk-table__cell">
-        <% if live_issue.commodities.size > 1 %>
-        <details class="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              <%= live_issue.commodities.count %> commodities affected
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            <% live_issue.commodities.each do |commodity_code| %>
-              <p class="govuk-body">
-                <a href="/commodities/<%= commodity_code %>" class="govuk-link">
-                  <%= commodity_code %>
-                </a>
-              </p>
-            <% end %>
-          </div>
-        </details>
-        <% elsif live_issue.commodities.empty? %>
-          <p class="govuk-body">
-            None affected
-          </p>
-        <% else %>
-        <p class="govuk-body">
-          <a href="/commodities/<%= live_issue.commodities.first %>" class="govuk-link">
-            <%= live_issue.commodities.first %>
-          </a>
-        </p>
-        <% end %>
+        <%= render partial: 'commodities', locals: { live_issue: live_issue } %>
       </td>
       <td class="govuk-table__cell"><%= live_issue.status %></td>
       <td class="govuk-table__cell"><%= live_issue.date_discovered.to_date.to_formatted_s(:long) %> to <%= live_issue.date_resolved ? live_issue.date_resolved&.to_date&.to_formatted_s(:long): 'Present' %></td>


### PR DESCRIPTION
### Jira link

[PRDEX-71](https://transformuk.atlassian.net/browse/PRDEX-71)

### What?

- [x] Display 'None affected' for commodities 
- [x] Add partial to abstract commodities displaying logic

### Why?

I am doing this because...

- We want to be able display 'None affected' 
