### PR TITLE
AI-148: Pass search request_id to backend via X-Search-Request-Id header

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -1,6 +1,6 @@
 class ChaptersController < GoodsNomenclaturesController
   def show
-    @chapter = Chapter.find(params[:id], query_params)
+    @chapter = Chapter.find(params[:id], query_params, search_tracking_headers)
     @headings = @chapter.headings
     @section = @chapter.section
   end

--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -65,13 +65,13 @@ class CommoditiesController < GoodsNomenclaturesController
   end
 
   def subheading
-    Subheading.find("#{params[:id]}-80", query_params)
+    Subheading.find("#{params[:id]}-80", query_params, search_tracking_headers)
   end
 
   def uk_heading
     @uk_heading ||= Rails.cache.fetch(['commodities#uk_heading', cache_key, heading_id, query_params]) do
       TradeTariffFrontend::ServiceChooser.with_source(:uk) do
-        HeadingPresenter.new(Heading.find(heading_id, query_params))
+        HeadingPresenter.new(Heading.find(heading_id, query_params, search_tracking_headers))
       end
     end
   end
@@ -79,7 +79,7 @@ class CommoditiesController < GoodsNomenclaturesController
   def xi_heading
     @xi_heading ||= Rails.cache.fetch(['commodities#xi_heading', cache_key, heading_id, query_params]) do
       TradeTariffFrontend::ServiceChooser.with_source(:xi) do
-        HeadingPresenter.new(Heading.find(heading_id, query_params))
+        HeadingPresenter.new(Heading.find(heading_id, query_params, search_tracking_headers))
       end
     end
   end
@@ -87,7 +87,7 @@ class CommoditiesController < GoodsNomenclaturesController
   def uk_commodity
     @uk_commodity ||= Rails.cache.fetch(['commodities#uk_commodity', cache_key, params[:id], query_params]) do
       TradeTariffFrontend::ServiceChooser.with_source(:uk) do
-        CommodityPresenter.new(Commodity.find(params[:id], query_params))
+        CommodityPresenter.new(Commodity.find(params[:id], query_params, search_tracking_headers))
       end
     end
   end
@@ -95,7 +95,7 @@ class CommoditiesController < GoodsNomenclaturesController
   def xi_commodity
     @xi_commodity ||= Rails.cache.fetch(['commodities#xi_commodity', cache_key, params[:id], query_params]) do
       TradeTariffFrontend::ServiceChooser.with_source(:xi) do
-        CommodityPresenter.new(Commodity.find(params[:id], query_params))
+        CommodityPresenter.new(Commodity.find(params[:id], query_params, search_tracking_headers))
       end
     end
   end

--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -28,4 +28,10 @@ class GoodsNomenclaturesController < ApplicationController
   def set_goods_nomenclature_code
     @goods_nomenclature_code = goods_code_id
   end
+
+  def search_tracking_headers
+    return {} if params[:request_id].blank?
+
+    { 'X-Search-Request-Id' => params[:request_id] }
+  end
 end

--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -33,13 +33,13 @@ class HeadingsController < GoodsNomenclaturesController
 
   def fetch_heading_from_xi
     @xi_heading = TradeTariffFrontend::ServiceChooser.with_source(:xi) do
-      HeadingPresenter.new(Heading.find(params[:id], query_params))
+      HeadingPresenter.new(Heading.find(params[:id], query_params, search_tracking_headers))
     end
   end
 
   def fetch_heading_from_uk
     @uk_heading = TradeTariffFrontend::ServiceChooser.with_source(:uk) do
-      HeadingPresenter.new(Heading.find(params[:id], query_params))
+      HeadingPresenter.new(Heading.find(params[:id], query_params, search_tracking_headers))
     end
   end
 
@@ -49,12 +49,12 @@ class HeadingsController < GoodsNomenclaturesController
     @meursing_additional_code = session[MeursingLookup::Result::CURRENT_MEURSING_ADDITIONAL_CODE_KEY]
 
     if TradeTariffFrontend::ServiceChooser.uk?
-      @headings[:uk] = HeadingPresenter.new(Heading.find(params[:id], query_params))
+      @headings[:uk] = HeadingPresenter.new(Heading.find(params[:id], query_params, search_tracking_headers))
       @headings[:xi] = nil
     else
-      @headings[:xi] = HeadingPresenter.new(Heading.find(params[:id], query_params))
+      @headings[:xi] = HeadingPresenter.new(Heading.find(params[:id], query_params, search_tracking_headers))
       @headings[:uk] = TradeTariffFrontend::ServiceChooser.with_source(:uk) do
-        HeadingPresenter.new(Heading.find(params[:id], query_params))
+        HeadingPresenter.new(Heading.find(params[:id], query_params, search_tracking_headers))
       end
     end
   end

--- a/spec/controllers/goods_nomenclatures_controller_spec.rb
+++ b/spec/controllers/goods_nomenclatures_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe GoodsNomenclaturesController, type: :controller do
+  controller(ChaptersController) {}
+
+  describe '#search_tracking_headers' do
+    subject { controller.send(:search_tracking_headers) }
+
+    context 'when request_id is present' do
+      before { controller.params = ActionController::Parameters.new(request_id: 'req-abc-123') }
+
+      it { is_expected.to eq('X-Search-Request-Id' => 'req-abc-123') }
+    end
+
+    context 'when request_id is blank' do
+      before { controller.params = ActionController::Parameters.new(request_id: '') }
+
+      it { is_expected.to eq({}) }
+    end
+
+    context 'when request_id is absent' do
+      before { controller.params = ActionController::Parameters.new({}) }
+
+      it { is_expected.to eq({}) }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-148](https://transformuk.atlassian.net/browse/AI-148)

```mermaid
flowchart LR
    A[User searches] --> B[Frontend adds request_id to goods nomenclature links]
    B --> C[User clicks a result]
    C --> D[Frontend reads request_id from URL params]
    D --> E[Frontend passes X-Search-Request-Id header to backend API]
    E --> F[Backend SearchResultTracking fires result_selected event]
```

### What?

- [x] Add `search_tracking_headers` helper to `GoodsNomenclaturesController` that builds `X-Search-Request-Id` header from `params[:request_id]`
- [x] Pass the header through all `find` calls in `CommoditiesController`, `HeadingsController`, and `ChaptersController`
- [x] Add spec for `search_tracking_headers` covering present, blank, and absent request_id

### Why?

Companion to [trade-tariff-backend#2780](https://github.com/trade-tariff/trade-tariff-backend/pull/2780). The backend now reads the search request_id from the `X-Search-Request-Id` header to fire `result_selected` instrumentation events. Using a header instead of a query param avoids CDN cache key pollution (`cache_all_qsa` includes all query strings) and frontend `Rails.cache` fragmentation.

The `request_id` stays in the frontend URL (stateless, multi-tab safe) but is forwarded to the backend as a header so it never touches any cache key.