### PR TITLE
HMRC-1362: Start identity service when running e2e tests

### DIFF
--- a/.github/workflows/deploy-to-development-full.yml
+++ b/.github/workflows/deploy-to-development-full.yml
@@ -37,6 +37,11 @@ jobs:
             "name": "tariff-admin",
             "repo": "trade-tariff/trade-tariff-admin",
             "service-names": ["admin"]
+          },
+          {
+            "name": "tariff-identity",
+            "repo": "trade-tariff/identity",
+            "service-names": ["identity"]
           }
         ]
       test-flavour: tariff


### PR DESCRIPTION
### Jira link

[HMRC-1362](https://transformuk.atlassian.net/browse/HMRC-1362)

### What?

I have a...

- Enabled identity service when running the e2e tests

### Why?

I am doing this because...

- This is required to make sure the e2e tests pass
