### PR TITLE
AI-226: Handle 422 validation errors from backend API

### DIFF
--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -11,6 +11,11 @@ module InteractiveSearchable
 
     @results = @search.perform
 
+    if @search.errors.any?
+      @results = Search::InternalSearchResult.new([], nil)
+      return
+    end
+
     respond_to do |format|
       format.html { route_interactive_results }
       format.json { render json: SearchPresenter.new(@search, @results) }

--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -12,7 +12,10 @@ module InteractiveSearchable
     @results = @search.perform
 
     if @search.errors.any?
-      @results = Search::InternalSearchResult.new([], nil)
+      @no_shared_search = true
+      @hero_story = nil
+      @recent_stories = []
+      render 'find_commodities/show'
       return
     end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -134,7 +134,7 @@ class Search
     parsed_data = [] unless parsed_data.is_a?(Array)
 
     InternalSearchResult.new(parsed_data, body['meta'])
-  rescue Faraday::UnprocessableEntity => e
+  rescue Faraday::UnprocessableContentError => e
     hydrate_errors_from_response(e)
     InternalSearchResult.new([], nil)
   end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -134,5 +134,8 @@ class Search
     parsed_data = [] unless parsed_data.is_a?(Array)
 
     InternalSearchResult.new(parsed_data, body['meta'])
+  rescue Faraday::UnprocessableEntity => e
+    hydrate_errors_from_response(e)
+    InternalSearchResult.new([], nil)
   end
 end

--- a/app/views/shared/search/_search_form.html.erb
+++ b/app/views/shared/search/_search_form.html.erb
@@ -40,30 +40,29 @@
 </div>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full govuk-form-group<%= ' govuk-form-group--error' if @search.errors.any? %>">
-    <%= label_tag :q, search_label_text, class: 'govuk-label' %>
-    <% if @search.errors.any? %>
-      <p class="govuk-error-message" id="q-error">
-        <span class="govuk-visually-hidden">Error:</span> <%= @search.errors.map(&:message).join('. ') %>
-      </p>
+<div class="govuk-form-group<%= ' govuk-form-group--error' if @search.errors.any? %>">
+  <%= label_tag :q, search_label_text, class: 'govuk-label' %>
+  <% if @search.errors.any? %>
+    <p class="govuk-error-message" id="q-error">
+      <span class="govuk-visually-hidden">Error:</span> <%= @search.errors.map(&:message).join('. ') %>
+    </p>
+  <% end %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters column-three-quarters-mobile-only">
+      <%= render 'shared/search/autocomplete' %>
+      <%= render 'shared/search/datepicker' if use_date_picker ||= false %>
+    </div>
+
+    <% if @no_shared_search %>
+    <div class="govuk-grid-column-three-quarters">
+      <%= submit_tag 'Search for a commodity', class: 'govuk-button govuk-!-margin-top-6'  %>
+      <hr>
+    </div>
+    <% else %>
+    <div class="govuk-grid-column-one-quarter column-one-quarter-mobile-only">
+      <%= submit_tag 'Search', class: 'govuk-button search-button' %>
+    </div>
     <% end %>
   </div>
-
-  <div class="govuk-grid-column-three-quarters column-three-quarters-mobile-only">
-    <%= render 'shared/search/autocomplete' %>
-    <%= render 'shared/search/datepicker' if use_date_picker ||= false %>
-  </div>
-
-  <% if @no_shared_search %>
-  <div class="govuk-grid-column-three-quarters">
-    <%= submit_tag 'Search for a commodity', class: 'govuk-button govuk-!-margin-top-6'  %>
-    <hr>
-  </div>
-  <% else %>
-  <div class="govuk-grid-column-one-quarter column-one-quarter-mobile-only">
-    <%= submit_tag 'Search', class: 'govuk-button search-button' %>
-  </div>
-  <% end %>
 </div>
 <% end %>

--- a/app/views/shared/search/_search_form.html.erb
+++ b/app/views/shared/search/_search_form.html.erb
@@ -41,8 +41,13 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-full govuk-form-group<%= ' govuk-form-group--error' if @search.errors.any? %>">
     <%= label_tag :q, search_label_text, class: 'govuk-label' %>
+    <% if @search.errors.any? %>
+      <p class="govuk-error-message" id="q-error">
+        <span class="govuk-visually-hidden">Error:</span> <%= @search.errors.map(&:message).join('. ') %>
+      </p>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-three-quarters column-three-quarters-mobile-only">

--- a/app/views/shared/search/_search_form.html.erb
+++ b/app/views/shared/search/_search_form.html.erb
@@ -1,5 +1,20 @@
 <%= form_tag perform_search_path, method: :get, id: "new_search" do |f| %>
 
+<% if @search.errors.any? %>
+<div class="govuk-error-summary" data-module="govuk-error-summary">
+  <div role="alert">
+    <h2 class="govuk-error-summary__title">There is a problem</h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <% @search.errors.each do |error| %>
+          <li><a href="#q"><%= error.message %></a></li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>
+<% end %>
+
 <% if @search.day_month_and_year_set? %>
 <%= hidden_field_tag :year, @search.year %>
 <%= hidden_field_tag :month, @search.month %>


### PR DESCRIPTION
### Jira link

[AI-226](https://transformuk.atlassian.net/browse/AI-226)

<img width="1462" height="2048" alt="image" src="https://github.com/user-attachments/assets/f0ed0702-daa3-4050-9854-68ab3347d0da" />


### What?

- [x] Add `ActiveModel::Validations` to `ApiEntity` so any API-backed model can carry validation errors
- [x] Add `hydrate_errors_from_response` to `ApiEntity` - parses JSON:API error responses and maps `source.pointer` to model attributes
- [x] Rescue `Faraday::UnprocessableEntity` in `Search#perform_internal_search` and hydrate errors on the search model
- [x] Check for errors in `InteractiveSearchable` and short-circuit rendering when present
- [x] Add GOV.UK error summary to the search form partial to display validation errors inline
- [x] Add specs for 422 error handling in search model

### Why?

The backend's new input sanitiser (trade-tariff-backend#2796) returns 422 with JSON:API errors for invalid queries. Previously, Faraday's `raise_error` middleware would throw `Faraday::UnprocessableEntity` before the response body was parsed, resulting in an unhandled exception and a 500 error page for the user.

This PR adds a generic error hydration pattern in `ApiEntity` that any model can reuse - no more special-case rescues with generic flash messages. Errors are mapped from the JSON:API `source.pointer` to model attributes and rendered via the standard GOV.UK error summary component in the search form.

### Deployment risks

- Depends on trade-tariff-backend#2796 being deployed first (the `source.pointer` field in error responses)
- Without the backend change, 422s from other sources will still be caught and mapped to `:base` errors gracefully