### PR TITLE
AI-148: Rename internal_search to interactive_search and extend rack-timeout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -139,8 +139,8 @@ class ApplicationController < ActionController::Base
     @path_info = { search_suggestions_path: search_suggestions_path(format: :json),
                    faq_send_feedback_path: green_lanes_send_feedback_path }
 
-    if TradeTariffFrontend.internal_search_enabled?
-      @path_info[:internal_search_suggestions_path] = internal_search_suggestions_path(format: :json)
+    if TradeTariffFrontend.interactive_search_enabled?
+      @path_info[:interactive_search_suggestions_path] = interactive_search_suggestions_path(format: :json)
     end
   end
 

--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -55,8 +55,8 @@ module InteractiveSearchable
     :invalid
   end
 
-  def internal_search?
-    @search.internal_search && TradeTariffFrontend.internal_search_enabled?
+  def interactive_search?
+    @search.interactive_search && TradeTariffFrontend.interactive_search_enabled?
   end
 
   def merge_current_answer

--- a/app/javascript/controllers/interactive_search_controller.js
+++ b/app/javascript/controllers/interactive_search_controller.js
@@ -5,11 +5,11 @@ export default class extends Controller {
   static targets = ['toggle', 'hiddenField']
   static values = {
     v2SuggestionsPath: String,
-    internalSuggestionsPath: String,
+    interactiveSuggestionsPath: String,
   }
 
   connect() {
-    const enabled = Cookies.get('internal_search') === 'true'
+    const enabled = Cookies.get('interactive_search') === 'true'
     this.toggleTarget.checked = enabled
     this.hiddenFieldTarget.value = enabled.toString()
     this.#updateSuggestionsPath(enabled)
@@ -19,7 +19,7 @@ export default class extends Controller {
     const enabled = this.toggleTarget.checked
     const isSecure = location.protocol === 'https:'
 
-    Cookies.set('internal_search', enabled.toString(), {
+    Cookies.set('interactive_search', enabled.toString(), {
       expires: 365,
       secure: isSecure,
       sameSite: 'Strict',
@@ -34,7 +34,7 @@ export default class extends Controller {
 
     if (pathInfoEl) {
       pathInfoEl.dataset.searchSuggestionsPath = enabled
-        ? this.internalSuggestionsPathValue
+        ? this.interactiveSuggestionsPathValue
         : this.v2SuggestionsPathValue
     }
   }

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -15,7 +15,7 @@ class Search
                 :month,
                 :year,
                 :resource_id,
-                :internal_search,
+                :interactive_search,
                 :answers,
                 :request_id
 
@@ -31,7 +31,7 @@ class Search
   end
 
   def perform
-    if internal_search && TradeTariffFrontend.internal_search_enabled?
+    if interactive_search && TradeTariffFrontend.interactive_search_enabled?
       perform_internal_search
     else
       perform_v2_search

--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -16,7 +16,7 @@
       <%= f.govuk_error_summary %>
 
       <%= hidden_field_tag :q, @search.q %>
-      <%= hidden_field_tag :internal_search, 'true' %>
+      <%= hidden_field_tag :interactive_search, 'true' %>
       <%= hidden_field_tag :request_id, @search.request_id %>
 
       <% @results.answered_questions.each do |qa| %>

--- a/app/views/shared/search/_search_form.html.erb
+++ b/app/views/shared/search/_search_form.html.erb
@@ -6,22 +6,22 @@
 <%= hidden_field_tag :day, @search.day %>
 <% end %>
 
-<% if TradeTariffFrontend.internal_search_enabled? %>
-<div data-controller="internal-search"
-     data-internal-search-v2-suggestions-path-value="<%= search_suggestions_path(format: :json) %>"
-     data-internal-search-internal-suggestions-path-value="<%= internal_search_suggestions_path(format: :json) %>">
+<% if TradeTariffFrontend.interactive_search_enabled? %>
+<div data-controller="interactive-search"
+     data-interactive-search-v2-suggestions-path-value="<%= search_suggestions_path(format: :json) %>"
+     data-interactive-search-interactive-suggestions-path-value="<%= interactive_search_suggestions_path(format: :json) %>">
   <div class="govuk-checkboxes govuk-checkboxes--small govuk-!-margin-bottom-2">
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="internal_search_toggle" type="checkbox"
-             data-internal-search-target="toggle"
-             data-action="internal-search#toggle">
-      <label class="govuk-label govuk-checkboxes__label" for="internal_search_toggle">
+      <input class="govuk-checkboxes__input" id="interactive_search_toggle" type="checkbox"
+             data-interactive-search-target="toggle"
+             data-action="interactive-search#toggle">
+      <label class="govuk-label govuk-checkboxes__label" for="interactive_search_toggle">
         Use new search
       </label>
     </div>
   </div>
-  <input type="hidden" name="internal_search" value="false"
-         data-internal-search-target="hiddenField">
+  <input type="hidden" name="interactive_search" value="false"
+         data-interactive-search-target="hiddenField">
 </div>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,7 +175,7 @@ Rails.application.routes.draw do
   end
 
   get 'search_suggestions', to: 'search#suggestions', as: :search_suggestions
-  get 'internal_search_suggestions', to: 'search#internal_suggestions', as: :internal_search_suggestions
+  get 'internal_search_suggestions', to: 'search#interactive_suggestions', as: :interactive_search_suggestions
   get 'quota_search', to: 'search#quota_search', as: :quota_search
   get 'simplified_procedure_value', to: 'simplified_procedural_values#index', as: :simplified_procedural_values
   get 'additional_code_search', to: 'additional_code_search#new', as: :additional_code_search

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -147,7 +147,7 @@ module TradeTariffFrontend
     ENV['GREEN_LANES_ENABLED'].to_s == 'true'
   end
 
-  def internal_search_enabled?
+  def interactive_search_enabled?
     !production?
   end
 

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -256,6 +256,36 @@ RSpec.describe SearchController, type: :controller do
       end
     end
 
+    describe 'rack-timeout extension for interactive search' do
+      context 'when interactive_search is true' do
+        let(:params) { { q: 'horses', interactive_search: 'true' } }
+
+        before do
+          allow(TradeTariffFrontend).to receive(:interactive_search_enabled?).and_return(true)
+          stub_api_request('search', :post, internal: true).to_return(
+            status: 200,
+            body: { 'data' => [], 'meta' => {} }.to_json,
+            headers: { 'content-type' => 'application/json; charset=utf-8' },
+          )
+          do_response
+        end
+
+        it 'sets rack-timeout service_timeout to 50' do
+          expect(request.env['rack-timeout.service_timeout']).to eq(50)
+        end
+      end
+
+      context 'when interactive_search is not set', vcr: { cassette_name: 'search#search_fuzzy' } do
+        let(:params) { { q: 'horses', day: '11', month: '05', year: '2023' } }
+
+        before { do_response }
+
+        it 'does not set rack-timeout service_timeout' do
+          expect(request.env['rack-timeout.service_timeout']).to be_nil
+        end
+      end
+    end
+
     context 'with internal interactive search' do
       subject(:do_response) { get :search, params: }
 
@@ -276,11 +306,11 @@ RSpec.describe SearchController, type: :controller do
       end
 
       before do
-        allow(TradeTariffFrontend).to receive(:internal_search_enabled?).and_return(true)
+        allow(TradeTariffFrontend).to receive(:interactive_search_enabled?).and_return(true)
       end
 
       context 'when backend returns a pending question' do
-        let(:params) { { q: 'horses', internal_search: 'true' } }
+        let(:params) { { q: 'horses', interactive_search: 'true' } }
 
         before do
           stub_api_request('search', :post, internal: true).to_return(
@@ -352,7 +382,7 @@ RSpec.describe SearchController, type: :controller do
         let(:params) do
           {
             q: 'horses',
-            internal_search: 'true',
+            interactive_search: 'true',
             request_id: 'abc-123',
             answers: [
               { question: 'What type of horse?', options: %w[Racing Breeding], answer: 'Breeding' },

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe SearchController, type: :controller do
       end
 
       context 'when backend returns a single exact match' do
-        let(:params) { { q: '0101210000', internal_search: 'true' } }
+        let(:params) { { q: '0101210000', interactive_search: 'true' } }
 
         let(:exact_match_data) do
           {

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -193,10 +193,10 @@ RSpec.describe Search do
   end
 
   describe '#perform' do
-    context 'when internal_search is true and INTERNAL_SEARCH_ENABLED is true' do
+    context 'when interactive_search is true and interactive search is enabled' do
       subject(:perform_search) do
         search = described_class.new(q: 'horses')
-        search.internal_search = true
+        search.interactive_search = true
         search.perform
       end
 
@@ -221,7 +221,7 @@ RSpec.describe Search do
       end
 
       before do
-        allow(TradeTariffFrontend).to receive(:internal_search_enabled?).and_return(true)
+        allow(TradeTariffFrontend).to receive(:interactive_search_enabled?).and_return(true)
         stub_api_request('search', :post, internal: true)
           .to_return(status: 200,
                      body: internal_response_body.to_json,
@@ -237,15 +237,15 @@ RSpec.describe Search do
       end
     end
 
-    context 'when internal_search is true and response is empty' do
+    context 'when interactive_search is true and response is empty' do
       subject(:perform_search) do
         search = described_class.new(q: 'xyznonexistent')
-        search.internal_search = true
+        search.interactive_search = true
         search.perform
       end
 
       before do
-        allow(TradeTariffFrontend).to receive(:internal_search_enabled?).and_return(true)
+        allow(TradeTariffFrontend).to receive(:interactive_search_enabled?).and_return(true)
         stub_api_request('search', :post, internal: true)
           .to_return(status: 200,
                      body: { 'data' => [] }.to_json,
@@ -257,11 +257,11 @@ RSpec.describe Search do
       end
     end
 
-    context 'when internal_search is false even though INTERNAL_SEARCH_ENABLED is true' do
+    context 'when interactive_search is false even though interactive search is enabled' do
       subject(:perform_search) { described_class.new(q: 'horses').perform }
 
       before do
-        allow(TradeTariffFrontend).to receive(:internal_search_enabled?).and_return(true)
+        allow(TradeTariffFrontend).to receive(:interactive_search_enabled?).and_return(true)
         stub_api_request('search', :post).to_return(
           jsonapi_response(:search, {
             type: 'fuzzy_match',
@@ -276,11 +276,11 @@ RSpec.describe Search do
       end
     end
 
-    context 'when INTERNAL_SEARCH_ENABLED is false' do
+    context 'when interactive search is disabled' do
       subject(:perform_search) { described_class.new(q: 'horses').perform }
 
       before do
-        allow(TradeTariffFrontend).to receive(:internal_search_enabled?).and_return(false)
+        allow(TradeTariffFrontend).to receive(:interactive_search_enabled?).and_return(false)
         stub_api_request('search', :post).to_return(
           jsonapi_response(:search, {
             type: 'fuzzy_match',


### PR DESCRIPTION
### Jira link

[AI-148](https://transformuk.atlassian.net/browse/AI-148)

### What?

- [x] Rename `internal_search` param/attribute/feature flag to `interactive_search` across the codebase
- [x] Rename Stimulus controller from `internal-search` to `interactive-search` (file, data attributes, cookie)
- [x] Rename `internal_search_enabled?` to `interactive_search_enabled?`
- [x] Rename `internal_suggestions` action to `interactive_suggestions` (URL path kept as `internal_search_suggestions`)
- [x] Add `before_action` to extend rack-timeout to 50s for interactive search requests
- [x] Add specs for the rack-timeout extension

### Why?

The user-facing search feature has always been called "interactive search" but the frontend code used `internal_search` throughout (inherited from the backend API path naming). This rename aligns the frontend naming with the feature's actual name.

The rack-timeout extension prevents the frontend's 15s default from killing interactive search requests before the backend responds. The chain is: query expansion (~125ms) + OpenSearch (<100ms) + GPT-5.2 (5-20s+) = frequently >15s total. The 50s limit matches the backend's own rack-timeout.

### Things intentionally left alone

- `perform_internal_search` method in `Search` model - describes the backend `/internal/` API path
- `Search::InternalSearchResult` class - same reasoning
- Route URL path `internal_search_suggestions` - matches the backend API path

### Potential concerns

- Cookie rename (`internal_search` -> `interactive_search`): users with the old cookie lose their toggle state (one-time reset, low impact)