### PR TITLE
MyOTT-263 & MyOTT-264 Iterate Upload CCs journey

### DIFF
--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -1,6 +1,9 @@
 module Myott
   class MycommoditiesController < MyottController
-    before_action :authenticate, only: %i[new create index confirmation]
+    before_action :authenticate
+    before_action except: %i[new create] do
+      redirect_to myott_path unless current_subscription('my_commodities')
+    end
 
     def new; end
 
@@ -17,8 +20,6 @@ module Myott
     end
 
     def index
-      redirect_to new_myott_mycommodity_path and return unless current_subscription('my_commodities')
-
       @meta = metadata_from_subscription
       @grouped_measure_changes = TariffChanges::GroupedMeasureChange.all(user_id_token, { as_of: as_of.strftime('%Y-%m-%d') })
       @commodity_changes = TariffChanges::CommodityChange.all(user_id_token, { as_of: as_of.strftime('%Y-%m-%d') })
@@ -39,7 +40,6 @@ module Myott
 
     def confirmation
       @new_subscriber = params[:new_subscriber] == 'true'
-      redirect_to myott_path unless current_subscription('my_commodities')
     end
 
     private

--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -1,6 +1,6 @@
 module Myott
   class MycommoditiesController < MyottController
-    before_action :authenticate, only: %i[new create index]
+    before_action :authenticate, only: %i[new create index confirmation]
 
     def new; end
 
@@ -25,6 +25,7 @@ module Myott
     end
 
     def create
+      new_subscriber = current_subscription('my_commodities').nil?
       result = CommodityCodesExtractionService.new(params[:fileUpload1]).call
 
       unless result.success?
@@ -33,7 +34,12 @@ module Myott
       end
 
       update_user_commodity_codes(result.codes)
-      redirect_to myott_mycommodities_path
+      redirect_to confirmation_myott_mycommodities_path params: { new_subscriber: new_subscriber } and return
+    end
+
+    def confirmation
+      @new_subscriber = params[:new_subscriber] == 'true'
+      redirect_to myott_path unless current_subscription('my_commodities')
     end
 
     private

--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -2,7 +2,7 @@ module Myott
   class MycommoditiesController < MyottController
     before_action :authenticate
     before_action except: %i[new create] do
-      redirect_to myott_path unless current_subscription('my_commodities')
+      redirect_to new_myott_mycommodity_path unless current_subscription('my_commodities')
     end
 
     def new; end

--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -21,6 +21,7 @@ module Myott
       @current_subscriptions ||= {}
       @current_subscriptions[subscription_type] ||= get_subscription(subscription_type)
     end
+    helper_method :current_subscription
 
     def user_id_token
       cookies[:id_token]

--- a/app/views/myott/mycommodities/confirmation.html.erb
+++ b/app/views/myott/mycommodities/confirmation.html.erb
@@ -1,4 +1,4 @@
-<% myott_page_title "Subscription updated" %>
+<% myott_page_title "Commodity code watch list #{@new_subscriber ? "created" : "updated"}" %>
 <div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/app/views/myott/mycommodities/confirmation.html.erb
+++ b/app/views/myott/mycommodities/confirmation.html.erb
@@ -1,0 +1,24 @@
+<% myott_page_title "Subscription updated" %>
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+          <h1 class="govuk-panel__title">
+            Commodity code watch list <%= @new_subscriber ? "created" : "updated" %>
+          </h1>
+        </div>
+        <h2 class="govuk-heading-m">What happens next</h2>
+        <p class="govuk-body">
+          When updates are published by the UK Trade Tariff Service which relate to the commodities you have chosen, an email will be sent to <strong><%= current_user&.email %></strong>
+        </p>
+        <p class="govuk-body">
+          You can also view your subscription to access these updates.
+        </p>
+        <p class="govuk-body">
+          <%= link_to "View your commodity watch list", myott_mycommodities_path, class: "govuk-button govuk-!-margin-top-4" %>
+        </p>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/myott/mycommodities/new.html.erb
+++ b/app/views/myott/mycommodities/new.html.erb
@@ -2,18 +2,25 @@
 <div class="govuk-body">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Upload your preferred commodities</h1>
-      <p>You will receive updates when there are changes to these commodities.</p>
-      <p class="govuk-inset-text">You can upload a new file or replace an existing file.</p>
+      <% if current_subscription('my_commodities') %>
+        <h1 class="govuk-heading-l">Replace all commodities</h1>
+        <h2 class="govuk-heading-m">Do not just upload the new commodity codes you’re interested in.</h2>
+        <p>You must upload a spreadsheet of all the commodity codes you want on your watch list.</p>
+      <% else %>
+        <h1 class="govuk-heading-l">Upload the commodity codes you want tariff updates about</h1>
+      <% end %>
+      <p>Before uploading, make sure the file meets the following criteria:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Spreadsheet in a CSV or XLSX format</li>
+        <li>10 digit Commodity codes listed in column A, with no data in any other columns</li>
+        <li>No headings or additional information, like commodity name</li>
+      </ul>
+      <p>There is no limit on how many commodity codes can be added to your watch list.</p>
+
+      <p class="govuk-inset-text">You can add or remove commodities from your watch list at any time</p>
 
       <%= form_with url:  myott_mycommodities_path, method: :post, local: true, :multipart => true do %>
