### PR TITLE
PRDEX-158 Fix Char Count Validation

### DIFF
--- a/app/helpers/enquiry_form_helper.rb
+++ b/app/helpers/enquiry_form_helper.rb
@@ -97,7 +97,9 @@ def validate_value(field, value)
   if field == 'email_address' && !value.match?(URI::MailTo::EMAIL_REGEXP)
     @alert = 'Please enter a valid email address.'
   end
-  if (field == 'query') && (value.length > 5004) # add some tolerance as GDS javascript char count is problematic known issue: https://github.com/alphagov/govuk-frontend/issues/1104
-    @alert = 'Please limit your query to 5000 characters or less.'
+
+  max = 5000
+  if field == 'query' && GovukFrontendHelper.utf16_code_units_length(value) > max
+    @alert = "Please limit your query to #{max} characters or less."
   end
 end

--- a/app/helpers/govuk_frontend_helper.rb
+++ b/app/helpers/govuk_frontend_helper.rb
@@ -1,4 +1,6 @@
 module GovukFrontendHelper
+  module_function
+
   def contents_list_item(text, target, classes = [], &_block)
     list_item_classes = %w[
       gem-c-contents-list__list-item
@@ -43,5 +45,15 @@ module GovukFrontendHelper
     tag.nav(**nav_options) do
       heading + list_html
     end
+  end
+
+  # Count UTF-16 code units (how JS .length / maxlength measure length)
+  def utf16_code_units_length(str)
+    normalize_newlines(str).encode('UTF-16LE').bytesize / 2
+  end
+
+  # remove extra characters from newlines so it matches frontend character count
+  def normalize_newlines(str)
+    str.to_s.gsub("\r\n", "\n").tr("\r", "\n")
   end
 end

--- a/spec/helpers/enquiry_form_helper_spec.rb
+++ b/spec/helpers/enquiry_form_helper_spec.rb
@@ -144,11 +144,21 @@ RSpec.describe EnquiryFormHelper, type: :helper do
 
     context 'when query exceeds character limit' do
       let(:field) { 'query' }
-      let(:value) { 'a' * 5005 }
+      let(:value) { 'a' * 5001 }
 
       it 'sets alert to length message' do
         validate
         expect(alert).to eq('Please limit your query to 5000 characters or less.')
+      end
+    end
+
+    context 'when query equals character limit' do
+      let(:field) { 'query' }
+      let(:value) { 'a' * 5000 }
+
+      it 'sets alert to length message' do
+        validate
+        expect(alert).not_to eq('Please limit your query to 5000 characters or less.')
       end
     end
 

--- a/spec/helpers/govuk_frontend_helper_spec.rb
+++ b/spec/helpers/govuk_frontend_helper_spec.rb
@@ -83,4 +83,26 @@ RSpec.describe GovukFrontendHelper, type: :helper do
       it { is_expected.to have_link 'First section', href: '/page/section1' }
     end
   end
+
+  describe '#utf16_code_units_length' do
+    it 'counts simple ASCII correctly' do
+      expect(described_class.utf16_code_units_length('abc')).to eq(3)
+    end
+
+    it 'normalises CRLF newlines to LF and counts them as one' do
+      str = "a\r\nb\r\nc"
+      expect(described_class.utf16_code_units_length(str)).to eq(5) # "a\nb\nc"
+    end
+
+    it 'counts emoji (outside BMP) as 2 code units each' do
+      str = 'a💩b' # "💩" is U+1F4A9
+      expect(described_class.utf16_code_units_length(str)).to eq(4) # "a"(1) + "💩"(2) + "b"(1)
+    end
+
+    it 'counts multiple lines with mixed endings consistently' do
+      str = "line1\r\nline2\nline3\rline4"
+      normalized = "line1\nline2\nline3\nline4"
+      expect(described_class.utf16_code_units_length(str)).to eq(normalized.length)
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[PRDEX-158](https://transformuk.atlassian.net/browse/PDEX-158)

### What?

I have added more robust char count validation by adding helpers to normalize new lines and count by bytesize / 2

### Why?

I am doing this because GDS character count component counts characters by byte size and server requests add extra characters when processing new lines.  This meant that things like emojis and paragraphs were miscounted server side hence validation failed.

More info here:
https://github.com/alphagov/govuk-frontend/issues/1104
https://design-system.service.gov.uk/components/character-count/

https://github.com/user-attachments/assets/bf0d3077-5c0b-42f3-8ebf-47bf74d20da9