### PR TITLE
MYOTT-496 Handle error response

### DIFF
--- a/app/models/concerns/authenticatable_api_entity.rb
+++ b/app/models/concerns/authenticatable_api_entity.rb
@@ -40,9 +40,11 @@ module AuthenticatableApiEntity
     end
 
     def extract_error_reason(error)
-      return nil unless error.response&.dig(:body)
+      body = error.response&.dig(:body)
 
-      body = JSON.parse(error.response[:body])
+      return nil if body.nil?
+
+      body = JSON.parse(body) if body.is_a?(String)
       body.dig('errors', 0, 'code')
     rescue JSON::ParserError
       nil

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,6 +25,31 @@ RSpec.describe User do
 
       it { is_expected.to be_nil }
     end
+
+    context 'when response is unauthorized with expired error message' do
+      let(:error_body) do
+        {
+          errors: [
+            {
+              code: 'expired',
+              detail: 'Token has expired',
+            },
+          ],
+        }.to_json
+      end
+
+      before do
+        stub_api_request('http://localhost:3018/uk/user/users')
+          .and_return(jsonapi_error_response(401, error_body))
+      end
+
+      it 'raises AuthenticationError with reason', :aggregate_failures do
+        expect { described_class.find(nil, token) }
+          .to raise_error(AuthenticationError) do |error|
+            expect(error.reason).to eq('expired')
+          end
+      end
+    end
   end
 
   describe '.update' do


### PR DESCRIPTION
### Jira link

[MYOTT-496](https://transformuk.atlassian.net/browse/MYOTT-496)

### What?

Handling of the authentication error from the backend was failing because the error had already been parsed. A check has been added so this will work if the response has already been parsed, or is still a string.

### Why?

An error occurs when a user's authentication has expired.
