### PR TITLE
BAU: Fix healthcheck log exclusion

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,9 +91,11 @@ Rails.application.configure do
   end
 
   config.lograge.ignore_actions = [
-    'HealthcheckController#index',
+    'HealthcheckController#check',
     'HealthcheckController#checkz',
   ]
+
+  config.silence_healthcheck_path = '/healthcheckz'
 
   # set default_url_options
   config.action_controller.default_url_options = {


### PR DESCRIPTION
### What?

- [x] Fix lograge `ignore_actions` - was referencing `HealthcheckController#index` but the actual route maps to `HealthcheckController#check`, meaning `/healthcheck` requests were not being excluded from structured logs
- [x] Add `silence_healthcheck_path` for `/healthcheckz` to suppress Rack-level "Started GET" lines that lograge does not cover

### Why?

The `/healthcheck` endpoint was being logged in production because the action name in `ignore_actions` was wrong (`index` instead of `check`). Additionally, `silence_healthcheck_path` was not configured, so Rack-level request lines ("Started GET /healthcheckz...") from `Rails::Rack::Logger` were not being suppressed - lograge only replaces the `ActionController::LogSubscriber`, not the Rack middleware.