### PR TITLE
HMRC-1809: Fix Expired Commodity View

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -776,6 +776,7 @@ PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
   x86_64-linux-musl
 

--- a/app/views/shared/_derived_goods_nomenclature.html.erb
+++ b/app/views/shared/_derived_goods_nomenclature.html.erb
@@ -1,21 +1,23 @@
-<table class="govuk-table">
-  <p>Goods previously classified under commodity <%= @commodity_code %> have been moved to the following codes:</p>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Classification</th>
-      <th scope="col" class="govuk-table__header">Description</th>
-      <th scope="col" class="govuk-table__header non-breaking-heading">Transfer date</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% deriving_goods_nomenclatures.each do |goods_nomenclature| %>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell"><%= link_to(goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature)) %></th>
-      <td class="govuk-table__cell">
-        <%= sanitize sanitize_quotes(goods_nomenclature.formatted_description) unless goods_nomenclature.formatted_description.nil? %>
-      </td>
-      <td class="govuk-table__cell"><%= goods_nomenclature.validity_start_date&.to_formatted_s(:long) %></td>
-    </tr>
-    <% end %>
-  </tbody>
-</table>
+<% unless deriving_goods_nomenclatures.empty? %>
+  <table class="govuk-table">
+    <p>Goods previously classified under commodity <%= @commodity_code %> have been moved to the following codes:</p>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Classification</th>
+        <th scope="col" class="govuk-table__header">Description</th>
+        <th scope="col" class="govuk-table__header non-breaking-heading">Transfer date</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% deriving_goods_nomenclatures.each do |goods_nomenclature| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= link_to(goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature)) %></th>
+        <td class="govuk-table__cell">
+          <%= sanitize sanitize_quotes(goods_nomenclature.formatted_description) unless goods_nomenclature.formatted_description.nil? %>
+        </td>
+        <td class="govuk-table__cell"><%= goods_nomenclature.validity_start_date&.to_formatted_s(:long) %></td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/shared/_derived_goods_nomenclature.html.erb
+++ b/app/views/shared/_derived_goods_nomenclature.html.erb
@@ -12,7 +12,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell"><%= link_to(goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature)) %></th>
       <td class="govuk-table__cell">
-        <%= sanitize sanitize_quotes(goods_nomenclature.formatted_description) %>
+        <%= sanitize sanitize_quotes(goods_nomenclature.formatted_description) unless goods_nomenclature.formatted_description.nil? %>
       </td>
       <td class="govuk-table__cell"><%= goods_nomenclature.validity_start_date&.to_formatted_s(:long) %></td>
     </tr>

--- a/app/views/shared/_derived_goods_nomenclature.html.erb
+++ b/app/views/shared/_derived_goods_nomenclature.html.erb
@@ -1,27 +1,21 @@
-<% if deriving_goods_nomenclatures.one? %>
-  <% goods_nomenclature = deriving_goods_nomenclatures.first %>
-  <p>Goods previously classified under commodity <%= @commodity_code %>
-  were moved to code <%= link_to(goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature)) %>
-  (<%= goods_nomenclature.formatted_description %>) on <%= goods_nomenclature.validity_start_date&.to_formatted_s(:long) %></p>
-<% elsif deriving_goods_nomenclatures.many? %>
-  <table class="govuk-table">
-    <p>Goods previously classified under commodity <%= @commodity_code %> have been  moved to the following codes:</p>
-
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Classification</th>
-        <th scope="col" class="govuk-table__header">Description</th>
-        <th scope="col" class="govuk-table__header non-breaking-heading">Transfer date</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <% deriving_goods_nomenclatures.each do |goods_nomenclature| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= link_to(goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature)) %></th>
-        <td class="govuk-table__cell"><%= goods_nomenclature.formatted_description %></td>
-        <td class="govuk-table__cell"><%= goods_nomenclature.validity_start_date&.to_formatted_s(:long) %></td>
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% end %>
+<table class="govuk-table">
+  <p>Goods previously classified under commodity <%= @commodity_code %> have been moved to the following codes:</p>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Classification</th>
+      <th scope="col" class="govuk-table__header">Description</th>
+      <th scope="col" class="govuk-table__header non-breaking-heading">Transfer date</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% deriving_goods_nomenclatures.each do |goods_nomenclature| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><%= link_to(goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature)) %></th>
+      <td class="govuk-table__cell">
+        <%= sanitize sanitize_quotes(goods_nomenclature.formatted_description) %>
+      </td>
+      <td class="govuk-table__cell"><%= goods_nomenclature.validity_start_date&.to_formatted_s(:long) %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/spec/views/shared/_derived_goods_nomenclature.html.erb_spec.rb
+++ b/spec/views/shared/_derived_goods_nomenclature.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'shared/_derived_goods_nomenclature', type: :view do
     render 'shared/derived_goods_nomenclature', deriving_goods_nomenclatures:
   end
 
