### PR TITLE
AI-117: Enable toggleable internal search

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -138,6 +138,10 @@ class ApplicationController < ActionController::Base
   def set_path_info
     @path_info = { search_suggestions_path: search_suggestions_path(format: :json),
                    faq_send_feedback_path: green_lanes_send_feedback_path }
+
+    if TradeTariffFrontend.internal_search_enabled?
+      @path_info[:internal_search_suggestions_path] = internal_search_suggestions_path(format: :json)
+    end
   end
 
   def country

--- a/app/javascript/controllers/internal_search_controller.js
+++ b/app/javascript/controllers/internal_search_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from '@hotwired/stimulus'
+import Cookies from 'js-cookie'
+
+export default class extends Controller {
+  static targets = ['toggle', 'hiddenField']
+  static values = {
+    v2SuggestionsPath: String,
+    internalSuggestionsPath: String,
+  }
+
+  connect() {
+    const enabled = Cookies.get('internal_search') === 'true'
+    this.toggleTarget.checked = enabled
+    this.hiddenFieldTarget.value = enabled.toString()
+    this.#updateSuggestionsPath(enabled)
+  }
+
+  toggle() {
+    const enabled = this.toggleTarget.checked
+    const isSecure = location.protocol === 'https:'
+
+    Cookies.set('internal_search', enabled.toString(), {
+      expires: 365,
+      secure: isSecure,
+      sameSite: 'Strict',
+    })
+
+    this.hiddenFieldTarget.value = enabled.toString()
+    this.#updateSuggestionsPath(enabled)
+  }
+
+  #updateSuggestionsPath(enabled) {
+    const pathInfoEl = document.querySelector('.path_info')
+
+    if (pathInfoEl) {
+      pathInfoEl.dataset.searchSuggestionsPath = enabled
+        ? this.internalSuggestionsPathValue
+        : this.v2SuggestionsPathValue
+    }
+  }
+}

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -15,7 +15,8 @@ class GoodsNomenclature
                 :heading_id,
                 :chapter_id,
                 :description_plain,
-                :declarable
+                :declarable,
+                :score
 
   has_many :ancestors, polymorphic: true
 

--- a/app/models/search/internal_search_result.rb
+++ b/app/models/search/internal_search_result.rb
@@ -1,0 +1,61 @@
+class Search
+  class InternalSearchResult
+    CONTROLLER_MAP = {
+      'Chapter' => 'chapters',
+      'Heading' => 'headings',
+      'Commodity' => 'commodities',
+      'Subheading' => 'subheadings',
+    }.freeze
+
+    attr_reader :type
+
+    def initialize(parsed_data)
+      @results = Array(parsed_data).map { |attrs| build_model(attrs) }
+      @type = @results.empty? ? nil : 'internal'
+    end
+
+    def exact_match?
+      @results.size == 1 && @results.first.score.nil?
+    end
+
+    def to_param
+      return {} unless exact_match?
+
+      result = @results.first
+      gn_class = result.attributes['goods_nomenclature_class'] || result.class.name
+      {
+        controller: CONTROLLER_MAP[gn_class] || 'commodities',
+        action: :show,
+        id: result.to_param,
+      }
+    end
+
+    delegate :any?, :none?, to: :@results
+
+    def commodities
+      @results
+        .select { |r| r.is_a?(Commodity) && r.declarable }
+        .first(TradeTariffFrontend.legacy_results_to_show)
+    end
+
+    def reference_matches_by_chapter = []
+    def gn_matches_without_duplicates_by_chapter = []
+    def reference_match = ReferenceMatch::BLANK_RESULT
+    def goods_nomenclature_match = GoodsNomenclatureMatch::BLANK_RESULT
+    def all = @results
+
+    delegate :size, to: :all
+
+    private
+
+    def build_model(entry)
+      gn_class = entry['goods_nomenclature_class']
+      klass = begin
+        gn_class.constantize
+      rescue StandardError
+        GoodsNomenclature
+      end
+      klass.new(entry)
+    end
+  end
+end

--- a/app/presenters/internal_results_presenter.rb
+++ b/app/presenters/internal_results_presenter.rb
@@ -1,0 +1,18 @@
+class InternalResultsPresenter
+  def initialize(_search, search_results)
+    @search_results = search_results
+  end
+
+  def as_json(_opts = {})
+    @search_results.all.map do |result|
+      {
+        type: result.class.name.underscore,
+        goods_nomenclature_item_id: result.goods_nomenclature_item_id,
+        description: result.description,
+        formatted_description: result.formatted_description,
+        declarable: result.respond_to?(:declarable) ? result.declarable : false,
+        score: result.respond_to?(:score) ? result.score : nil,
+      }
+    end
+  end
+end

