### PR TITLE
Extract commodity counts logic and partial

### DIFF
--- a/app/views/myott/mycommodities/_meta.html.erb
+++ b/app/views/myott/mycommodities/_meta.html.erb
@@ -1,0 +1,43 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">Total commodities uploaded: <%= number_with_delimiter(meta.total) %></h2>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= link_to "Upload and update commodities", new_myott_mycommodity_path, class: "govuk-button govuk-!-margin-top-4" %>
+  </div>
+</div>
+<div class="govuk-grid-row summary_background">
+  <div class="govuk-grid-column-one-third">
+    <div class='summary_container'>
+      <strong>Active commodities:</strong>
+      <br />
+      <% if meta.active.zero? %>
+        0
+      <% else %>
+        <%= link_to number_with_delimiter(meta.active), active_myott_mycommodities_path %>
+      <% end %>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div class="summary_container">
+      <strong>Expired commodity codes:</strong>
+      <br />
+        <% if meta.expired.zero? %>
+        0
+      <% else %>
+        <%= link_to number_with_delimiter(meta.expired), expired_myott_mycommodities_path %>
+      <% end %>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div class="summary_container">
+      <strong>Upload errors:</strong>
+      <br />
+      <% if meta.invalid.zero? %>
+        0
+      <% else %>
+        <%= link_to number_with_delimiter(meta.invalid), invalid_myott_mycommodities_path %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/myott/mycommodities/index.html.erb
+++ b/app/views/myott/mycommodities/index.html.erb
@@ -3,49 +3,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">Your commodity watchlist</h1>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-heading-m">Total commodities uploaded: <%= number_with_delimiter(@total_commodity_codes, :delimeter => ',') %></h2>
-        </div>
-        <div class="govuk-grid-column-one-third">
-          <%= link_to "Upload and update commodities", new_myott_mycommodity_path, class: "govuk-button govuk-!-margin-top-4" %>
-        </div>
-      </div>
-      <div class="govuk-grid-row summary_background">
-        <div class="govuk-grid-column-one-third">
-          <div class='summary_container'>
-            <strong>Active commodities:</strong>
-            <br />
-            <% if @active_commodity_codes.count == 0 %>
-              0
-            <% else %>
-              <%= link_to  number_with_delimiter(@active_commodity_codes.count, :delimeter => ','), active_myott_mycommodities_path %>
-            <% end %>
-          </div>
-        </div>
-        <div class="govuk-grid-column-one-third">
-          <div class="summary_container">
-            <strong>Expired commodity codes:</strong>
-            <br />
-             <% if @expired_commodity_codes.count == 0 %>
-              0
-            <% else %>
-              <%= link_to number_with_delimiter(@expired_commodity_codes.count, :delimeter => ','), expired_myott_mycommodities_path %>
-            <% end %>
-          </div>
-        </div>
-        <div class="govuk-grid-column-one-third">
-          <div class="summary_container">
-            <strong>Upload errors:</strong>
-            <br />
-            <% if @invalid_commodity_codes.count == 0 %>
-              0
-            <% else %>
-              <%= link_to number_with_delimiter(@invalid_commodity_codes.count, :delimeter => ','), invalid_myott_mycommodities_path %>
-            <% end %>
-          </div>
-        </div>
-      </div>
+      <%= render partial: 'meta', locals: { meta: @meta } %>
     </div>
   </div>
 </div>

--- a/spec/controllers/myott/mycommodities_controller_spec.rb
+++ b/spec/controllers/myott/mycommodities_controller_spec.rb
@@ -71,9 +71,10 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
 
         it { is_expected.to respond_with(:success) }
 
-        it { expect(assigns(:active_commodity_codes)).to eq(subscription.meta[:active]) }
-        it { expect(assigns(:expired_commodity_codes)).to eq(subscription.meta[:expired]) }
-        it { expect(assigns(:invalid_commodity_codes)).to eq(subscription.meta[:invalid]) }
+        it { expect(assigns(:meta).total).to eq(subscription.meta.values.flatten.size) }
+        it { expect(assigns(:meta).active).to eq(subscription.meta[:active].count) }
+        it { expect(assigns(:meta).expired).to eq(subscription.meta[:expired].count) }
+        it { expect(assigns(:meta).invalid).to eq(subscription.meta[:invalid].count) }
       end
 
       context 'when user does not have a my commodities subscription' do


### PR DESCRIPTION
### What?

- Moves loading of subscription into a single method
- Moves view into a partial
- Uses 1 instance variable to hold all counts of commodities in the various buckets

### Why?

Simplifying the index action before adding more components to this page.
