### PR TITLE
MYOTT-482 Refactor preferences form

### DIFF
--- a/app/controllers/myott/preferences_controller.rb
+++ b/app/controllers/myott/preferences_controller.rb
@@ -2,21 +2,20 @@ module Myott
   class PreferencesController < MyottController
     def new
       session_chapters.delete
+      @form = Myott::StopPressPreferenceForm.new
     end
 
     def create
-      case params[:preference]
-      when 'selectChapters'
+      @form = Myott::StopPressPreferenceForm.new(preference_params)
+
+      if @form.select_chapters?
         session[:all_tariff_updates] = false
-        redirect_to edit_myott_stop_press_preferences_path
-      when 'allChapters'
+        redirect_to edit_myott_stop_press_preferences_path and return
+      elsif @form.all_chapters?
         session_chapters.delete
         session[:all_tariff_updates] = true
-        redirect_to check_your_answers_myott_stop_press_path
+        redirect_to check_your_answers_myott_stop_press_path and return
       else
-        @alert = 'Select a subscription preference to continue'
-        @div_id = 'radio-buttons'
-        flash.now[:select_error] = 'Select an option to continue'
         render :new
       end
     end
@@ -39,6 +38,10 @@ module Myott
     end
 
   private
+
+    def preference_params
+      params.fetch(:myott_stop_press_preference_form, {}).permit(:preference)
+    end
 
     def session_chapters
       @session_chapters ||= SessionChaptersDecorator.new(session)

--- a/app/forms/myott/stop_press_preference_form.rb
+++ b/app/forms/myott/stop_press_preference_form.rb
@@ -1,0 +1,20 @@
+class Myott::StopPressPreferenceForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  SELECT_CHAPTERS = 'selectChapters'.freeze
+  ALL_CHAPTERS = 'allChapters'.freeze
+
+  attribute :preference, :string
+
+  validates :preference, presence: { message: 'Select a subscription preference to continue' },
+                         inclusion: { in: [SELECT_CHAPTERS, ALL_CHAPTERS], message: 'Select a subscription preference to continue' }
+
+  def select_chapters?
+    valid? && preference == SELECT_CHAPTERS
+  end
+
+  def all_chapters?
+    valid? && preference == ALL_CHAPTERS
+  end
+end

--- a/app/views/myott/preferences/new.html.erb
+++ b/app/views/myott/preferences/new.html.erb
@@ -7,40 +7,22 @@
         <% back_link myott_path %>
       <% end %>
 
-      <h1 class="govuk-heading-l">Set subscription preferences</h1>
-      <p>You can choose to receive updates on all tariff chapters, or  select specific tariff chapters you are interested in.</p>
-      <p class="govuk-inset-text">You can change what tariff chapters you receive updates about at any time
-        by following the link in the tariff update emails.</p>
+      <%= form_with model: @form, url: myott_stop_press_preferences_path, method: :post, local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+        <%= f.govuk_error_summary %>
 
-      <%= form_with url: myott_stop_press_preferences_path, method: :post, local: true do %>
-        <fieldset class="govuk-fieldset" aria-describedby="select-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-            <h2 class="govuk-fieldset__heading govuk-heading-m">What tariff updates would you like to receive?</h2>
-          </legend>
-          <div id="select-hint" class="govuk-hint">
-            If you want to select specific chapters, you should have a list of all the chapters you want before starting.
-          </div>
-          <% if flash.now[:select_error] %>
-            <p class="govuk-error-message">
-              <%= flash.now[:select_error] %>
-            </p>
-          <% end %>
-          <div class="govuk-radios" data-module="govuk-radios" id="radio-buttons">
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="selectChapters" name="preference" type="radio" value="selectChapters">
-              <label class="govuk-label govuk-radios__label" for="selectChapters">
-                Select the tariff chapters I am interested in
-              </label>
-            </div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="allChapters" name="preference" type="radio" value="allChapters">
-              <label class="govuk-label govuk-radios__label" for="allChapters">
-                All tariff chapter updates
-              </label>
-            </div>
-          </div>
-        </fieldset>
-        <%= submit_tag "Continue", class: "govuk-button govuk-!-margin-top-4" %>
+        <h1 class="govuk-heading-l">Set subscription preferences</h1>
+        <p>You can choose to receive updates on all tariff chapters, or  select specific tariff chapters you are interested in.</p>
+        <p class="govuk-inset-text">You can change what tariff chapters you receive updates about at any time
+          by following the link in the tariff update emails.</p>
+
+        <%= f.govuk_radio_buttons_fieldset :preference,
+            id: "myott-stop-press-preference-form-preference-field-error",
+            legend: { text: "What tariff updates would you like to receive?", size: "m" },
+            hint: { text: "If you want to select specific chapters, you should have a list of all the chapters you want before starting." } do %>
+          <%= f.govuk_radio_button :preference, Myott::StopPressPreferenceForm::SELECT_CHAPTERS, label: { text: "Select the tariff chapters I am interested in" } %>
+          <%= f.govuk_radio_button :preference, Myott::StopPressPreferenceForm::ALL_CHAPTERS, label: { text: "All tariff chapter updates" } %>
+        <% end %>
+        <%= f.submit "Continue", class: "govuk-button govuk-!-margin-top-4" %>
       <% end %>
     </div>
   </div>

