### PR TITLE
Refactor MyOTT authentication

### DIFF
--- a/app/controllers/myott/commodity_changes_controller.rb
+++ b/app/controllers/myott/commodity_changes_controller.rb
@@ -1,7 +1,5 @@
 module Myott
   class CommodityChangesController < MycommoditiesController
-    before_action :authenticate
-
     def ending
       @change = changes('ending')
     end

--- a/app/controllers/myott/grouped_measure_changes_controller.rb
+++ b/app/controllers/myott/grouped_measure_changes_controller.rb
@@ -1,7 +1,5 @@
 module Myott
   class GroupedMeasureChangesController < MycommoditiesController
-    before_action :authenticate
-
     def show
       opts = { page: (params[:page].presence || 1).to_i,
                per_page: (params[:per_page].presence || 10).to_i,

--- a/app/controllers/myott/grouped_measure_commodity_changes_controller.rb
+++ b/app/controllers/myott/grouped_measure_commodity_changes_controller.rb
@@ -1,7 +1,5 @@
 module Myott
   class GroupedMeasureCommodityChangesController < MycommoditiesController
-    before_action :authenticate
-
     def show
       @grouped_measure_commodity_changes = TariffChanges::GroupedMeasureCommodityChange.find(
         params[:id],

--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -1,6 +1,5 @@
 module Myott
   class MycommoditiesController < MyottController
-    before_action :authenticate
     before_action except: %i[new create] do
       redirect_to new_myott_mycommodity_path unless current_subscription('my_commodities')
     end

--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -1,6 +1,7 @@
 module Myott
   class MyottController < ApplicationController
-    before_action :disable_search_form,
+    before_action :authenticate,
+                  :disable_search_form,
                   :disable_switch_service_banner,
                   :disable_last_updated_footnote
 

--- a/app/controllers/myott/preferences_controller.rb
+++ b/app/controllers/myott/preferences_controller.rb
@@ -1,7 +1,5 @@
 module Myott
   class PreferencesController < MyottController
-    before_action :authenticate
-
     def new
       session_chapters.delete
     end

--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -1,6 +1,6 @@
 module Myott
   class SubscriptionsController < MyottController
-    before_action :authenticate, except: %i[start invalid]
+    skip_before_action :authenticate, only: %i[start invalid]
 
     def start
       render :start_old and return unless TradeTariffFrontend.my_commodities?

--- a/app/controllers/myott/unsubscribes_controller.rb
+++ b/app/controllers/myott/unsubscribes_controller.rb
@@ -2,7 +2,7 @@ module Myott
   class UnsubscribesController < MyottController
     include UnsubscribesHelper
 
-    before_action :authentication, except: :confirmation
+    skip_before_action :authenticate, only: :confirmation
 
     def show
       render subscription_type
@@ -22,7 +22,7 @@ module Myott
 
   private
 
-    def authentication
+    def authenticate
       if params[:id].nil? || subscription_type.nil?
         redirect_to myott_start_path
       end

--- a/spec/controllers/myott/commodity_changes_controller_spec.rb
+++ b/spec/controllers/myott/commodity_changes_controller_spec.rb
@@ -1,43 +1,52 @@
 RSpec.describe Myott::CommodityChangesController, type: :controller do
-  let(:user_id_token) { 'test_token' }
+  include MyottAuthenticationHelpers
+
   let(:as_of) { Time.zone.today }
   let(:commodity_change) { instance_double(TariffChanges::CommodityChange, count: 1, tariff_changes: []) }
-  let(:subscription) do
-    build(:subscription,
-          active: true,
-          subscription_type: 'my_commodities',
-          metadata: { commodity_codes: %w[1111111111 22222222222 3333333333 4444444444 5555555555] },
-          meta: { active: %w[1111111111 22222222222], expired: %w[33333333333 44444444444], invalid: %w[55555555555] })
-  end
 
   before do
-    allow(controller).to receive_messages(user_id_token: user_id_token, as_of: as_of)
     allow(TariffChanges::CommodityChange).to receive(:find).and_return(commodity_change)
-    allow(controller).to receive(:authenticate)
-    allow(controller).to receive(:current_subscription).and_return(subscription)
   end
 
   describe 'GET #ending' do
-    it 'assigns @change' do
-      get :ending
-      expect(assigns(:change)).to eq(commodity_change)
-    end
+    it_behaves_like 'a protected myott page', :ending
 
-    it 'renders the ending template' do
-      get :ending
-      expect(response).to render_template(:ending)
+    context 'when user is authenticated' do
+      before do
+        subscription = setup_mycommodities_context(as_of: as_of)
+        stub_current_subscription('my_commodities', subscription)
+      end
+
+      it 'assigns @change' do
+        get :ending
+        expect(assigns(:change)).to eq(commodity_change)
+      end
+
+      it 'renders the ending template' do
+        get :ending
+        expect(response).to render_template(:ending)
+      end
     end
   end
 
   describe 'GET #classification' do
-    it 'assigns @change' do
-      get :classification
-      expect(assigns(:change)).to eq(commodity_change)
-    end
+    it_behaves_like 'a protected myott page', :classification
 
-    it 'renders the classification template' do
-      get :classification
-      expect(response).to render_template(:classification)
+    context 'when user is authenticated' do
+      before do
+        subscription = setup_mycommodities_context(as_of: as_of)
+        stub_current_subscription('my_commodities', subscription)
+      end
+
+      it 'assigns @change' do
+        get :classification
+        expect(assigns(:change)).to eq(commodity_change)
+      end
+
+      it 'renders the classification template' do
+        get :classification
+        expect(response).to render_template(:classification)
+      end
     end
   end
 end

--- a/spec/controllers/myott/grouped_measure_changes_controller_spec.rb
+++ b/spec/controllers/myott/grouped_measure_changes_controller_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
-
 RSpec.describe Myott::GroupedMeasureChangesController, type: :controller do
+  include MyottAuthenticationHelpers
+
   describe 'GET #show' do
     let(:user_id_token) { 'token' }
     let(:as_of) { Time.zone.today }
@@ -9,17 +9,9 @@ RSpec.describe Myott::GroupedMeasureChangesController, type: :controller do
       instance_double(TariffChanges::GroupedMeasureChange,
                       grouped_measure_commodity_changes: commodity_changes)
     end
-    let(:subscription) do
-      build(:subscription,
-            active: true,
-            subscription_type: 'my_commodities',
-            metadata: { commodity_codes: %w[1111111111 22222222222 3333333333 4444444444 5555555555] },
-            meta: { active: %w[1111111111 22222222222], expired: %w[33333333333 44444444444], invalid: %w[55555555555] })
-    end
 
     before do
-      allow(controller).to receive_messages(user_id_token: user_id_token, as_of: as_of, authenticate: true)
-      allow(controller).to receive(:current_subscription).and_return(subscription)
+      setup_mycommodities_context(user_id_token: user_id_token, as_of: as_of)
     end
 
     it 'assigns @grouped_measure_changes' do

--- a/spec/controllers/myott/grouped_measure_commodity_changes_controller_spec.rb
+++ b/spec/controllers/myott/grouped_measure_commodity_changes_controller_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
-
 RSpec.describe Myott::GroupedMeasureCommodityChangesController, type: :controller do
+  include MyottAuthenticationHelpers
+
   let(:user_id_token) { 'test-token' }
   let(:id) { 'import_IL__0807190050' }
   let(:as_of) { Time.zone.today.strftime('%Y-%m-%d') }
@@ -12,17 +12,10 @@ RSpec.describe Myott::GroupedMeasureCommodityChangesController, type: :controlle
     change.grouped_measure_change = grouped_measure_change_hash
     change
   end
-  let(:subscription) do
-    build(:subscription,
-          active: true,
-          subscription_type: 'my_commodities',
-          metadata: { commodity_codes: %w[1111111111 22222222222 3333333333 4444444444 5555555555] },
-          meta: { active: %w[1111111111 22222222222], expired: %w[33333333333 44444444444], invalid: %w[55555555555] })
-  end
 
   before do
-    allow(controller).to receive_messages(user_id_token: user_id_token, as_of: Time.zone.today, authenticate: true)
-    allow(controller).to receive(:current_subscription).and_return(subscription)
+    subscription = setup_mycommodities_context(user_id_token: user_id_token, as_of: Time.zone.today)
+    stub_current_subscription('my_commodities', subscription)
   end
 
   describe 'GET #show' do

--- a/spec/controllers/myott/myott_controller_spec.rb
+++ b/spec/controllers/myott/myott_controller_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
-
 RSpec.describe Myott::MyottController, type: :controller do
+  include MyottAuthenticationHelpers
+
   describe '#current_user' do
     let(:user) { build(:user) }
     let(:id_token) { 'encrypted_token' }

--- a/spec/controllers/myott/preferences_controller_spec.rb
+++ b/spec/controllers/myott/preferences_controller_spec.rb
@@ -1,25 +1,17 @@
-require 'spec_helper'
-
 RSpec.describe Myott::PreferencesController, type: :controller do
+  include MyottAuthenticationHelpers
   include_context 'with cached chapters'
 
   let(:user) { build(:user, chapter_ids: '') }
 
   describe 'GET #new' do
-    context 'when current_user is not valid' do
-      before do
-        allow(controller).to receive(:current_user).and_return(nil)
-        get :new
-      end
-
-      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
-    end
+    it_behaves_like 'a protected myott page', :new
 
     context 'when current_user is valid' do
       before do
         session[:chapter_ids] = %w[01 02]
         session[:all_tariff_updates] = true
-        allow(controller).to receive(:current_user).and_return(user)
+        stub_authenticated_user(user)
         get :new
       end
 
@@ -38,7 +30,7 @@ RSpec.describe Myott::PreferencesController, type: :controller do
   describe 'POST #create' do
     context 'when current_user is not valid' do
       before do
-        allow(controller).to receive(:current_user).and_return(nil)
+        stub_unauthenticated_user
         post :create, params: { preference: 'selectChapters' }
       end
 
@@ -47,7 +39,7 @@ RSpec.describe Myott::PreferencesController, type: :controller do
 
     context 'when current_user is valid' do
       before do
-        allow(controller).to receive(:current_user).and_return(user)
+        stub_authenticated_user(user)
       end
 
       context 'when selectChapters is selected' do
@@ -85,18 +77,11 @@ RSpec.describe Myott::PreferencesController, type: :controller do
   end
 
   describe 'GET #edit' do
-    context 'when current_user is not valid' do
-      before do
-        allow(controller).to receive(:current_user).and_return(nil)
-        get :edit
-      end
-
-      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
-    end
+    it_behaves_like 'a protected myott page', :edit
 
     context 'when current_user is valid' do
       before do
-        allow(controller).to receive(:current_user).and_return(user)
+        stub_authenticated_user(user)
         session[:chapter_ids] = %w[01]
         get :edit
       end

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
-
 RSpec.describe Myott::SubscriptionsController, type: :controller do
+  include MyottAuthenticationHelpers
+
   include_context 'with cached chapters'
 
   let(:user) { build(:user, chapter_ids: '') }
@@ -24,7 +24,7 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
 
     context 'when a user does exist' do
       before do
-        allow(controller).to receive(:current_user).and_return(user)
+        stub_authenticated_user(user)
         get :invalid
       end
 
@@ -33,7 +33,7 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
 
     context 'when a user does not exist' do
       before do
-        allow(controller).to receive(:current_user).and_return(nil)
+        stub_unauthenticated_user
         get :invalid
       end
 
@@ -42,18 +42,11 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
   end
 
   describe 'GET #index' do
-    context 'when current_user is not valid' do
-      before do
-        allow(controller).to receive(:current_user).and_return(nil)
-        get :index
-      end
-
-      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
-    end
+    it_behaves_like 'a protected myott page', :index
 
     context 'when current_user is valid' do
       before do
-        allow(controller).to receive(:current_user).and_return(user)
+        stub_authenticated_user(user)
       end
 
       context 'when my_commodities is not enabled' do
@@ -73,8 +66,8 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
 
         before do
           allow(TradeTariffFrontend).to receive(:my_commodities?).and_return(true)
-          allow(controller).to receive(:current_subscription).with('stop_press').and_return(stop_press_subscription)
-          allow(controller).to receive(:current_subscription).with('my_commodities').and_return(my_commodities_subscription)
+          stub_current_subscription('stop_press', stop_press_subscription)
+          stub_current_subscription('my_commodities', my_commodities_subscription)
           get :index
         end
 

--- a/spec/controllers/myott/unsubscribes_controller_spec.rb
+++ b/spec/controllers/myott/unsubscribes_controller_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
-
 RSpec.describe Myott::UnsubscribesController, type: :controller do
+  include MyottAuthenticationHelpers
+
   let(:subscription) { build(:subscription, subscription_type: 'stop_press') }
 
   describe 'GET #show' do

--- a/spec/support/helpers/myott_authentication_helpers.rb
+++ b/spec/support/helpers/myott_authentication_helpers.rb
@@ -1,0 +1,81 @@
+module MyottAuthenticationHelpers
+  def stub_unauthenticated_user
+    allow(controller).to receive(:current_user).and_return(nil)
+  end
+
+  def stub_authenticated_user(user = nil)
+    user ||= build(:user)
+    allow(controller).to receive(:current_user).and_return(user)
+    user
+  end
+
+  def stub_current_subscription(subscription_type, subscription)
+    allow(controller).to receive(:current_subscription).with(subscription_type).and_return(subscription)
+    subscription
+  end
+
+  def stub_unauthenticated_user_with_bypass
+    allow(controller).to receive(:authenticate)
+    stub_unauthenticated_user
+  end
+
+  def setup_myott_authentication(
+    user: nil,
+    user_id_token: 'test_token',
+    subscription_type: nil,
+    subscription: nil,
+    as_of: Time.zone.today,
+    bypass_auth: false
+  )
+    # Always stub authentication method to prevent redirect loops
+    allow(controller).to receive(:authenticate) if bypass_auth
+
+    if user == :none || user.nil? && !bypass_auth
+      stub_unauthenticated_user
+      return { user: nil, user_id_token: user_id_token, subscription: subscription }
+    else
+      user = stub_authenticated_user(user)
+    end
+
+    allow(controller).to receive(:user_id_token).and_return(user_id_token) if user_id_token
+
+    if subscription_type
+      subscription = stub_current_subscription(subscription_type, subscription)
+    end
+
+    allow(controller).to receive(:as_of).and_return(as_of) if as_of
+
+    {
+      user: user,
+      user_id_token: user_id_token,
+      subscription: subscription,
+      as_of: as_of,
+    }
+  end
+
+  def setup_mycommodities_context(
+    user: nil,
+    subscription_type: 'my_commodities',
+    user_id_token: 'test_token',
+    as_of: Time.zone.today
+  )
+    user ||= build(:user, my_commodities_subscription: true)
+
+    subscription = build(:subscription,
+                         active: true,
+                         subscription_type: subscription_type,
+                         metadata: { commodity_codes: %w[1111111111 22222222222 3333333333 4444444444 5555555555] },
+                         meta: { active: %w[1111111111 22222222222], expired: %w[33333333333 44444444444], invalid: %w[55555555555] })
+
+    setup_myott_authentication(
+      user: user,
+      user_id_token: user_id_token,
+      subscription_type: subscription_type,
+      subscription: subscription,
+      as_of: as_of,
+      bypass_auth: true,
+    )
+
+    subscription
+  end
+end

--- a/spec/support/shared_examples/a_commodity_category_page.rb
+++ b/spec/support/shared_examples/a_commodity_category_page.rb
@@ -1,9 +1,11 @@
-RSpec.shared_examples 'a commodity category page' do |action, category|
+RSpec.shared_examples 'a commodity category page' do |action|
   subject { response }
 
   let(:page) { '2' }
   let(:per_page) { '20' }
   let(:user_id_token) { 'valid-jwt-token' }
+
+  it_behaves_like 'a protected myott page', action
 
   before do
     allow(controller).to receive_messages(get_subscription: subscription, user_id_token: user_id_token)
@@ -12,7 +14,7 @@ RSpec.shared_examples 'a commodity category page' do |action, category|
     allow(targets).to receive(:count).and_return(3)
 
     expected_params = {
-      filter: { active_commodities_type: category },
+      filter: { active_commodities_type: action.to_s },
       page: page,
       per_page: per_page,
     }

--- a/spec/support/shared_examples/a_protected_myott_page.rb
+++ b/spec/support/shared_examples/a_protected_myott_page.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples 'a protected myott page' do |action|
+  context 'when current_user is not valid' do
+    before do
+      stub_unauthenticated_user
+      get action
+    end
+
+    it { is_expected.to redirect_to 'http://localhost:3005/myott' }
+  end
+end

--- a/spec/support/shared_examples/a_valid_commodity_file_upload.rb
+++ b/spec/support/shared_examples/a_valid_commodity_file_upload.rb
@@ -38,8 +38,8 @@ RSpec.shared_examples 'a valid commodity file upload' do |fixture_path, content_
       allow(Subscription).to receive(:batch)
 
       allow(controller).to receive(:current_subscription)
-      .with('my_commodities')
-      .and_return(nil, subscription)
+                       .with('my_commodities')
+                       .and_return(nil, subscription)
 
       post :create, params: { fileUpload1: valid_file }
     end


### PR DESCRIPTION
### What?

Ensure all myott actions use the same authentication method by moving the authenticate before_action to MyOTTController. Where authentication is not required, `skip_before_action` is used for those actions.

Also creates shared methods for testing