### PR TITLE
MyOTT 296 subscription targets improvements

### DIFF
--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -5,15 +5,15 @@ module Myott
     def new; end
 
     def active
-      @commodities = get_subscription_targets('active')
+      @targets = get_subscription_targets('active')
     end
 
     def expired
-      @commodities = get_subscription_targets('expired')
+      @targets = get_subscription_targets('expired')
     end
 
     def invalid
-      @commodities = get_subscription_targets('invalid')
+      @targets = get_subscription_targets('invalid')
     end
 
     def index

--- a/app/models/subscription_target.rb
+++ b/app/models/subscription_target.rb
@@ -1,17 +1,14 @@
 class SubscriptionTarget
   include AuthenticatableApiEntity
 
-  attr_accessor :target_type,
-                :chapter_short_code,
-                :goods_nomenclature_item_id,
-                :classification_description,
-                :meta,
-                :validity_end_date
+  attr_accessor :target_type, :target_object
+
+  has_one :target_object, class_name: 'TariffChanges::Commodity'
 
   def self.all(id, token, params)
     return nil if token.nil? && !Rails.env.development?
 
-    path = "/uk/user/subscription_targets/#{id}"
+    path = "/uk/user/subscriptions/#{id}/targets"
     collection(path, params, headers(token))
   rescue Faraday::UnauthorizedError
     nil

--- a/app/models/tariff_changes/commodity.rb
+++ b/app/models/tariff_changes/commodity.rb
@@ -2,6 +2,6 @@ module TariffChanges
   class Commodity
     include AuthenticatableApiEntity
 
-    attr_accessor :classification_description, :goods_nomenclature_item_id, :heading, :chapter
+    attr_accessor :classification_description, :goods_nomenclature_item_id, :heading, :chapter, :validity_end_date
   end
 end

--- a/app/views/myott/mycommodities/active.html.erb
+++ b/app/views/myott/mycommodities/active.html.erb
@@ -14,13 +14,13 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <% @targets.each do |commodity| %>
+          <% @targets.each do |target| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <strong><%= commodity.target_object.goods_nomenclature_item_id %></strong>
+              <strong><%= target.target_object.goods_nomenclature_item_id %></strong>
             </td>
             <td class="govuk-table__cell">
-              <%= commodity.target_object.classification_description %>
+              <%= target.target_object.classification_description %>
             </td>
           </tr>
           <% end %>

--- a/app/views/myott/mycommodities/active.html.erb
+++ b/app/views/myott/mycommodities/active.html.erb
@@ -5,28 +5,28 @@
 <div class="govuk-body myott-mycommodities">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl">Active commodities: <%= number_with_delimiter(@commodities.total_count) %></h1>
-      <table class="govuk-table">
+      <h1 class="govuk-heading-xl">Active commodities: <%= number_with_delimiter(@targets.total_count) %></h1>
+       <table class="govuk-table">
         <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th class="govuk-table__header">Commodity</th>
-              <th class="govuk-table__header">Classification</th>
-            </tr>
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header">Commodity</th>
+            <th class="govuk-table__header">Classification</th>
+          </tr>
         </thead>
         <tbody class="govuk-table__body">
-            <% @commodities.each do |commodity| %>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">
-                <strong><%= commodity.try(:goods_nomenclature_item_id) %></strong>
-                </td>
-                <td class="govuk-table__cell">
-                    <%= commodity.try(:classification_description) %>
-                </td>
-            </tr>
-            <% end %>
+          <% @targets.each do |commodity| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <strong><%= commodity.target_object.goods_nomenclature_item_id %></strong>
+            </td>
+            <td class="govuk-table__cell">
+              <%= commodity.target_object.classification_description %>
+            </td>
+          </tr>
+          <% end %>
         </tbody>
       </table>
-      <%= paginate @commodities %>
+      <%= paginate @targets %>
     </div>
   </div>
 </div>