--- a/app/views/shared/search/_search_form.html.erb
+++ b/app/views/shared/search/_search_form.html.erb
@@ -6,6 +6,25 @@
 <%= hidden_field_tag :day, @search.day %>
 <% end %>
 
+<% if TradeTariffFrontend.internal_search_enabled? %>
+<div data-controller="internal-search"
+     data-internal-search-v2-suggestions-path-value="<%= search_suggestions_path(format: :json) %>"
+     data-internal-search-internal-suggestions-path-value="<%= internal_search_suggestions_path(format: :json) %>">
+  <div class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-bottom-2">
+    <div class="govuk-checkboxes__item">
+      <input class="govuk-checkboxes__input" id="internal_search_toggle" type="checkbox"
+             data-internal-search-target="toggle"
+             data-action="internal-search#toggle">
+      <label class="govuk-label govuk-checkboxes__label" for="internal_search_toggle">
+        Use new search
+      </label>
+    </div>
+  </div>
+  <input type="hidden" name="internal_search" value="false"
+         data-internal-search-target="hiddenField">
+</div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= label_tag :q, search_label_text, class: 'govuk-label' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,7 @@ Rails.application.routes.draw do
   end
 
   get 'search_suggestions', to: 'search#suggestions', as: :search_suggestions
+  get 'internal_search_suggestions', to: 'search#internal_suggestions', as: :internal_search_suggestions
   get 'quota_search', to: 'search#quota_search', as: :quota_search
   get 'simplified_procedure_value', to: 'simplified_procedural_values#index', as: :simplified_procedural_values
   get 'additional_code_search', to: 'additional_code_search#new', as: :additional_code_search

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -147,6 +147,10 @@ module TradeTariffFrontend
     ENV['GREEN_LANES_ENABLED'].to_s == 'true'
   end
 
+  def internal_search_enabled?
+    !production?
+  end
+
   def green_lanes_api_token
     "Bearer #{ENV['GREEN_LANES_API_TOKEN']}"
   end

