### PR TITLE
HMRC-1844: Adds rack-timeout with a 15 second timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'kaminari'
 gem 'multi_json'
 gem 'net-http-persistent'
 gem 'newrelic_rpm'
-gem 'rack-attack'
 gem 'roo'
 gem 'routing-filter', github: 'trade-tariff/routing-filter'
 gem 'uktt', git: 'https://github.com/trade-tariff/uktt.git'
@@ -83,4 +82,9 @@ group :test do
   gem 'simplecov'
   gem 'vcr'
   gem 'webmock'
+end
+
+group :production do
+  gem 'rack-attack'
+  gem 'rack-timeout'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -590,6 +590,7 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
+    rack-timeout (0.7.0)
     rackup (2.3.1)
       rack (>= 3)
     rails (8.0.3)
@@ -822,6 +823,7 @@ DEPENDENCIES
   rack-attack
   rack-cors
   rack-test
+  rack-timeout
   rails (~> 8.0)
   rails-controller-testing!
   redis

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,3 @@
 if Rails.env.production?
   Rack::Attack.throttle('requests by ip', limit: 500, period: 60, &:ip)
-else
-  Rails.logger.info 'Rack::Attack is disabled in Dev env.'
 end

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,14 @@
+# Rack Timeout Configuration
+# See: https://github.com/zombocom/rack-timeout
+#
+# RACK_TIMEOUT_SERVICE_TIMEOUT (seconds, default: 15)
+# Maximum time the application can take to process and respond to a request once received.
+# Requests exceeding this will be terminated (SIGTERM sent to worker).
+# Current setting: 15 seconds (same as default).
+ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] ||= '15'
+
+# Other available settings (using defaults if not set):
+# - RACK_TIMEOUT_WAIT_TIMEOUT: Maximum wait time in the web server queue (default: 30)
+# - RACK_TIMEOUT_WAIT_OVERTIME: Additional wait time for requests with a body (POST, PUT, etc.) (default: 60)
+# - RACK_TIMEOUT_SERVICE_PAST_WAIT: Whether to use full service_timeout even after wait_timeout (default: false)
+# - RACK_TIMEOUT_TERM_ON_TIMEOUT: Send SIGTERM when timeout occurs (default: 0/false)


### PR DESCRIPTION
### Jira link

[HMRC-1844](https://transformuk.atlassian.net/browse/HMRC-1844)

### What?

- Added the `rack-timeout` gem and configured it with a 15-second service timeout.

### Why?

- To ensure requests don't hang indefinitely and to enforce a strict timeout policy for the application.