### PR TITLE
MYOTT-289 Add subscription info

### DIFF
--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -19,7 +19,7 @@ module Myott
     end
 
     def index
-      @meta = counts_from_subscription_metadata
+      @commodity_code_counts = counts_from_subscription_metadata
       @grouped_measure_changes = TariffChanges::GroupedMeasureChange.all(user_id_token, { as_of: as_of.to_fs(:dashed) })
       @commodity_changes = TariffChanges::CommodityChange.all(user_id_token, { as_of: as_of.to_fs(:dashed) })
     end

--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -77,13 +77,13 @@ module Myott
     end
 
     def metadata_from_subscription
-      meta = current_subscription('my_commodities')[:meta]
+      counts = current_subscription('my_commodities')[:meta][:counts]
 
       OpenStruct.new(
-        active: meta['active'],
-        expired: meta['expired'],
-        invalid: meta['invalid'],
-        total: meta.values.sum,
+        active: counts['active'],
+        expired: counts['expired'],
+        invalid: counts['invalid'],
+        total: counts['total'],
       )
     end
 

--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -19,7 +19,7 @@ module Myott
     end
 
     def index
-      @meta = metadata_from_subscription
+      @meta = counts_from_subscription_metadata
       @grouped_measure_changes = TariffChanges::GroupedMeasureChange.all(user_id_token, { as_of: as_of.to_fs(:dashed) })
       @commodity_changes = TariffChanges::CommodityChange.all(user_id_token, { as_of: as_of.to_fs(:dashed) })
     end
@@ -76,14 +76,15 @@ module Myott
       SubscriptionTarget.all(current_subscription('my_commodities').resource_id, user_id_token, params)
     end
 
-    def metadata_from_subscription
-      counts = current_subscription('my_commodities')[:meta][:counts]
+    def counts_from_subscription_metadata
+      subscription = current_subscription('my_commodities')
+      counts = subscription&.dig(:meta, :counts) || {}
 
       OpenStruct.new(
-        active: counts['active'],
-        expired: counts['expired'],
-        invalid: counts['invalid'],
-        total: counts['total'],
+        active: counts['active'] || 0,
+        expired: counts['expired'] || 0,
+        invalid: counts['invalid'] || 0,
+        total: counts['total'] || 0,
       )
     end
 

--- a/app/views/myott/mycommodities/_counts.html.erb
+++ b/app/views/myott/mycommodities/_counts.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Total commodities uploaded: <%= number_with_delimiter(meta.total) %></h2>
+    <h2 class="govuk-heading-l">Total commodities uploaded: <%= number_with_delimiter(commodity_codes.total) %></h2>
   </div>
 </div>
 <div class="govuk-grid-row ">
@@ -8,24 +8,24 @@
     <div class="category_container">
       <strong>Errors from commodity upload:</strong>
       <br />
-      <%= link_to number_with_delimiter(meta.invalid), invalid_myott_mycommodities_path %>
+      <%= link_to number_with_delimiter(commodity_codes.invalid), invalid_myott_mycommodities_path %>
     </div>
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="category_container">
       <strong>Expired commodity codes:</strong>
       <br />
-      <%= link_to number_with_delimiter(meta.expired), expired_myott_mycommodities_path %>
+      <%= link_to number_with_delimiter(commodity_codes.expired), expired_myott_mycommodities_path %>
     </div>
   </div>
   <div class="govuk-grid-column-one-third">
     <div class='category_container'>
       <strong>Active commodities:</strong>
       <br />
-      <% if meta.active.zero? %>
+      <% if commodity_codes.active.zero? %>
         0
       <% else %>
-        <%= link_to number_with_delimiter(meta.active), active_myott_mycommodities_path %>
+        <%= link_to number_with_delimiter(commodity_codes.active), active_myott_mycommodities_path %>
       <% end %>
     </div>
   </div>

--- a/app/views/myott/mycommodities/index.html.erb
+++ b/app/views/myott/mycommodities/index.html.erb
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full watch-list-container">
       <h1 class="govuk-heading-xl">Your commodity watch list</h1>
-      <%= render 'meta',  meta: @meta %>
+      <%= render 'counts',  commodity_codes: @commodity_code_counts %>
     </div>
 
       <div class="govuk-grid-row">

--- a/app/views/myott/subscriptions/index.html.erb
+++ b/app/views/myott/subscriptions/index.html.erb
@@ -12,9 +12,11 @@
       <div class="app-card">
         <h2 class="govuk-heading-m app-card__heading">Commodity watch list</h2>
         <% if @my_commodities.present? %>
