### PR TITLE
BAU: Disable verbose rack-timeout logging

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -12,3 +12,7 @@ ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] ||= '15'
 # - RACK_TIMEOUT_WAIT_OVERTIME: Additional wait time for requests with a body (POST, PUT, etc.) (default: 60)
 # - RACK_TIMEOUT_SERVICE_PAST_WAIT: Whether to use full service_timeout even after wait_timeout (default: false)
 # - RACK_TIMEOUT_TERM_ON_TIMEOUT: Send SIGTERM when timeout occurs (default: 0/false)
+
+# Disable verbose logging - only log when timeouts actually occur
+# Timeout exceptions will still be raised and logged by Rails as 503 errors
+Rack::Timeout::Logger.disable if Rails.env.production?


### PR DESCRIPTION
### Jira link

N/A (BAU fix)

### What?

I have added/removed/altered:

- [x] Disabled rack-timeout verbose logging by calling `Rack::Timeout::Logger.disable`

### Why?

I am doing this because:

- rack-timeout was logging two lines (state=ready, state=completed) for every single request
- This clutters the logs with unhelpful noise, making it harder to find actual issues
- Timeout exceptions will still be raised and logged by Rails as 503 errors, so we still get visibility when actual timeouts occur

### Have you? (optional)

- N/A - Configuration change only, no new APIs or environment variables

### Deployment risks (optional)

- Low risk: Only affects logging output, does not change timeout behavior
- Timeout exceptions will still be raised and visible in Rails logs