### PR TITLE
MYOTT-234 Add commodity changes to dashboard

### DIFF
--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -21,6 +21,7 @@ module Myott
 
       @meta = metadata_from_subscription
       @grouped_measure_changes = TariffChanges::GroupedMeasureChange.all(user_id_token, { as_of: as_of.strftime('%Y-%m-%d') })
+      @commodity_changes = TariffChanges::CommodityChange.all(user_id_token, { as_of: as_of.strftime('%Y-%m-%d') })
     end
 
     def create

--- a/app/models/concerns/authenticatable_api_entity.rb
+++ b/app/models/concerns/authenticatable_api_entity.rb
@@ -11,6 +11,16 @@ module AuthenticatableApiEntity
       nil
     end
 
+    def all(token, params = {})
+      if token.nil? && !Rails.env.development?
+        return []
+      end
+
+      collection(collection_path, params, headers(token))
+    rescue Faraday::UnauthorizedError
+      []
+    end
+
     def headers(token)
       {
         authorization: "Bearer #{token}",

--- a/app/models/tariff_changes/commodity_change.rb
+++ b/app/models/tariff_changes/commodity_change.rb
@@ -1,0 +1,9 @@
+module TariffChanges
+  class CommodityChange
+    include AuthenticatableApiEntity
+
+    set_collection_path '/uk/user/commodity_changes'
+
+    attr_accessor :description, :count
+  end
+end

--- a/app/views/myott/mycommodities/_commodity_changes.html.erb
+++ b/app/views/myott/mycommodities/_commodity_changes.html.erb
@@ -1,0 +1,26 @@
+<h4 class="govuk-heading-s">Changes to your commodities</h4>
+
+<% if changes.empty? %>
+  <p class="govuk-body">No changes to commodities on this date</p>
+<% else %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">Change type</th>
+        <th class="govuk-table__header">Commodities Affected</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+        <% changes.each do |change| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= change.description %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= change.count %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/myott/mycommodities/_grouped_measure_changes.html.erb
+++ b/app/views/myott/mycommodities/_grouped_measure_changes.html.erb
@@ -1,6 +1,6 @@
 <h4 class="govuk-heading-s">Changes to your measures</h4>
 
-<% if @grouped_measure_changes.empty? %>
+<% if changes.empty? %>
   <p class="govuk-body">No changes to measure on this date</p>
 <% else %>
   <table class="govuk-table">
@@ -12,7 +12,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-        <% @grouped_measure_changes.each do |change| %>
+        <% changes.each do |change| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
             <%= change.trade_direction.capitalize %>

--- a/app/views/myott/mycommodities/index.html.erb
+++ b/app/views/myott/mycommodities/index.html.erb
@@ -9,7 +9,9 @@
         <h2 class="govuk-heading-l">Changes affecting your commodity watchlist:</h2>
         <h3 class="govuk-heading-m">Changes published: <%= as_of.strftime("%d/%m/%Y") %></h3>
 
-        <%= render partial: 'grouped_measure_changes', locals: { grouped_measure_changes: @grouped_measure_changes } %>
+        <%= render partial: 'commodity_changes', locals: { changes: @commodity_changes } %>
+
+        <%= render partial: 'grouped_measure_changes', locals: { changes: @grouped_measure_changes } %>
       </div>
     </div>
   </div>

--- a/spec/controllers/myott/mycommodities_controller_spec.rb
+++ b/spec/controllers/myott/mycommodities_controller_spec.rb
@@ -66,9 +66,11 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
 
       context 'when commodity codes are present' do
         let(:grouped_measure_changes) { [TariffChanges::GroupedMeasureChange.new] }
+        let(:commodity_changes) { [TariffChanges::CommodityChange.new] }
 
         before do
           allow(TariffChanges::GroupedMeasureChange).to receive(:all).and_return(grouped_measure_changes)
+          allow(TariffChanges::CommodityChange).to receive(:all).and_return(commodity_changes)
           get :index
         end
 
@@ -81,6 +83,10 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
 
         it 'assigns @grouped_measure_changes' do
           expect(assigns(:grouped_measure_changes)).to eq(grouped_measure_changes)
+        end
+
+        it 'assigns @commodity_changes' do
+          expect(assigns(:commodity_changes)).to eq(commodity_changes)
         end
       end
 

--- a/spec/factories/commodity_change_factory.rb
+++ b/spec/factories/commodity_change_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :commodity_change, class: 'TariffChanges::CommodityChange' do
+    resource_id { 'commodity_endings' }
+    description { 'Changes to end date' }
+    count { 3 }
+  end
+end

--- a/spec/models/tariff_changes/commodity_change_spec.rb
+++ b/spec/models/tariff_changes/commodity_change_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+
+RSpec.describe TariffChanges::CommodityChange do
+  let(:token) { 'valid_token' }
+  let(:params) { {} }
+  let(:collection_path) { '/uk/user/commodity_changes' }
+  let(:headers) { { authorization: "Bearer #{token}" } }
+
+  describe '.all' do
+    context 'when token is provided' do
+      let(:collection_data) do
+        [
+          build(:commodity_change),
+          build(:commodity_change, description: 'Changes to classification'),
+        ]
+      end
+
+      before do
+        allow(described_class).to receive_messages(
+          collection: collection_data,
+          headers: headers,
+        )
+      end
+
+      it 'calls collection with correct parameters' do
+        described_class.all(token, params)
+
+        expect(described_class).to have_received(:collection)
+          .with(collection_path, params, headers)
+      end
+
+      it 'returns an array' do
+        result = described_class.all(token, params)
+        expect(result).to be_an(Array)
+      end
+    end
+
+    context 'when token is nil and not in development environment' do
+      before do
+        allow(Rails.env).to receive(:development?).and_return(false)
+      end
+
+      it 'returns empty array' do
+        result = described_class.all(nil, params)
+        expect(result).to eq([])
+      end
+
+      it 'does not call collection method' do
+        allow(described_class).to receive(:collection)
+        described_class.all(nil, params)
+        expect(described_class).not_to have_received(:collection)
+      end
+    end
+
+    context 'when token is nil but in development environment' do
+      let(:collection_data) { [] }
+
+      before do
+        allow(Rails.env).to receive(:development?).and_return(true)
+        allow(described_class).to receive_messages(
+          collection: collection_data,
+          headers: headers,
+        )
+      end
+
+      it 'calls collection method' do
+        described_class.all(nil, params)
+        expect(described_class).to have_received(:collection)
+      end
+    end
+
+    context 'when Faraday::UnauthorizedError is raised' do
+      before do
+        allow(described_class).to receive(:collection).and_raise(Faraday::UnauthorizedError)
+        allow(described_class).to receive(:headers).and_return(headers)
+      end
+
+      it 'returns empty array' do
+        result = described_class.all(token, params)
+        expect(result).to eq([])
+      end
+    end
+
+    context 'with date parameter' do
+      let(:date) { Date.current }
+      let(:params) { { as_of: date } }
+      let(:collection_data) { [] }
+
+      before do
+        allow(described_class).to receive_messages(
+          collection: collection_data,
+          headers: headers,
+        )
+      end
+
+      it 'passes date parameter to collection' do
+        described_class.all(token, params)
+        expect(described_class).to have_received(:collection)
+          .with(collection_path, params, headers)
+      end
+    end
+  end
+end

--- a/spec/views/myott/mycommodities/_commodity_changes.html.erb_spec.rb
+++ b/spec/views/myott/mycommodities/_commodity_changes.html.erb_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe 'myott/mycommodities/_commodity_changes.html.erb', type: :view do
+  let(:change) do
+    build(:commodity_change, description: 'test description', count: 10)
+  end
+
+  before do
+    assign(:commodity_change, [change])
+    allow(view).to receive(:params).and_return(as_of: '2025-11-21')
+    render partial: 'myott/mycommodities/commodity_changes', locals: { changes: [change] }
+  end
+
+  it 'renders the description' do
+    expect(rendered).to match(/test description/)
+  end
+
+  it 'renders the count' do
+    expect(rendered).to match(/10/)
+  end
+end

--- a/spec/views/myott/mycommodities/_grouped_measure_changes.html.erb_spec.rb
+++ b/spec/views/myott/mycommodities/_grouped_measure_changes.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'myott/mycommodities/_grouped_measure_changes.html.erb', type: :v
     allow(change).to receive(:geographical_area_description).and_return('United Kingdom')
     assign(:grouped_measure_changes, [change])
     allow(view).to receive(:params).and_return(as_of: '2025-11-21')
-    render partial: 'myott/mycommodities/grouped_measure_changes', locals: { grouped_measure_changes: [change] }
+    render partial: 'myott/mycommodities/grouped_measure_changes', locals: { changes: [change] }
   end
 
   it 'renders the trade direction' do


### PR DESCRIPTION
### Jira link

[MYOTT-234](https://transformuk.atlassian.net/browse/MYOTT-234)

### What?

Adds summary information about commodity changes for a particular day (defaults to yesterday).

### Why?

Informs users about changes to commodities they are watching.