+          <p class="govuk-body govuk-!-static-margin-bottom-0"><strong>Changes published yesterday: <%= @my_commodities[:meta][:published][:yesterday] %></strong></p>
+          <p class="govuk-body">Total commodities selected: <%= @my_commodities[:meta][:counts][:total] %></p>
           <%= link_to 'View commodity watch list', myott_mycommodities_path %>
         <% else %>
-          <p class="govuk-body"><strong>No commodities selected</strong></p>
+          <p class="govuk-body govuk-!-static-margin-bottom-0"><strong>No commodities selected</strong></p>
           <p class="govuk-body">You will receive updates on specific commodities</p>
           <%= link_to 'Create a commodity watch list',  new_myott_mycommodity_path %>
         <% end %>
@@ -25,9 +27,11 @@
       <div class="app-card">
         <h2 class="govuk-heading-m app-card__heading">Stop Press watch list</h2>
         <% if @stop_press.present? %>
+          <p class="govuk-body govuk-!-static-margin-bottom-0"><strong>Updates published yesterday: <%= @stop_press[:meta][:published][:yesterday] %></strong></p>
+          <p class="govuk-body">Total chapters selected: <%= @stop_press[:meta][:chapters] %></p>
           <%= link_to 'View Stop Press watch list', myott_stop_press_path %>
         <% else %>
-          <p class="govuk-body"><strong>No chapters selected</strong></p>
+          <p class="govuk-body govuk-!-static-margin-bottom-0"><strong>No chapters selected</strong></p>
           <p class="govuk-body">You will receive updates on specific chapters</p>
           <%= link_to 'Create a Stop Press watch list', myott_stop_press_path %>
         <% end %>

--- a/spec/controllers/myott/mycommodities_controller_spec.rb
+++ b/spec/controllers/myott/mycommodities_controller_spec.rb
@@ -10,13 +10,7 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
     build(:user,
           my_commodities_subscription: true)
   end
-  let(:subscription) do
-    build(:subscription,
-          active: true,
-          subscription_type: 'my_commodities',
-          metadata: { commodity_codes: %w[1111111111 22222222222 3333333333 4444444444 5555555555] },
-          meta: { active: 2, expired: 2, invalid: 1 })
-  end
+  let(:subscription) { build(:subscription, :my_commodities) }
 
   before do
     allow(Subscription).to receive(:find).and_return(subscription)
@@ -74,10 +68,10 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
 
         it { is_expected.to respond_with(:success) }
 
-        it { expect(assigns(:meta).total).to eq(subscription.meta.values.sum) }
-        it { expect(assigns(:meta).active).to eq(subscription.meta[:active]) }
-        it { expect(assigns(:meta).expired).to eq(subscription.meta[:expired]) }
-        it { expect(assigns(:meta).invalid).to eq(subscription.meta[:invalid]) }
+        it { expect(assigns(:commodity_code_counts).total).to eq(subscription.meta[:counts]['total']) }
+        it { expect(assigns(:commodity_code_counts).active).to eq(subscription.meta[:counts]['active']) }
+        it { expect(assigns(:commodity_code_counts).expired).to eq(subscription.meta[:counts]['expired']) }
+        it { expect(assigns(:commodity_code_counts).invalid).to eq(subscription.meta[:counts]['invalid']) }
 
         it 'assigns @grouped_measure_changes' do
           expect(assigns(:grouped_measure_changes)).to eq(grouped_measure_changes)
@@ -95,6 +89,51 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
         end
 
         it { is_expected.to redirect_to(new_myott_mycommodity_path) }
+      end
+
+      context 'when subscription meta is nil' do
+        let(:subscription_with_nil_meta) do
+          build(:subscription, :my_commodities, meta: nil)
+        end
+
+        before do
+          stub_get_subscription('my_commodities', subscription_with_nil_meta)
+          allow(TariffChanges::GroupedMeasureChange).to receive(:all).and_return([])
+          allow(TariffChanges::CommodityChange).to receive(:all).and_return([])
+          get :index
+        end
+
+        it { is_expected.to respond_with(:success) }
+
+        it 'assigns default meta values', :aggregate_failures do
+          expect(assigns(:commodity_code_counts).total).to eq(0)
+          expect(assigns(:commodity_code_counts).active).to eq(0)
+          expect(assigns(:commodity_code_counts).expired).to eq(0)
+          expect(assigns(:commodity_code_counts).invalid).to eq(0)
+        end
+      end
+
+      context 'when subscription counts is missing' do
+        let(:subscription_without_counts) do
+          build(:subscription, :my_commodities,
+                meta: { some_other_key: 'value' })
+        end
+
+        before do
+          stub_get_subscription('my_commodities', subscription_without_counts)
+          allow(TariffChanges::GroupedMeasureChange).to receive(:all).and_return([])
+          allow(TariffChanges::CommodityChange).to receive(:all).and_return([])
+          get :index
+        end
+
+        it { is_expected.to respond_with(:success) }
+
+        it 'assigns default meta values', :aggregate_failures do
+          expect(assigns(:commodity_code_counts).total).to eq(0)
+          expect(assigns(:commodity_code_counts).active).to eq(0)
+          expect(assigns(:commodity_code_counts).expired).to eq(0)
+          expect(assigns(:commodity_code_counts).invalid).to eq(0)
+        end
       end
     end
   end

