### PR TITLE
HMRC-1766: Update autoscaling metrics

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,5 +30,16 @@ module "service" {
   min_capacity   = var.min_capacity
   max_capacity   = var.max_capacity
 
+  autoscaling_metrics = {
+    cpu = {
+      metric_type  = "ECSServiceAverageCPUUtilization"
+      target_value = 55
+    }
+    memory = {
+      metric_type  = "ECSServiceAverageMemoryUtilization"
+      target_value = 70
+    }
+  }
+
   sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
 }


### PR DESCRIPTION
### Jira link

[HMRC-1766](https://transformuk.atlassian.net/browse/HMRC-1766)

### What?

- Lowered the ECS Target Tracking CPU threshold from 75% to 55%.

### Why?

I am doing this because
- The previous threshold (75%) caused the service to scale out too late, often only after tasks were already saturated (90–98% CPU).
- By reducing the threshold to 55%, we allow the service to react earlier to increasing load.