-        <fieldset class="govuk-fieldset" aria-describedby="select-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-            <h2 class="govuk-fieldset__heading govuk-heading-m">What commodities do you want to upload?</h2>
-          </legend>
-          <div id="select-hint" class="govuk-hint">
-            You can upload a CSV or Excel file. The file should contain a list of commodity codes, one per row.  Please note duplicates will be ignored.
-          </div>
+        <fieldset class="govuk-fieldset">
           <% if flash.now[:select_error] %>
             <p class="govuk-error-message">
               <%= flash.now[:select_error] %>
@@ -21,7 +28,7 @@
           <% end %>
           <div class="govuk-form-group">
             <label class="govuk-label" for="file-upload-1">
-                Upload a file
+              <h2 class="govuk-heading-m">Upload a file</h2>
             </label>
             <div
               class="govuk-drop-zone"

--- a/app/views/myott/subscriptions/index.html.erb
+++ b/app/views/myott/subscriptions/index.html.erb
@@ -16,7 +16,7 @@
         <% else %>
           <p class="govuk-body"><strong>No commodities selected</strong></p>
           <p class="govuk-body">You will receive updates on specific commodities</p>
-          <%= link_to 'Create a commodity watch list', myott_mycommodities_path %>
+          <%= link_to 'Create a commodity watch list',  new_myott_mycommodity_path %>
         <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
             get :active
             get :expired
             get :invalid
+            get :confirmation
           end
         end
 

--- a/spec/controllers/myott/commodity_changes_controller_spec.rb
+++ b/spec/controllers/myott/commodity_changes_controller_spec.rb
@@ -2,11 +2,19 @@ RSpec.describe Myott::CommodityChangesController, type: :controller do
   let(:user_id_token) { 'test_token' }
   let(:as_of) { Time.zone.today }
   let(:commodity_change) { instance_double(TariffChanges::CommodityChange, count: 1, tariff_changes: []) }
+  let(:subscription) do
+    build(:subscription,
+          active: true,
+          subscription_type: 'my_commodities',
+          metadata: { commodity_codes: %w[1111111111 22222222222 3333333333 4444444444 5555555555] },
+          meta: { active: %w[1111111111 22222222222], expired: %w[33333333333 44444444444], invalid: %w[55555555555] })
+  end
 
   before do
     allow(controller).to receive_messages(user_id_token: user_id_token, as_of: as_of)
     allow(TariffChanges::CommodityChange).to receive(:find).and_return(commodity_change)
     allow(controller).to receive(:authenticate)
+    allow(controller).to receive(:current_subscription).and_return(subscription)
   end
 
   describe 'GET #ending' do

--- a/spec/controllers/myott/grouped_measure_changes_controller_spec.rb
+++ b/spec/controllers/myott/grouped_measure_changes_controller_spec.rb
@@ -5,9 +5,17 @@ RSpec.describe Myott::GroupedMeasureChangesController, type: :controller do
     let(:user_id_token) { 'token' }
     let(:as_of) { Time.zone.today }
     let(:grouped_measure_change) { instance_double(TariffChanges::GroupedMeasureChange) }
+    let(:subscription) do
+      build(:subscription,
+            active: true,
+            subscription_type: 'my_commodities',
+            metadata: { commodity_codes: %w[1111111111 22222222222 3333333333 4444444444 5555555555] },
+            meta: { active: %w[1111111111 22222222222], expired: %w[33333333333 44444444444], invalid: %w[55555555555] })
+    end
 
     before do
       allow(controller).to receive_messages(user_id_token: user_id_token, as_of: as_of, authenticate: true)
+      allow(controller).to receive(:current_subscription).and_return(subscription)
     end
 
     it 'assigns @grouped_measure_changes' do

--- a/spec/controllers/myott/grouped_measure_commodity_changes_controller_spec.rb
+++ b/spec/controllers/myott/grouped_measure_commodity_changes_controller_spec.rb
@@ -12,9 +12,17 @@ RSpec.describe Myott::GroupedMeasureCommodityChangesController, type: :controlle
     change.grouped_measure_change = grouped_measure_change_hash
     change
   end
+  let(:subscription) do
+    build(:subscription,
+          active: true,
+          subscription_type: 'my_commodities',
+          metadata: { commodity_codes: %w[1111111111 22222222222 3333333333 4444444444 5555555555] },
+          meta: { active: %w[1111111111 22222222222], expired: %w[33333333333 44444444444], invalid: %w[55555555555] })
+  end
 
   before do
     allow(controller).to receive_messages(user_id_token: user_id_token, as_of: Time.zone.today, authenticate: true)
+    allow(controller).to receive(:current_subscription).and_return(subscription)
   end
 
   describe 'GET #show' do

--- a/spec/controllers/myott/mycommodities_controller_spec.rb
+++ b/spec/controllers/myott/mycommodities_controller_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
           get :index
         end
 
