### PR TITLE
BAU_ : disable unnecessary request parameters in new relic

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -18,6 +18,13 @@ common:
     exclude:
       - request.parameters.password
       - request.parameters.token
+    transaction_events:
+      exclude: request.parameters.*
+    transaction_tracer:
+      exclude: request.parameters.*
+    span_events:
+      exclude: request.parameters.*
+
   license_key: <%= ENV['NEW_RELIC_LICENSE_KEY'] %>
 
   # Your application name. Renaming here affects where data displays in New


### PR DESCRIPTION
### Jira link

[BAU_]

### What?

I have disabled request parameters in all other than errors in new relic agent

### Why?

I am doing this because we need to see user parameters in error logs to understant what cause any parameter related errors
