### PR TITLE
HMRC-1937: Missing Application Security Headers

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -1,0 +1,8 @@
+class CspReportsController < ApplicationController
+  skip_before_action :require_authentication, only: %i[create]
+  def create
+    Rails.logger.warn "CSP Violation: #{request.body.read}"
+    NewRelic::Agent.notice_error("CSP Violation: #{request.body.read}")
+    head :ok
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,7 +51,7 @@ module TradeTariffFrontend
       'X-Frame-Options' => 'SAMEORIGIN',
       'X-XSS-Protection' => '0',
       'X-Content-Type-Options' => 'nosniff',
-      )
+    )
 
     # Tells Rails to serve error pages from the app itself, rather than using static error pages in public/
     config.exceptions_app = routes

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,12 @@ module TradeTariffFrontend
     # Disable Rack::Cache.
     config.action_dispatch.rack_cache = nil
 
+    config.action_dispatch.default_headers.merge!(
+      'X-Frame-Options' => 'SAMEORIGIN',
+      'X-XSS-Protection' => '0',
+      'X-Content-Type-Options' => 'nosniff',
+      )
+
     # Tells Rails to serve error pages from the app itself, rather than using static error pages in public/
     config.exceptions_app = routes
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,12 @@ Rails.application.configure do
   config.assume_ssl = ENV.fetch('RAILS_ASSUME_SSL', 'true') == 'true'
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = false
+  config.force_ssl = true
+
+  # HSTS should only be set over HTTPS
+  config.action_dispatch.default_headers.merge!(
+    "Strict-Transport-Security" => "max-age=31536000; includeSubDomains",
+    )
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new($stdout)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,10 +37,18 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # HSTS should only be set over HTTPS
-  config.action_dispatch.default_headers.merge!(
-    'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains',
-  )
+  # force_ssl = true does the following:
+  #   Redirects HTTP → HTTPS
+  #   Marks cookies as Secure
+  #   Adds the HSTS header
+  #   Enables SSL middleware
+  #
+  #   The HSTS header Rails sends by default is: Strict-Transport-Security: max-age=63072000; includeSubDomains
+
+  # Uncomment HSTS config to change default values
+  # config.action_dispatch.default_headers.merge!(
+  #   'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains',
+  #   )
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new($stdout)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,8 +39,8 @@ Rails.application.configure do
 
   # HSTS should only be set over HTTPS
   config.action_dispatch.default_headers.merge!(
-    "Strict-Transport-Security" => "max-age=31536000; includeSubDomains",
-    )
+    'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains',
+  )
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new($stdout)

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,12 +13,12 @@ Rails.application.configure do
     policy.script_src  :self, :https
     policy.style_src   :self, :https
     # Specify URI for violation reports
-    policy.report_uri "/csp-violation-report"
+    policy.report_uri '/csp-violation-report'
   end
 
   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  config.content_security_policy_nonce_directives = %w(script-src style-src)
+  config.content_security_policy_nonce_directives = %w[script-src style-src]
 
   # Report violations without enforcing the policy.
   config.content_security_policy_report_only = true

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,22 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https
+    policy.style_src   :self, :https
+    # Specify URI for violation reports
+    policy.report_uri "/csp-violation-report"
+  end
+
+  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w(script-src style-src)
+
+  # Report violations without enforcing the policy.
+  config.content_security_policy_report_only = true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -243,7 +243,7 @@ Rails.application.routes.draw do
 
   draw('duty_calculator')
 
-  post "/csp-violation-report", to: "csp_reports#create"
+  post '/csp-violation-report', to: 'csp_reports#create'
 
   get '/robots.:format', to: 'pages#robots'
   match '/400', to: 'errors#bad_request', via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -243,6 +243,8 @@ Rails.application.routes.draw do
 
   draw('duty_calculator')
 
+  post "/csp-violation-report", to: "csp_reports#create"
+
   get '/robots.:format', to: 'pages#robots'
   match '/400', to: 'errors#bad_request', via: :all
   match '/404', to: 'errors#not_found', via: :all, as: :not_found


### PR DESCRIPTION
### Jira link

[HMRC-1937](https://transformuk.atlassian.net/browse/HMRC-1937)

### What?

I have added/removed/altered:

- [ ] Added security response headers 
- [ ] Added report only content security policy

### Why?

I am doing this because:

- PEN test report recomended web server to return thesecurity-related HTTP response headers