### PR TITLE
Add authentication to subscriptions

### DIFF
--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -13,7 +13,7 @@ module Myott
     end
 
     def current_user
-      @current_user ||= User.find(cookies[:id_token])
+      @current_user ||= User.find(nil, cookies[:id_token])
     end
     helper_method :current_user
 

--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -13,12 +13,16 @@ module Myott
     end
 
     def current_user
-      @current_user ||= User.find(nil, cookies[:id_token])
+      @current_user ||= User.find(nil, user_id_token)
     end
     helper_method :current_user
 
     def current_subscription
-      @current_subscription ||= Subscription.find(params[:id])
+      @current_subscription ||= Subscription.find(params[:id], user_id_token)
+    end
+
+    def user_id_token
+      cookies[:id_token]
     end
   end
 end

--- a/app/models/concerns/authenticatable_api_entity.rb
+++ b/app/models/concerns/authenticatable_api_entity.rb
@@ -1,0 +1,20 @@
+module AuthenticatableApiEntity
+  extend ActiveSupport::Concern
+  include UkOnlyApiEntity
+
+  module ClassMethods
+    def find(id, token)
+      return nil if token.nil? && !Rails.env.development?
+
+      super(id, {}, headers(token))
+    rescue Faraday::UnauthorizedError
+      nil
+    end
+
+    def headers(token)
+      {
+        authorization: "Bearer #{token}",
+      }
+    end
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,5 +1,5 @@
 class Subscription
-  include ApiEntity
+  include AuthenticatableApiEntity
 
   set_singular_path '/uk/user/subscriptions/:id'
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,17 +1,9 @@
 class User
-  include UkOnlyApiEntity
+  include AuthenticatableApiEntity
 
   set_singular_path '/uk/user/users'
 
   attr_accessor :email, :chapter_ids, :stop_press_subscription
-
-  def self.find(token)
-    return nil if token.nil? && !Rails.env.development?
-
-    super(nil, {}, headers(token))
-  rescue Faraday::UnauthorizedError
-    nil
-  end
 
   def self.update(token, attributes)
     return nil if token.nil? && !Rails.env.development?
@@ -24,11 +16,5 @@ class User
     super(json_api_params, headers(token))
   rescue Faraday::UnauthorizedError
     nil
-  end
-
-  def self.headers(token)
-    {
-      authorization: "Bearer #{token}",
-    }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe User do
   describe '.find' do
-    subject(:response) { described_class.find(token) }
+    subject(:response) { described_class.find(nil, token) }
 
     let(:token) { 'valid jwt' }
 


### PR DESCRIPTION
### What?

Adds a concern - AuthenticatableApiEntity - so that authentication with a bearer token can be used with more models.

### Why?

Access to subscriptions needs to be authenticated.
