### PR TITLE
HMRC-1577: Ignore known errors in NR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.0
+    rev: v1.101.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -13,7 +13,7 @@ repos:
           - --hook-config=--create-file-if-not-exist=true
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: ^spec/vcr|vendor/|app/assets/images
@@ -25,12 +25,12 @@ repos:
         files: '.env.development|.env.test'
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.88.29
+    rev: v3.90.8
     hooks:
       - id: trufflehog
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.45.0
     hooks:
       - id: markdownlint-docker
         args:

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -28,6 +28,15 @@ common:
   # Logging level for log/newrelic_agent.log
   log_level: info
 
+  error_collector:
+    expected_classes:
+      - 'Faraday::ResourceNotFound'
+      - 'DutyCalculator::Errors::SessionIntegrityError'
+      - 'ActionController::InvalidAuthenticityToken'
+      - 'ArgumentError'
+      - 'Search::InvalidDate'
+      - 'ActionView::Template::Error'
+
   application_logging:
     # If `true`, all logging-related features for the agent can be enabled or disabled
     # independently. If `false`, all logging-related features are disabled.

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -33,9 +33,7 @@ common:
       - 'Faraday::ResourceNotFound'
       - 'DutyCalculator::Errors::SessionIntegrityError'
       - 'ActionController::InvalidAuthenticityToken'
-      - 'ArgumentError'
       - 'Search::InvalidDate'
-      - 'ActionView::Template::Error'
 
   application_logging:
     # If `true`, all logging-related features for the agent can be enabled or disabled


### PR DESCRIPTION
### Jira link

[HMRC-1577](https://transformuk.atlassian.net/browse/HMRC-1577)

### What?

I have 
- Added several error classes to `error_collector.expected_classes` in `newrelic.yml` so that these known or harmless exceptions are treated as expected by the New Relic Ruby agent.

### Why?

I am doing this because
- This reduces false positives in error-rate alerts while still allowing the team to triage them in the Errors Inbox.
