### PR TITLE
HMRC-1492 Move file paths to front end path

### DIFF
--- a/app/controllers/exchange_rates_controller.rb
+++ b/app/controllers/exchange_rates_controller.rb
@@ -11,6 +11,10 @@ class ExchangeRatesController < ApplicationController
     render :show_404, status: :not_found if @period_list.exchange_rate_periods.blank?
   end
 
+  def files
+    redirect_to "/uk/api/exchange_rates/files/#{params[:id]}" and return true
+  end
+
   def show
     @exchange_rate_collection = ExchangeRateCollection.find(
       "#{year}-#{month}",

--- a/app/views/exchange_rates/_document_detail.html.erb
+++ b/app/views/exchange_rates/_document_detail.html.erb
@@ -19,7 +19,7 @@
 
         <% if period.files.any? %>
           <% period.files.each do |file| %>
-            <a title="Download <%= period.month%> <%= period.year %> monthly exchange rates in <%= file.format.upcase %> format" href="<%= file.adjusted_file_path %>">
+            <a title="Download <%= period.month%> <%= period.year %> monthly exchange rates in <%= file.format.upcase %> format" href="<%= exchange_rate_file_path(URI(file.adjusted_file_path).path.split('/').last) %>">
               <strong><%= file.format.upcase %></strong> <%= file.file_size_in_kb %> KB
             </a>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,8 +128,8 @@ Rails.application.routes.draw do
 
   scope constraints: ->(_req) { TradeTariffFrontend::ServiceChooser.uk? } do
     get 'exchange_rates(/:type)', to: 'exchange_rates#index', as: 'exchange_rates'
-
     get 'exchange_rates/view/:id', to: 'exchange_rates#show', as: 'exchange_rate_collection'
+    get 'exchange_rates/view/files/:id', to: 'exchange_rates#files', as: 'exchange_rate_file'
   end
 
   get 'search_suggestions', to: 'search#suggestions', as: :search_suggestions

--- a/spec/views/exchange_rates/_document_detail.html.erb_spec.rb
+++ b/spec/views/exchange_rates/_document_detail.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'exchange_rates/_document_detail', type: :view do
 
   it { is_expected.to have_css 'h3', text: "June #{period.year} spot exchange rates" }
 
-  it { is_expected.to have_link('CSV', href: '/exchange_rates/csv/exrates-monthly-0623.csv'), count: 2 }
+  it { is_expected.to have_link('CSV', href: '/exchange_rates/view/files/exrates-monthly-0623.csv'), count: 2 }
 
   it { is_expected.to have_link('View online', href: "/exchange_rates/view/#{period.year}-#{period.month}?type=spot") }
 end


### PR DESCRIPTION
### Jira link

[HMRC-1492](https://transformuk.atlassian.net/browse/HMRC-1492)

### What?

Moves CSV/XML file download links to front-end specific URLs that don't mention the API.  Old URLs still work.
