### PR TITLE
MyOTT-506 Fix Invalid Verification Link Page

### DIFF
--- a/app/views/myott/subscriptions/invalid.html.erb
+++ b/app/views/myott/subscriptions/invalid.html.erb
@@ -10,8 +10,7 @@
     </ul>
 
     <p class="govuk-body">
-      To resend the verification email for Stop Press updates from the
-      UK Trade Tariff Service, continue to subscribe and manage updates.
+      To resend the verification email, continue to create and manage your tariff watch lists.
     </p>
 
     <a href="<%= myott_start_path %>" role="button" draggable="false" class="govuk-button" data-module="govuk-button">

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
         get :invalid
       end
 
-      it { is_expected.not_to redirect_to myott_invalid_path }
+      it { is_expected.not_to redirect_to myott_path }
+      it { is_expected.to render_template(:invalid) }
     end
   end
 

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
         get :invalid
       end
 
-      it { is_expected.not_to redirect_to myott_path }
+      it { is_expected.not_to redirect_to myott_invalid_path }
     end
   end
 


### PR DESCRIPTION
### Jira link

[MyOTT-506](https://transformuk.atlassian.net/browse/MyOTT-506)

### What?

I have moved `invalid.html.erb` file and updated wording and spec

### Why?

I am doing this as a 404 error was being generated as the route had moved from `stop_press` to `subscription`

<img width="492" height="431" alt="image" src="https://github.com/user-attachments/assets/136e03c6-4230-404a-800d-5575879f6bba" />