-        it { is_expected.to redirect_to(myott_path) }
+        it { is_expected.to redirect_to(new_myott_mycommodity_path) }
       end
     end
   end

--- a/spec/controllers/myott/mycommodities_controller_spec.rb
+++ b/spec/controllers/myott/mycommodities_controller_spec.rb
@@ -38,14 +38,26 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
   end
 
   describe 'GET #active' do
+    before do
+      allow(controller).to receive_messages(current_user: user, get_subscription: subscription)
+    end
+
     it_behaves_like 'a commodity category page', :active, 'active'
   end
 
   describe 'GET #expired' do
+    before do
+      allow(controller).to receive_messages(current_user: user, get_subscription: subscription)
+    end
+
     it_behaves_like 'a commodity category page', :expired, 'expired'
   end
 
   describe 'GET #invalid' do
+    before do
+      allow(controller).to receive_messages(current_user: user, get_subscription: subscription)
+    end
+
     it_behaves_like 'a commodity category page', :invalid, 'invalid'
   end
 
@@ -96,7 +108,7 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
           get :index
         end
 
-        it { is_expected.to redirect_to(new_myott_mycommodity_path) }
+        it { is_expected.to redirect_to(myott_path) }
       end
     end
   end

--- a/spec/support/shared_examples/a_valid_commodity_file_upload.rb
+++ b/spec/support/shared_examples/a_valid_commodity_file_upload.rb
@@ -2,30 +2,64 @@ RSpec.shared_examples 'a valid commodity file upload' do |fixture_path, content_
   let(:valid_file) { fixture_file_upload(fixture_path, content_type) }
   let(:token) { 'valid-jwt-token' }
 
-  before do
-    cookies[:id_token] = token
+  context 'when the user has an existing subscription' do
+    before do
+      cookies[:id_token] = token
 
-    allow(Subscription).to receive(:batch)
-    allow(controller).to receive(:get_subscription).and_return(subscription)
+      allow(Subscription).to receive(:batch)
+      allow(controller).to receive(:get_subscription).and_return(subscription)
 
-    post :create, params: { fileUpload1: valid_file }
+      post :create, params: { fileUpload1: valid_file }
+    end
+
+    it 'does not set an alert' do
+      expect(assigns(:alert)).to be_nil
+    end
+
+    it 'calls Subscription.batch with parsed commodity codes' do
+      expect(Subscription).to have_received(:batch).with(
+        subscription.resource_id,
+        token,
+        hash_including(
+          targets: kind_of(Array),
+        ),
+      )
+    end
+
+    it 'redirects to the index page' do
+      expect(response).to redirect_to(confirmation_myott_mycommodities_path(params: { new_subscriber: false }))
+    end
   end
 
-  it 'does not set an alert' do
-    expect(assigns(:alert)).to be_nil
-  end
+  context 'when the user does not have an existing subscription' do
+    before do
+      cookies[:id_token] = token
 
-  it 'calls Subscription.batch with parsed commodity codes' do
-    expect(Subscription).to have_received(:batch).with(
-      subscription.resource_id,
-      token,
-      hash_including(
-        targets: kind_of(Array),
-      ),
-    )
-  end
+      allow(Subscription).to receive(:batch)
 
-  it 'redirects to the index page' do
-    expect(response).to redirect_to(myott_mycommodities_path)
+      allow(controller).to receive(:current_subscription)
+      .with('my_commodities')
+      .and_return(nil, subscription)
+
+      post :create, params: { fileUpload1: valid_file }
+    end
+
+    it 'does not set an alert' do
+      expect(assigns(:alert)).to be_nil
+    end
+
+    it 'calls Subscription.batch with parsed commodity codes' do
+      expect(Subscription).to have_received(:batch).with(
+        subscription.resource_id,
+        token,
+        hash_including(
+          targets: kind_of(Array),
+        ),
+      )
+    end
+
+    it 'redirects to the index page' do
+      expect(response).to redirect_to(confirmation_myott_mycommodities_path(params: { new_subscriber: true }))
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[MyOTT-263](https://transformuk.atlassian.net/browse/MyOTT-263)
[MyOTT-264](https://transformuk.atlassian.net/browse/MyOTT-264)

### What?

I have added dynamic `confirmation` view and dynamic `new` view based on user subscription status

### Why?

I am doing this because it's part of the journey design iteration.

**new subscriber upload page**
<img width="625" height="853" alt="image" src="https://github.com/user-attachments/assets/cd685370-53b8-4a31-95c1-bba8eed743a4" />

**new subscriber confirmation page**
<img width="625" height="609" alt="image" src="https://github.com/user-attachments/assets/f4ba8d60-a6ee-44a1-b7f5-76db38924d23" />

**existing subscriber upload page**
<img width="630" height="964" alt="image" src="https://github.com/user-attachments/assets/13305ec1-1946-4817-af0c-a7bcfffa095d" />

**existing subscriber confirmation page**
<img width="618" height="611" alt="image" src="https://github.com/user-attachments/assets/1034a1d0-4baa-4b7e-bf67-5ad161af5574" />

