### PR TITLE
AI-148: Replace rack-timeout with per-path service timeout middleware

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,7 +7,6 @@ class SearchController < ApplicationController
 
   before_action :disable_switch_service_banner, only: [:quota_search]
   before_action :disable_search_form, except: [:search]
-  before_action :extend_timeout_for_interactive_search, only: [:search]
 
   def search
     @search.q = params[:q] if params[:q]
@@ -96,12 +95,6 @@ class SearchController < ApplicationController
   end
 
   private
-
-  def extend_timeout_for_interactive_search
-    return unless params[:interactive_search] == 'true'
-
-    request.env['rack-timeout.service_timeout'] = 50
-  end
 
   def anchor
     params.dig(:search, :anchor).to_s.gsub(/[^a-zA-Z_-]/, '').presence

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,18 +1,12 @@
-# Rack Timeout Configuration
-# See: https://github.com/zombocom/rack-timeout
-#
-# RACK_TIMEOUT_SERVICE_TIMEOUT (seconds, default: 15)
-# Maximum time the application can take to process and respond to a request once received.
-# Requests exceeding this will be terminated (SIGTERM sent to worker).
-# Current setting: 15 seconds (same as default).
 ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] ||= '15'
 
-# Other available settings (using defaults if not set):
-# - RACK_TIMEOUT_WAIT_TIMEOUT: Maximum wait time in the web server queue (default: 30)
-# - RACK_TIMEOUT_WAIT_OVERTIME: Additional wait time for requests with a body (POST, PUT, etc.) (default: 60)
-# - RACK_TIMEOUT_SERVICE_PAST_WAIT: Whether to use full service_timeout even after wait_timeout (default: false)
-# - RACK_TIMEOUT_TERM_ON_TIMEOUT: Send SIGTERM when timeout occurs (default: 0/false)
+require 'trade_tariff_frontend/service_timeout'
 
-# Disable verbose logging - only log when timeouts actually occur
-# Timeout exceptions will still be raised and logged by Rails as 503 errors
-Rack::Timeout::Logger.disable if Rails.env.production?
+if defined?(Rack::Timeout)
+  Rails.application.config.middleware.delete Rack::Timeout
+end
+
+Rails.application.config.middleware.insert_after(
+  ActionDispatch::RequestId,
+  TradeTariffFrontend::ServiceTimeout,
+)

--- a/lib/trade_tariff_frontend/service_timeout.rb
+++ b/lib/trade_tariff_frontend/service_timeout.rb
@@ -1,0 +1,36 @@
+module TradeTariffFrontend
+  class ServiceTimeout
+    DEFAULT_PATH_OVERRIDES = '/uk/search:50,/xi/search:50,/search:50'.freeze
+
+    def initialize(app)
+      @app = app
+      @default_timeout = ENV.fetch('RACK_TIMEOUT_SERVICE_TIMEOUT', '15').to_i
+      @path_timeouts = parse_path_timeouts
+    end
+
+    def call(env)
+      timeout = timeout_for(env['PATH_INFO'])
+      ::Timeout.timeout(timeout) { @app.call(env) }
+    end
+
+    private
+
+    def timeout_for(path)
+      @path_timeouts.each do |prefix, seconds|
+        return seconds if path.start_with?(prefix)
+      end
+      @default_timeout
+    end
+
+    def parse_path_timeouts
+      ENV.fetch('RACK_TIMEOUT_PATH_OVERRIDES', DEFAULT_PATH_OVERRIDES)
+         .split(',')
+         .filter_map do |entry|
+           parts = entry.strip.split(':')
+           next if parts.length < 2
+
+           [parts[0], parts[1].to_i]
+         end
+    end
+  end
+end

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -256,36 +256,6 @@ RSpec.describe SearchController, type: :controller do
       end
     end
 
-    describe 'rack-timeout extension for interactive search' do
-      context 'when interactive_search is true' do
-        let(:params) { { q: 'horses', interactive_search: 'true' } }
-
-        before do
-          allow(TradeTariffFrontend).to receive(:interactive_search_enabled?).and_return(true)
-          stub_api_request('search', :post, internal: true).to_return(
-            status: 200,
-            body: { 'data' => [], 'meta' => {} }.to_json,
-            headers: { 'content-type' => 'application/json; charset=utf-8' },
-          )
-          do_response
-        end
-
-        it 'sets rack-timeout service_timeout to 50' do
-          expect(request.env['rack-timeout.service_timeout']).to eq(50)
-        end
-      end
-
-      context 'when interactive_search is not set', vcr: { cassette_name: 'search#search_fuzzy' } do
-        let(:params) { { q: 'horses', day: '11', month: '05', year: '2023' } }
-
-        before { do_response }
-
-        it 'does not set rack-timeout service_timeout' do
-          expect(request.env['rack-timeout.service_timeout']).to be_nil
-        end
-      end
-    end
-
     context 'with internal interactive search' do
       subject(:do_response) { get :search, params: }
 

