### PR TITLE
HMRC-1769: NoMethodError in frontend

### DIFF
--- a/app/models/duty_calculator/steps/import_date.rb
+++ b/app/models/duty_calculator/steps/import_date.rb
@@ -30,7 +30,7 @@ module DutyCalculator
       end
 
       def import_date
-        super || user_session.import_date
+        super || user_session.import_date || Time.zone.now.strftime('%Y-%m-%d')
       end
 
       def save!


### PR DESCRIPTION
### Jira link

[HMRC-1769](https://transformuk.atlassian.net/browse/HMRC-1769)

### What?

I have added default import_date value to duty calculator

### Why?

I am doing this because, invalid session cause NoMethodError in import_date 
