### PR TITLE
AI-148: Exclude request_id from fragment cache keys

### DIFF
--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -1,4 +1,6 @@
 module CacheHelper
+  CACHE_EXCLUDED_PARAMS = %w[request_id].freeze
+
   def cache_key
     [TradeTariffFrontend::ServiceChooser.cache_prefix, @tariff_last_updated, TradeTariffFrontend.revision].join('/')
   end
@@ -8,7 +10,11 @@ module CacheHelper
       'commodities#show',
       cache_key,
       meursing_lookup_result.meursing_additional_code_id,
-      params.to_unsafe_h.sort.map { |_, v| v }.compact.join('/'),
+      cache_params.sort.map { |_, v| v }.compact.join('/'),
     ].compact
+  end
+
+  def cache_params
+    params.to_unsafe_h.except(*CACHE_EXCLUDED_PARAMS)
   end
 end

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -29,7 +29,7 @@
 <% end %>
 
 <% if cacheable %>
-  <% heading_cache_key = ['headings#show', cache_key, params.values.compact.map(&:to_s).sort.join('/')] %>
+  <% heading_cache_key = ['headings#show', cache_key, cache_params.values.compact.map(&:to_s).sort.join('/')] %>
   <%= cache(heading_cache_key) { concat(content) } %>
 <% else %>
   <%= content %>

--- a/spec/helpers/cache_helper_spec.rb
+++ b/spec/helpers/cache_helper_spec.rb
@@ -33,5 +33,12 @@ RSpec.describe CacheHelper, type: :helper do
 
       it { expect(instance.commodity_cache_key).not_to eq(instance2.commodity_cache_key) }
     end
+
+    context 'when request_id is present, it is excluded from the cache key' do
+      let(:without_request_id) { cacheable.new('2025-01-01', { day: '04', month: '01', year: '2025', id: '2008605010' }) }
+      let(:with_request_id) { cacheable.new('2025-01-01', { day: '04', month: '01', year: '2025', id: '2008605010', request_id: SecureRandom.uuid }) }
+
+      it { expect(with_request_id.commodity_cache_key).to eq(without_request_id.commodity_cache_key) }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[AI-148](https://transformuk.atlassian.net/browse/AI-148)

### What?

- [x] Add `cache_params` helper that excludes instrumentation-only params (`request_id`) from the params hash
- [x] Use `cache_params` in `commodity_cache_key` (CacheHelper)
- [x] Use `cache_params` in heading view fragment cache key
- [x] Add spec verifying `request_id` does not affect cache key

### Why?

PR #2729 added `request_id` as a query parameter on all goods nomenclature links in search results. Since `commodity_cache_key` and the heading view cache key both include all params, every unique `request_id` (a UUID generated per search) creates a new cache fragment for identical page content. This defeats fragment caching for any page reached via search.