### PR TITLE
Potential fix for code scanning alert no. 19: DOM text reinterpreted as HTML

### DIFF
--- a/app/javascript/src/step-by-step-nav.js
+++ b/app/javascript/src/step-by-step-nav.js
@@ -62,7 +62,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function addShowHideAllButton() {
-        $element.prepend('<div class="app-step-nav__controls"><button aria-expanded="false" class="app-step-nav__button app-step-nav__button--controls js-step-controls-button">' + actions.showAllText + '</button></div>');
+        var $controlsDiv = $('<div>').addClass('app-step-nav__controls');
+        var $button = $('<button>')
+          .attr('aria-expanded', 'false')
+          .addClass('app-step-nav__button app-step-nav__button--controls js-step-controls-button')
+          .text(actions.showAllText);
+        $controlsDiv.append($button);
+        $element.prepend($controlsDiv);
       }
 
       function addShowHideToggle() {


### PR DESCRIPTION
Potential fix for [https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/19](https://github.com/trade-tariff/trade-tariff-frontend/security/code-scanning/19)

**General approach:**  
Ensure that any user-supplied data inserted into the DOM as HTML is properly escaped, or (preferably) that DOM-manipulation APIs inserting the data only treat it as text, not HTML.

**Best fix in this context:**  
Rather than assembling a raw HTML string possibly containing untrusted text, use safer jQuery patterns:  
1. Build the structure as detached DOM nodes/elements using jQuery or plain DOM methods,
2. Insert the untrusted text only as text nodes or using a `.text()` call, ensuring no interpretation as HTML.

**Specifically for file `app/javascript/src/step-by-step-nav.js` lines 65:**  
- Change from string concatenation and `.prepend()` to:
  - Create the `<div>` and `<button>` elements,
  - Set their classes and attributes,
  - Add the untrusted text to the button using `.text(actions.showAllText)`,
  - Prepend the now-safe DOM structure.

**Required changes:**
- Edit the function `addShowHideAllButton` (line 64-66) to build and insert elements safely as described.
- No new methods or imports are needed; jQuery is already in use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
