### PR TITLE
Use JSON bodies in ApiEntity#create!/update to bypass Rack param limits

### DIFF
--- a/app/models/enquiry_form.rb
+++ b/app/models/enquiry_form.rb
@@ -12,9 +12,6 @@ class EnquiryForm
       },
     }
 
-    body = json_api_params.to_json
-    headers = { 'Content-Type' => 'application/json' }
-
-    super(body, headers)
+    super(json_api_params, { 'Content-Type' => 'application/json' })
   end
 end

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -88,12 +88,14 @@ private
     delegate :get, :post, to: :api
 
     def create!(params = {}, headers = {})
-      response = api.post(singular_path, params, headers)
+      request = prepare_json_request(params, headers)
+      response = api.post(singular_path, request[:body], request[:headers])
       new parse_jsonapi(response)
     end
 
     def update(params = {}, headers = {})
-      response = api.put(singular_path, params, headers)
+      request = prepare_json_request(params, headers)
+      response = api.put(singular_path, request[:body], request[:headers])
       new parse_jsonapi(response)
     end
 
@@ -273,6 +275,13 @@ private
       TariffJsonapiParser.new(resp.body).parse
     rescue TariffJsonapiParser::ParsingError
       raise UnparseableResponseError, resp
+    end
+
+    def prepare_json_request(params, headers)
+      {
+        body: MultiJson.dump(params),
+        headers: headers.merge('Content-Type' => 'application/json'),
+      }
     end
   end
 end


### PR DESCRIPTION
### What?

Refactor `ApiEntity#create!` and `ApiEntity#update` to send JSON bodies instead of form-encoded params.

Models now pass plain Ruby hashes to `create!`/`update`.

The shared logic in `ApiEntity` handles JSON encoding + headers.

This avoids Rack’s query parameter limit (4096) which was previously hit when sending large arrays (e.g. bulk commodity codes).

### Why?

Form-encoded params are unsuitable for bulk operations — they hit framework limits and are harder to work with.
By standardising JSON requests, models stay decoupled from transport details, and we can safely support large `create!`/`update` payloads (e.g. thousands of commodity codes).

This means that [Rack restrictions](https://github.com/rack/rack/blob/main/lib/rack/query_parser.rb#L43) do not need to be changed globally for large requests. 

Locally tested for MyOTT phase 1 sub/unsub. specs pass.