### PR TITLE
[HMRC-1947]- Login Credentials Sent Over Network Unencrypted

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   config.assume_ssl = ENV.fetch('RAILS_ASSUME_SSL', 'true') == 'true'
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = false
+  config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new($stdout)


### PR DESCRIPTION
### Jira link

[HMRC-1947](https://transformuk.atlassian.net/browse/HMRC-1947)

### What?

The pentest flagged up the transmission of login credentials over an unencypted network.

The ticket mentions this was detected using automated scanning and could not be validated.

Without diving too deep into infra, it looks like we’re already using https for everything in production so this could potentially be a misfire from the vulnerability scanner. It's a really hard one to test without knowing more.

But either way, this PR brings both the frontend and backend repos in line with the production config for `trade-tariff-admin` and `trade-tariff-dev-hub` so everything is the same; setting force_ssl to true and securing session cookies.

### Why?

I am doing this because 

- The pentest flagged up the transmission of login credentials over an unencypted network.
- It's nice to have the same config across the board where possible