### PR TITLE
MYOTT-453 Update headings on final measure changes screen

### DIFF
--- a/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
+++ b/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
@@ -1,6 +1,6 @@
 <% has_additional_code = changes.any? { |change| change['additional_code'].present? } %>
 
-<h3 class="govuk-heading-m"><%= measure_type %></h3>
+<h2 class="govuk-heading-l"><%= measure_type %></h2>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/app/views/myott/grouped_measure_commodity_changes/show.html.erb
+++ b/app/views/myott/grouped_measure_commodity_changes/show.html.erb
@@ -26,7 +26,7 @@
         Changes published: <%= as_of.to_fs %>
       </div>
 
-      <h2 class="govuk-heading-l">Impacted trades</h2>
+      <h2 class="govuk-heading-l">Trades affected</h2>
 
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
@@ -71,7 +71,6 @@
         </div>
       </dl>
 
-      <h2 class="govuk-heading-l">Impacted measures</h2>
       <% @grouped_measure_commodity_changes.impacted_measures.each do |measure_type, changes| %>
         <%= render 'impacted_measures', measure_type: measure_type, changes: changes %>
       <% end %>

--- a/spec/features/myott_my_commodities_spec.rb
+++ b/spec/features/myott_my_commodities_spec.rb
@@ -195,9 +195,9 @@ RSpec.describe 'Myott my commodities subscription', type: :feature do
         expect(page).to have_content('Imports from')
         expect(page).to have_content('Total commodities affected: 1')
         click_link '2 changes'
-        expect(page).to have_content('1234567890')
-        expect(page).to have_content('Impacted trades')
-        expect(page).to have_content('Impacted measures')
+        expect(page).to have_selector('h1', text: 'Commodity: 1234567890')
+        expect(page).to have_selector('h2', text: 'Trades affected')
+        expect(page).to have_selector('h2', text: 'Preferential tariff quota')
       end
     end
   end


### PR DESCRIPTION
### Jira link

[MYOTT-453](https://transformuk.atlassian.net/browse/MYOTT-453)

### What?

Before:
<img width="1036" height="856" alt="Screenshot 2026-02-04 at 10 12 29" src="https://github.com/user-attachments/assets/c885e431-6eca-417f-b349-5b815a8653c2" />

After:
<img width="1117" height="858" alt="Screenshot 2026-02-04 at 10 11 21" src="https://github.com/user-attachments/assets/8709c17b-3f6e-4249-9029-d34b68b61b75" />

### Why?

Updated to match current design.
