### PR TITLE
Update feedback banners and add feedback banner beta on commodity page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -785,6 +785,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-darwin-22
   x86_64-darwin-23
   x86_64-linux

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -61,6 +61,7 @@ $govuk-images-path: '/govuk-frontend/dist/govuk/assets/images/';
 @import 'src/govuk-frontend-extensions';
 @import 'src/exchange_rates';
 @import 'src/feedback_useful_banner';
+@import 'src/feedback_banner_beta';
 @import 'src/feedback_banner';
 @import 'src/notification_banner';
 @import 'src/modal';

--- a/app/assets/stylesheets/src/_feedback_banner_beta.scss
+++ b/app/assets/stylesheets/src/_feedback_banner_beta.scss
@@ -1,0 +1,5 @@
+// Modifier for panel: blue left border and light blue background (GOV.UK notice style)
+.panel--feedback {
+  border-left-color: govuk-colour("blue");
+  background-color: govuk-tint(govuk-colour("blue"), 90%);
+}

--- a/app/assets/stylesheets/src/_feedback_useful_banner.scss
+++ b/app/assets/stylesheets/src/_feedback_useful_banner.scss
@@ -1,73 +1,45 @@
+// Uses GOV.UK footer meta structure for layout; styles scoped so we don't affect main footer
 .feedback-useful-banner {
   border-top: 1px solid govuk-functional-colour(border);
 
-  .feedback-useful-container {
-    position: relative;
-    background-color: govuk-colour("black", $variant: "tint-95");
-    height: 36px;
-    padding-top: 17px;
-  }
+  &__inner {
+    background-color: govuk-colour("light-grey");
+    border-bottom: 1px solid $govuk-border-colour;
+    padding: govuk-spacing(4);
+    // Reapply footer meta flex layout (normally scoped under .govuk-footer)
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: govuk-spacing(4);
 
-  p {
-    font-weight: bold;
-    float: left;
-    padding-top: 7px;
-    padding-left: 11px;
-    padding-right: 15px;
-  }
-
-  .govuk-button {
-    border: 1px solid govuk-colour("black");
-    box-shadow: 0 2px 0 govuk-colour("black");
-    min-width: 6em;
-  }
-}
-
-.govuk-footer {
-  border-top: 10px solid govuk-colour("blue");
-}
-
-@media (max-width: 900px) {
-  .feedback-useful-banner {
-    .report-problem {
-      display: none;
-    }
     .govuk-footer__meta-item {
-      margin-right: 0 !important;
+      margin-right: 0;
+      margin-left: 0;
+      margin-bottom: 0;
     }
-    .govuk-footer__inline-list-item{
-      margin-right: 0 !important;
+
+    .govuk-footer__meta-item--grow {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .govuk-button {
+      border: 1px solid govuk-colour("black");
+      box-shadow: 0 2px 0 govuk-colour("black");
+      min-width: 6em;
     }
   }
 }
 
 @include govuk-media-query($until: tablet) {
-  .feedback-useful-banner {
-    p {
-      padding-top: 9px;
-    }
+  .feedback-useful-banner__inner {
+    flex-direction: column;
+    align-items: stretch;
 
-    .govuk-button {
-      min-width: 3.5em;
-    }
-  }
-}
-
-// for the older devices with smaller screens show the buttons as a block
-@media (max-width: 384px) {
-  .feedback-useful-banner {
-    .feedback-useful-container {
-      height: auto;
-      padding-bottom: 20px;
-    }
-
-    .govuk-footer__inline-list-item {
-      display: block;
-      margin-bottom: 10px;
-    }
-
-    .govuk-button {
+    .govuk-footer__meta-item .govuk-button {
       width: 100%;
+      min-width: 0;
     }
   }
 }

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -16,6 +16,7 @@
   <%= render 'goods_nomenclatures/ancestors', goods_nomenclature: declarable %>
 
   <%= render 'commodities/interactive_search_feedback' %>
+  <%= render 'shared/feedback_banner_commodities' %>
 
   <%= render 'shared/context_tables/commodity' %>
 

--- a/app/views/shared/_feedback_banner.html.erb
+++ b/app/views/shared/_feedback_banner.html.erb
@@ -6,7 +6,7 @@
         FEEDBACK
       </strong>
       <span class="govuk-phase-banner__text">
-        Tell us what you think - your <%= link_to 'feedback', feedback_path, class: 'govuk-link' %> will help us improve.
+        Help us improve this service and <%= link_to 'give your feedback (opens in new tab)', 'https://surveys.transformuk.com/s3/d95fad286fcd', class: 'govuk-link', target: '_blank' %>.
       </span>
     </p>
   </div>

--- a/app/views/shared/_feedback_banner_commodities.html.erb
+++ b/app/views/shared/_feedback_banner_commodities.html.erb
@@ -1,0 +1,7 @@
+<div class="panel panel-border-wide govuk-panel panel--feedback" role="region" aria-labelledby="feedback-banner-beta-heading">
+  <h2 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-2" id="feedback-banner-beta-heading">Give feedback about this service</h2>
+  <p class="govuk-body govuk-!-margin-bottom-0">
+    Help us improve this service by
+    <%= link_to 'giving your feedback (opens in a new tab)', 'https://surveys.transformuk.com/s3/40f03c68329d', class: 'govuk-link', target: '_blank', rel: 'noopener noreferrer' %>.
+  </p>
+</div>

--- a/app/views/shared/_feedback_useful_banner.html.erb
+++ b/app/views/shared/_feedback_useful_banner.html.erb
@@ -1,25 +1,11 @@
 <div class="feedback-useful-banner govuk-width-container">
-  <div class="feedback-useful-container govuk-!-padding-4">
-    <div class="govuk-footer__meta">
-      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-        <p>Is this page useful?</p>
-
-        <ul class="govuk-footer__inline-list">
-          <li class="govuk-footer__inline-list-item">
-            <%= link_to 'Yes', feedback_path(page_useful: 'yes'), class: 'govuk-button govuk-button--secondary' %>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <%= link_to 'No', feedback_path(page_useful: 'no'), class: 'govuk-button govuk-button--secondary' %>
-          </li>
-        </ul>
-      </div>
-      <div class="govuk-footer__meta-item">
-        <ul class="govuk-footer__inline-list">
-          <li class="govuk-footer__inline-list-item">
-              <%= link_to 'Report a problem with this page', feedback_path, class: 'govuk-button govuk-button--secondary report-problem' %>
-          </li>
-        </ul>
-      </div>
+  <div class="feedback-useful-banner__inner govuk-footer__meta">
+    <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+      <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Give feedback about this service</p>
+      <p class="govuk-body govuk-!-margin-bottom-0">Tell us about your experience using this service to help us improve it.</p>
+    </div>
+    <div class="govuk-footer__meta-item">
+      <%= link_to 'Share your feedback', 'https://surveys.transformuk.com/s3/17fead99a348', class: 'govuk-button govuk-button--secondary', target: '_blank', rel: 'noopener' %>
     </div>
   </div>
 </div>

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -35,25 +35,22 @@ RSpec.feature 'Feedback', type: :feature do
 
   scenario 'feedback bottom banner is not shown on feedback page' do
     visit '/404'
-    expect(page).to have_css 'a', text: 'Yes'
-    expect(page).to have_css 'a', text: 'No'
-    expect(page).to have_css 'a', text: 'Report a problem with this page'
-    expect(page).to have_css 'p', text: 'Is this page useful?'
+    expect(page).to have_css 'a', text: 'Share your feedback'
+    expect(page).to have_css 'p', text: 'Give feedback about this service'
+    expect(page).to have_text 'Tell us about your experience using this service to help us improve it.'
 
-    click_on 'Yes'
-    expect(page).not_to have_css 'a', text: 'Yes'
-    expect(page).not_to have_css 'a', text: 'No'
-    expect(page).not_to have_css 'a', text: 'Report a problem with this page'
-    expect(page).not_to have_css 'p', text: 'Is this page useful?'
+    click_on 'Feedback'
+    expect(page).not_to have_css '.feedback-useful-banner'
+    expect(page).not_to have_css 'a', text: 'Share your feedback'
   end
 
   scenario 'feedback banner is not shown on feedback page' do
     visit '/404'
-    expect(page).to have_css 'a', exact_text: 'feedback'
-    expect(page).to have_css 'p', text: 'Tell us what you think - your feedback will help us improve.'
+    expect(page).to have_css 'a', text: 'give your feedback (opens in new tab)'
+    expect(page).to have_text 'Help us improve this service'
 
-    click_on 'feedback'
-    expect(page).not_to have_css 'a', exact_text: 'feedback'
-    expect(page).not_to have_css 'p', text: 'Tell us what you think - your feedback will help us improve.'
+    click_on 'Feedback'
+    expect(page).not_to have_css '.tariff-feedback-banner'
+    expect(page).not_to have_css 'a', text: 'give your feedback (opens in new tab)'
   end
 end

--- a/spec/views/shared/_feedback_banner.html.erb_spec.rb
+++ b/spec/views/shared/_feedback_banner.html.erb_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe 'shared/_feedback_banner', type: :view do
   subject { render partial: 'shared/feedback_banner' }
 
   it { is_expected.to have_css('.govuk-tag', text: 'FEEDBACK') }
-  it { is_expected.to have_text('Tell us what you think') }
-  it { is_expected.to have_link('feedback') }
+  it { is_expected.to have_text('Help us improve this service') }
+  it { is_expected.to have_link('give your feedback (opens in new tab)') }
 
   context 'when @feedback is set' do
     before { assign(:feedback, true) }

--- a/spec/views/shared/_feedback_useful_banner.html.erb_spec.rb
+++ b/spec/views/shared/_feedback_useful_banner.html.erb_spec.rb
@@ -1,8 +1,7 @@
 RSpec.describe 'shared/_feedback_useful_banner', type: :view do
   subject { render partial: 'shared/feedback_useful_banner' }
 
-  it { is_expected.to have_text('Is this page useful?') }
-  it { is_expected.to have_link('Yes') }
-  it { is_expected.to have_link('No') }
-  it { is_expected.to have_link('Report a problem with this page') }
+  it { is_expected.to have_text('Give feedback about this service') }
+  it { is_expected.to have_text('Tell us about your experience using this service to help us improve it.') }
+  it { is_expected.to have_link('Share your feedback', href: 'https://surveys.transformuk.com/s3/17fead99a348') }
 end


### PR DESCRIPTION
### Jira link

[OTTIMP-367](https://transformuk.atlassian.net/browse/OTTIMP-367)

#Feedback banner updates

- Bottom feedback banner: Replaced “Is this page useful?” (Yes/No) and “Report a problem” with a single block: heading “Give feedback about this service”, short description, and a “Share your feedback” button. Link currently points to Google and opens in a new tab.
Commodity page feedback call-out

- New “feedback banner beta” component: light blue panel with blue left border, “Give feedback about this service” and “Help us improve this service by giving your feedback (opens in a new link)”. Rendered on the commodity show page above the context table. Link goes to Google and opens in a new tab.

<img width="763" height="196" alt="Screenshot 2026-02-05 at 18 40 18" src="https://github.com/user-attachments/assets/aac113f2-9246-48db-be7d-10d6bdbc9d52" />

<img width="1134" height="581" alt="Screenshot 2026-02-05 at 18 40 37" src="https://github.com/user-attachments/assets/ac605b16-e7c9-4961-891c-88542d0260b8" />

<img width="1062" height="177" alt="Screenshot 2026-02-05 at 18 40 49" src="https://github.com/user-attachments/assets/0e5e5af8-a6e3-426e-8555-479bc59ae6dd" />

