### PR TITLE
HMRC-1819: Fix parameter missing error in meursing lookup results controller

### DIFF
--- a/app/controllers/meursing_lookup/results_controller.rb
+++ b/app/controllers/meursing_lookup/results_controller.rb
@@ -25,8 +25,11 @@ module MeursingLookup
     end
 
     def set_goods_nomenclature_code
-      @goods_nomenclature_code = params[:goods_nomenclature_code] || # Set by the link to show action query param
-        result_params[:goods_nomenclature_code] # Set by the update form submission
+      @goods_nomenclature_code = if params[:goods_nomenclature_code].present?
+                                   params[:goods_nomenclature_code]
+                                 elsif params[:meursing_lookup_result].present?
+                                   result_params[:goods_nomenclature_code]
+                                 end
     end
   end
 end

--- a/spec/controllers/meursing_lookup/results_controller_spec.rb
+++ b/spec/controllers/meursing_lookup/results_controller_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe MeursingLookup::ResultsController, type: :controller do
 
     it { expect { do_response }.to change { session[:current_meursing_additional_code_id] }.from('706').to(nil) }
     it { is_expected.to redirect_to(commodity_path(goods_nomenclature_code)) }
+
+    context 'when goods_nomenclature_code parameter is missing' do
+      subject(:do_response) do
+        get :show, params: {}
+      end
+
+      it 'does not raise ParameterMissing error' do
+        expect { do_response }.not_to raise_error
+      end
+
+      it { expect { do_response }.to change { session[:current_meursing_additional_code_id] }.from('706').to(nil) }
+    end
   end
 
   describe 'POST #create' do

--- a/spec/controllers/meursing_lookup/results_controller_spec.rb
+++ b/spec/controllers/meursing_lookup/results_controller_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe MeursingLookup::ResultsController, type: :controller do
       end
 
       it { expect { do_response }.to change { session[:current_meursing_additional_code_id] }.from('706').to(nil) }
+
+      it 'redirects to find_commodity page' do
+        do_response
+        expect(response).to redirect_to(find_commodity_path)
+      end
     end
   end
 


### PR DESCRIPTION
### Jira link

[HMRC-1819](https://transformuk.atlassian.net/browse/HMRC-1819)

### What?

Fixes a production bug causing `ActionController::ParameterMissing` errors when users accessed the meursing lookup results page without required parameters.

### Why?

**The Bug:**
The `set_goods_nomenclature_code` method attempted to access `result_params` when the `meursing_lookup_result` parameter didn't exist:

```ruby
@goods_nomenclature_code = params[:goods_nomenclature_code] || result_params[:goods_nomenclature_code]
```

When `params[:goods_nomenclature_code]` was nil, the `||` operator evaluated `result_params`, which calls `params.require(:meursing_lookup_result)` and raises an error if that parameter is missing (common for GET requests).

**The Fix:**
Check if parameters exist before accessing them:

```ruby
@goods_nomenclature_code = if params[:goods_nomenclature_code].present?
                             params[:goods_nomenclature_code]
                           elsif params[:meursing_lookup_result].present?
                             result_params[:goods_nomenclature_code]
                           end
```

Now when parameters are missing, `@goods_nomenclature_code` is nil and users are gracefully redirected to `/find_commodity` instead of seeing a 400 error.

**Testing:**
- Added test coverage for missing parameters scenario
- Verified redirect behavior when goods nomenclature code is unavailable
- All existing tests pass