### PR TITLE
HMRC 1151: add preview health check

### DIFF
--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -100,23 +100,23 @@ jobs:
     secrets:
       basic_password: ${{ secrets.BASIC_PASSWORD }}
 
-  # notification:
-  #     needs: [deploy, e2e-test]
-  #     if: failure()
-  #     runs-on: ubuntu-latest
+  notification:
+      needs: [deploy, e2e-test]
+      if: failure()
+      runs-on: ubuntu-latest
 
-  #     steps:
-  #       - name: Notify Slack
-  #         uses: rtCamp/action-slack-notify@v2
-  #         env:
-  #           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #           SLACK_USERNAME: GitHub Actions
-  #           SLACK_CHANNEL: '#deployments'
-  #           SLACK_TITLE: 'Preview Deploy or E2E Test Failed'
-  #           SLACK_ICON_EMOJI: ':warning:'
-  #           SLACK_MESSAGE: |
-  #             *Repository:* ${{ github.repository }}
-  #             *PR:* <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}>
-  #             *Commit:* <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>
-  #             *Preview URL:* <${{ needs.deploy.outputs.preview_url }}|View Preview>
-  #           SLACK_COLOR: danger
+      steps:
+        - name: Notify Slack
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+            SLACK_USERNAME: GitHub Actions
+            SLACK_CHANNEL: '#deployments'
+            SLACK_TITLE: 'Preview Deploy or E2E Test Failed'
+            SLACK_ICON_EMOJI: ':warning:'
+            SLACK_MESSAGE: |
+              *Repository:* ${{ github.repository }}
+              *PR:* <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}>
+              *Commit:* <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>
+              *Preview URL:* <${{ needs.deploy.outputs.preview_url }}|View Preview>
+            SLACK_COLOR: danger

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -42,7 +42,11 @@ jobs:
             --query "SecretString" \
             --output text)
 
-          echo "$SECRET_JSON" | jq -r 'to_entries[] | "::add-mask::\(.value)"'
+          for key in BASIC_PASSWORD GREEN_LANES_API_TOKEN MYOTT_ENCRYPTION_SECRET \
+                     NEW_RELIC_LICENSE_KEY SECRET_KEY_BASE SMTP_PASSWORD SMTP_USERNAME; do
+              value=$(echo "$SECRET_JSON" | jq -r --arg k "$key" '.[$k]')
+              [[ "$value" != "null" ]] && echo "::add-mask::$value"
+          done
           echo "$SECRET_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env
 
       - uses: livecycle/preevy-up-action@v2.4.0
@@ -54,6 +58,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           BUILDX_BAKE_ENTITLEMENTS_FS: 0
+
       - name: Get preview environment URL
         id: get-url
         run: |
@@ -61,6 +66,27 @@ jobs:
           PREVIEW_URL=$(npx preevy urls --json --wait --profile "$PREEVY_PROFILE_URL" | jq -r '.[0].url')
           echo "✅ Using preview URL: $PREVIEW_URL"
           echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Run health check
+        id: check
+        run: |
+          URL="${{ steps.get-url.outputs.preview_url }}"
+
+          for i in {1..10}; do
+            STATUS=$(curl -L -s -o /dev/null -w "%{http_code}" "$URL")
+            echo "Attempt $i: HTTP $STATUS"
+
+            if [[ "$STATUS" -ge 200 && "$STATUS" -lt 400 ]]; then
+              echo "✅ Health check passed"
+              echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            sleep 6
+          done
+
+          echo "❌ Health check failed after retries"
+          exit 1
 
   e2e-test:
     needs: deploy
@@ -72,3 +98,24 @@ jobs:
       skip-api: true
     secrets:
       basic_password: ${{ secrets.BASIC_PASSWORD }}
+
+  notification:
+      needs: [deploy, e2e-test]
+      if: failure()
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Notify Slack
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+            SLACK_USERNAME: GitHub Actions
+            SLACK_CHANNEL: '#deployments'
+            SLACK_TITLE: 'Preview Deploy or E2E Test Failed'
+            SLACK_ICON_EMOJI: ':warning:'
+            SLACK_MESSAGE: |
+              *Repository:* ${{ github.repository }}
+              *PR:* <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}>
+              *Commit:* <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>
+              *Preview URL:* <${{ needs.deploy.outputs.preview_url }}|View Preview>
+            SLACK_COLOR: danger

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -42,11 +42,12 @@ jobs:
             --query "SecretString" \
             --output text)
 
