### PR TITLE
MYOTT-430 Update Stop Press confirmation screen

### DIFF
--- a/app/views/myott/mycommodities/confirmation.html.erb
+++ b/app/views/myott/mycommodities/confirmation.html.erb
@@ -1,4 +1,5 @@
 <% myott_page_title "Commodity code watch list #{@new_subscriber ? "created" : "updated"}" %>
+
 <div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/app/views/myott/stop_presses/confirmation.html.erb
+++ b/app/views/myott/stop_presses/confirmation.html.erb
@@ -1,4 +1,4 @@
-<% myott_page_title "Subscription updated" %>
+<% myott_page_title "Stop Press watch list updated" %>
 
 <div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
@@ -6,7 +6,7 @@
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-panel govuk-panel--confirmation">
           <h1 class="govuk-panel__title">
-            You have updated your subscription
+            You have updated your Stop Press watch list
           </h1>
         </div>
         <h2 class="govuk-heading-m">What happens next</h2>
@@ -14,24 +14,8 @@
           When Stop Press updates are published by the UK Trade Tariff Service which relate to the chapters you have chosen, an email will be sent to <strong><%= current_user&.email %></strong>
         </p>
         <p class="govuk-body">
-          You can now close this window.
+          <%= link_to "View your tariff watch lists", myott_path, class: "govuk-button govuk-!-margin-top-4" %>
         </p>
-        <p class="govuk-body govuk-!-display-none"><!-- remove govuk-!-display-none for MyOTT public beta -->
-          <%= link_to 'What did you think of this service?', feedback_path, class: 'govuk-link' %>
-          (takes 30 seconds)
-        </p>
-      </div>
-    </div>
-    <!-- Call to action section to be deleted for MyOTT public beta-->
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <div class="call-to-action">
-          <h2 class="govuk-heading-m">What did you think of this pilot service?</h2>
-          <a href="https://forms.office.com/pages/responsepage.aspx?id=PPdSrBr9mkqOekokjzE54X0kqBRefDRFuf1EImP7KcNUMkxKNEhBWThHVzQwSExTVDZRT1pYU0pFRy4u&route=shorturl" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
-            Complete the survey
-            <%= render 'shared/start_arrow' %>
-          </a>
-        </div>
       </div>
     </div>
   </main>

--- a/spec/features/myott_stop_press_spec.rb
+++ b/spec/features/myott_stop_press_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe 'Myott stop press subscription', type: :feature do
 
         click_button 'Continue'
 
-        expect(page).to have_title('Subscription updated')
-        expect(page).to have_content('You have updated your subscription')
+        expect(page).to have_title('Stop Press watch list updated')
+        expect(page).to have_content('You have updated your Stop Press watch list')
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe 'Myott stop press subscription', type: :feature do
         expect(page).not_to have_content(chapter3.to_s)
         click_button 'Continue'
 
-        expect(page).to have_content('You have updated your subscription')
+        expect(page).to have_content('You have updated your Stop Press watch list')
       end
     end
   end


### PR DESCRIPTION
### Jira link

[MYOTT-430](https://transformuk.atlassian.net/browse/MYOTT-430)

### What?

I have update the copy on the confirmation page when creating a stop press subscription

<img width="853" height="619" alt="Screenshot 2026-01-23 at 14 44 08" src="https://github.com/user-attachments/assets/9b86d6a1-17bf-4503-a722-7de5eb421c9c" />