--- a/spec/lib/trade_tariff_frontend/service_timeout_spec.rb
+++ b/spec/lib/trade_tariff_frontend/service_timeout_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+require 'trade_tariff_frontend/service_timeout'
+
+RSpec.describe TradeTariffFrontend::ServiceTimeout do
+  subject(:middleware) { described_class.new(app) }
+
+  let(:app) { ->(_env) { [200, {}, %w[OK]] } }
+
+  around do |example|
+    original_timeout = ENV['RACK_TIMEOUT_SERVICE_TIMEOUT']
+    original_overrides = ENV['RACK_TIMEOUT_PATH_OVERRIDES']
+    example.run
+  ensure
+    ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] = original_timeout
+    ENV['RACK_TIMEOUT_PATH_OVERRIDES'] = original_overrides
+  end
+
+  before do
+    allow(Timeout).to receive(:timeout).and_call_original
+  end
+
+  describe '#call' do
+    context 'with default path overrides (env var unset)' do
+      before do
+        ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] = '15'
+        ENV.delete('RACK_TIMEOUT_PATH_OVERRIDES')
+      end
+
+      it 'applies 50s timeout to /uk/search' do
+        middleware.call('PATH_INFO' => '/uk/search')
+        expect(Timeout).to have_received(:timeout).with(50)
+      end
+
+      it 'applies 50s timeout to /xi/search' do
+        middleware.call('PATH_INFO' => '/xi/search')
+        expect(Timeout).to have_received(:timeout).with(50)
+      end
+
+      it 'applies 50s timeout to /search' do
+        middleware.call('PATH_INFO' => '/search')
+        expect(Timeout).to have_received(:timeout).with(50)
+      end
+
+      it 'applies default timeout to non-search paths' do
+        middleware.call('PATH_INFO' => '/uk/commodities/1234')
+        expect(Timeout).to have_received(:timeout).with(15)
+      end
+    end
+
+    context 'with custom path overrides' do
+      before do
+        ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] = '15'
+        ENV['RACK_TIMEOUT_PATH_OVERRIDES'] = '/api/slow:60'
+      end
+
+      it 'uses the custom override' do
+        middleware.call('PATH_INFO' => '/api/slow')
+        expect(Timeout).to have_received(:timeout).with(60)
+      end
+
+      it 'uses the default timeout for non-matching paths' do
+        middleware.call('PATH_INFO' => '/uk/search')
+        expect(Timeout).to have_received(:timeout).with(15)
+      end
+    end
+
+    context 'with empty RACK_TIMEOUT_PATH_OVERRIDES' do
+      before do
+        ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] = '20'
+        ENV['RACK_TIMEOUT_PATH_OVERRIDES'] = ''
+      end
+
+      it 'uses the default timeout for all paths' do
+        middleware.call('PATH_INFO' => '/uk/search')
+        expect(Timeout).to have_received(:timeout).with(20)
+      end
+    end
+
+    it 'calls the downstream app' do
+      status, = middleware.call('PATH_INFO' => '/')
+      expect(status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-148](https://transformuk.atlassian.net/browse/AI-148)

### What?

- [x] Add custom `TradeTariffFrontend::ServiceTimeout` middleware that supports per-path timeout overrides via `RACK_TIMEOUT_PATH_OVERRIDES` env var
- [x] Replace rack-timeout's auto-inserted middleware with the custom one
- [x] Remove non-working `extend_timeout_for_interactive_search` before_action from SearchController
- [x] Remove dead specs for the deleted before_action
- [x] Add middleware unit specs

### Why?

The previous fix (PR #2752) set `request.env['rack-timeout.service_timeout']` in a `before_action`, but rack-timeout v0.7.0 never reads that value back - it uses an `@service_timeout` instance variable set once at boot. The timer starts in middleware _before_ controller code runs, so `before_action` cannot influence it.

This replaces rack-timeout's middleware with a custom one that selects the timeout duration based on the request path prefix. Setting `RACK_TIMEOUT_PATH_OVERRIDES=/uk/search:50,/xi/search:50` gives search requests a 50s ceiling matching the backend's timeout.