### PR TITLE
Potential fix for code scanning alert no. 20: DOM text reinterpreted as HTML

### DIFF
--- a/app/javascript/src/step-by-step-nav.js
+++ b/app/javascript/src/step-by-step-nav.js
@@ -268,7 +268,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
           if ($showOrHideAllButton.text() === actions.showAllText) {
             $showOrHideAllButton.text(actions.hideAllText);
-            $element.find('.js-toggle-link').html(actions.hideText);
+            $element.find('.js-toggle-link').text(actions.hideText);
             shouldshowAll = true;
 
             stepNavTracker.track('pageElementInteraction', 'stepNavAllShown', {
@@ -276,7 +276,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
             });
           } else {
             $showOrHideAllButton.text(actions.showAllText);
-            $element.find('.js-toggle-link').html(actions.showText);
+            $element.find('.js-toggle-link').text(actions.showText);
             shouldshowAll = false;
 
             stepNavTracker.track('pageElementInteraction', 'stepNavAllHidden', {


### PR DESCRIPTION
Potential fix for [https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/20](https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/20)

To fix the problem, we must ensure that any string inserted into the DOM via `.html()` is contextually escaped so that it cannot be interpreted as HTML. For these dynamically-inserted text values (like `actions.hideText` and `actions.showText`), the correct approach is to use jQuery’s `.text()` method rather than `.html()`, as `.text()` always escapes meta-characters, rendering the content as plain text.

Thus, any place in the code where `actions.showText`, `actions.hideText`, etc. are inserted using `.html()` should be changed to use `.text()`. For example, change:
```js
$element.find('.js-toggle-link').html(actions.hideText);
```
to:
```js
$element.find('.js-toggle-link').text(actions.hideText);
```
Similarly, in other places where those values are set by `.html()`, switch to `.text()`, but if the string inserted genuinely contains HTML that _should_ be rendered (which is not the case suggested here), then instead sanitize the input before insertion, e.g., by using a library like DOMPurify, but that's unnecessary (and overkill) for plain text.

Carefully review only those locations where unsanitized data makes it from attributes to the DOM using `.html()` and change to `.text()`. Do **not** change code that is deliberately inserting HTML markup, or where an explicit requirement for HTML is documented.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
