### PR TITLE
MYOTT-483 Apply HTML in commodity descriptions

### DIFF
--- a/app/views/myott/commodity_changes/classification.html.erb
+++ b/app/views/myott/commodity_changes/classification.html.erb
@@ -51,7 +51,7 @@
                   <%= change.goods_nomenclature_item_id %>
                 </td>
                 <td class="govuk-table__cell">
-                  <%= change.classification_description %>
+                  <%= sanitize change.classification_description %>
                 </td>
                 <td class="govuk-table__cell">
                   <%= change.date_of_effect %>

--- a/app/views/myott/commodity_changes/ending.html.erb
+++ b/app/views/myott/commodity_changes/ending.html.erb
@@ -53,7 +53,7 @@
                   <%= change.goods_nomenclature_item_id %>
                 </td>
                 <td class="govuk-table__cell">
-                  <%= change.classification_description %>
+                  <%= sanitize change.classification_description %>
                 </td>
                 <td class="govuk-table__cell">
                   <%= change.date_of_effect %>

--- a/app/views/myott/grouped_measure_changes/show.html.erb
+++ b/app/views/myott/grouped_measure_changes/show.html.erb
@@ -39,7 +39,7 @@
           <% @commodity_changes.each do |commodity_change| %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= commodity_change.commodity.goods_nomenclature_item_id %></td>
-              <td class="govuk-table__cell"><%= commodity_change.commodity.classification_description %></td>
+              <td class="govuk-table__cell"><%= sanitize commodity_change.commodity.classification_description %></td>
               <td class="govuk-table__cell"><%= link_to(pluralize(commodity_change.count, 'change'), myott_grouped_measure_commodity_change_path(commodity_change.resource_id, as_of:)) %></td>
             </tr>
           <% end %>

--- a/app/views/myott/grouped_measure_commodity_changes/show.html.erb
+++ b/app/views/myott/grouped_measure_commodity_changes/show.html.erb
@@ -58,7 +58,7 @@
             Heading
           </dt>
           <dd class="govuk-summary-list__value">
-            <%= @grouped_measure_commodity_changes.heading %>
+            <%= sanitize @grouped_measure_commodity_changes.heading %>
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -66,7 +66,7 @@
             Classification
           </dt>
           <dd class="govuk-summary-list__value">
-            <%= @grouped_measure_commodity_changes.classification_description %>
+            <%= sanitize @grouped_measure_commodity_changes.classification_description %>
           </dd>
         </div>
       </dl>

--- a/app/views/myott/mycommodities/active.html.erb
+++ b/app/views/myott/mycommodities/active.html.erb
@@ -34,7 +34,7 @@
               <strong><%= target.goods_nomenclature_item_id %></strong>
             </td>
             <td class="govuk-table__cell">
-              <%= target.classification_description %>
+              <%= sanitize target.classification_description %>
             </td>
           </tr>
           <% end %>

--- a/app/views/myott/mycommodities/expired.html.erb
+++ b/app/views/myott/mycommodities/expired.html.erb
@@ -47,7 +47,7 @@
                 <strong><%= target.goods_nomenclature_item_id %></strong>
               </td>
               <td class="govuk-table__cell">
-                <%= target.classification_description %>
+                <%= sanitize target.classification_description %>
               </td>
               <td class="govuk-table__cell">
                 <%= target.validity_end_date.to_fs %>


### PR DESCRIPTION
### Jira link

[MYOTT-483](https://transformuk.atlassian.net/browse/MYOTT-483)

### What?

Some commodity descriptions include HTML (mainly `<br>`). These should be interpreted as HTML to match other parts of the site.

### Why?

To be consistent and show the description as intended.
