### PR TITLE
BAU: User paths should be: /uk/user/subscriptions and /uk/user/users

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,7 +1,7 @@
 class Subscription
   include ApiEntity
 
-  set_singular_path 'user/subscriptions/:id'
+  set_singular_path '/uk/user/subscriptions/:id'
 
   attr_accessor :active, :uuid
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User
-  include ApiEntity
+  include UkOnlyApiEntity
 
-  set_singular_path 'user/users'
+  set_singular_path '/uk/user/users'
 
   attr_accessor :email, :chapter_ids, :stop_press_subscription
 

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
 
       context 'when the update is successful' do
         before do
-          stub_api_request('/user/users', :put)
+          stub_api_request('http://localhost:3018/uk/user/users', :put)
             .with(body: {
               data: {
                 attributes: attributes,
@@ -184,7 +184,7 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
 
       context 'when the update fails' do
         before do
-          stub_api_request('/user/users', :put)
+          stub_api_request('http://localhost:3018/uk/user/users', :put)
             .and_return(jsonapi_error_response(401))
 
           post :subscribe

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe User do
 
     context 'when response is successful' do
       before do
-        stub_api_request('/user/users').and_return(jsonapi_response(:user, attributes_for(:user)))
+        stub_api_request('http://localhost:3018/uk/user/users').and_return(jsonapi_response(:user, attributes_for(:user)))
       end
 
       it { is_expected.to be_a described_class }
@@ -20,7 +20,7 @@ RSpec.describe User do
 
     context 'when response is unauthorised' do
       before do
-        stub_api_request('/user/users').and_return(jsonapi_error_response(401))
+        stub_api_request('http://localhost:3018/uk/user/users').and_return(jsonapi_error_response(401))
       end
 
       it { is_expected.to be_nil }
@@ -41,7 +41,7 @@ RSpec.describe User do
 
     context 'when the request is successful' do
       before do
-        stub_api_request('/user/users', :put)
+        stub_api_request('http://localhost:3018/uk/user/users', :put)
           .with(body: {
             data: {
               attributes: attributes,
@@ -57,7 +57,7 @@ RSpec.describe User do
 
     context 'when response is unauthorised' do
       before do
-        stub_api_request('/user/users', :put)
+        stub_api_request('http://localhost:3018/uk/user/users', :put)
         .with(body: {
           data: {
             attributes: attributes,

--- a/spec/support/api_responses_helper.rb
+++ b/spec/support/api_responses_helper.rb
@@ -11,8 +11,13 @@ module ApiResponsesHelper
                     TradeTariffFrontend::ServiceChooser.api_host
                   end
 
-    endpoint = "/#{endpoint}" unless endpoint.starts_with?('/')
-    url = "#{backend_url}#{endpoint}"
+    url = if endpoint.starts_with?('http')
+            endpoint
+          elsif endpoint.starts_with?('/')
+            "#{backend_url}#{endpoint}"
+          else
+            "#{backend_url}/#{endpoint}"
+          end
 
     stub_request(method, url)
   end


### PR DESCRIPTION
### Jira link

BAU

### What?

I have a...

- Move to explicit over relative-to-host pathing for user routes

### Why?

I am doing this because...

- We need to be explicit about exact pathing for these endpoints unlike the others that use public endpoints under the /uk/api and /xi/api scopes