--- a/spec/controllers/myott/stop_presses_controller_spec.rb
+++ b/spec/controllers/myott/stop_presses_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Myott::StopPressesController, type: :controller do
     end
 
     context 'when current_user is valid' do
-      let(:subscription) { build(:subscription, subscription_type: 'stop_press') }
+      let(:subscription) { build(:subscription, :stop_press) }
 
       before do
         stub_authenticated_user(user)
@@ -191,7 +191,7 @@ RSpec.describe Myott::StopPressesController, type: :controller do
     it_behaves_like 'a protected myott page', :confirmation
 
     context 'when current_user is valid' do
-      let(:subscription) { build(:subscription, subscription_type: 'stop_press') }
+      let(:subscription) { build(:subscription, :stop_press) }
 
       before do
         stub_authenticated_user(user)

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
       end
 
       context 'when my_commodities is enabled' do
-        let(:stop_press_subscription) { build(:subscription, subscription_type: 'stop_press') }
-        let(:my_commodities_subscription) { build(:subscription, subscription_type: 'my_commodities') }
+        let(:stop_press_subscription) { build(:subscription, :stop_press) }
+        let(:my_commodities_subscription) { build(:subscription, :my_commodities) }
 
         before do
           allow(TradeTariffFrontend).to receive(:my_commodities?).and_return(true)

--- a/spec/controllers/myott/unsubscribes_controller_spec.rb
+++ b/spec/controllers/myott/unsubscribes_controller_spec.rb
@@ -1,22 +1,22 @@
 RSpec.describe Myott::UnsubscribesController, type: :controller do
   include MyottAuthenticationHelpers
 
-  let(:subscription) { build(:subscription, subscription_type: 'stop_press') }
+  let(:subscription) { build(:subscription, :stop_press) }
 
   describe 'GET #show' do
     before do
-      allow(controller).to receive_messages(current_subscription: subscription, subscription_type: subscription['subscription_type'])
-      get :show, params: { id: subscription.uuid, subscription_type: subscription['subscription_type'] }
+      allow(controller).to receive_messages(current_subscription: subscription, subscription_type: subscription.subscription_type_name)
+      get :show, params: { id: subscription.uuid, subscription_type: subscription.subscription_type_name }
     end
 
     it 'renders the subscription-specific template' do
-      expect(response).to render_template("myott/unsubscribes/#{subscription['subscription_type']}")
+      expect(response).to render_template("myott/unsubscribes/#{subscription.subscription_type_name}")
     end
   end
 
   describe 'DELETE #destroy' do
     before do
-      allow(controller).to receive_messages(current_subscription: subscription, subscription_type: subscription['subscription_type'])
+      allow(controller).to receive_messages(current_subscription: subscription, subscription_type: subscription.subscription_type_name)
     end
 
     context 'when subscription_type is stop_press' do
@@ -24,20 +24,20 @@ RSpec.describe Myott::UnsubscribesController, type: :controller do
         it 'redirects to the confirmation page' do
           allow(Subscription).to receive(:delete).with(subscription.uuid).and_return(true)
           delete :destroy, params: { id: subscription.uuid }
-          expect(response).to redirect_to(confirmation_myott_unsubscribes_path(subscription_type: subscription['subscription_type']))
+          expect(response).to redirect_to(confirmation_myott_unsubscribes_path(subscription_type: subscription.subscription_type_name))
         end
       end
     end
 
     context 'when subscription_type is my_commodities' do
-      let(:subscription) { build(:subscription, subscription_type: 'my_commodities') }
+      let(:subscription) { build(:subscription, :my_commodities) }
 
       context 'when user confirms' do
         it 'redirects to the confirmation page' do
           allow(Subscription).to receive(:delete).with(subscription.uuid).and_return(true)
           allow(controller).to receive_messages(user_declined?: false, user_confirmed?: true)
           delete :destroy, params: { id: subscription.uuid }