--- a/spec/controllers/myott/preferences_controller_spec.rb
+++ b/spec/controllers/myott/preferences_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Myott::PreferencesController, type: :controller do
 
       context 'when selectChapters is selected' do
         before do
-          post :create, params: { preference: 'selectChapters' }
+          post :create, params: { myott_stop_press_preference_form: { preference: 'selectChapters' } }
         end
 
         it { is_expected.to redirect_to(edit_myott_stop_press_preferences_path) }
@@ -52,7 +52,7 @@ RSpec.describe Myott::PreferencesController, type: :controller do
 
       context 'when allChapters is selected' do
         before do
-          post :create, params: { preference: 'allChapters' }
+          post :create, params: { myott_stop_press_preference_form: { preference: 'allChapters' } }
         end
 
         it { is_expected.to redirect_to(check_your_answers_myott_stop_press_path) }
@@ -67,10 +67,8 @@ RSpec.describe Myott::PreferencesController, type: :controller do
           expect(response).to render_template(:new)
         end
 
-        it { expect(assigns(:alert)).to eq('Select a subscription preference to continue') }
-
-        it 'sets a flash select_error message' do
-          expect(flash.now[:select_error]).to eq('Select an option to continue')
+        it 'displays validation errors' do
+          expect(assigns(:form).errors[:preference]).to be_present
         end
       end
     end

--- a/spec/forms/myott/stop_press_preference_form_spec.rb
+++ b/spec/forms/myott/stop_press_preference_form_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+RSpec.describe Myott::StopPressPreferenceForm, type: :model do
+  describe 'validations' do
+    context 'when preference is blank' do
+      subject(:form) { described_class.new(preference: '') }
+
+      before { form.valid? }
+
+      it { is_expected.not_to be_valid }
+      it { expect(form.errors[:preference]).to include('Select a subscription preference to continue') }
+    end
+
+    context 'when preference is nil' do
+      subject(:form) { described_class.new(preference: nil) }
+
+      before { form.valid? }
+
+      it { is_expected.not_to be_valid }
+      it { expect(form.errors[:preference]).to include('Select a subscription preference to continue') }
+    end
+
+    context 'when preference is invalid' do
+      subject(:form) { described_class.new(preference: 'invalid') }
+
+      before { form.valid? }
+
+      it { is_expected.not_to be_valid }
+      it { expect(form.errors[:preference]).to include('Select a subscription preference to continue') }
+    end
+
+    context 'with a valid selectChapters' do
+      subject(:form) { described_class.new(preference: Myott::StopPressPreferenceForm::SELECT_CHAPTERS) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with a valid allChapters' do
+      subject(:form) { described_class.new(preference: Myott::StopPressPreferenceForm::ALL_CHAPTERS) }
+
+      it { is_expected.to be_valid }
+    end
+  end
+
+  describe '#select_chapters?' do
+    it { expect(described_class.new(preference: Myott::StopPressPreferenceForm::SELECT_CHAPTERS).select_chapters?).to be true }
+    it { expect(described_class.new(preference: Myott::StopPressPreferenceForm::ALL_CHAPTERS).select_chapters?).to be false }
+    it { expect(described_class.new(preference: nil).select_chapters?).to be false }
+  end
+
+  describe '#all_chapters?' do
+    it { expect(described_class.new(preference: Myott::StopPressPreferenceForm::ALL_CHAPTERS).all_chapters?).to be true }
+    it { expect(described_class.new(preference: Myott::StopPressPreferenceForm::SELECT_CHAPTERS).all_chapters?).to be false }
+    it { expect(described_class.new(preference: nil).all_chapters?).to be false }
+  end
+end


### PR DESCRIPTION
### Jira link

[MYOTT-482](https://transformuk.atlassian.net/browse/MYOTT-482)

### What?

Refactors the preference selection form to use GOVUKDesignSystemFormBuilder and a form object.

### Why?

- Simplifies the frontend code
- Moves the validation logic out of the controller
- Moves the submit button lower for better accessibility
