### PR TITLE
HMRC-1870: Handle authentication failures and clear cookies in frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ yarn-debug.log*
 /test-results
 /playwright-report/
 /dist
+
+.claude/

--- a/app/controllers/myott/unsubscribes_controller.rb
+++ b/app/controllers/myott/unsubscribes_controller.rb
@@ -17,7 +17,7 @@ module Myott
       content = unsubscribe_confirmation_content(@subscription_type)
       @header = content[:header]
       @message = content[:message]
-      delete_cookie
+      clear_authentication_cookies
     end
 
   private
@@ -34,11 +34,6 @@ module Myott
 
     def my_commodities_subscription?
       subscription_type == Subscription::SUBSCRIPTION_TYPES[:my_commodities]
-    end
-
-    def delete_cookie
-      domain = ".#{request.host.sub(/^www\./, '')}"
-      cookies.delete(:id_token, domain:)
     end
 
     def unsubscribe

--- a/app/lib/authentication_error.rb
+++ b/app/lib/authentication_error.rb
@@ -1,0 +1,16 @@
+class AuthenticationError < StandardError
+  attr_reader :reason
+
+  def initialize(message, reason: nil)
+    super(message)
+    @reason = reason
+  end
+
+  def expired?
+    reason == 'expired'
+  end
+
+  def should_clear_cookies?
+    %w[not_in_group invalid_token missing_jwks_keys].include?(reason)
+  end
+end

--- a/app/models/concerns/authenticatable_api_entity.rb
+++ b/app/models/concerns/authenticatable_api_entity.rb
@@ -7,8 +7,8 @@ module AuthenticatableApiEntity
       return nil if token.nil? && !Rails.env.development?
 
       super(id, options, headers(token))
-    rescue Faraday::UnauthorizedError
-      nil
+    rescue Faraday::UnauthorizedError => e
+      handle_unauthorized_error(e)
     end
 
     def all(token, params = {})
@@ -17,14 +17,35 @@ module AuthenticatableApiEntity
       end
 
       collection(collection_path, params, headers(token))
-    rescue Faraday::UnauthorizedError
-      []
+    rescue Faraday::UnauthorizedError => e
+      handle_unauthorized_error(e, default_return: [])
     end
 
     def headers(token)
       {
         authorization: "Bearer #{token}",
       }
+    end
+
+  private
+
+    def handle_unauthorized_error(error, default_return: nil)
+      reason = extract_error_reason(error)
+
+      if reason
+        raise AuthenticationError.new(error.message, reason:)
+      else
+        default_return
+      end
+    end
+
+    def extract_error_reason(error)
+      return nil unless error.response&.dig(:body)
+
+      body = JSON.parse(error.response[:body])
+      body.dig('errors', 0, 'code')
+    rescue JSON::ParserError
+      nil
     end
   end
 end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -47,6 +47,26 @@ module TradeTariffFrontend
     ENV.fetch('IDENTITY_BASE_URL', 'http://localhost:3005')
   end
 
+  def identity_cookie_domain
+    @identity_cookie_domain ||= if Rails.env.production?
+                                  ".#{base_domain}"
+                                else
+                                  :all
+                                end
+  end
+
+  def base_domain
+    @base_domain ||= begin
+      domain = ENV['GOVUK_APP_DOMAIN']
+
+      unless /(http(s?):).*/.match(domain)
+        domain = "https://#{domain}"
+      end
+
+      URI.parse(domain).host
+    end
+  end
+
   def backend_base_domain
     ENV['BACKEND_BASE_DOMAIN']
   end

--- a/spec/controllers/myott/myott_controller_spec.rb
+++ b/spec/controllers/myott/myott_controller_spec.rb
@@ -154,4 +154,88 @@ RSpec.describe Myott::MyottController, type: :controller do
       end
     end
   end
