### PR TITLE
PRDEX-161 Enquiry Form Submission Token Validation Fix

### DIFF
--- a/app/controllers/product_experience/enquiry_form_controller.rb
+++ b/app/controllers/product_experience/enquiry_form_controller.rb
@@ -6,7 +6,7 @@ module ProductExperience
                   :initialize_enquiry_data
 
     before_action :validate_field, except: %i[show check_your_answers submit_form confirmation]
-    before_action :verify_submission_token, only: %i[form submit submit_form]
+    before_action :verify_submission_token, only: %i[submit submit_form]
 
     helper EnquiryFormHelper
 
@@ -103,7 +103,7 @@ module ProductExperience
 
     def verify_submission_token
       token_param = params[:submission_token]
-      if token_param.present? && token_param != session[:submission_token]
+      if token_param != session[:submission_token]
         redirect_to product_experience_enquiry_form_path
       end
     end

--- a/spec/controllers/product_experience/enquiry_form_controller_spec.rb
+++ b/spec/controllers/product_experience/enquiry_form_controller_spec.rb
@@ -49,13 +49,6 @@ RSpec.describe ProductExperience::EnquiryFormController, type: :controller do
         expect(response).to render_template(:form)
       end
     end
-
-    # context 'with invalid token' do
-    #   it 'redirects back to the start' do
-    #     get :form, params: { field: 'full_name', submission_token: 'wrong-token' }
-    #     expect(response).to redirect_to(product_experience_enquiry_form_path)
-    #   end
-    # end
   end
 
   describe 'POST #submit' do

--- a/spec/controllers/product_experience/enquiry_form_controller_spec.rb
+++ b/spec/controllers/product_experience/enquiry_form_controller_spec.rb
@@ -50,12 +50,12 @@ RSpec.describe ProductExperience::EnquiryFormController, type: :controller do
       end
     end
 
-    context 'with invalid token' do
-      it 'redirects back to the start' do
-        get :form, params: { field: 'full_name', submission_token: 'wrong-token' }
-        expect(response).to redirect_to(product_experience_enquiry_form_path)
-      end
-    end
+    # context 'with invalid token' do
+    #   it 'redirects back to the start' do
+    #     get :form, params: { field: 'full_name', submission_token: 'wrong-token' }
+    #     expect(response).to redirect_to(product_experience_enquiry_form_path)
+    #   end
+    # end
   end
 
   describe 'POST #submit' do
@@ -78,7 +78,7 @@ RSpec.describe ProductExperience::EnquiryFormController, type: :controller do
     end
 
     context 'with missing required field' do
-      before { post :submit, params: { field: 'full_name', full_name: '' } }
+      before { post :submit, params: { field: 'full_name', full_name: '', submission_token: submission_token } }
 
       it { expect(assigns(:alert)).to be_present }
 
@@ -86,14 +86,14 @@ RSpec.describe ProductExperience::EnquiryFormController, type: :controller do
     end
 
     context 'with invalid email' do
-      before { post :submit, params: { field: 'email_address', email_address: 'bad-email' } }
+      before { post :submit, params: { field: 'email_address', email_address: 'bad-email', submission_token: submission_token } }
 
       it { expect(assigns(:alert)).to eq('Please enter a valid email address.') }
       it { expect(response).to render_template(:form) }
     end
 
     context 'with valid submission' do
-      before { post :submit, params: { field: 'full_name', full_name: 'John Doe' } }
+      before { post :submit, params: { field: 'full_name', full_name: 'John Doe', submission_token: submission_token } }
 
       it { expect(session[:enquiry_data]['full_name']).to eq('John Doe') }
 
@@ -107,9 +107,15 @@ RSpec.describe ProductExperience::EnquiryFormController, type: :controller do
     end
 
     context 'when editing' do
-      before { post :submit, params: { field: 'query', query: 'Some question?', editing: 'true' } }
+      before { post :submit, params: { field: 'query', query: 'Some question?', editing: 'true', submission_token: submission_token } }
 
       it { expect(response).to redirect_to(product_experience_enquiry_form_check_your_answers_path) }
+    end
+
+    context 'when editing and no submission token' do
+      before { post :submit, params: { field: 'query', query: 'Some question?', editing: 'true', submission_token: nil } }
+
+      it { expect(response).to redirect_to(product_experience_enquiry_form_path) }
     end
   end
 


### PR DESCRIPTION
### Jira link

[PRDEX-161](https://transformuk.atlassian.net/browse/PRDEX-161)

### What?

I have simplified the submission session token validation process.  Form can load without a submission token but will need a valid one to submit pages to the server or else be re-directed to the start.

### Why?

I am doing this because before the token in the param is not available during form load which was making the check irrelevant thus giving a false positive.

https://github.com/user-attachments/assets/60464048-4099-4a27-b510-f3e6c1c64e0c