### PR TITLE
PRDEX-168 Enquiry Form Remove Tariff Preferences Category

### DIFF
--- a/app/helpers/enquiry_form_helper.rb
+++ b/app/helpers/enquiry_form_helper.rb
@@ -65,7 +65,6 @@ def radio_button_category_options
     ['Import Duties', 'import_duties'],
     ['Origin (Preferential and non-preferential)', 'origin'],
     ['Quotas', 'quotas'],
-    ['Tariff Preferences', 'preferences'],
     ['Stop Press Subscription', 'stop_press_subscription'],
   ]
 end


### PR DESCRIPTION
### Jira link

[PRDEX-168](https://transformuk.atlassian.net/browse/PRDEX-168)

### What?

I have removed Tariff Preferences Category from form

### Why?

I am doing this because it's not required.

<img width="405" height="501" alt="image" src="https://github.com/user-attachments/assets/7ae13a08-df9b-4fc2-a366-3489fd70a9c9" />