+
+  describe '#handle_authentication_error' do
+    let(:identity_base_url) { 'https://auth.example.com' }
+    let(:request_fullpath) { '/myott/commodities/123' }
+    let(:error) { AuthenticationError.new('Authentication failed', reason: error_reason) }
+
+    before do
+      allow(controller).to receive(:request).and_return(instance_double(ActionDispatch::Request, fullpath: request_fullpath))
+      allow(TradeTariffFrontend).to receive(:identity_base_url).and_return(identity_base_url)
+      allow(controller).to receive(:redirect_to)
+      allow(controller).to receive(:clear_authentication_cookies)
+    end
+
+    context 'when error requires clearing cookies' do
+      let(:error_reason) { 'invalid_token' }
+
+      it 'clears authentication cookies' do
+        controller.send(:handle_authentication_error, error)
+
+        expect(controller).to have_received(:clear_authentication_cookies)
+      end
+
+      it 'stores the current URL in session' do
+        controller.send(:handle_authentication_error, error)
+
+        expect(controller.session[:myott_return_url]).to eq(request_fullpath)
+      end
+
+      it 'redirects to identity service' do
+        controller.send(:handle_authentication_error, error)
+
+        expect(controller).to have_received(:redirect_to)
+          .with('https://auth.example.com/myott', allow_other_host: true)
+      end
+    end
+
+    context 'when error does not require clearing cookies' do
+      let(:error_reason) { 'expired' }
+
+      it 'does not clear authentication cookies' do
+        controller.send(:handle_authentication_error, error)
+
+        expect(controller).not_to have_received(:clear_authentication_cookies)
+      end
+
+      it 'stores the current URL in session' do
+        controller.send(:handle_authentication_error, error)
+
+        expect(controller.session[:myott_return_url]).to eq(request_fullpath)
+      end
+
+      it 'redirects to identity service' do
+        controller.send(:handle_authentication_error, error)
+
+        expect(controller).to have_received(:redirect_to)
+          .with('https://auth.example.com/myott', allow_other_host: true)
+      end
+    end
+  end
+
+  describe '#clear_authentication_cookies' do
+    let(:cookies_double) { instance_double(ActionDispatch::Cookies::CookieJar) }
+    let(:identity_cookie_domain) { '.example.com' }
+
+    before do
+      allow(controller).to receive(:cookies).and_return(cookies_double)
+      allow(TradeTariffFrontend).to receive(:identity_cookie_domain).and_return(identity_cookie_domain)
+      allow(cookies_double).to receive(:delete)
+    end
+
+    it 'deletes the id_token cookie with correct domain' do
+      controller.send(:clear_authentication_cookies)
+
+      expect(cookies_double).to have_received(:delete)
+        .with(:id_token, domain: identity_cookie_domain)
+    end
+
+    it 'deletes the refresh_token cookie with correct domain' do
+      controller.send(:clear_authentication_cookies)
+
+      expect(cookies_double).to have_received(:delete)
+        .with(:refresh_token, domain: identity_cookie_domain)
+    end
+  end
 end

--- a/spec/controllers/myott/unsubscribes_controller_spec.rb
+++ b/spec/controllers/myott/unsubscribes_controller_spec.rb
@@ -108,16 +108,14 @@ RSpec.describe Myott::UnsubscribesController, type: :controller do
       expect(assigns(:message)).to eq('You will no longer receive any Stop Press emails from the UK Trade Tariff Service.')
     end
 
-    context 'when request host contains www' do
-      before do
-        request.host = 'www.example.com'
-        allow(cookies).to receive(:delete).and_call_original
-      end
+    it 'deletes the id_token and refresh_token cookie', :aggregate_failures do
+      cookies_spy = instance_spy(ActionDispatch::Cookies::CookieJar)
+      allow(controller).to receive(:cookies).and_return(cookies_spy)
 
-      it 'deletes the id_token cookie with the correct domain' do
-        expect_any_instance_of(ActionDispatch::Cookies::CookieJar).to receive(:delete).with(:id_token, hash_including(domain: '.example.com')) # rubocop:disable RSpec/AnyInstance
-        get :confirmation, params: { subscription_type: subscription['subscription_type'] }
-      end
+      get :confirmation, params: { subscription_type: subscription['subscription_type'] }
+
+      expect(cookies_spy).to have_received(:delete).with(:id_token, hash_including(domain: :all))
+      expect(cookies_spy).to have_received(:delete).with(:refresh_token, hash_including(domain: :all))
     end
   end
 

