### PR TITLE
Potential fix for code scanning alert no. 21: DOM text reinterpreted as HTML

### DIFF
--- a/app/javascript/src/step-by-step-nav.js
+++ b/app/javascript/src/step-by-step-nav.js
@@ -268,7 +268,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
           if ($showOrHideAllButton.text() === actions.showAllText) {
             $showOrHideAllButton.text(actions.hideAllText);
-            $element.find('.js-toggle-link').html(actions.hideText);
+            $element.find('.js-toggle-link').text(actions.hideText);
             shouldshowAll = true;
 
             stepNavTracker.track('pageElementInteraction', 'stepNavAllShown', {
@@ -276,7 +276,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
             });
           } else {
             $showOrHideAllButton.text(actions.showAllText);
-            $element.find('.js-toggle-link').html(actions.showText);
+            $element.find('.js-toggle-link').text(actions.showText);
             shouldshowAll = false;
 
             stepNavTracker.track('pageElementInteraction', 'stepNavAllHidden', {


### PR DESCRIPTION
Potential fix for [https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/21](https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/21)

To fix the problem, we must ensure that **untrusted data extracted from the DOM is never inserted into the DOM as HTML** unless it is explicitly sanitized. Since `actions.showText`, as well as other related labels like `actions.hideText`, `actions.showAllText`, `actions.hideAllText`, all come from data attributes and are used as raw HTML in several places via `.html()`, we should insert them as plain text instead.

**Best fix:**  
- Replace the use of jQuery's `.html()` (lines 271, 279, possibly others) with `.text()` which inserts the values as plain text, not as HTML.
- If for some reason the intention is to support limited HTML (e.g., to bold words in the label), then a sanitization step must be added. But given the context (UI text like "Show all", "Hide all"), these only need to be treated as text, not HTML.

**Required changes:**
1. In `bindToggleShowHideAllButton`, change
   - `$element.find('.js-toggle-link').html(actions.hideText)`
   - `$element.find('.js-toggle-link').html(actions.showText)`
   to use `.text()`.

2. Optionally, review elsewhere in the file for other uses of `.html(actions.*Text)` and switch to `.text()` as appropriate.

**Imports/definitions:**  
No new imports are required — this is a change from using `.html()` to `.text()` in the code already using jQuery.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
