### PR TITLE
HMRC-1958: Different excluded countries showing on OTT - Potential Caching issue

### DIFF
--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -23,7 +23,19 @@ class GeographicalArea
 
   class << self
     def european_union
-      @european_union ||= find(EUROPEAN_UNION_ID)
+      @european_union ||= Rails.cache.fetch("european_union", EUROPEAN_UNION_ID) do
+        find(EUROPEAN_UNION_ID).tap do |eu|
+          if eu.description != 'European Union'
+            info = {
+              id: eu.id,
+              description: eu.description,
+              messages: "EU description is '#{eu.description}' instead of 'European Union'",
+              cache: from_cache
+            }
+            Rails.logger.warn info.to_json
+          end
+        end
+      end
     end
 
     def european_union_members

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -6,6 +6,7 @@ class GeographicalArea
   ERGA_OMNES = '1011'.freeze
 
   include ApiEntity
+  extend CacheHelper
 
   enum :id, {
     channel_islands: '1080',
@@ -23,7 +24,7 @@ class GeographicalArea
 
   class << self
     def european_union
-      @european_union ||= Rails.cache.fetch("european_union", EUROPEAN_UNION_ID) do
+      @european_union ||= Rails.cache.fetch(["european_union", cache_key, EUROPEAN_UNION_ID]) do
         find(EUROPEAN_UNION_ID).tap do |eu|
           if eu.description != 'European Union'
             info = {

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -24,14 +24,14 @@ class GeographicalArea
 
   class << self
     def european_union
-      @european_union ||= Rails.cache.fetch(["european_union", cache_key, EUROPEAN_UNION_ID]) do
+      @european_union ||= Rails.cache.fetch(['european_union', cache_key, EUROPEAN_UNION_ID]) do
         find(EUROPEAN_UNION_ID).tap do |eu|
           if eu.description != 'European Union'
             info = {
               id: eu.id,
               description: eu.description,
               messages: "EU description is '#{eu.description}' instead of 'European Union'",
-              cache: from_cache
+              cache: from_cache,
             }
             Rails.logger.warn info.to_json
           end


### PR DESCRIPTION
### Jira link

[HMRC-1958](https://transformuk.atlassian.net/browse/HMRC-1958)

### What?

I have added new cache key to european union geo area description.
Added logs to investigate how older description is fetched

### Why?

I am doing this because...
OTT is showing two different excluded countries description for EU