--- a/spec/lib/authentication_error_spec.rb
+++ b/spec/lib/authentication_error_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+RSpec.describe AuthenticationError do
+  describe '#initialize' do
+    it 'sets the message' do
+      error = described_class.new('Authentication failed')
+
+      expect(error.message).to eq('Authentication failed')
+    end
+
+    it 'sets the reason when provided' do
+      error = described_class.new('Token expired', reason: 'expired')
+
+      expect(error.reason).to eq('expired')
+    end
+
+    it 'allows nil reason' do
+      error = described_class.new('Authentication failed', reason: nil)
+
+      expect(error.reason).to be_nil
+    end
+  end
+
+  describe '#expired?' do
+    context 'when reason is "expired"' do
+      it 'returns true' do
+        error = described_class.new('Token expired', reason: 'expired')
+
+        expect(error.expired?).to be true
+      end
+    end
+
+    context 'when reason is not "expired"' do
+      it 'returns false for invalid_token' do
+        error = described_class.new('Invalid token', reason: 'invalid_token')
+
+        expect(error.expired?).to be false
+      end
+
+      it 'returns false for nil' do
+        error = described_class.new('Error', reason: nil)
+
+        expect(error.expired?).to be false
+      end
+    end
+  end
+
+  describe '#should_clear_cookies?' do
+    context 'when reason requires cookie clearing' do
+      it 'returns true for not_in_group' do
+        error = described_class.new('Not in group', reason: 'not_in_group')
+
+        expect(error.should_clear_cookies?).to be true
+      end
+
+      it 'returns true for invalid_token' do
+        error = described_class.new('Invalid token', reason: 'invalid_token')
+
+        expect(error.should_clear_cookies?).to be true
+      end
+
+      it 'returns true for missing_jwks_keys' do
+        error = described_class.new('Missing JWKS keys', reason: 'missing_jwks_keys')
+
+        expect(error.should_clear_cookies?).to be true
+      end
+    end
+
+    context 'when reason does not require cookie clearing' do
+      it 'returns false for expired' do
+        error = described_class.new('Token expired', reason: 'expired')
+
+        expect(error.should_clear_cookies?).to be false
+      end
+
+      it 'returns false for nil' do
+        error = described_class.new('Error', reason: nil)
+
+        expect(error.should_clear_cookies?).to be false
+      end
+
+      it 'returns false for unknown reason' do
+        error = described_class.new('Error', reason: 'unknown_error')
+
+        expect(error.should_clear_cookies?).to be false
+      end
+    end
+  end
+end

