### PR TITLE
MyOTT-465, MyOTT-473, MyOTT-474, MyOTT-479 Fixes to Unsubscribe Pages

### DIFF
--- a/app/controllers/myott/unsubscribes_controller.rb
+++ b/app/controllers/myott/unsubscribes_controller.rb
@@ -15,6 +15,7 @@ module Myott
     def confirmation
       @subscription_type = params[:subscription_type]
       content = unsubscribe_confirmation_content(@subscription_type)
+      @title = content[:title]
       @header = content[:header]
       @message = content[:message]
       clear_authentication_cookies
@@ -45,7 +46,7 @@ module Myott
     end
 
     def handle_my_commodities_unsubscribe
-      return redirect_to myott_path if user_declined?
+      return redirect_to myott_mycommodities_path if user_declined?
       return show_confirmation_error unless user_confirmed?
 
       delete_subscription
@@ -71,6 +72,7 @@ module Myott
       errors = unsubscribe_error_messages
       @alert = errors[:confirmation]
       flash.now[:select_error] = @alert
+      @div_id = 'radio-buttons'
       render subscription_type
     end
 

--- a/app/helpers/unsubscribes_helper.rb
+++ b/app/helpers/unsubscribes_helper.rb
@@ -2,11 +2,13 @@ module UnsubscribesHelper
   def unsubscribe_confirmation_content(subscription_type)
     if subscription_type == 'stop_press'
       {
+        title: "You're unsubscribed from Stop Press watch list",
         header: 'You have unsubscribed',
         message: 'You will no longer receive any Stop Press emails from the UK Trade Tariff Service.',
       }
     else
       {
+        title: "You're unsubscribed from commodity watch list",
         header: 'You have unsubscribed from your commodity watch list',
         message: 'You will no longer have access to your commodity watch list dashboard or receive email notifications.<br><br>If you have other UK Trade Tariff subscriptions, they will continue'.html_safe,
       }

--- a/app/views/myott/unsubscribes/confirmation.html.erb
+++ b/app/views/myott/unsubscribes/confirmation.html.erb
@@ -1,4 +1,4 @@
-<% myott_page_title "You have unsubscribed" %>
+<% myott_page_title @title %>
 
 <div class="govuk-width-container">
   <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">

--- a/app/views/myott/unsubscribes/my_commodities.html.erb
+++ b/app/views/myott/unsubscribes/my_commodities.html.erb
@@ -1,4 +1,4 @@
-<% myott_page_title "Unsubscribe" %>
+<% myott_page_title "Unsubscribe from commodity watch list" %>
 
 <% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(

--- a/app/views/myott/unsubscribes/stop_press.html.erb
+++ b/app/views/myott/unsubscribes/stop_press.html.erb
@@ -1,4 +1,4 @@
-<% myott_page_title "Unsubscribe" %>
+<% myott_page_title "Unsubscribe from Stop Press watch list" %>
 
 <% content_for :top_breadcrumbs do %>
   <%= generate_breadcrumbs(

--- a/spec/controllers/myott/unsubscribes_controller_spec.rb
+++ b/spec/controllers/myott/unsubscribes_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Myott::UnsubscribesController, type: :controller do
         it 'redirects to myott_path' do
           allow(controller).to receive_messages(user_declined?: true)
           delete :destroy, params: { id: subscription.uuid }
-          expect(response).to redirect_to(myott_path)
+          expect(response).to redirect_to(myott_mycommodities_path)
         end
       end
 

--- a/spec/features/myott_my_commodities_spec.rb
+++ b/spec/features/myott_my_commodities_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'Myott my commodities subscription', type: :feature do
         expect(page).to have_content('Are you sure you want to unsubscribe from your commodity watch list?')
         choose('no')
         click_button 'Confirm'
-        expect(page).to have_content('Your tariff watch lists')
+        expect(page).to have_content('Your commodity watch list')
       end
 
       it 'errors if user attempts to unsubscribe without selecting an option' do
@@ -128,6 +128,7 @@ RSpec.describe 'Myott my commodities subscription', type: :feature do
         expect(page).to have_content('Are you sure you want to unsubscribe from your commodity watch list?')
         click_button 'Confirm'
         expect(page).to have_content('Select yes if you want to unsubscribe from your commodity watch list')
+        expect(page).to have_link('Select yes if you want to unsubscribe from your commodity watch list', href: '#radio-buttons')
       end
 
       it 'errors if unsubscription fails' do


### PR DESCRIPTION
### Jira link

[MyOTT-465](https://transformuk.atlassian.net/browse/MyOTT-465)
[MyOTT-473](https://transformuk.atlassian.net/browse/MyOTT-473)
[MyOTT-474](https://transformuk.atlassian.net/browse/MyOTT-474)
[MyOTT-479](https://transformuk.atlassian.net/browse/MyOTT-479)

### What?

I have:
- [x] Updated unsubscribe page titles
- [x] Redirect to commodity watch list on cancel unsubscribe
- [x] Link to radio buttons for unsubscribe flash message

### Why?

I am doing this because these were issues found wrong following UAT.
