### PR TITLE
HMRC-1843: Removes e2e tests during preview deployments

### DIFF
--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -87,20 +87,8 @@ jobs:
           echo "❌ Health check failed after retries"
           exit 1
 
-  e2e-test:
-    needs: deploy
-    uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
-    with:
-      test-environment: staging
-      base-url: ${{ needs.deploy.outputs.preview_url }}
-      skip-admin: true
-      skip-api: true
-      skip-passwordless: true
-    secrets:
-      basic_password: ${{ secrets.BASIC_PASSWORD }}
-
   notification:
-      needs: [deploy, e2e-test]
+      needs: [deploy]
       if: failure()
       runs-on: ubuntu-latest
       steps:
@@ -110,7 +98,7 @@ jobs:
             SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
             SLACK_USERNAME: GitHub Actions
             SLACK_CHANNEL: '#non-production-alerts'
-            SLACK_TITLE: 'Preview Deploy or E2E Test Failed'
+            SLACK_TITLE: 'Preview Deploy Failed'
             SLACK_ICON_EMOJI: ':warning:'
             SLACK_MESSAGE: |
               *Repository:* ${{ github.repository }}


### PR DESCRIPTION
### Jira link

[HMRC-1843](https://transformuk.atlassian.net/browse/HMRC-1843)

### What?

I have a...

- Removed the e2e tests from the preview deployment workflow

### Why?

I am doing this because...

- This is a cost/benefit choice based off of the slowness of these preview environments and the fact that the timeout on the e2e suite got increased to 60 second to accommodate it. This timeout increase meant we didn't get the benefits of performance checks that are implicit with each run every 15 minutes and the cost is just too high. We've reset the timeout to be 10 seconds rather than 60 seconds so these preview deployment tests will almost never pass.
