### PR TITLE
BAU: Redirect to commodity on exact match in interactive search

### DIFF
--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -19,7 +19,9 @@ module InteractiveSearchable
   end
 
   def route_interactive_results
-    if @results.has_pending_question?
+    if @results.exact_match?
+      redirect_to url_for @results.to_param.merge(url_options).merge(request_id: @search.request_id, only_path: true)
+    elsif @results.has_pending_question?
       render_interactive_question
     else
       render_interactive_results


### PR DESCRIPTION
### What?

- [x] Add exact match redirect to the interactive search path, matching the behaviour already present in classic search

### Why?

When the backend returns a single exact match result (score: nil) during interactive search, the frontend was rendering a results page with one item instead of redirecting directly to the commodity/heading/chapter page. Classic search already handles this correctly via `ClassicSearchable#route_classic_results`. This adds the same check to `InteractiveSearchable#route_interactive_results`.