### PR TITLE
Handle CSV files more liberally

### DIFF
--- a/app/services/commodity_codes_extraction_service.rb
+++ b/app/services/commodity_codes_extraction_service.rb
@@ -22,7 +22,7 @@ class CommodityCodesExtractionService
     rows =
       case file.content_type
       when 'text/csv'
-        CSV.parse(file.read).map { |row| row[0] }
+        file.read.lines.map { |line| line.split(',').first&.strip }
       else
         sheet = Roo::Spreadsheet.open(file).sheet(0)
         sheet.last_row.present? ? sheet.column(COMMODITY_CODES_COLUMN).compact : []


### PR DESCRIPTION
### What?

The CSV library is strict about the file having correct line endings. We only need to extract the first value in each line so this can be done simply without the library.
