### PR TITLE
HMRC-1819: Fixes bug in meursing results

### DIFF
--- a/app/views/measures/_meursing_form.html.erb
+++ b/app/views/measures/_meursing_form.html.erb
@@ -2,7 +2,7 @@
 <% meursing_clear_link = link_to 'Clear additional code', meursing_lookup_result_path(goods_nomenclature_code: current_goods_nomenclature_code), class: 'govuk-link meursing-form-textual-button' %>
 
 <div id="meursing" class="govuk-inset-text govuk-inset-text--s no-inset tariff-inset-meursing">
-  <%= form_for MeursingLookup::Result.new, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= form_for MeursingLookup::Result.new, url: meursing_lookup_result_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
     <h4 class="govuk-heading-s">Enter a 'Meursing code' to work out applicable duties</h4>
     <p class="govuk-body">This commodity code features duties which may be dependent on the <b>sugar, flour, milk fat and milk protein</b> content. To fully define the applicable duties, you need to specify the additional code that defines the content of these ingredients.</p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   namespace :meursing_lookup do
     resources :steps, only: %i[show update]
-    resources :results, only: %i[show create]
+    resource :result, only: %i[show create]
   end
 
   namespace :feed, defaults: { format: 'atom' } do

--- a/spec/controllers/meursing_lookup/results_controller_spec.rb
+++ b/spec/controllers/meursing_lookup/results_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MeursingLookup::ResultsController, type: :controller do
 
   describe 'GET #show' do
     subject(:do_response) do
-      get :show, params: { id: 'foo', goods_nomenclature_code: }
+      get :show, params: { goods_nomenclature_code: }
     end
 
     it { expect { do_response }.to change { session[:current_meursing_additional_code_id] }.from('706').to(nil) }


### PR DESCRIPTION
### Jira link

[HMRC-1819](https://transformuk.atlassian.net/browse/HMRC-1819)

### What?

I have a...

- Moved to singular results for the meursing path and jettisoned the :id param on the show action

### Why?

I am doing this because...

- This enables us to just pass a goods nomenclature code to the params helper on clearing that isn't interpreted as an id field
- It makes more sense since we're not showing multiple results - just one
