### PR TITLE
MyOTT-310 Iterate Start Page

### DIFF
--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -2,7 +2,9 @@ module Myott
   class SubscriptionsController < MyottController
     before_action :authenticate, except: %i[start invalid]
 
-    def start; end
+    def start
+      render :start_old and return unless TradeTariffFrontend.my_commodities?
+    end
 
     def invalid
       redirect_to myott_path if current_user.present?

--- a/app/views/myott/subscriptions/start.html.erb
+++ b/app/views/myott/subscriptions/start.html.erb
@@ -2,34 +2,34 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-      <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-          Important
-        </h2>
-      </div>
-      <div class="govuk-notification-banner__content">
-        This service is in the private beta phase. All information in this service is accurate, but some aspects might change during this phase.
-      </div>
-    </div>
 
-    <h1 class="govuk-heading-l">Subscribe and manage tariff updates</h1>
+    <h1 class="govuk-heading-l">Create and manage your tariff watch lists</h1>
 
-    <p class="govuk-body">
-      Stay up to date with the latest tariff updates by subscribing to Stop Press alerts.
-    </p>
-    <p class="govuk-body">
-      This service can be used by anyone who needs to stay informed about updates
-      to import or export measures and changes to the tariff data structure.
+     <p class="govuk-body">
+      Stay up to date by managing your updates from the UK Trade Tariff Service.
     </p>
 
-    <p class="govuk-body"><strong>What you need to do:</strong></p>
+    <h2 class="govuk-heading-m">What is this service for?</h2>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>Enter your email address</li>
-      <li>Verify your email address</li>
-      <li>Choose your preferences</li>
-    </ul>
+    <p class="govuk-body">
+      This service can be used by anyone who needs to stay informed about changes to UK tariff data for imports and exports.
+    </p>
+
+    <p class="govuk-body">You cannot use this service to get Northern Ireland Online Tariff updates.</p>
+
+    <h2 class="govuk-heading-m">What updates can I receive?</h2>
+
+    <ol class="govuk-list govuk-list--number">
+      <strong><li>Commodity updates:</li></strong>
+        <p class="govuk-body">Receive only updates based on the commodity codes you’re interested in.</p>
+      <strong><li>Stop Press updates:</li></strong>
+        <p class="govuk-body">Select which chapters you’re interested in and you will be informed when there are changes impacting these chapters.</p>
+    </ol>
+
+    <p class="govuk-inset-text">
+      You can change your choices at any time regardless of which update option you choose.
+    </p>
+
 
     <a href="<%= myott_path %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
       Start now

--- a/app/views/myott/subscriptions/start_old.html.erb
+++ b/app/views/myott/subscriptions/start_old.html.erb
@@ -1,0 +1,52 @@
+<% myott_page_title "Subscribe and manage" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          Important
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        This service is in the private beta phase. All information in this service is accurate, but some aspects might change during this phase.
+      </div>
+    </div>
+
+    <h1 class="govuk-heading-l">Subscribe and manage tariff updates</h1>
+
+    <p class="govuk-body">
+      Stay up to date with the latest tariff updates by subscribing to Stop Press alerts.
+    </p>
+    <p class="govuk-body">
+      This service can be used by anyone who needs to stay informed about updates
+      to import or export measures and changes to the tariff data structure.
+    </p>
+
+    <p class="govuk-body"><strong>What you need to do:</strong></p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Enter your email address</li>
+      <li>Verify your email address</li>
+      <li>Choose your preferences</li>
+    </ul>
+
+    <a href="<%= myott_path %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+      Start now
+      <%= render 'shared/start_arrow' %>
+    </a>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m">Manage your subscription</h2>
+
+    <p class="govuk-body">
+      Once you are subscribed, you can manage your subscription,
+      change your preferences or unsubscribe from all emails.
+    </p>
+
+    <a href="<%= myott_path %>" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+      Continue
+    </a>
+  </div>
+</div>


### PR DESCRIPTION
### Jira link

[MyOTT-310](https://transformuk.atlassian.net/browse/MyOTT-310)

### What?

I have added new start page for use in staging only by using existing `my_commodities_enabled` feature flag

### Why?

I am doing this because the old start page is required for production whilst `my_commodities` is disabled in production.

**Existing Start Page**
<img width="559" height="846" alt="image" src="https://github.com/user-attachments/assets/f462bc03-9bd2-461d-8afd-5247db55af36" />

**New Start Page (to appear in staging)**
<img width="546" height="912" alt="image" src="https://github.com/user-attachments/assets/275a1924-c7ab-40a8-ad8c-cfdef8af887b" />
