### PR TITLE
MyOTT-243 Refactor hierarchical_description to classification_description

### DIFF
--- a/app/models/subscription_target.rb
+++ b/app/models/subscription_target.rb
@@ -4,7 +4,7 @@ class SubscriptionTarget
   attr_accessor :target_type,
                 :chapter_short_code,
                 :goods_nomenclature_item_id,
-                :hierarchical_description,
+                :classification_description,
                 :meta
 
   def self.all(id, token, params)

--- a/app/views/myott/mycommodities/list.html.erb
+++ b/app/views/myott/mycommodities/list.html.erb
@@ -43,7 +43,7 @@
                 </div>
               </td>
                <td class="govuk-table__cell">
-                <%= commodity.try(:hierarchical_description) %>
+                <%= commodity.try(:classification_description) %>
               </td>
             </tr>
           <% end %>

--- a/spec/factories/subscription_target_factory.rb
+++ b/spec/factories/subscription_target_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     target_type { 'my_commodities' }
     chapter_short_code { '11' }
     goods_nomenclature_item_id { '1234567890' }
-    hierarchical_description { 'Food and Tobacco' }
+    classification_description { 'Food and Tobacco' }
     meta do
       {
         pagination: {


### PR DESCRIPTION
### Jira link

[MyOTT-243](https://transformuk.atlassian.net/browse/MyOTT-243)

### What?

I have renamed `hierarchical_description` to `classification_description`.

### Why?

I am doing this because it replicates `classifiable.rb` for MyOTT

<img width="771" height="780" alt="image" src="https://github.com/user-attachments/assets/6d3c94c1-620b-4053-b039-be4392e40594" />