### PR TITLE
BAU_ : enable request parameters in new relic

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -13,12 +13,11 @@
 common:
   &default_settings # Required license key associated with your New Relic account.
   attributes:
-    error_collector:
-      include:
-        - request.parameters.*
-      exclude:
-        - request.parameters.password
-        - request.parameters.token
+    include:
+      - request.parameters.*
+    exclude:
+      - request.parameters.password
+      - request.parameters.token
   license_key: <%= ENV['NEW_RELIC_LICENSE_KEY'] %>
 
   # Your application name. Renaming here affects where data displays in New


### PR DESCRIPTION
### Jira link

[BAU_]

### What?

I have enables request parameters collector in new relic agent

### Why?

I am doing this because we need to see user parameters in error logs to understant what cause any parameter related errors
