### PR TITLE
HMRC-1654: Improvement for presentation of absorbed commodities on XI and UK front ends

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -117,7 +117,7 @@ class CommoditiesController < GoodsNomenclaturesController
   end
 
   def show_validity_periods
-    @validity_periods = ValidityPeriod.all(goods_nomenclature_class, params[:id], query_params)
+    @validity_periods = ValidityPeriod.all(goods_nomenclature_class, params[:id], as_of: query_params[:as_of])
     @commodity_code = params[:id]
     @heading_code = params[:id].first(4)
     @chapter_code = params[:id].first(2)

--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -117,7 +117,7 @@ class CommoditiesController < GoodsNomenclaturesController
   end
 
   def show_validity_periods
-    @validity_periods = ValidityPeriod.all(goods_nomenclature_class, params[:id])
+    @validity_periods = ValidityPeriod.all(goods_nomenclature_class, params[:id], query_params)
     @commodity_code = params[:id]
     @heading_code = params[:id].first(4)
     @chapter_code = params[:id].first(2)

--- a/app/controllers/subheadings_controller.rb
+++ b/app/controllers/subheadings_controller.rb
@@ -32,8 +32,9 @@ class SubheadingsController < GoodsNomenclaturesController
   end
 
   def show_validity_periods
-    @validity_periods = ValidityPeriod.all(Subheading, params[:id])
+    @validity_periods = ValidityPeriod.all(Subheading, params[:id], query_params)
     @subheading_code = params[:id].first(10)
+    @commodity_code = @subheading_code
     @chapter_code = params[:id].first(2)
 
     @remove_country_url_option = true

--- a/app/controllers/subheadings_controller.rb
+++ b/app/controllers/subheadings_controller.rb
@@ -32,7 +32,7 @@ class SubheadingsController < GoodsNomenclaturesController
   end
 
   def show_validity_periods
-    @validity_periods = ValidityPeriod.all(Subheading, params[:id], query_params)
+    @validity_periods = ValidityPeriod.all(Subheading, params[:id], as_of: query_params[:as_of])
     @subheading_code = params[:id].first(10)
     @commodity_code = @subheading_code
     @chapter_code = params[:id].first(2)

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CommoditiesController, type: :controller do
 
         before do
           stub_api_request('commodities/0101999999/validity_periods')
-            .with(query: {as_of: Time.zone.today})
+            .with(query: { as_of: Time.zone.today })
             .and_return jsonapi_error_response(404)
         end
 
@@ -136,7 +136,7 @@ RSpec.describe CommoditiesController, type: :controller do
               vcr: { cassette_name: 'commodities#show_0101999999' } do
         before do
           stub_api_request("commodities/#{commodity_id}/validity_periods")
-            .with(query: {as_of: Time.zone.today})
+            .with(query: { as_of: Time.zone.today })
             .to_return jsonapi_response(:validity_periods, validity_periods)
 
           TradeTariffFrontend::ServiceChooser.service_choice = nil
@@ -156,7 +156,7 @@ RSpec.describe CommoditiesController, type: :controller do
               vcr: { cassette_name: 'commodities#show_0101999999' } do
         before do
           stub_api_request("commodities/#{commodity_id}/validity_periods")
-            .with(query: {as_of: Time.zone.today})
+            .with(query: { as_of: Time.zone.today })
             .to_return jsonapi_error_response(404)
 
           TradeTariffFrontend::ServiceChooser.service_choice = nil
@@ -174,7 +174,7 @@ RSpec.describe CommoditiesController, type: :controller do
 
         before do
           stub_api_request("commodities/#{commodity_id}/validity_periods")
-            .with(query: {as_of: '2000-01-01'})
+            .with(query: { as_of: '2000-01-01' })
             .to_return jsonapi_response(:validity_periods, validity_periods)
 
           TradeTariffFrontend::ServiceChooser.service_choice = nil

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe CommoditiesController, type: :controller do
 
         before do
           stub_api_request('commodities/0101999999/validity_periods')
+            .with(query: {as_of: Time.zone.today})
             .and_return jsonapi_error_response(404)
         end
 
@@ -135,6 +136,7 @@ RSpec.describe CommoditiesController, type: :controller do
               vcr: { cassette_name: 'commodities#show_0101999999' } do
         before do
           stub_api_request("commodities/#{commodity_id}/validity_periods")
+            .with(query: {as_of: Time.zone.today})
             .to_return jsonapi_response(:validity_periods, validity_periods)
 
           TradeTariffFrontend::ServiceChooser.service_choice = nil
@@ -154,6 +156,7 @@ RSpec.describe CommoditiesController, type: :controller do
               vcr: { cassette_name: 'commodities#show_0101999999' } do
         before do
           stub_api_request("commodities/#{commodity_id}/validity_periods")
+            .with(query: {as_of: Time.zone.today})
             .to_return jsonapi_error_response(404)
 
           TradeTariffFrontend::ServiceChooser.service_choice = nil
@@ -171,6 +174,7 @@ RSpec.describe CommoditiesController, type: :controller do
 
         before do
           stub_api_request("commodities/#{commodity_id}/validity_periods")
+            .with(query: {as_of: '2000-01-01'})
             .to_return jsonapi_response(:validity_periods, validity_periods)
 
           TradeTariffFrontend::ServiceChooser.service_choice = nil

--- a/spec/requests/subheadings_controller_spec.rb
+++ b/spec/requests/subheadings_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SubheadingsController, type: :request do
     context 'when the validity periods are present' do
       before do
         stub_api_request('subheadings/0101999999-80/validity_periods')
-          .with(query: {as_of: Time.zone.today})
+          .with(query: { as_of: Time.zone.today })
           .to_return jsonapi_response(:validity_periods, validity_periods)
 
         get subheading_path('0101999999-80')
@@ -44,7 +44,7 @@ RSpec.describe SubheadingsController, type: :request do
     context 'when the validity periods returns not found' do
       before do
         stub_api_request('subheadings/0101999999-80/validity_periods')
-          .with(query: {as_of: Time.zone.today})
+          .with(query: { as_of: Time.zone.today })
           .to_return jsonapi_not_found_response
 
         get subheading_path('0101999999-80')

--- a/spec/requests/subheadings_controller_spec.rb
+++ b/spec/requests/subheadings_controller_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe SubheadingsController, type: :request do
     context 'when the validity periods are present' do
       before do
         stub_api_request('subheadings/0101999999-80/validity_periods')
+          .with(query: {as_of: Time.zone.today})
           .to_return jsonapi_response(:validity_periods, validity_periods)
 
         get subheading_path('0101999999-80')
@@ -43,6 +44,7 @@ RSpec.describe SubheadingsController, type: :request do
     context 'when the validity periods returns not found' do
       before do
         stub_api_request('subheadings/0101999999-80/validity_periods')
+          .with(query: {as_of: Time.zone.today})
           .to_return jsonapi_not_found_response
 
         get subheading_path('0101999999-80')


### PR DESCRIPTION
### Jira link

[HMRC-1654](https://transformuk.atlassian.net/browse/HMRC-1654)

### What?

I have add as_of date to validity period request as a parameter

### Why?

I am doing this because the date is needed to fetch the description of good nomenclature origin that valid in future date.
