### PR TITLE
Update subscription meta

### DIFF
--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -80,10 +80,10 @@ module Myott
       meta = current_subscription('my_commodities')[:meta]
 
       OpenStruct.new(
-        active: meta['active'].count,
-        expired: meta['expired'].count,
-        invalid: meta['invalid'].count,
-        total: meta.values.flatten.size,
+        active: meta['active'],
+        expired: meta['expired'],
+        invalid: meta['invalid'],
+        total: meta.values.sum,
       )
     end
 

--- a/spec/controllers/myott/mycommodities_controller_spec.rb
+++ b/spec/controllers/myott/mycommodities_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
           active: true,
           subscription_type: 'my_commodities',
           metadata: { commodity_codes: %w[1111111111 22222222222 3333333333 4444444444 5555555555] },
-          meta: { active: %w[1111111111 22222222222], expired: %w[33333333333 44444444444], invalid: %w[55555555555] })
+          meta: { active: 2, expired: 2, invalid: 1 })
   end
 
   before do
@@ -74,10 +74,10 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
 
         it { is_expected.to respond_with(:success) }
 
-        it { expect(assigns(:meta).total).to eq(subscription.meta.values.flatten.size) }
-        it { expect(assigns(:meta).active).to eq(subscription.meta[:active].count) }
-        it { expect(assigns(:meta).expired).to eq(subscription.meta[:expired].count) }
-        it { expect(assigns(:meta).invalid).to eq(subscription.meta[:invalid].count) }
+        it { expect(assigns(:meta).total).to eq(subscription.meta.values.sum) }
+        it { expect(assigns(:meta).active).to eq(subscription.meta[:active]) }
+        it { expect(assigns(:meta).expired).to eq(subscription.meta[:expired]) }
+        it { expect(assigns(:meta).invalid).to eq(subscription.meta[:invalid]) }
 
         it 'assigns @grouped_measure_changes' do
           expect(assigns(:grouped_measure_changes)).to eq(grouped_measure_changes)


### PR DESCRIPTION
### What?

https://github.com/trade-tariff/trade-tariff-backend/pull/2702 changes the API so the meta component only returns counts. This is an update to match.

### Why?

This was done to speed up the API
