### PR TITLE
HMRC-1086: Update axxy test threshold configuration to match actual failue threshold

### DIFF
--- a/spec/javascript/accessibility/accessibility.spec.js
+++ b/spec/javascript/accessibility/accessibility.spec.js
@@ -42,7 +42,7 @@ async function runAccessibilityScan(page, pageName, url, threshold) {
       results,
     });
 
-    expect(results.violations.length).toBeLessThan(threshold);
+    expect(results.violations.length).toBe(threshold);
 
     return results;
   } catch (error) {

--- a/spec/javascript/accessibility/config.json
+++ b/spec/javascript/accessibility/config.json
@@ -3,54 +3,54 @@
     {
       "name": "Quota Search",
       "path": "/quota_search?order_number=052012",
-      "threshold": 5
+      "threshold": 1
     },
     {
       "name": "Find Commodity",
       "path": "/find_commodity",
-      "threshold": 5
+      "threshold": 2
     },
     {
       "name": "Browse Tariff",
       "path": "/browse",
-      "threshold": 5
+      "threshold": 1
     },
     {
       "name": "A-Z Index",
       "path": "/a-z-index/a",
-      "threshold": 5
+      "threshold": 1
     },
     {
       "name": "Commodities",
       "path": "/commodities/0409000010",
-      "threshold": 9
+      "threshold": 4
     },
     {
       "name": "Duty Calculator",
       "path": "/duty-calculator/0702001007/import-date",
-      "threshold": 5
+      "threshold": 1
     },
     {
       "name": "Exchange Rates",
       "path": "/exchange_rates",
-      "threshold": 9
+      "threshold": 4
     }
   ],
   "adminPages": [
     {
       "name": "Admin Section Notes",
       "path": "/",
-      "threshold": 9
+      "threshold": 2
     },
     {
       "name": "Admin Search References",
       "path": "/search_references/sections",
-      "threshold": 9
+      "threshold": 2
     },
     {
       "name": "Admin Tariff Updates",
       "path": "/tariff_updates",
-      "threshold": 9
+      "threshold": 2
     }
   ]
 }


### PR DESCRIPTION
### Jira link

[HMRC-1086: Support better configuration in axxy tests](https://transformuk.atlassian.net/browse/HMRC-1471)

### What?
This PR updates the configuration of axxy tests to match the actual number of expected failures.
- Adjusted the failure threshold in the configuration file.
- Ensured the tests fail when the threshold is exceeded.
- Verified axxy tests locally.

### Why?

I am doing this because the previous configuration did not reflect the current failure tolerance, which led to misleading test results. 
This update ensures that the axxy tests behave correctly and alert the team when real accessibility issues arise.

