### PR TITLE
MyOTT-244 Implement Commodity Codes Extraction Service

### DIFF
--- a/app/services/commodity_codes_extraction_service.rb
+++ b/app/services/commodity_codes_extraction_service.rb
@@ -1,0 +1,46 @@
+class CommodityCodesExtractionService
+  Result = Struct.new(:success?, :codes, :error_message)
+
+  VALID_FILE_TYPES = [
+    'text/csv',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ].freeze
+
+  def initialize(file)
+    @file = file
+  end
+
+  def call
+    return Result.new(false, [], 'Please upload a file using the Choose file button or drag and drop.') if @file.blank?
+
+    unless VALID_FILE_TYPES.include?(@file.content_type)
+      return Result.new(false, [], 'Please upload a csv/excel file')
+    end
+
+    codes = extract_codes_from_file(@file)
+
+    if codes.blank?
+      return Result.new(false, [], 'No commodities uploaded, please ensure valid commodity codes are in column A')
+    end
+
+    Result.new(true, codes, nil)
+  end
+
+  private
+
+  def extract_codes_from_file(file)
+    rows =
+      case file.content_type
+      when 'text/csv'
+        CSV.parse(file.read).map { |row| row[0] }
+      else
+        Roo::Spreadsheet.open(file).sheet(0).map { |row| row[0] }
+      end
+
+    rows.filter_map do |value|
+      code = value.to_s.gsub(/[^0-9]/, '')
+      code if code.present? && code.length.between?(1, 20)
+    end
+  end
+end

--- a/spec/controllers/myott/mycommodities_controller_spec.rb
+++ b/spec/controllers/myott/mycommodities_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
         end
 
         it 'sets an alert' do
-          expect(assigns(:alert)).to eq('please upload a csv/excel file')
+          expect(assigns(:alert)).to eq('Please upload a csv/excel file')
         end
 
         it 'renders the new template again' do

--- a/spec/services/commodity_codes_extraction_service_spec.rb
+++ b/spec/services/commodity_codes_extraction_service_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+RSpec.describe CommodityCodesExtractionService do
+  subject(:result) { described_class.new(file).call }
+
+  describe '#call' do
+    context 'when file is nil' do
+      let(:file) { nil }
+
+      it { is_expected.not_to be_success }
+      it { expect(result.codes).to eq([]) }
+      it { expect(result.error_message).to eq('Please upload a file using the Choose file button or drag and drop.') }
+    end
+
+    context 'when the file type is invalid' do
+      let(:file) do
+        fixture_file_upload(
+          'myott/mycommodities_files/invalid_file_type.txt',
+          'text/plain',
+        )
+      end
+
+      it { is_expected.not_to be_success }
+      it { expect(result.codes).to eq([]) }
+      it { expect(result.error_message).to eq('Please upload a csv/excel file') }
+    end
+
+    context 'when the file is a valid CSV with valid codes' do
+      let(:file) do
+        fixture_file_upload(
+          'myott/mycommodities_files/valid_csv_file.csv',
+          'text/csv',
+        )
+      end
+
+      it { is_expected.to be_success }
+      it { expect(result.error_message).to be_nil }
+      it { expect(result.codes).not_to be_empty }
+      it { expect(result.codes).to all(be_a(String)) }
+    end
+
+    context 'when the CSV contains no valid commodity codes' do
+      let(:file) do
+        fixture_file_upload(
+          'myott/mycommodities_files/invalid_csv_file.csv',
+          'text/csv',
+        )
+      end
+
+      it { is_expected.not_to be_success }
+      it { expect(result.codes).to eq([]) }
+      it { expect(result.error_message).to eq('No commodities uploaded, please ensure valid commodity codes are in column A') }
+    end
+
+    context 'when the file is a valid Excel file with valid codes' do
+      let(:file) do
+        fixture_file_upload(
+          'myott/mycommodities_files/valid_excel_file.xlsx',
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
+      end
+
+      it { is_expected.to be_success }
+      it { expect(result.error_message).to be_nil }
+      it { expect(result.codes).not_to be_empty }
+      it { expect(result.codes).to all(be_a(String)) }
+    end
+
+    context 'when Excel contains no valid commodity codes' do
+      let(:file) do
+        fixture_file_upload(
+          'myott/mycommodities_files/invalid_excel_file.xlsx',
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
+      end
+
+      it { is_expected.not_to be_success }
+      it { expect(result.codes).to eq([]) }
+      it { expect(result.error_message).to eq('No commodities uploaded, please ensure valid commodity codes are in column A') }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[MyOTT-244](https://transformuk.atlassian.net/browse/MyOTT-244)

### What?

I have refactored `extract_codes_from_file` into a service

### Why?

I am doing this because the function should be separated from the `my_commodities_controller`.
