### PR TITLE
HMRC-1412: Adds specs for live issues controller, helper and view

### DIFF
--- a/app/helpers/live_issue_helper.rb
+++ b/app/helpers/live_issue_helper.rb
@@ -1,5 +1,12 @@
 module LiveIssueHelper
-  def markdown_field(attr)
-    raw Kramdown::Document.new(attr).to_html
+  def markdown_field(markdown)
+    raw Kramdown::Document.new(markdown).to_html
+  end
+
+  def live_issue_from_to_date(live_issue)
+    from = live_issue.date_discovered.to_date.to_formatted_s(:long)
+    to = live_issue.date_resolved ? live_issue.date_resolved&.to_date&.to_formatted_s(:long) : 'Present'
+
+    "#{from} - #{to}"
   end
 end

--- a/app/views/live_issues/index.html.erb
+++ b/app/views/live_issues/index.html.erb
@@ -33,7 +33,7 @@
         <%= render partial: 'commodities', locals: { live_issue: live_issue } %>
       </td>
       <td class="govuk-table__cell"><%= live_issue.status %></td>
-      <td class="govuk-table__cell"><%= live_issue.date_discovered.to_date.to_formatted_s(:long) %> to <%= live_issue.date_resolved ? live_issue.date_resolved&.to_date&.to_formatted_s(:long): 'Present' %></td>
+      <td class="govuk-table__cell"><%= live_issue_from_to_date(live_issue) %></td>
       <td class="govuk-table__cell"><%= markdown_field(live_issue.suggested_action) %></td>
     </tr>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,6 +191,7 @@ en:
       import_controls_xi: ""
 
   breadcrumb:
+    live_issues: Live issues
     monthly_exchange_rates: Monthly exchange rates
     average_exchange_rates: Average exchange rates
     spot_exchange_rates: Spot exchange rates

--- a/spec/controllers/live_issues_controller_spec.rb
+++ b/spec/controllers/live_issues_controller_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe LiveIssuesController, type: :controller do
+  subject { response }
+
+  before do
+    stub_api_request('live_issues')
+      .to_return jsonapi_response(:live_issues, live_issues)
+
+    get :index
+  end
+
+  let(:live_issues) { attributes_for_list(:live_issue, 2) }
+
+  it { is_expected.to have_http_status(:success) }
+  it { is_expected.to render_template(:index) }
+
+  it 'assigns @live_issues', :aggregate_failures do
+    expect(assigns(:live_issues)).to be_present
+    expect(assigns(:live_issues).length).to eq(2)
+    expect(assigns(:live_issues).first).to be_a(LiveIssue)
+  end
+end

--- a/spec/factories/live_issue.rb
+++ b/spec/factories/live_issue.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :live_issue do
+    commodities do
+      %w[
+        2106909815
+        2106909816
+      ]
+    end
+
+    date_discovered { '2025-07-08' }
+    date_resolved { nil }
+    description { "# Kramdown\n\n- Bullet point 1\n- Bullet point 2" }
+    resource_id { '1' }
+    resource_type { 'live_issue' }
+    status { 'Active' }
+    suggested_action { 'The Third Country duty rate or, with relevant proof, the CPTPP duty rate can be claimed. The Japan duty rate can only be processed once the DBT update has occurred.' }
+    title { 'Missing Japan Preference' }
+    updated_at { '2025-07-15T12:26:23.955Z' }
+  end
+end

--- a/spec/helpers/live_issue_helper_spec.rb
+++ b/spec/helpers/live_issue_helper_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe LiveIssue, type: :helper do
+  describe '#markdown_field' do
+    subject(:markdown_field) { helper.markdown_field(markdown) }
+
+    let(:markdown) { 'This is **bold** text.' }
+    let(:expected_html) { "<p>This is <strong>bold</strong> text.</p>\n" }
+
+    it { is_expected.to eq(expected_html) }
+  end
+
+  describe '#live_issue_from_to_date' do
+    subject(:live_issue_from_to_date) { helper.live_issue_from_to_date(live_issue) }
+
+    let(:live_issue) { build(:live_issue, date_discovered: date_discovered, date_resolved: date_resolved) }
+
+    let(:date_discovered) { Time.zone.parse('2025-07-15') }
+
+    context 'when date_resolved is present' do
+      let(:date_resolved) { Time.zone.parse('2025-08-01') }
+
+      it { is_expected.to eq('15 July 2025 - 1 August 2025') }
+    end
+
+    context 'when date_resolved is nil' do
+      let(:date_resolved) { nil }
+
+      it { is_expected.to eq('15 July 2025 - Present') }
+    end
+  end
+end

--- a/spec/support/api_responses_helper.rb
+++ b/spec/support/api_responses_helper.rb
@@ -1,10 +1,6 @@
 module ApiResponsesHelper
   # Wrapper around WebMock's stub_request with defaults that apply to all our api requests
   def stub_api_request(endpoint, method = :get, backend: nil)
-    unless %i[head get post patch put delete].include?(method)
-      raise "Stubbing unknown HTTP method, '#{method}'"
-    end
-
     backend_url = if backend
                     TradeTariffFrontend::ServiceChooser.service_choices[backend]
                   else

--- a/spec/views/live_issues/index.html.erb_spec.rb
+++ b/spec/views/live_issues/index.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe 'live_issues/index', type: :view do
+  subject { render }
+
+  before do
+    assign :live_issues, [
+      build(
+        :live_issue,
+        updated_at: Time.zone.parse('2025-07-15'),
+      ),
+    ]
+  end
+
+  it { is_expected.to have_css 'th > div', text: '15 July 2025' }
+  it { is_expected.to have_css 'h1#kramdown', text: 'Kramdown' }
+  it { is_expected.to render_template 'live_issues/_commodities' }
+end


### PR DESCRIPTION
### Jira link

[HMRC-1412](https://transformuk.atlassian.net/browse/HMRC-1412)

### What?

I have a...

- Adds various missing unit tests for the live issues log
- Also removes some defensive programming around api stubbing using webmock verbs
- Refactors some view logic out of the template into the view helper

### Why?

I am doing this because...

- These were missing and more coverage is helpful
