### PR TITLE
HMRC-1809: Fix commodity description link colour

### DIFF
--- a/app/assets/stylesheets/src/_commodity-tree.scss
+++ b/app/assets/stylesheets/src/_commodity-tree.scss
@@ -389,6 +389,10 @@ li:not(.has_children) .description {
   position: relative;
   /* to give z-index */
 
+  p {
+    color: inherit;
+  }
+
   @media (min-width: 641px) {
     float: left;
     width: calc(100% - 165px);


### PR DESCRIPTION
### Jira link

[HMRC-1809](https://transformuk.atlassian.net/browse/HMRC-1809)

### What?

- [x] Add `color: inherit` to `p` elements inside `.description` in the commodity tree

### Why?

Some commodity descriptions from the API contain `<p/>` self-closing tags as line separators (e.g. subheading 8479899700-80). Browsers interpret these as opening `<p>` tags, creating paragraph elements. GOV.UK Frontend sets `color: $govuk-text-colour` on `<p>` elements globally, which overrides the blue `$govuk-link-colour` inherited from the parent `.description` div.

This caused the first line of a description to appear blue (direct text node of `.description`) while subsequent lines appeared black (wrapped in browser-generated `<p>` elements).

The fix ensures `<p>` elements inside `.description` inherit the link colour from their parent.