### PR TITLE
HMRC-1563: Reduce ECS task resources

### DIFF
--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -1,7 +1,7 @@
 region        = "eu-west-2"
 environment   = "production"
-cpu           = 4096
-memory        = 8192
+cpu           = 2048
+memory        = 4096
 service_count = 4
 min_capacity  = 3
 max_capacity  = 16


### PR DESCRIPTION
### Jira link
[HMRC-1563](https://transformuk.atlassian.net/browse/HMRC-1563)

### What?

I have 
- Updated all ECS task definitions to reduce CPU from 4 vCPU to 2 vCPU
- Reduced memory from 8 GB to 4 GB

### Why?

I am doing this because...
- CloudWatch metrics show CPU usage averaging <30% and memory usage consistently below 21% over the last 3 months.
- This change will reduce costs while keeping enough headroom for spikes.
