### PR TITLE
MyOTT-245 Remove subscription_type From Subscription.Batch API

### DIFF
--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -55,8 +55,7 @@ module Myott
 
       Subscription.batch(subscription_id,
                          user_id_token,
-                         targets: TariffJsonapiParser.new(commodity_codes.uniq).parse,
-                         subscription_type: 'my_commodities')
+                         targets: TariffJsonapiParser.new(commodity_codes.uniq).parse)
     end
 
     def get_subscription_targets(category)

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe ApiEntity do
   describe '#batch' do
     subject(:result) do
       mock_entity.batch(
-        { targets: %w[1234567890 1234567891], subscription_type: 'my_commodities' },
+        { targets: %w[1234567890 1234567891] },
         { authorization: 'Bearer abc123' },
       )
     end

--- a/spec/support/shared_examples/a_valid_commodity_file_upload.rb
+++ b/spec/support/shared_examples/a_valid_commodity_file_upload.rb
@@ -21,7 +21,6 @@ RSpec.shared_examples 'a valid commodity file upload' do |fixture_path, content_
       token,
       hash_including(
         targets: kind_of(Array),
-        subscription_type: 'my_commodities',
       ),
     )
   end


### PR DESCRIPTION
### Jira link

[MyOTT-245](https://transformuk.atlassian.net/browse/MyOTT-245)

### What?

I have removed

- [x] `subscription_type` parameter from `Subscription.batch` API.

### Why?

I am doing this because:

- `subscription_type` is unique to `subscription_id` by default so parameter is therefore redundant.