### PR TITLE
HMRC-1793: CC 8409990035 issue when entering date 4th January 2025 show 1st April 2025

### DIFF
--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -8,7 +8,7 @@ module CacheHelper
       'commodities#show',
       cache_key,
       meursing_lookup_result.meursing_additional_code_id,
-      params.values.compact.map(&:to_s).sort.join('/'),
+      params.to_unsafe_h.sort.map { |_, v| v }.compact.join('/'),
     ].compact
   end
 end

--- a/spec/helpers/cache_helper_spec.rb
+++ b/spec/helpers/cache_helper_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe CacheHelper, type: :helper do
+  describe '#commodity_cache_key' do
+    let(:cacheable) do
+      Class.new do
+        include CacheHelper
+        attr_accessor :tariff_last_updated
+
+        def initialize(last_updated)
+          @tariff_last_updated = last_updated
+        end
+      end
+    end
+
+    subject(:instance) { cacheable.new("2025-01-01") }
+
+    before do
+      allow(TradeTariffFrontend::ServiceChooser).to receive(:cache_prefix).and_return('uk')
+      allow(TradeTariffFrontend).to receive(:revision).and_return('1')
+      allow(instance).to receive(:meursing_lookup_result).and_return(double(meursing_additional_code_id: "100"))
+      allow(instance).to receive(:params).and_return(ActionController::Parameters.new(params_hash))
+    end
+
+    context 'when date params are available, builds the correct commodity cache key' do
+      let(:params_hash) { {day: '04', month: '01', year: '2025', id: '2008605010'} }
+
+      it { expect(instance.commodity_cache_key).to eq(%W[commodities#show uk/2025-01-01/1 100 04/2008605010/01/2025]) }
+    end
+
+    context 'when date and month swapped for subsequent requests, cache keys are different' do
+      let(:params_hash) { {day: '01', month: '04', year: '2025', id: '2008605010'} }
+
+      it { expect(instance.commodity_cache_key).to eq(%W[commodities#show uk/2025-01-01/1 100 01/2008605010/04/2025]) }
+    end
+  end
+end

--- a/spec/helpers/cache_helper_spec.rb
+++ b/spec/helpers/cache_helper_spec.rb
@@ -1,14 +1,13 @@
 RSpec.describe CacheHelper, type: :helper do
   describe '#commodity_cache_key' do
-    subject(:instance) { cacheable.new('2025-01-01') }
-
     let(:cacheable) do
       Class.new do
         include CacheHelper
-        attr_accessor :tariff_last_updated
+        attr_accessor :tariff_last_updated, :params
 
-        def initialize(last_updated)
+        def initialize(last_updated, params_hash)
           @tariff_last_updated = last_updated
+          @params = ActionController::Parameters.new(params_hash)
         end
 
         def meursing_lookup_result
@@ -20,19 +19,19 @@ RSpec.describe CacheHelper, type: :helper do
     before do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:cache_prefix).and_return('uk')
       allow(TradeTariffFrontend).to receive(:revision).and_return('1')
-      allow(instance).to receive(:params).and_return(ActionController::Parameters.new(params_hash))
     end
 
     context 'when date params are available, builds the correct commodity cache key' do
-      let(:params_hash) { { day: '04', month: '01', year: '2025', id: '2008605010' } }
+      let(:instance) { cacheable.new('2025-01-01', { day: '04', month: '01', year: '2025', id: '2008605010' }) }
 
       it { expect(instance.commodity_cache_key).to eq(%w[commodities#show uk/2025-01-01/1 100 04/2008605010/01/2025]) }
     end
 
     context 'when date and month swapped for subsequent requests, cache keys are different' do
-      let(:params_hash) { { day: '01', month: '04', year: '2025', id: '2008605010' } }
+      let(:instance) { cacheable.new('2025-01-01', { day: '04', month: '01', year: '2025', id: '2008605010' }) }
+      let(:instance2) { cacheable.new('2025-01-01', { day: '01', month: '04', year: '2025', id: '2008605010' }) }
 
-      it { expect(instance.commodity_cache_key).to eq(%w[commodities#show uk/2025-01-01/1 100 01/2008605010/04/2025]) }
+      it { expect(instance.commodity_cache_key).not_to eq(instance2.commodity_cache_key) }
     end
   end
 end

--- a/spec/helpers/cache_helper_spec.rb
+++ b/spec/helpers/cache_helper_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe CacheHelper, type: :helper do
   describe '#commodity_cache_key' do
+    subject(:instance) { cacheable.new('2025-01-01') }
+
     let(:cacheable) do
       Class.new do
         include CacheHelper
@@ -8,28 +10,29 @@ RSpec.describe CacheHelper, type: :helper do
         def initialize(last_updated)
           @tariff_last_updated = last_updated
         end
+
+        def meursing_lookup_result
+          MeursingLookup::Result.new(meursing_additional_code_id: '100')
+        end
       end
     end
-
-    subject(:instance) { cacheable.new("2025-01-01") }
 
     before do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:cache_prefix).and_return('uk')
       allow(TradeTariffFrontend).to receive(:revision).and_return('1')
-      allow(instance).to receive(:meursing_lookup_result).and_return(double(meursing_additional_code_id: "100"))
       allow(instance).to receive(:params).and_return(ActionController::Parameters.new(params_hash))
     end
 
     context 'when date params are available, builds the correct commodity cache key' do
-      let(:params_hash) { {day: '04', month: '01', year: '2025', id: '2008605010'} }
+      let(:params_hash) { { day: '04', month: '01', year: '2025', id: '2008605010' } }
 
-      it { expect(instance.commodity_cache_key).to eq(%W[commodities#show uk/2025-01-01/1 100 04/2008605010/01/2025]) }
+      it { expect(instance.commodity_cache_key).to eq(%w[commodities#show uk/2025-01-01/1 100 04/2008605010/01/2025]) }
     end
 
     context 'when date and month swapped for subsequent requests, cache keys are different' do
-      let(:params_hash) { {day: '01', month: '04', year: '2025', id: '2008605010'} }
+      let(:params_hash) { { day: '01', month: '04', year: '2025', id: '2008605010' } }
 
-      it { expect(instance.commodity_cache_key).to eq(%W[commodities#show uk/2025-01-01/1 100 01/2008605010/04/2025]) }
+      it { expect(instance.commodity_cache_key).to eq(%w[commodities#show uk/2025-01-01/1 100 01/2008605010/04/2025]) }
     end
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-1793](https://transformuk.atlassian.net/browse/HMRC-1793)

### What?

I have changed commodity cache key

### Why?

I am doing this because

- Currently request parameter values are sorted and formated into a string to append into the cache key
- When date is sorted by value, cache key is not unique
- as an example, 01/04/2025 and 04/01/2025 both generate same cache key - 01/04/2008605010/2025/commodities/show
- now params are sorted by key and then append into the cache key

`=> #<ActionController::Parameters {"day" => "04", "month" => "01", "year" => "2025", "controller" => "commodities", "action" => "show", "id" => "2008605010"} permitted: false>
[2] pry(#<CommoditiesController>)> params.values.compact.map(&:to_s).sort.join('/')
=> "01/04/2008605010/2025/commodities/show"`

`=> #<ActionController::Parameters {"day" => "01", "month" => "04", "year" => "2025", "controller" => "commodities", "action" => "show", "id" => "2008605010"} permitted: false>
[5] pry(#<CommoditiesController>)> params.values.compact.map(&:to_s).sort.join('/')
=> "01/04/2008605010/2025/commodities/show"`
