### PR TITLE
MYOTT-249 Add pagination to measure changes page

### DIFF
--- a/app/controllers/myott/grouped_measure_changes_controller.rb
+++ b/app/controllers/myott/grouped_measure_changes_controller.rb
@@ -3,11 +3,16 @@ module Myott
     before_action :authenticate
 
     def show
+      opts = { page: (params[:page].presence || 1).to_i,
+               per_page: (params[:per_page].presence || 10).to_i,
+               as_of: as_of.strftime('%Y-%m-%d') }
+
       @grouped_measure_changes = TariffChanges::GroupedMeasureChange.find(
         params[:id],
         user_id_token,
-        { as_of: as_of.strftime('%Y-%m-%d') },
+        opts,
       )
+      @commodity_changes = @grouped_measure_changes.grouped_measure_commodity_changes
     end
   end
 end

--- a/app/views/myott/grouped_measure_changes/show.html.erb
+++ b/app/views/myott/grouped_measure_changes/show.html.erb
@@ -9,6 +9,8 @@
       </span>
       <h1 class="govuk-heading-xl"><%= @grouped_measure_changes.trade_direction_description %> from <%= @grouped_measure_changes.geographical_area_description %></h1>
 
+      <h2 class="govuk-heading-m">Total commodities affected: <%= @commodity_changes.total_count %></h2>
+
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
@@ -18,15 +20,16 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <% @grouped_measure_changes.grouped_measure_commodity_changes.each do |measure_change| %>
+          <% @commodity_changes.each do |commodity_change| %>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell"><%= measure_change.commodity.goods_nomenclature_item_id %></td>
-              <td class="govuk-table__cell"><%= measure_change.commodity.classification_description %></td>
-              <td class="govuk-table__cell"><%= link_to(pluralize(measure_change.count, 'change'), myott_grouped_measure_commodity_change_path(measure_change.resource_id, as_of: params[:as_of])) %></td>
+              <td class="govuk-table__cell"><%= commodity_change.commodity.goods_nomenclature_item_id %></td>
+              <td class="govuk-table__cell"><%= commodity_change.commodity.classification_description %></td>
+              <td class="govuk-table__cell"><%= link_to(pluralize(commodity_change.count, 'change'), myott_grouped_measure_commodity_change_path(commodity_change.resource_id, as_of: params[:as_of])) %></td>
             </tr>
           <% end %>
         </tbody>
       </table>
+      <%= paginate @commodity_changes %>
     </div>
   </div>
 </div>

--- a/spec/controllers/myott/grouped_measure_changes_controller_spec.rb
+++ b/spec/controllers/myott/grouped_measure_changes_controller_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe Myott::GroupedMeasureChangesController, type: :controller do
   describe 'GET #show' do
     let(:user_id_token) { 'token' }
     let(:as_of) { Time.zone.today }
-    let(:grouped_measure_change) { instance_double(TariffChanges::GroupedMeasureChange) }
+    let(:commodity_changes) { [build(:grouped_measure_commodity_change)] }
+    let(:grouped_measure_change) do
+      instance_double(TariffChanges::GroupedMeasureChange,
+                      grouped_measure_commodity_changes: commodity_changes)
+    end
     let(:subscription) do
       build(:subscription,
             active: true,
@@ -27,7 +31,35 @@ RSpec.describe Myott::GroupedMeasureChangesController, type: :controller do
     it 'calls find with correct arguments' do
       allow(TariffChanges::GroupedMeasureChange).to receive(:find).and_return(grouped_measure_change)
       get :show, params: { id: '1' }
-      expect(TariffChanges::GroupedMeasureChange).to have_received(:find).with('1', user_id_token, { as_of: as_of.strftime('%Y-%m-%d') })
+      expect(TariffChanges::GroupedMeasureChange).to have_received(:find).with(
+        '1',
+        user_id_token,
+        hash_including(
+          page: 1,
+          per_page: 10,
+          as_of: as_of.strftime('%Y-%m-%d'),
+        ),
+      )
+    end
+
+    it 'calls find with custom pagination params' do
+      allow(TariffChanges::GroupedMeasureChange).to receive(:find).and_return(grouped_measure_change)
+      get :show, params: { id: '1', page: 3, per_page: 25 }
+      expect(TariffChanges::GroupedMeasureChange).to have_received(:find).with(
+        '1',
+        user_id_token,
+        hash_including(
+          page: 3,
+          per_page: 25,
+          as_of: as_of.strftime('%Y-%m-%d'),
+        ),
+      )
+    end
+
+    it 'assigns @commodity_changes from grouped_measure_changes' do
+      allow(TariffChanges::GroupedMeasureChange).to receive(:find).and_return(grouped_measure_change)
+      get :show, params: { id: '1' }
+      expect(assigns(:commodity_changes)).to eq(commodity_changes)
     end
   end
 end

--- a/spec/views/myott/grouped_measure_changes/show.html.erb_spec.rb
+++ b/spec/views/myott/grouped_measure_changes/show.html.erb_spec.rb
@@ -1,21 +1,22 @@
 require 'spec_helper'
 
 RSpec.describe 'myott/grouped_measure_changes/show.html.erb', type: :view do
-  let(:measure_change_attrs) { attributes_for(:grouped_measure_commodity_change, count: 2, resource_id: 'import_IL__0807190050') }
-  let(:grouped_measure_changes) do
-    build(
-      :grouped_measure_change,
-      trade_direction: 'import',
-      geographical_area: { 'long_description' => 'United Kingdom' },
-      grouped_measure_commodity_changes: [measure_change_attrs],
-      count: 2,
-      resource_id: 99,
-    )
+  let(:commodity_changes) do
+    Kaminari.paginate_array(
+      [build(:grouped_measure_commodity_change, count: 2, resource_id: 'import_IL__0807190050')],
+      total_count: 1,
+    ).page(1).per(10)
   end
+  let(:grouped_measure_changes) { instance_double(TariffChanges::GroupedMeasureChange) }
 
   before do
-    allow(grouped_measure_changes).to receive_messages(trade_direction_description: 'Imports', geographical_area_description: 'United Kingdom')
+    allow(grouped_measure_changes).to receive_messages(
+      trade_direction_description: 'Imports',
+      geographical_area_description: 'United Kingdom',
+      grouped_measure_commodity_changes: commodity_changes,
+    )
     assign(:grouped_measure_changes, grouped_measure_changes)
+    assign(:commodity_changes, commodity_changes)
     allow(view).to receive(:params).and_return(as_of: '2025-11-21')
     render
   end


### PR DESCRIPTION
### Jira link

[MYOTT-249](https://transformuk.atlassian.net/browse/MYOTT-249)

### What?

Adds pagination to the page that shows commodities affected by particular measure changes

### Why?

Sometimes there can be a lot of commodities affected by measure changes.