--- a/app/views/myott/mycommodities/expired.html.erb
+++ b/app/views/myott/mycommodities/expired.html.erb
@@ -8,7 +8,7 @@
       <h1 class="govuk-heading-xl">Expired commodities</h1>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <p>When commodity codes expire they’re no longer usable. The codes might have been removed or absorbed into different commodity codes.</p>
+          <p>When target codes expire they’re no longer usable. The codes might have been removed or absorbed into different target codes.</p>
           <p>On this page you can review the changes for commodities. If you want you can also remove these codes from your watch list.</p>
           <h3>Total expired commodities: <%= number_with_delimiter(@targets.total_count) %></h3>
         </div>
@@ -16,29 +16,29 @@
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th class="govuk-table__header">Commodity</th>
+            <th class="govuk-table__header">target</th>
             <th class="govuk-table__header">Classification</th>
             <th class="govuk-table__header">End date</th>
             <th class="govuk-table__header">Action</th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <% @targets.each do |commodity| %>
+          <% @targets.each do |target| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <strong><%= commodity.target_object.goods_nomenclature_item_id %></strong>
+              <strong><%= target.target_object.goods_nomenclature_item_id %></strong>
             </td>
             <td class="govuk-table__cell">
-              <%= commodity.target_object.classification_description %>
+              <%= target.target_object.classification_description %>
             </td>
             <td class="govuk-table__cell">
-              <%= commodity.target_object.validity_end_date.to_date.to_formatted_s(:long) %>
+              <%= target.target_object.validity_end_date.to_date.to_formatted_s(:long) %>
             </td>
             <td class="govuk-table__cell">
