### PR TITLE
AI-148: Propagate request_id from search through to goods nomenclature links

### DIFF
--- a/app/controllers/concerns/classic_searchable.rb
+++ b/app/controllers/concerns/classic_searchable.rb
@@ -17,11 +17,11 @@ module ClassicSearchable
     if @search.missing_search_term?
       redirect_to missing_search_query_fallback_url
     elsif @results.exact_match?
-      redirect_to url_for @results.to_param.merge(url_options).merge(only_path: true)
+      redirect_to url_for @results.to_param.merge(url_options).merge(request_id: @search.request_id, only_path: true)
     elsif @results.none? && @search.search_term_is_commodity_code?
-      redirect_to commodity_path(@search.q)
+      redirect_to commodity_path(@search.q, request_id: @search.request_id)
     elsif @results.none? && @search.search_term_is_heading_code?
-      redirect_to heading_path(@search.q)
+      redirect_to heading_path(@search.q, request_id: @search.request_id)
     end
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -12,7 +12,7 @@ class SearchController < ApplicationController
     @search.q = params[:q] if params[:q]
     @search.internal_search = params[:internal_search] == 'true'
     @search.answers = params[:answers] if params[:answers].present?
-    @search.request_id = params[:request_id] if params[:request_id].present?
+    @search.request_id = params[:request_id].presence || SecureRandom.uuid
 
     if internal_search?
       perform_interactive_search

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -111,12 +111,10 @@ class Search
   private
 
   def perform_v2_search
-    response = self.class.post(
-      'search',
-      q:,
-      as_of: date.to_fs(:db),
-      resource_id:,
-    )
+    params = { q:, as_of: date.to_fs(:db), resource_id: }
+    params[:request_id] = request_id if request_id.present?
+
+    response = self.class.post('search', params)
     response = TariffJsonapiParser.new(response.body).parse
 
     Outcome.new(response)

--- a/app/views/search/_commodity.html.erb
+++ b/app/views/search/_commodity.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell commodity-result">
-    <a href="<%= commodity_path(commodity) %>" aria-describedby="code-for-commodity-<%= commodity.id %>">
+    <a href="<%= commodity_path(commodity, request_id: @search.request_id) %>" aria-describedby="code-for-commodity-<%= commodity.id %>">
       <% if commodity.ancestor_descriptions.present? %>
         <%= descriptions_with_other_handling(commodity) %>
       <% else %>

--- a/app/views/search/_interactive_results_content.html.erb
+++ b/app/views/search/_interactive_results_content.html.erb
@@ -26,7 +26,7 @@
               <%= result.heading_description %>
             </p>
             <%= link_to "View this commodity code",
-                commodity_path(result.goods_nomenclature_item_id),
+                commodity_path(result.goods_nomenclature_item_id, request_id: @search.request_id),
                 class: "govuk-link" %>
           </div>
           <div class="interactive-result__confidence">

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="line-text">
       <h4 class="govuk-heading-s govuk-!-margin-bottom-2">
-        <a href="<%= chapter_path(chapter) %>"><%= sanitize chapter.description %></a>
+        <a href="<%= chapter_path(chapter, request_id: @search.request_id) %>"><%= sanitize chapter.description %></a>
       </h4>
     </div>
   </div>
@@ -25,7 +25,7 @@
         <li>
           <div class="heading">
             <div class="line-text">
-              <a href="<%= heading_path(heading) %>"><%= sanitize heading.description %></a>
+              <a href="<%= heading_path(heading, request_id: @search.request_id) %>"><%= sanitize heading.description %></a>
             </div>
             <div class="full-code">
               <div class="chapter-code">

--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -17,7 +17,7 @@
 
       <%= hidden_field_tag :q, @search.q %>
       <%= hidden_field_tag :internal_search, 'true' %>
-      <%= hidden_field_tag :request_id, @results.request_id %>
+      <%= hidden_field_tag :request_id, @search.request_id %>
 
       <% @results.answered_questions.each do |qa| %>
         <%= hidden_field_tag "answers[][question]", qa['question'] %>

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -173,6 +173,25 @@ RSpec.describe Search do
     end
   end
 
+  describe '#perform_v2_search request_id' do
+    it 'sends request_id to the V2 search endpoint' do
+      search = described_class.new(q: 'horses')
+      search.request_id = 'test-uuid-456'
+
+      stub = stub_api_request('search', :post).to_return(
+        jsonapi_response(:search, {
+          type: 'fuzzy_match',
+          goods_nomenclature_match: { chapters: [], headings: [], commodities: [], sections: [] },
+          reference_match: { chapters: [], headings: [], commodities: [], sections: [] },
+        }),
+      )
+
+      search.perform
+
+      expect(stub).to have_been_requested
+    end
+  end
+
   describe '#perform' do
     context 'when internal_search is true and INTERNAL_SEARCH_ENABLED is true' do
       subject(:perform_search) do

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -11,6 +11,11 @@ VCR.configure do |c|
     record: :new_episodes,
   }
   c.configure_rspec_metadata!
+  c.register_request_matcher :body_without_request_id do |request_1, request_2|
+    body_1 = request_1.body.to_s.gsub(/&?request_id=[^&]*/, '')
+    body_2 = request_2.body.to_s.gsub(/&?request_id=[^&]*/, '')
+    body_1 == body_2
+  end
   c.ignore_request do |request|
     chrome_urls = [
       'https://chromedriver.storage.googleapis.com',

--- a/spec/views/search/_commodity.html.erb_spec.rb
+++ b/spec/views/search/_commodity.html.erb_spec.rb
@@ -1,7 +1,10 @@
 RSpec.describe 'search/_commodity', type: :view do
   subject { render }
 
-  before { allow(view).to receive(:commodity).and_return(commodity) }
+  before do
+    assign(:search, build(:search, q: 'test'))
+    allow(view).to receive(:commodity).and_return(commodity)
+  end
 
   context 'when there are ancestor descriptions' do
     let(:commodity) { build(:commodity, :with_other_ancestor_descriptions) }


### PR DESCRIPTION
### Jira link

[AI-148](https://transformuk.atlassian.net/browse/AI-148)

```mermaid
flowchart LR
    A[User searches] --> B[Frontend generates request_id]
    B --> C[Backend search endpoint]
    C --> D[Results rendered with request_id in links]
    D --> E[User clicks commodity/heading/chapter]
    E --> F[Backend fires result_selected event]
```

### What?

- [x] Generate `request_id` (UUID) in `SearchController#search` when not provided in params
- [x] Propagate `request_id` to exact-match, commodity-code, and heading-code redirects
- [x] Pass `request_id` to V2 search endpoint for backend event correlation
- [x] Add `request_id` query param to all goods nomenclature links in search results (commodities, headings, chapters)
- [x] Switch `interactive_question` hidden field from `@results.request_id` to `@search.request_id` (frontend as source of truth)
- [x] Add specs for `request_id` generation, preservation, and propagation
- [x] Register custom VCR body matcher to handle dynamic `request_id` in cassette matching

### Why?

Wave 1 backend instrumentation is in place, but `result_selected` events never fire because the frontend doesn't pass `request_id` through to goods nomenclature pages. This closes the loop so search journeys can be traced end-to-end from search → result click.

### Have you?

- [ ] Validated on development environment (deploy needed)