### PR TITLE
MYOTT-432 Link to today's tariff from expired screen

### DIFF
--- a/app/views/myott/mycommodities/expired.html.erb
+++ b/app/views/myott/mycommodities/expired.html.erb
@@ -53,11 +53,7 @@
                 <%= target.validity_end_date.to_fs %>
               </td>
               <td class="govuk-table__cell">
-                <%= link_to('Review on tariff', commodity_path(target.goods_nomenclature_item_id,
-                            day: target.validity_end_date.day,
-                            month: target.validity_end_date.month,
-                            year: target.validity_end_date.year),
-                            target: '_blank')%></td>
+                <%= link_to('Review on tariff', commodity_path(target.goods_nomenclature_item_id, target: '_blank')) %></td>
               </td>
             </tr>
             <% end %>


### PR DESCRIPTION
### Jira link

[MYOTT-432](https://transformuk.atlassian.net/browse/MYOTT-432)

### What?

Remove data param from link

### Why?

So user is taken to the commodity as it is today and not on the day it expires (when it was still declarable)