-              <%= link_to('Review on tariff', commodity_path(commodity.target_object.goods_nomenclature_item_id,
-                          day: commodity.target_object.validity_end_date.to_date.day,
-                          month: commodity.target_object.validity_end_date.to_date.month,
-                          year: commodity.target_object.validity_end_date.to_date.year),
+              <%= link_to('Review on tariff', commodity_path(target.target_object.goods_nomenclature_item_id,
+                          day: target.target_object.validity_end_date.to_date.day,
+                          month: target.target_object.validity_end_date.to_date.month,
+                          year: target.target_object.validity_end_date.to_date.year),
                           target: '_blank')%></td>
             </td>
           </tr>

--- a/app/views/myott/mycommodities/expired.html.erb
+++ b/app/views/myott/mycommodities/expired.html.erb
@@ -10,7 +10,7 @@
         <div class="govuk-grid-column-two-thirds">
           <p>When commodity codes expire they’re no longer usable. The codes might have been removed or absorbed into different commodity codes.</p>
           <p>On this page you can review the changes for commodities. If you want you can also remove these codes from your watch list.</p>
-          <h3>Total expired commodities: <%= number_with_delimiter(@commodities.total_count) %></h3>
+          <h3>Total expired commodities: <%= number_with_delimiter(@targets.total_count) %></h3>
         </div>
       </div>
       <table class="govuk-table">
@@ -23,29 +23,29 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <% @commodities.each do |commodity| %>
+          <% @targets.each do |commodity| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <strong><%= commodity.try(:goods_nomenclature_item_id) %></strong>
+              <strong><%= commodity.target_object.goods_nomenclature_item_id %></strong>
             </td>
             <td class="govuk-table__cell">
-              <%= commodity.try(:classification_description) %>
+              <%= commodity.target_object.classification_description %>
             </td>
             <td class="govuk-table__cell">
-              <%= commodity.try(:validity_end_date).to_date.to_formatted_s(:long) %>
+              <%= commodity.target_object.validity_end_date.to_date.to_formatted_s(:long) %>
             </td>
             <td class="govuk-table__cell">
-              <%= link_to('Review on tariff', commodity_path(commodity.try(:goods_nomenclature_item_id),
-                          day: commodity.try(:validity_end_date).to_date.day,
-                          month: commodity.try(:validity_end_date).to_date.month,
-                          year: commodity.try(:validity_end_date).to_date.year),
+              <%= link_to('Review on tariff', commodity_path(commodity.target_object.goods_nomenclature_item_id,
+                          day: commodity.target_object.validity_end_date.to_date.day,
+                          month: commodity.target_object.validity_end_date.to_date.month,
+                          year: commodity.target_object.validity_end_date.to_date.year),
                           target: '_blank')%></td>
             </td>
           </tr>
           <% end %>
         </tbody>
       </table>
-      <%= paginate @commodities %>
+      <%= paginate @targets %>
     </div>
   </div>
 </div>

--- a/app/views/myott/mycommodities/invalid.html.erb
+++ b/app/views/myott/mycommodities/invalid.html.erb
@@ -29,7 +29,7 @@
           <% @targets.each do |target| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <%= target.resource_id %>
+              <%= target.target_object.goods_nomenclature_item_id %>
             </td>
           </tr>
         <% end %>

--- a/app/views/myott/mycommodities/invalid.html.erb
+++ b/app/views/myott/mycommodities/invalid.html.erb
@@ -15,7 +15,7 @@
             <li>Commodity codes which have expired and are no longer in use</li>
           </ul>
           <p>You can choose to remove all these errors, remove them individually, or upload a new spreadsheet.</p>
-          <h3>Total input errors: <%= number_with_delimiter(@commodities.total_count) %></h3>
+          <h3>Total input errors: <%= number_with_delimiter(@targets.total_count) %></h3>
           <p>You should remove invalid inputs if they have been actioned</p>
         </div>
       </div>
@@ -26,16 +26,16 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <% @commodities.each do |commodity| %>
+          <% @targets.each do |target| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <%= commodity.try(:goods_nomenclature_item_id) %>
+              <%= target.resource_id %>
             </td>
           </tr>
         <% end %>
         </tbody>
       </table>
-      <%= paginate @commodities %>
+      <%= paginate @targets %>
     </div>
   </div>
 </div>

--- a/spec/models/tariff_changes/commodity_spec.rb
+++ b/spec/models/tariff_changes/commodity_spec.rb
@@ -11,5 +11,9 @@ RSpec.describe TariffChanges::Commodity do
     it 'responds to goods_nomenclature_item_id' do
       expect(commodity).to respond_to(:goods_nomenclature_item_id)
     end
+
+    it 'responds to validity_end_date' do
+      expect(commodity).to respond_to(:validity_end_date)
+    end
   end
 end

--- a/spec/support/shared_examples/a_commodity_category_page.rb
+++ b/spec/support/shared_examples/a_commodity_category_page.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples 'a commodity category page' do |action, category|
     allow(controller).to receive_messages(get_subscription: subscription, user_id_token: user_id_token)
 
     targets = build_list(:subscription_target, 3)
-    allow(targets).to receive(:total_count).and_return(3)
+    allow(targets).to receive(:count).and_return(3)
 
     expected_params = {
       filter: { active_commodities_type: category },
@@ -24,11 +24,11 @@ RSpec.shared_examples 'a commodity category page' do |action, category|
     get action, params: { page: page, per_page: per_page }
   end
 
-  it 'assigns commodities as SubscriptionTarget instances' do
-    expect(assigns(:commodities)).to all(be_a(SubscriptionTarget))
+  it 'assigns targets as SubscriptionTarget instances' do
+    expect(assigns(:targets)).to all(be_a(SubscriptionTarget))
   end
 
-  it 'assigns the correct number of commodities' do
-    expect(assigns(:commodities).size).to eq(3)
+  it 'assigns the correct number of targets' do
+    expect(assigns(:targets).count).to eq(3)
   end
 end


### PR DESCRIPTION
### Jira link

[MyOTT-296](https://transformuk.atlassian.net/browse/MyOTT-296)

### What?

I have made `SubscriptionTarget` more generic to include a hydrated `TariffChange::Commodity` if available and updated views to consume the object.

### Why?

I am doing this because this is required for the model to be more in line with other PORO MyOTT `Subscription` models and part of backend PR https://github.com/trade-tariff/trade-tariff-backend/pull/2613
