### PR TITLE
MYOTT-433 Use date_of_effect_visible

### DIFF
--- a/app/models/tariff_changes/tariff_change.rb
+++ b/app/models/tariff_changes/tariff_change.rb
@@ -4,7 +4,7 @@ module TariffChanges
 
     set_collection_path '/uk/user/tariff_changes'
 
-    attr_accessor :classification_description, :goods_nomenclature_item_id, :date_of_effect
+    attr_accessor :classification_description, :goods_nomenclature_item_id, :date_of_effect, :date_of_effect_visible
 
     def self.download_file(token, opts = {})
       path = "#{collection_path}/download"

--- a/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
+++ b/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
@@ -16,13 +16,14 @@
   <tbody class="govuk-table__body">
     <% changes.each do |change| %>
       <% date = Date.parse(change['date_of_effect']) %>
+      <% date_visible = Date.parse(change['date_of_effect_visible']) %>
       <tr class="govuk-table__row">
         <th class="govuk-table__header"><%= change['change_type'] %></th>
         <% if has_additional_code %>
           <td class="govuk-table__cell"><%= change['additional_code'].presence || 'N/A' %></td>
         <% end %>
         <td class="govuk-table__cell"><%= date.to_fs %></td>
-        <td class="govuk-table__cell"><%= link_to("View commodity on #{date.to_fs}", commodity_path(@grouped_measure_commodity_changes.goods_nomenclature_item_id, day: date.day, month: date.month, year: date.year)) %></td>
+        <td class="govuk-table__cell"><%= link_to("View commodity on #{date_visible.to_fs}", commodity_path(@grouped_measure_commodity_changes.goods_nomenclature_item_id, day: date_visible.day, month: date_visible.month, year: date_visible.year)) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/views/myott/grouped_measure_commodity_changes/show.html.erb_spec.rb
+++ b/spec/views/myott/grouped_measure_commodity_changes/show.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'myott/grouped_measure_commodity_changes/show.html.erb', type: :v
   let(:impacted_measures) do
     {
       'Preferential tariff quota' => [
-        { 'date_of_effect' => '2025-12-01', 'change_type' => 'Measure will begin' },
+        { 'date_of_effect' => '2025-12-01', 'date_of_effect_visible' => '2025-12-02', 'change_type' => 'Measure will begin' },
       ],
     }
   end
@@ -30,7 +30,10 @@ RSpec.describe 'myott/grouped_measure_commodity_changes/show.html.erb', type: :v
 
   before do
     assign(:grouped_measure_commodity_changes, grouped_measure_commodity_change)
-    allow(view).to receive_messages(as_of: Date.new(2025, 11, 21), commodity_path: '/commodities/1234567890?day=1&month=12&year=2025')
+    allow(view).to receive(:as_of).and_return(Date.new(2025, 11, 21))
+    allow(view).to receive(:commodity_path) do |id, params|
+      "/commodities/#{id}?day=#{params[:day]}&month=#{params[:month]}&year=#{params[:year]}"
+    end
     render
   end
 
@@ -71,7 +74,7 @@ RSpec.describe 'myott/grouped_measure_commodity_changes/show.html.erb', type: :v
   end
 
   it 'renders the link to the commodity' do
-    expect(rendered).to have_link('View commodity on 01/12/2025', href: '/commodities/1234567890?day=1&month=12&year=2025')
+    expect(rendered).to have_link('View commodity on 02/12/2025', href: '/commodities/1234567890?day=2&month=12&year=2025')
   end
 
   it 'does not render an additional code column when none are present' do
@@ -82,8 +85,8 @@ RSpec.describe 'myott/grouped_measure_commodity_changes/show.html.erb', type: :v
     let(:impacted_measures) do
       {
         'Preferential tariff quota' => [
-          { 'date_of_effect' => '2025-12-01', 'change_type' => 'Measure will begin', 'additional_code' => 'AC01' },
-          { 'date_of_effect' => '2025-12-02', 'change_type' => 'Measure will change', 'additional_code' => nil },
+          { 'date_of_effect' => '2025-12-01', 'date_of_effect_visible' => '2025-12-02', 'change_type' => 'Measure will begin', 'additional_code' => 'AC01' },
+          { 'date_of_effect' => '2025-12-02', 'date_of_effect_visible' => '2025-12-03', 'change_type' => 'Measure will change', 'additional_code' => nil },
         ],
       }
     end


### PR DESCRIPTION
### Jira link

[MYOTT-433](https://transformuk.atlassian.net/browse/MYOTT-433)

### What?

The link to view a commodity on the OTT should be for the date after the change has taken effect. This uses a newly created attribute from the API to achieve this. (see https://github.com/trade-tariff/trade-tariff-backend/pull/2732)
