### PR TITLE
Potential fix for code scanning alert no. 22: DOM text reinterpreted as HTML

### DIFF
--- a/app/javascript/src/step-by-step-nav.js
+++ b/app/javascript/src/step-by-step-nav.js
@@ -334,7 +334,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         $stepElement.toggleClass('step-is-shown', isShown);
         $stepContent.toggleClass('js-hidden', !isShown);
         $titleLink.attr('aria-expanded', isShown);
-        $stepElement.find('.js-toggle-link').html(isShown ? actions.hideText : actions.showText);
+        $stepElement.find('.js-toggle-link').text(isShown ? actions.hideText : actions.showText);
       }
 
       function isShown() {


### PR DESCRIPTION
Potential fix for [https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/22](https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/22)

The best way to fix this problem is to ensure that the text from the `data-show-text` and `data-hide-text` attributes is inserted into the DOM as *text*, not as *HTML*. This avoids reinterpreting potentially malicious strings as markup, preventing XSS. In jQuery, this means using `.text()` instead of `.html()` when updating `.js-toggle-link`, or, if HTML is required for formatting, then the attributes should be sanitized/escaped before insertion.

1. In `setIsShown`, change `.html(...)` on the `.js-toggle-link` element to `.text(...)`.
2. This is safe provided that the text does not intentionally include HTML markup; if actual HTML content is needed (rare and discouraged in this context), escaping logic or a sanitizer should be added. In the code shown, `data-show-text` and `data-hide-text` are most likely simple strings like "Show" and "Hide".
3. Only line 337 needs to be updated: replace `.html(...)` with `.text(...)`.

No imports or new dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