-  context 'with 1 or more items in deriving goods nomanclature array' do
+  context 'with 1 or more derived goods nomenclatures' do
     let(:deriving_goods_nomenclatures) { build_list :goods_nomenclature, 2 }
 
     it { is_expected.to have_css 'table' }
@@ -16,5 +16,11 @@ RSpec.describe 'shared/_derived_goods_nomenclature', type: :view do
     it { is_expected.to have_css 'td', text: deriving_goods_nomenclatures.first.formatted_description }
     it { is_expected.to have_css 'td', text: deriving_goods_nomenclatures.first.validity_start_date.to_formatted_s(:long) }
     it { is_expected.to have_css 'td', count: 6 }
+  end
+
+  context 'with 0 derived goods nomenclatures' do
+    let(:deriving_goods_nomenclatures) { [] }
+
+    it { is_expected.not_to have_css 'table' }
   end
 end

--- a/spec/views/shared/_derived_goods_nomenclature.html.erb_spec.rb
+++ b/spec/views/shared/_derived_goods_nomenclature.html.erb_spec.rb
@@ -7,37 +7,14 @@ RSpec.describe 'shared/_derived_goods_nomenclature', type: :view do
     render 'shared/derived_goods_nomenclature', deriving_goods_nomenclatures:
   end
 
-  context 'with 1 item in deriving goods nomanclature array' do
-    let(:deriving_goods_nomenclatures) { build_list :goods_nomenclature, 1 }
-
-    it { is_expected.to have_css 'p', text: /Goods previously classified under/ }
-
-    it { is_expected.to have_css 'p', text: deriving_goods_nomenclatures.first.goods_nomenclature_item_id }
-
-    it { is_expected.to have_css 'p', text: deriving_goods_nomenclatures.first.formatted_description }
-
-    it { is_expected.to have_css 'p', text: deriving_goods_nomenclatures.first.validity_start_date.to_formatted_s(:long) }
-  end
-
-  context 'with more than 1 item in deriving goods nomanclature array' do
+  context 'with 1 or more items in deriving goods nomanclature array' do
     let(:deriving_goods_nomenclatures) { build_list :goods_nomenclature, 2 }
 
     it { is_expected.to have_css 'table' }
-
     it { is_expected.to have_css 'p', text: /Goods previously classified under/ }
-
     it { is_expected.to have_css 'td', text: deriving_goods_nomenclatures.first.goods_nomenclature_item_id }
-
     it { is_expected.to have_css 'td', text: deriving_goods_nomenclatures.first.formatted_description }
-
     it { is_expected.to have_css 'td', text: deriving_goods_nomenclatures.first.validity_start_date.to_formatted_s(:long) }
-
     it { is_expected.to have_css 'td', count: 6 }
-  end
-
-  context 'with 0 items in goods nomanclature array' do
-    let(:deriving_goods_nomenclatures) { [] }
-
-    it { is_expected.not_to have_css 'table' }
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-1809](https://transformuk.atlassian.net/browse/HMRC-1809)

### What?

- Removed the `if` block for displaying single items differently
- Added `sanitize` to goods nomenclature description

### Why?

- The two different views are inconsistent; this change brings both scenarios inline.
- The inline HTML in commodity code descriptions was displayed as raw HTML 

### Before
---

<img width="1229" height="1260" alt="Screenshot 2026-02-12 at 16-46-49 UK Integrated Online Tariff Look up commodity codes duty and VAT rates - GOV UK" src="https://github.com/user-attachments/assets/9e863496-ddfd-44ba-88aa-51327c7978ee" />

### After
---

<img width="1269" height="1129" alt="Screenshot 2026-02-12 at 16-50-32 UK Integrated Online Tariff Look up commodity codes duty and VAT rates - GOV UK" src="https://github.com/user-attachments/assets/c4ec7344-7be3-475c-921c-8ef741546952" />



