### PR TITLE
HMRC-1766: Increased number of min tasks

### DIFF
--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -3,5 +3,5 @@ environment   = "production"
 cpu           = 2048
 memory        = 4096
 service_count = 4
-min_capacity  = 3
+min_capacity  = 4
 max_capacity  = 16


### PR DESCRIPTION
### Jira link

[HMRC-1766](https://transformuk.atlassian.net/browse/HMRC-1766)

### What?

Increase the minimum task count for the ECS Service from 3 to 4 to assess impact on CPU utilization and application performance.

### Why?

I am doing this because...
- Our production ECS service is experiencing sustained high CPU utilization during peak hours
- Current metrics show CPU regularly reaching 90-100% utilization, causing potential performance degradation
