### PR TITLE
MYOTT-378 Store URL whilst user authenticates

### DIFF
--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -9,7 +9,10 @@ module Myott
 
     def authenticate
       if current_user.nil?
+        session[:myott_return_url] = request.fullpath
         redirect_to(URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s, allow_other_host: true)
+      elsif session[:myott_return_url]
+        redirect_to(session.delete(:myott_return_url))
       end
     end
 


### PR DESCRIPTION
### Jira link

[MYOTT-378](https://transformuk.atlassian.net/browse/MYOTT-378)

### What?

Currently when a user is not authenticated they are redirected to the Identity service. After logging in they are always returned to the watch lists dashboard page, not the page they were trying to access.

Now their intended URL is stored in the session so they are redirected to that page after logging in.

### Why?

This allows links to specific pages to be added to notification emails, and for these links to work when the user needs to login to the service.
