### PR TITLE
PRDEX-136 Enquiry Form Confirmation Page Use Session For Reference Number

### DIFF
--- a/app/controllers/product_experience/enquiry_form_controller.rb
+++ b/app/controllers/product_experience/enquiry_form_controller.rb
@@ -64,7 +64,9 @@ module ProductExperience
         if response['resource_id']
           Rails.cache.delete(form_data['query']) if form_data['query'].present?
           session.delete(:enquiry_data)
-          session[:reference_number] = response['resource_id']
+          session[:product_experience_enquiry] = {
+            reference_number: response['resource_id'],
+          }
           redirect_to product_experience_enquiry_form_confirmation_path
         else
           flash[:alert] = 'There was a problem submitting your enquiry. Please try again later.'
@@ -77,7 +79,7 @@ module ProductExperience
     end
 
     def confirmation
-      @reference_number = session.delete(:reference_number)
+      @reference_number = session.delete(:product_experience_enquiry)['reference_number'] if session[:product_experience_enquiry].present?
       redirect_to product_experience_enquiry_form_path if @reference_number.blank?
     end
 

--- a/app/controllers/product_experience/enquiry_form_controller.rb
+++ b/app/controllers/product_experience/enquiry_form_controller.rb
@@ -64,7 +64,8 @@ module ProductExperience
         if response['resource_id']
           Rails.cache.delete(form_data['query']) if form_data['query'].present?
           session.delete(:enquiry_data)
-          redirect_to product_experience_enquiry_form_confirmation_path(reference_number: response['resource_id'])
+          session[:reference_number] = response['resource_id']
+          redirect_to product_experience_enquiry_form_confirmation_path
         else
           flash[:alert] = 'There was a problem submitting your enquiry. Please try again later.'
           redirect_to product_experience_enquiry_form_check_your_answers_path
@@ -76,7 +77,8 @@ module ProductExperience
     end
 
     def confirmation
-      @reference_number = params[:reference_number]
+      @reference_number = session.delete(:reference_number)
+      redirect_to product_experience_enquiry_form_path if @reference_number.blank?
     end
 
     def check_your_answers

--- a/spec/controllers/product_experience/enquiry_form_controller_spec.rb
+++ b/spec/controllers/product_experience/enquiry_form_controller_spec.rb
@@ -210,7 +210,9 @@ RSpec.describe ProductExperience::EnquiryFormController, type: :controller do
 
     context 'when reference number is present' do
       before do
-        session[:reference_number] = reference_number
+        session[:product_experience_enquiry] = {
+          'reference_number' => reference_number,
+        }
         get :confirmation
       end
 

--- a/spec/controllers/product_experience/enquiry_form_controller_spec.rb
+++ b/spec/controllers/product_experience/enquiry_form_controller_spec.rb
@@ -142,13 +142,14 @@ RSpec.describe ProductExperience::EnquiryFormController, type: :controller do
             headers: { 'Content-Type' => 'application/json' },
           )
           .and_return(jsonapi_response(:enquiry_form_submission, { resource_id: resource_id }))
+        session[:reference_number] = resource_id
       end
 
       it 'redirects to the confirmation page' do
         post :submit_form, params: { submission_token: submission_token }
 
         expect(response).to redirect_to(
-          product_experience_enquiry_form_confirmation_path(reference_number: resource_id),
+          product_experience_enquiry_form_confirmation_path,
         )
       end
 
@@ -207,14 +208,29 @@ RSpec.describe ProductExperience::EnquiryFormController, type: :controller do
   describe 'GET #confirmation' do
     let(:reference_number) { 'R1M5X8LU' }
 
-    before { get :confirmation, params: { reference_number: reference_number } }
+    context 'when reference number is present' do
+      before do
+        session[:reference_number] = reference_number
+        get :confirmation
+      end
 
-    it 'assigns the reference number' do
-      expect(assigns(:reference_number)).to eq(reference_number)
+      it 'assigns the reference number' do
+        expect(assigns(:reference_number)).to eq(reference_number)
+      end
+
+      it 'renders the confirmation page' do
+        expect(response).to be_successful
+      end
     end
 
-    it 'renders the confirmation page' do
-      expect(response).to be_successful
+    context 'when reference number is not present' do
+      before do
+        get :confirmation
+      end
+
+      it 'redirects to the start page' do
+        expect(response).to redirect_to(product_experience_enquiry_form_path)
+      end
     end
   end
 end


### PR DESCRIPTION


### Jira link

[PRDEX-136](https://transformuk.atlassian.net/browse/PRDEX-136)

### What?

I have updated controller to store reference_number in session and use in confirmation page instead of inline parameter

### Why?

I am doing this because it prevents users from generating a confirmation page from erroneous URLs such as https://staging.trade-tariff.service.gov.uk/enquiry_form/confirmation?reference_number=foobar:

<img width="731" height="679" alt="image" src="https://github.com/user-attachments/assets/7fa8c91e-814f-4c48-872f-db578380cbbf" />

