### PR TITLE
BAU: Upgrade pry to 0.16.0 for Ruby 4.0 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -559,9 +559,10 @@ GEM
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-    pry (0.15.2)
+    pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
+      reline (>= 0.6.0)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
     psych (5.3.1)
@@ -839,7 +840,7 @@ DEPENDENCIES
   wizard_steps
 
 RUBY VERSION
-   ruby 4.0.1p0
+  ruby 4.0.1p0
 
 BUNDLED WITH
-   2.5.18
+  4.0.3


### PR DESCRIPTION
### What?

- [x] Upgrade pry from 0.15.2 to 0.16.0

### Why?

Pry 0.15.2 is incompatible with Ruby 4.0 - `rails console` crashes with `private method 'readline' called for nil`. Pry 0.16.0 (Dec 2025) fixes this by switching to Reline for newer Rubies.