--- a/spec/models/search/internal_search_result_spec.rb
+++ b/spec/models/search/internal_search_result_spec.rb
@@ -1,0 +1,246 @@
+require 'spec_helper'
+
+RSpec.describe Search::InternalSearchResult do
+  def commodity_attrs(overrides = {})
+    {
+      'goods_nomenclature_item_id' => '0101210000',
+      'producline_suffix' => '80',
+      'goods_nomenclature_class' => 'Commodity',
+      'description' => 'Pure-bred breeding animals',
+      'formatted_description' => 'Pure-bred breeding animals',
+      'declarable' => true,
+      'score' => 12.5,
+    }.merge(overrides)
+  end
+
+  def heading_attrs(overrides = {})
+    {
+      'goods_nomenclature_item_id' => '0101000000',
+      'producline_suffix' => '80',
+      'goods_nomenclature_class' => 'Heading',
+      'description' => 'Live horses',
+      'formatted_description' => 'Live horses',
+      'declarable' => false,
+      'score' => 10.0,
+    }.merge(overrides)
+  end
+
+  def chapter_attrs(overrides = {})
+    {
+      'goods_nomenclature_item_id' => '0100000000',
+      'producline_suffix' => '80',
+      'goods_nomenclature_class' => 'Chapter',
+      'description' => 'Live animals',
+      'formatted_description' => 'Live animals',
+      'declarable' => false,
+      'score' => 8.0,
+    }.merge(overrides)
+  end
+
+  def subheading_attrs(overrides = {})
+    {
+      'goods_nomenclature_item_id' => '0101290000',
+      'producline_suffix' => '10',
+      'goods_nomenclature_class' => 'Subheading',
+      'description' => 'Other horses',
+      'formatted_description' => 'Other horses',
+      'declarable' => false,
+      'score' => 9.0,
+    }.merge(overrides)
+  end
+
+  describe '#type' do
+    context 'with results' do
+      subject { described_class.new([commodity_attrs]).type }
+
+      it { is_expected.to eq('internal') }
+    end
+
+    context 'with empty results' do
+      subject { described_class.new([]).type }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#exact_match?' do
+    context 'with a single result with nil score' do
+      subject { described_class.new([commodity_attrs('score' => nil)]) }
+
+      it { is_expected.to be_exact_match }
+    end
+
+    context 'with a single result with a numeric score' do
+      subject { described_class.new([commodity_attrs('score' => 12.5)]) }
+
+      it { is_expected.not_to be_exact_match }
+    end
+
+    context 'with multiple results' do
+      subject { described_class.new([commodity_attrs, heading_attrs]) }
+
+      it { is_expected.not_to be_exact_match }
+    end
+
+    context 'with no results' do
+      subject { described_class.new([]) }
+
+      it { is_expected.not_to be_exact_match }
+    end
+  end
+
+  describe '#to_param' do
+    context 'when exact match for a Commodity' do
+      subject { described_class.new([commodity_attrs('score' => nil)]).to_param }
+
+      it { is_expected.to eq(controller: 'commodities', action: :show, id: '0101210000') }
+    end
+
+    context 'when exact match for a Heading' do
+      subject { described_class.new([heading_attrs('score' => nil)]).to_param }
+
+      it { is_expected.to eq(controller: 'headings', action: :show, id: '0101') }
+    end
+
+    context 'when exact match for a Chapter' do
+      subject { described_class.new([chapter_attrs('score' => nil)]).to_param }
+
+      it { is_expected.to eq(controller: 'chapters', action: :show, id: '01') }
+    end
+
+    context 'when exact match for a Subheading' do
+      subject { described_class.new([subheading_attrs('score' => nil)]).to_param }
+
+      it { is_expected.to eq(controller: 'subheadings', action: :show, id: '0101290000-10') }
+    end
+
+    context 'when not an exact match' do
+      subject { described_class.new([commodity_attrs, heading_attrs]).to_param }
+
+      it { is_expected.to eq({}) }
+    end
+  end
+
+  describe '#any?' do
+    context 'with results' do
+      subject { described_class.new([commodity_attrs]) }
+
+      it { is_expected.to be_any }
+    end
+
+    context 'with empty results' do
+      subject { described_class.new([]) }
+
+      it { is_expected.not_to be_any }
+    end
+  end
+
+  describe '#none?' do
+    context 'with results' do
+      subject { described_class.new([commodity_attrs]) }
+
+      it { is_expected.not_to be_none }
+    end
+
+    context 'with empty results' do
+      subject { described_class.new([]) }
+
+      it { is_expected.to be_none }
+    end
+  end
+
+  describe '#commodities' do
+    it 'returns only declarable Commodity instances', :aggregate_failures do
+      result = described_class.new([
+        commodity_attrs('declarable' => true),
+        commodity_attrs('declarable' => false, 'goods_nomenclature_item_id' => '0101220000'),
+        heading_attrs,
+      ])
+
+      expect(result.commodities).to all(be_a(Commodity))
+      expect(result.commodities.size).to eq(1)
+    end
+
+    it 'caps results at legacy_results_to_show' do
+      entries = 10.times.map do |i|
+        commodity_attrs('goods_nomenclature_item_id' => sprintf('01012%05d', i))
+      end
+      result = described_class.new(entries)
+
+      expect(result.commodities.size).to be <= TradeTariffFrontend.legacy_results_to_show
+    end
+  end
+
+  describe '#reference_matches_by_chapter' do
+    subject { described_class.new([commodity_attrs]).reference_matches_by_chapter }
+
+    it { is_expected.to eq([]) }
+  end
+
+  describe '#gn_matches_without_duplicates_by_chapter' do
+    subject { described_class.new([commodity_attrs]).gn_matches_without_duplicates_by_chapter }
+
+    it { is_expected.to eq([]) }
+  end
+
+  describe '#reference_match' do
+    subject { described_class.new([commodity_attrs]).reference_match }
+
+    it { is_expected.to eq(Search::ReferenceMatch::BLANK_RESULT) }
+  end
+
+  describe '#goods_nomenclature_match' do
+    subject { described_class.new([commodity_attrs]).goods_nomenclature_match }
+
+    it { is_expected.to eq(Search::GoodsNomenclatureMatch::BLANK_RESULT) }
+  end
+
+  describe '#all' do
+    it 'returns all results' do
+      result = described_class.new([commodity_attrs, heading_attrs])
+
+      expect(result.all.size).to eq(2)
+    end
+  end
+
+  describe '#size' do
+    it 'delegates to all' do
+      result = described_class.new([commodity_attrs, heading_attrs, chapter_attrs])
+
+      expect(result.size).to eq(3)
+    end
+  end
+
+  describe 'build_model' do
+    it 'instantiates a Commodity for goods_nomenclature_class Commodity' do
+      result = described_class.new([commodity_attrs])
+
+      expect(result.all.first).to be_a(Commodity)
+    end
+
+    it 'instantiates a Heading for goods_nomenclature_class Heading' do
+      result = described_class.new([heading_attrs])
+
+      expect(result.all.first).to be_a(Heading)
+    end
+
+    it 'instantiates a Chapter for goods_nomenclature_class Chapter' do
+      result = described_class.new([chapter_attrs])
+
+      expect(result.all.first).to be_a(Chapter)
+    end
+
+    it 'instantiates a Subheading for goods_nomenclature_class Subheading' do
+      result = described_class.new([subheading_attrs])
+
+      expect(result.all.first).to be_a(Subheading)
+    end
+
+    it 'falls back to GoodsNomenclature for unknown class' do
+      attrs = commodity_attrs('goods_nomenclature_class' => 'UnknownThing')
+      result = described_class.new([attrs])
+
+      expect(result.all.first).to be_a(GoodsNomenclature)
+    end
+  end
+end