-          expect(response).to redirect_to(confirmation_myott_unsubscribes_path(subscription_type: subscription['subscription_type']))
+          expect(response).to redirect_to(confirmation_myott_unsubscribes_path(subscription_type: subscription.subscription_type_name))
         end
       end
 
@@ -89,11 +89,11 @@ RSpec.describe Myott::UnsubscribesController, type: :controller do
   describe 'GET #confirmation' do
     before do
       cookies[:id_token] = 'test_uuid'
-      get :confirmation, params: { subscription_type: subscription['subscription_type'] }
+      get :confirmation, params: { subscription_type: subscription.subscription_type_name }
     end
 
     it 'assigns the subscription_type' do
-      expect(assigns(:subscription_type)).to eq(subscription['subscription_type'])
+      expect(assigns(:subscription_type)).to eq(subscription.subscription_type_name)
     end
 
     it 'deletes the subscription_uuid cookie' do
@@ -112,7 +112,7 @@ RSpec.describe Myott::UnsubscribesController, type: :controller do
       cookies_spy = instance_spy(ActionDispatch::Cookies::CookieJar)
       allow(controller).to receive(:cookies).and_return(cookies_spy)
 
-      get :confirmation, params: { subscription_type: subscription['subscription_type'] }
+      get :confirmation, params: { subscription_type: subscription.subscription_type_name }
 
       expect(cookies_spy).to have_received(:delete).with(:id_token, hash_including(domain: :all))
       expect(cookies_spy).to have_received(:delete).with(:refresh_token, hash_including(domain: :all))

--- a/spec/factories/subscription_factory.rb
+++ b/spec/factories/subscription_factory.rb
@@ -3,7 +3,26 @@ FactoryBot.define do
     active { true }
     uuid { SecureRandom.uuid }
     resource_id { uuid }
-    meta { { active: 1, expired: 1, invalid: 1 } }
-    subscription_type { { 'name' => Subscription::SUBSCRIPTION_TYPES[:my_commodities] } }
+    subscription_type { { name: Subscription::SUBSCRIPTION_TYPES[:my_commodities] } }
+
+    trait :stop_press do
+      subscription_type { { name: Subscription::SUBSCRIPTION_TYPES[:stop_press] } }
+      meta do
+        {
+          published: { yesterday: 5 },
+          chapters: 10,
+        }
+      end
+    end
+
+    trait :my_commodities do
+      subscription_type { { name: Subscription::SUBSCRIPTION_TYPES[:my_commodities] } }
+      meta do
+        {
+          published: { yesterday: 3 },
+          counts: { 'active' => 3, 'expired' => 2, 'invalid' => 1, 'total' => 5 },
+        }
+      end
+    end
   end
 end

--- a/spec/features/myott_stop_press_spec.rb
+++ b/spec/features/myott_stop_press_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe 'Myott stop press subscription', type: :feature do
   describe 'new subscriber' do
     let(:user) do
       build(:user,
-            subscriptions: [
-              { 'id' => '123', 'subscription_type' => 'stop_press', 'active' => false },
-            ])
+            subscriptions: [])
     end
 
     let(:updated_user) do
@@ -17,7 +15,7 @@ RSpec.describe 'Myott stop press subscription', type: :feature do
               { 'id' => '123', 'subscription_type' => 'stop_press', 'active' => true },
             ])
     end
-    let(:subscription) { build(:subscription, active: true, subscription_type: 'stop_press') }
+    let(:subscription) { build(:subscription, :stop_press) }
 
     before do
       allow(User).to receive(:find).and_return(user, updated_user)
@@ -98,11 +96,16 @@ RSpec.describe 'Myott stop press subscription', type: :feature do
     end
 
     let(:subscription) do
-      Subscription.new(subscription_hash)
+      build(:subscription, :stop_press,
+            meta: {
+              published: { yesterday: 3 },
+              chapters: chapter_ids.present? ? chapter_ids.split(',').length : 0,
+            })
     end
 
     before do
-      allow(User).to receive_messages(find: user, update: true)
+      allow(User).to receive_messages(update: true)
+      allow(User).to receive(:find).with(nil, any_args).and_return(user)
       allow(Subscription).to receive(:find).and_return(subscription)
     end
 


### PR DESCRIPTION
### Jira link

[MYOTT-289](https://transformuk.atlassian.net/browse/MYOTT-289)

### What?

Adds summary details about the user's subscription to the overall dashboard. Also handles changes to the format of commodity count data from the API.

<img width="1074" height="382" alt="Screenshot 2026-01-22 at 14 16 34" src="https://github.com/user-attachments/assets/dbf47427-d9f8-4672-ad30-001bccad96d4" />
