### PR TITLE
MyOTT-255 Fix Expired Screen Column title

### DIFF
--- a/app/views/myott/mycommodities/expired.html.erb
+++ b/app/views/myott/mycommodities/expired.html.erb
@@ -16,7 +16,7 @@
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th class="govuk-table__header">target</th>
+            <th class="govuk-table__header">Commodity</th>
             <th class="govuk-table__header">Classification</th>
             <th class="govuk-table__header">End date</th>
             <th class="govuk-table__header">Action</th>


### PR DESCRIPTION
### Jira link

[MyOTT-255](https://transformuk.atlassian.net/browse/MyOTT-255)

### What?

I have a changed heading from **target** to **Commodity** in `expired.html.erb`

### Why?

I am doing this because it was wrong.

BEFORE
<img width="824" height="579" alt="image" src="https://github.com/user-attachments/assets/704d4c89-a3aa-4a83-9f14-5c5eed7e32e1" />


AFTER
<img width="819" height="562" alt="image" src="https://github.com/user-attachments/assets/6c983c84-5edc-480e-8155-de43e1a84545" />
