### PR TITLE
BAU: NewRelic configs

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -7,12 +7,14 @@ class HealthcheckController < ActionController::Base
   end
 
   def check
+    NewRelic::Agent.ignore_transaction
     # Check API connectivity
     Section.all(headers: original_ua_headers)
     render json: { git_sha1: CURRENT_REVISION }
   end
 
   def checkz
+    NewRelic::Agent.ignore_transaction
     render json: { git_sha1: CURRENT_REVISION }
   end
 

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -12,24 +12,20 @@
 
 common:
   &default_settings # Required license key associated with your New Relic account.
-  attributes:
-    include:
-      - request.parameters.*
-    exclude:
-      - request.parameters.password
-      - request.parameters.token
-    transaction_events:
-      exclude: request.parameters.*
-    transaction_tracer:
-      exclude: request.parameters.*
-    span_events:
-      exclude: request.parameters.*
-
   license_key: <%= ENV['NEW_RELIC_LICENSE_KEY'] %>
 
   # Your application name. Renaming here affects where data displays in New
   # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
   app_name: "tariff-frontend"
+
+  attributes:
+    enabled: true
+    error_collector:
+      include:
+        - request.parameters.*
+      exclude:
+        - request.parameters.password
+        - request.parameters.token
 
   distributed_tracing:
     enabled: true


### PR DESCRIPTION
### Jira link

BAU

### What?

I have 
- Added configuration to exclude health check endpoints from New Relic transaction monitoring
- Limited request parameters to the errors collector event only

### Why?

I am doing this because
- Health checks skew performance metrics with artificially fast response times, and it will provide more accurate representation of the actual user experience
- We want to optimise New Relic data ingestion and costs