--- a/spec/lib/trade_tariff_frontend_spec.rb
+++ b/spec/lib/trade_tariff_frontend_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+
+RSpec.describe TradeTariffFrontend do
+  describe '.identity_cookie_domain' do
+    around do |example|
+      # Clear cached values before and after each test to prevent contamination
+      described_class.instance_variable_set(:@identity_cookie_domain, nil)
+      described_class.instance_variable_set(:@base_domain, nil)
+
+      example.run
+
+      described_class.instance_variable_set(:@identity_cookie_domain, nil)
+      described_class.instance_variable_set(:@base_domain, nil)
+    end
+
+    context 'when in production environment' do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      shared_examples 'returns correct domain' do |env_value, expected_domain|
+        around do |example|
+          original = ENV['GOVUK_APP_DOMAIN']
+          ENV['GOVUK_APP_DOMAIN'] = env_value
+          example.run
+          ENV['GOVUK_APP_DOMAIN'] = original
+        end
+
+        it "returns '#{expected_domain}' for GOVUK_APP_DOMAIN='#{env_value}'" do
+          expect(described_class.identity_cookie_domain).to eq(expected_domain)
+        end
+      end
+
+      context 'with GOVUK_APP_DOMAIN set' do
+        around do |example|
+          original = ENV['GOVUK_APP_DOMAIN']
+          ENV['GOVUK_APP_DOMAIN'] = 'https://trade-tariff.service.gov.uk'
+          example.run
+          ENV['GOVUK_APP_DOMAIN'] = original
+        end
+
+        it 'returns the base domain with leading dot' do
+          expect(described_class.identity_cookie_domain).to eq('.trade-tariff.service.gov.uk')
+        end
+      end
+
+      it_behaves_like 'returns correct domain', 'trade-tariff.service.gov.uk', '.trade-tariff.service.gov.uk'
+      it_behaves_like 'returns correct domain', 'https://trade-tariff.service.gov.uk', '.trade-tariff.service.gov.uk'
+      it_behaves_like 'returns correct domain', 'http://trade-tariff.service.gov.uk', '.trade-tariff.service.gov.uk'
+    end
+
+    context 'when in non-production environment' do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(false)
+      end
+
+      it 'returns :all' do
+        expect(described_class.identity_cookie_domain).to eq(:all)
+      end
+    end
+  end
+
+  describe '.base_domain' do
+    around do |example|
+      # Clear cached values before and after each test to prevent contamination
+      described_class.instance_variable_set(:@identity_cookie_domain, nil)
+      described_class.instance_variable_set(:@base_domain, nil)
+
+      example.run
+
+      described_class.instance_variable_set(:@identity_cookie_domain, nil)
+      described_class.instance_variable_set(:@base_domain, nil)
+    end
+
+    context 'with GOVUK_APP_DOMAIN without protocol' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('GOVUK_APP_DOMAIN' => 'www.trade-tariff.service.gov.uk'))
+      end
+
+      it 'extracts the domain host' do
+        expect(described_class.base_domain).to eq('www.trade-tariff.service.gov.uk')
+      end
+    end
+
+    context 'with GOVUK_APP_DOMAIN with https protocol' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('GOVUK_APP_DOMAIN' => 'https://www.trade-tariff.service.gov.uk'))
+      end
+
+      it 'extracts the domain host' do
+        expect(described_class.base_domain).to eq('www.trade-tariff.service.gov.uk')
+      end
+    end
+
+    context 'with GOVUK_APP_DOMAIN with http protocol' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('GOVUK_APP_DOMAIN' => 'http://www.trade-tariff.service.gov.uk'))
+      end
+
+      it 'extracts the domain host' do
+        expect(described_class.base_domain).to eq('www.trade-tariff.service.gov.uk')
+      end
+    end
+
+    context 'with GOVUK_APP_DOMAIN including path' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('GOVUK_APP_DOMAIN' => 'https://www.trade-tariff.service.gov.uk/path'))
+      end
+
+      it 'extracts only the host part' do
+        expect(described_class.base_domain).to eq('www.trade-tariff.service.gov.uk')
+      end
+    end
+
+    context 'with GOVUK_APP_DOMAIN including port' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('GOVUK_APP_DOMAIN' => 'https://localhost:3000'))
+      end
+
+      it 'extracts only the host part' do
+        expect(described_class.base_domain).to eq('localhost')
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Jira link

[HMRC-1870](https://transformuk.atlassian.net/browse/HMRC-1870)

## What?

I have:

- [x] Created `AuthenticationError` class with `should_clear_cookies?` logic
- [x] Updated `AuthenticatableApiEntity` to parse JSON:API error responses from backend
- [x] Updated `MyottController` to handle `AuthenticationError` and selectively clear cookies
- [x] Added `identity_cookie_domain` helper to `TradeTariffFrontend` (derived from `base_domain`)

## Why?

I am doing this because:

- When the backend returns specific authentication error codes, the frontend needs to take appropriate action
- For `not_in_group`, `invalid_token`, and `missing_jwks_keys` errors, cookies must be cleared to force clean re-authentication
- For `expired` token errors, cookies should be preserved so the identity service can refresh them automatically
- Without clearing cookies for invalid authentication states, users get stuck in redirect loops between services
- This completes the authentication failure handling flow started in the backend

The frontend now:
1. Catches `Faraday::UnauthorizedError` from API calls
2. Parses the JSON:API error response to extract the error code
3. Raises `AuthenticationError` with the specific reason
4. Clears `id_token` and `refresh_token` cookies if needed
5. Redirects to identity service for re-authentication

## Related PRs

- Backend: https://github.com/trade-tariff/trade-tariff-backend/pull/2691