-          for key in BASIC_PASSWORD GREEN_LANES_API_TOKEN MYOTT_ENCRYPTION_SECRET \
-                     NEW_RELIC_LICENSE_KEY SECRET_KEY_BASE SMTP_PASSWORD SMTP_USERNAME; do
-              value=$(echo "$SECRET_JSON" | jq -r --arg k "$key" '.[$k]')
-              [[ "$value" != "null" ]] && echo "::add-mask::$value"
-          done
+          echo "$SECRET_JSON" | jq -r '
+            to_entries[]
+            | select(.value | type == "string")
+            | select(.value | length > 8)  # Skip short/common values
+            | "::add-mask::" + .value
+          '
           echo "$SECRET_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> .env
 
       - uses: livecycle/preevy-up-action@v2.4.0
@@ -99,23 +100,23 @@ jobs:
     secrets:
       basic_password: ${{ secrets.BASIC_PASSWORD }}
 
-  notification:
-      needs: [deploy, e2e-test]
-      if: failure()
-      runs-on: ubuntu-latest
+  # notification:
+  #     needs: [deploy, e2e-test]
+  #     if: failure()
+  #     runs-on: ubuntu-latest
 
-      steps:
-        - name: Notify Slack
-          uses: rtCamp/action-slack-notify@v2
-          env:
-            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-            SLACK_USERNAME: GitHub Actions
-            SLACK_CHANNEL: '#deployments'
-            SLACK_TITLE: 'Preview Deploy or E2E Test Failed'
-            SLACK_ICON_EMOJI: ':warning:'
-            SLACK_MESSAGE: |
-              *Repository:* ${{ github.repository }}
-              *PR:* <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}>
-              *Commit:* <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>
-              *Preview URL:* <${{ needs.deploy.outputs.preview_url }}|View Preview>
-            SLACK_COLOR: danger
+  #     steps:
+  #       - name: Notify Slack
+  #         uses: rtCamp/action-slack-notify@v2
+  #         env:
+  #           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #           SLACK_USERNAME: GitHub Actions
+  #           SLACK_CHANNEL: '#deployments'
+  #           SLACK_TITLE: 'Preview Deploy or E2E Test Failed'
+  #           SLACK_ICON_EMOJI: ':warning:'
+  #           SLACK_MESSAGE: |
+  #             *Repository:* ${{ github.repository }}
+  #             *PR:* <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}>
+  #             *Commit:* <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>
+  #             *Preview URL:* <${{ needs.deploy.outputs.preview_url }}|View Preview>
+  #           SLACK_COLOR: danger

--- a/compose.yml
+++ b/compose.yml
@@ -40,9 +40,12 @@ x-preevy:
         {% endif %}
 
         💸 **Preview Environment Estimated Cost**: £0.50/day
-        *(AWS Lightsail small_3_0, $12/mo, eu-west-2 — 2025)*
+         *(AWS Lightsail small_3_0, $12/mo, eu-west-2 — 2025)*
 
-        **Environment Cleanup Policy**
-        🕛 Nightly cleanup: All preview environments with the `needs-preview` label are removed automatically at midnight.
-        ❌ Immediate teardown: When a PR is closed or the `needs-preview`/`keep-preview` label is removed, the associated environment is destroyed immediately.
-        📌 Retention override: Add the `keep-preview` label to retain a preview environment beyond the nightly cleanup.
+        🧹**Environment Cleanup Policy**
+         - Nightly cleanup: All preview environments with the `needs-preview` label are removed automatically at midnight.
+         - Immediate teardown: When a PR is closed or the `needs-preview`/`keep-preview` label is removed, the associated environment is destroyed immediately.
+         - Retention override: Add the `keep-preview` label to retain a preview environment beyond the nightly cleanup.
+
+        📘 **How to manage preview environments**
+         [View internal doc](https://docs.trade-tariff.service.gov.uk/manual/how-to-manage-review-apps.html)


### PR DESCRIPTION
### Jira link

[HMRC-1151](https://transformuk.atlassian.net/browse/HMRC-1151)

### What?

I have added a preview healthcheck endpoint and integrated Slack alerts for monitoring.

### Why?

I am doing this because...
This change improves system observability by:
- Providing a dedicated healthcheck endpoint for preview environments
- Enabling real-time Slack notifications for critical health issues
