### PR TITLE
HMRC-1766: Return number of min tasks back to 3

### DIFF
--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -3,5 +3,5 @@ environment   = "production"
 cpu           = 2048
 memory        = 4096
 service_count = 4
-min_capacity  = 4
+min_capacity  = 3
 max_capacity  = 16


### PR DESCRIPTION
### Jira link

[HMRC-1766](https://transformuk.atlassian.net/browse/HMRC-1766)

### What?

- Reduced ECS service minimum task count from 4 to 3
- Reverts the capacity increase from [HMRC-1766](https://github.com/trade-tariff/trade-tariff-frontend/pull/2599)

### Why?

Analysis of CPU utilisation metrics reveals that:
- Persistent load imbalance - Max CPU vs Average CPU gap remained

I will test another approach by reducing the auto-scaling policy threshold from 75% to 65% 