### PR TITLE
AI-163: Remove skip-to-results from interactive question flow

### DIFF
--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -19,9 +19,7 @@ module InteractiveSearchable
   end
 
   def route_interactive_results
-    if skip_questions?
-      render_interactive_results
-    elsif @results.has_pending_question?
+    if @results.has_pending_question?
       render_interactive_question
     else
       render_interactive_results
@@ -105,10 +103,6 @@ module InteractiveSearchable
     JSON.parse(value)
   rescue JSON::ParserError
     []
-  end
-
-  def skip_questions?
-    params[:skip_questions] == 'true' && @results.interactive_search?
   end
 
   def render_interactive_question

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -135,7 +135,6 @@ class SearchController < ApplicationController
       :request_id,
       :current_question,
       :current_options,
-      :skip_questions,
       answers: %i[question options answer],
       interactive_search_form: [:answer],
     ).to_h

--- a/app/javascript/controllers/interactive_question_controller.js
+++ b/app/javascript/controllers/interactive_question_controller.js
@@ -3,11 +3,6 @@ import { Controller } from '@hotwired/stimulus'
 export default class extends Controller {
   static targets = ['form', 'results']
 
-  skipToResults(event) {
-    event.preventDefault()
-    this.#showResults()
-  }
-
   selectUnknown(event) {
     // When "I don't know" is selected, show pre-rendered results
     // Use a small delay to show the selection before transitioning

--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -47,19 +47,6 @@
       </div>
     <% end %>
 
-    <% if @results.answered_questions.any? %>
-      <div class="govuk-!-margin-top-6">
-        <h2 class="govuk-heading-s">Skip to results</h2>
-        <p class="govuk-body">
-          If you have answered a few questions, you can skip forward to see what results
-          have already been found. If you need to come back and refine the results, you
-          will have that chance.
-        </p>
-        <%= link_to "Skip to results page", "#",
-            class: "govuk-button govuk-button--secondary",
-            data: { action: "click->interactive-question#skipToResults" } %>
-      </div>
-    <% end %>
 
     <% if @results.result_limit.positive? && @results.any? %>
       <div class="govuk-!-margin-top-6">

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -343,41 +343,6 @@ RSpec.describe SearchController, type: :controller do
         it { is_expected.to have_http_status(:ok) }
         it { is_expected.to render_template(:interactive_results) }
       end
-
-      context 'when skip_questions is true' do
-        let(:params) do
-          {
-            q: 'horses',
-            internal_search: 'true',
-            skip_questions: 'true',
-            request_id: 'abc-123',
-          }
-        end
-
-        before do
-          stub_api_request('search', :post, internal: true).to_return(
-            status: 200,
-            body: {
-              'data' => [commodity_data],
-              'meta' => {
-                'interactive_search' => {
-                  'query' => 'horses',
-                  'request_id' => 'abc-123',
-                  'result_limit' => 5,
-                  'answers' => [
-                    { 'question' => 'What type of horse?', 'options' => %w[Racing Breeding], 'answer' => nil },
-                  ],
-                },
-              },
-            }.to_json,
-            headers: { 'content-type' => 'application/json; charset=utf-8' },
-          )
-          do_response
-        end
-
-        it { is_expected.to have_http_status(:ok) }
-        it { is_expected.to render_template(:interactive_results) }
-      end
     end
 
     describe 'header for crawlers', vcr: { cassette_name: 'search#blank_match' } do

--- a/spec/javascript/controllers/interactive_question_controller_spec.js
+++ b/spec/javascript/controllers/interactive_question_controller_spec.js
@@ -9,7 +9,6 @@ describe('InteractiveQuestionController', () => {
       <div data-controller="interactive-question">
         <div data-interactive-question-target="form" id="form">
           <input type="radio" id="unknown" data-action="change->interactive-question#selectUnknown">
-          <a href="#" data-action="click->interactive-question#skipToResults">Skip</a>
         </div>
         <div data-interactive-question-target="results" id="results" class="govuk-!-display-none">
           <p>Pre-rendered results</p>
@@ -24,31 +23,6 @@ describe('InteractiveQuestionController', () => {
   afterEach(() => {
     application.stop();
     jest.useRealTimers();
-  });
-
-  describe('#skipToResults', () => {
-    it('hides the form', () => {
-      const form = document.querySelector('#form');
-      const skipLink = document.querySelector('a[data-action]');
-
-      const event = new Event('click', {bubbles: true});
-      jest.spyOn(event, 'preventDefault');
-
-      skipLink.dispatchEvent(event);
-
-      expect(event.preventDefault).toHaveBeenCalled();
-      expect(form.classList.contains('govuk-!-display-none')).toBe(true);
-    });
-
-    it('shows the results', () => {
-      const results = document.querySelector('#results');
-      const skipLink = document.querySelector('a[data-action]');
-
-      const event = new Event('click', {bubbles: true});
-      skipLink.dispatchEvent(event);
-
-      expect(results.classList.contains('govuk-!-display-none')).toBe(false);
-    });
   });
 
   describe('#selectUnknown', () => {


### PR DESCRIPTION
### Jira link

[AI-163](https://transformuk.atlassian.net/browse/AI-163)

### What?

- [x] Remove "Skip to results" section from `interactive_question.html.erb`
- [x] Remove `skipToResults()` method from `interactive_question_controller.js`
- [x] Remove `skip_questions?` method and simplify `route_interactive_results` in `InteractiveSearchable`
- [x] Remove `skip_questions` from permitted params in `SearchController`
- [x] Remove corresponding controller and JS specs

### Why?

HMRC prototype feedback confirmed that traders should answer each question in the guided flow - there should be no option to skip ahead to results before the flow completes. Removing skip maintains classification accuracy.

Note: The "I don't know" path (`selectUnknown`) and its hidden results div are intentionally left intact - that behaviour is being redesigned in [AI-164](https://transformuk.atlassian.net/browse/AI-164).