### PR TITLE
BAU: Handle different environment cookies

### DIFF
--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -26,8 +26,8 @@ module Myott
     end
 
     def clear_authentication_cookies
-      cookies.delete(:id_token, domain: TradeTariffFrontend.identity_cookie_domain)
-      cookies.delete(:refresh_token, domain: TradeTariffFrontend.identity_cookie_domain)
+      cookies.delete(id_token_cookie_name, domain: TradeTariffFrontend.identity_cookie_domain)
+      cookies.delete(refresh_token_cookie_name, domain: TradeTariffFrontend.identity_cookie_domain)
     end
 
     def current_user
@@ -42,7 +42,15 @@ module Myott
     helper_method :current_subscription
 
     def user_id_token
-      cookies[:id_token]
+      cookies[id_token_cookie_name]
+    end
+
+    def id_token_cookie_name
+      TradeTariffFrontend.id_token_cookie_name
+    end
+
+    def refresh_token_cookie_name
+      TradeTariffFrontend.refresh_token_cookie_name
     end
 
     def get_subscription(subscription_type)

--- a/app/controllers/myott/stop_presses_controller.rb
+++ b/app/controllers/myott/stop_presses_controller.rb
@@ -22,7 +22,7 @@ module Myott
                       session[:chapter_ids].join(',')
                     end
 
-      if User.update(cookies[:id_token], chapter_ids: chapter_ids, stop_press_subscription: 'true')
+      if User.update(user_id_token, chapter_ids: chapter_ids, stop_press_subscription: 'true')
         session_chapters.delete
         redirect_to confirmation_myott_stop_press_path and return
       end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -10,7 +10,24 @@ module TradeTariffFrontend
   end
 
   def environment
-    ENV.fetch('ENVIRONMENT', Rails.env)
+    ENV.fetch('ENVIRONMENT', 'production')
+  end
+
+  def id_token_cookie_name
+    cookie_name_for('id_token')
+  end
+
+  def refresh_token_cookie_name
+    cookie_name_for('refresh_token')
+  end
+
+  def cookie_name_for(base_name)
+    case environment
+    when 'production'
+      base_name
+    else
+      "#{environment}_#{base_name}"
+    end.to_sym
   end
 
   def redis_config


### PR DESCRIPTION
### Jira link

BAU

### What?

I have a...

- Added handling for cookies across different environments

### Why?

I am doing this because...

- This is needed to make sure we're in a position to differentiate between each of the different environments when it comes to passwordless sessions