--- a/spec/presenters/internal_results_presenter_spec.rb
+++ b/spec/presenters/internal_results_presenter_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe InternalResultsPresenter do
+  subject(:presenter) { described_class.new(search, search_results) }
+
+  let(:search) { Search.new(q: 'horses') }
+
+  describe '#as_json' do
+    context 'with mixed result types' do
+      let(:search_results) do
+        Search::InternalSearchResult.new([
+          {
+            'goods_nomenclature_item_id' => '0101210000',
+            'producline_suffix' => '80',
+            'goods_nomenclature_class' => 'Commodity',
+            'description' => 'Pure-bred breeding animals',
+            'formatted_description' => 'Pure-bred breeding animals',
+            'declarable' => true,
+            'score' => 12.5,
+          },
+          {
+            'goods_nomenclature_item_id' => '0101000000',
+            'producline_suffix' => '80',
+            'goods_nomenclature_class' => 'Heading',
+            'description' => 'Live horses',
+            'formatted_description' => 'Live horses',
+            'declarable' => false,
+            'score' => 10.0,
+          },
+        ])
+      end
+
+      let(:json) { presenter.as_json }
+
+      it 'returns an array of results', :aggregate_failures do
+        expect(json).to be_an(Array)
+        expect(json.size).to eq(2)
+      end
+
+      it 'serializes commodity attributes', :aggregate_failures do
+        commodity_json = json.first
+
+        expect(commodity_json[:type]).to eq('commodity')
+        expect(commodity_json[:goods_nomenclature_item_id]).to eq('0101210000')
+        expect(commodity_json[:description]).to eq('Pure-bred breeding animals')
+        expect(commodity_json[:formatted_description]).to eq('Pure-bred breeding animals')
+        expect(commodity_json[:declarable]).to be true
+        expect(commodity_json[:score]).to eq(12.5)
+      end
+
+      it 'serializes heading attributes', :aggregate_failures do
+        heading_json = json.second
+
+        expect(heading_json[:type]).to eq('heading')
+        expect(heading_json[:goods_nomenclature_item_id]).to eq('0101000000')
+        expect(heading_json[:declarable]).to be false
+        expect(heading_json[:score]).to eq(10.0)
+      end
+    end
+
+    context 'with empty results' do
+      let(:search_results) { Search::InternalSearchResult.new([]) }
+
+      it 'returns an empty array' do
+        expect(presenter.as_json).to eq([])
+      end
+    end
+  end
+end

--- a/spec/support/api_responses_helper.rb
+++ b/spec/support/api_responses_helper.rb
@@ -1,8 +1,11 @@
 module ApiResponsesHelper
   # Wrapper around WebMock's stub_request with defaults that apply to all our api requests
-  def stub_api_request(endpoint, method = :get, backend: nil)
+  def stub_api_request(endpoint, method = :get, backend: nil, internal: false)
     backend_url = if backend
                     TradeTariffFrontend::ServiceChooser.service_choices[backend]
+                  elsif internal
+                    TradeTariffFrontend::ServiceChooser.api_host
+                      .sub(%r{/api\b}, '/internal')
                   else
                     TradeTariffFrontend::ServiceChooser.api_host
                   end


### PR DESCRIPTION
### Jira link

[AI-117](https://transformuk.atlassian.net/browse/AI-117)

<img width="942" height="1038" alt="image" src="https://github.com/user-attachments/assets/42a6062f-79c4-4417-9bb6-97a4686e7d85" />

### What?

Add internal search API integration (`POST /internal/search`) behind an environment-based feature flag, enabled for development and staging, disabled in production.

- New `Search::InternalSearchResult` class that implements the same interface as `Search::Outcome`, mapping the flat internal API response into existing frontend models
- New `InternalResultsPresenter` for JSON rendering
- Stimulus controller with cookie-persisted checkbox toggle in the search form, allowing users to opt in to the new search
- Internal suggestions endpoint (`/internal/search_suggestions`) that switches alongside the search toggle
- Dual-gated via `internal_search` toggle (per-request) and `TradeTariffFrontend.internal_search_enabled?` (per-environment)

### Why?

To validate the new internal search API against the existing V2 search in non-production environments before rolling it out to production.