### PR TITLE
HMRC-1963: Enable HTTPS dual-bind on all ECS services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apk add --no-cache tzdata && \
 
 ENV RAILS_SERVE_STATIC_FILES=true \
     RAILS_ENV=production \
-    PORT=8082 \
+    PORT=8081 \
     TZ=Europe/London
 
 RUN addgroup -S tariff && \
@@ -61,7 +61,7 @@ USER tariff
 COPY --chown=tariff:tariff --from=builder /build .
 COPY --chown=tariff:tariff --from=builder /usr/local/bundle/ /usr/local/bundle/
 
-EXPOSE 8080
+EXPOSE 8081
 
 HEALTHCHECK CMD nc -z 0.0.0.0 $PORT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apk add --no-cache tzdata && \
 
 ENV RAILS_SERVE_STATIC_FILES=true \
     RAILS_ENV=production \
-    PORT=8080 \
+    PORT=8082 \
     TZ=Europe/London
 
 RUN addgroup -S tariff && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} AS builder
 
 WORKDIR /build
 
-RUN apk add --no-cache build-base git yarn tzdata yaml-dev && \
+RUN apk add --no-cache build-base git yarn tzdata yaml-dev openssl-dev && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apk add --no-cache tzdata && \
 
 ENV RAILS_SERVE_STATIC_FILES=true \
     RAILS_ENV=production \
-    PORT=8081 \
+    PORT=8080 \
     TZ=Europe/London
 
 RUN addgroup -S tariff && \
@@ -61,7 +61,7 @@ USER tariff
 COPY --chown=tariff:tariff --from=builder /build .
 COPY --chown=tariff:tariff --from=builder /usr/local/bundle/ /usr/local/bundle/
 
-EXPOSE 8081
+EXPOSE 8080
 
 HEALTHCHECK CMD nc -z 0.0.0.0 $PORT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ EXPOSE 8080
 
 HEALTHCHECK CMD nc -z 0.0.0.0 $PORT
 
-#CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
-CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
+#CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 
 #### End production image #####

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,9 @@ RUN rm -rf node_modules log tmp /usr/local/bundle/cache /yarn/cache .env && \
 
 FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} AS production
 
-RUN apk add --no-cache tzdata && \
+RUN apk add --no-cache \
+    tzdata \
+    openssl-dev && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ EXPOSE 8080
 
 HEALTHCHECK CMD nc -z 0.0.0.0 $PORT
 
-CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
+#CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 
 #### End production image #####

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,7 @@ RUN rm -rf node_modules log tmp /usr/local/bundle/cache /yarn/cache .env && \
 FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} AS production
 
 RUN apk add --no-cache \
-    tzdata \
-    openssl-dev && \
+    tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 
@@ -67,7 +66,7 @@ EXPOSE 8080
 
 HEALTHCHECK CMD nc -z 0.0.0.0 $PORT
 
-CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
-#CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
+#CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 
 #### End production image #####

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apk add --no-cache tzdata && \
 
 ENV RAILS_SERVE_STATIC_FILES=true \
     RAILS_ENV=production \
-    PORT=8080 \
+    PORT=8081 \
     TZ=Europe/London
 
 RUN addgroup -S tariff && \
@@ -61,7 +61,7 @@ USER tariff
 COPY --chown=tariff:tariff --from=builder /build .
 COPY --chown=tariff:tariff --from=builder /usr/local/bundle/ /usr/local/bundle/
 
-EXPOSE 8080
+EXPOSE 8081
 
 HEALTHCHECK CMD nc -z 0.0.0.0 $PORT
 

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080:8080"
+      - "8081:8080"
     env_file:
       - .env
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
+      - "8443:8443"
     env_file:
       - .env
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080:8080"
+      - "8080:8081"
     env_file:
       - .env
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080:8081"
+      - "8080:8080"
     env_file:
       - .env
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8081:8080"
+      - "8080:8080"
     env_file:
       - .env
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -7,8 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080:8080"
-      - "8443:8443"
+      - "8081:8080"
     env_file:
       - .env
     environment:

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -37,7 +37,12 @@ bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 3000)}"
 # Explicit HTTPS bind
 cert = ENV['SSL_CERT_PEM']&.gsub("\\n", "\n")
 key  = ENV['SSL_KEY_PEM']&.gsub("\\n", "\n")
+
 if cert.present? && key.present?
+  puts "SSL_CERT present? #{cert.present?}"
+  puts "SSL_KEY present? #{key.present?}"
+  puts "SSL_PORT: #{ENV['SSL_PORT']}"
+
   ssl_bind '0.0.0.0', ENV.fetch('SSL_PORT', 8443),
            cert_pem: cert,
            key_pem: key

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,6 +32,13 @@ threads threads_count, threads_count
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT", 3000)
 environment ENV['RACK_ENV'] || 'development'
+
+if ENV['SSL_CERT_PEM'].present? && ENV['SSL_KEY_PEM'].present?
+  ssl_bind '0.0.0.0', ENV['SSL_PORT'],
+           cert_pem: ENV['SSL_CERT_PEM'],
+           key_pem:  ENV['SSL_KEY_PEM']
+end
+
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -29,17 +29,14 @@ workers Integer(ENV['WEB_CONCURRENCY'] || 1)
 threads_count = ENV.fetch('MAX_THREADS', 3)
 threads threads_count, threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch('PORT', 3000)
 environment ENV['RACK_ENV'] || 'development'
 
+# Explicit HTTP bind,  default is 3000.
+bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 3000)}"
+
+# Explicit HTTPS bind
 cert = ENV['SSL_CERT_PEM']&.gsub("\\n", "\n")
 key  = ENV['SSL_KEY_PEM']&.gsub("\\n", "\n")
-
-puts "SSL_CERT present? #{ENV['SSL_CERT_PEM'].present?}"
-puts "SSL_KEY present? #{ENV['SSL_KEY_PEM'].present?}"
-puts "SSL_PORT: #{ENV['SSL_PORT']}"
-
 if cert.present? && key.present?
   ssl_bind '0.0.0.0', ENV.fetch('SSL_PORT', 8443),
            cert_pem: cert,

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,7 +32,7 @@ threads threads_count, threads_count
 environment ENV['RACK_ENV'] || 'development'
 
 # Explicit HTTP bind,  default is 3000.
-bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 3000)}"
+bind "tcp://0.0.0.0:8081"
 
 # Explicit HTTPS bind
 cert = ENV['SSL_CERT_PEM']&.gsub("\\n", "\n")

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,7 +32,7 @@ threads threads_count, threads_count
 environment ENV['RACK_ENV'] || 'development'
 
 # Explicit HTTP bind,  default is 3000.
-bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 8080)}"
+bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 3000)}"
 
 # Explicit HTTPS bind
 cert = ENV['SSL_CERT_PEM']&.gsub("\\n", "\n")

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,10 +33,17 @@ threads threads_count, threads_count
 port ENV.fetch('PORT', 3000)
 environment ENV['RACK_ENV'] || 'development'
 
-if ENV['SSL_CERT_PEM'].present? && ENV['SSL_KEY_PEM'].present?
-  ssl_bind '0.0.0.0', ENV['SSL_PORT'],
-           cert_pem: ENV['SSL_CERT_PEM'],
-           key_pem: ENV['SSL_KEY_PEM']
+cert = ENV['SSL_CERT_PEM']&.gsub("\\n", "\n")
+key  = ENV['SSL_KEY_PEM']&.gsub("\\n", "\n")
+
+puts "SSL_CERT present? #{ENV['SSL_CERT_PEM'].present?}"
+puts "SSL_KEY present? #{ENV['SSL_KEY_PEM'].present?}"
+puts "SSL_PORT: #{ENV['SSL_PORT']}"
+
+if cert.present? && key.present?
+  ssl_bind '0.0.0.0', ENV.fetch('SSL_PORT', 8443),
+           cert_pem: cert,
+           key_pem: key
 end
 
 # Allow puma to be restarted by `bin/rails restart` command.

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,17 +32,13 @@ threads threads_count, threads_count
 environment ENV['RACK_ENV'] || 'development'
 
 # Explicit HTTP bind,  default is 3000.
-bind "tcp://0.0.0.0:8080"
+bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 8080)}"
 
 # Explicit HTTPS bind
 cert = ENV['SSL_CERT_PEM']&.gsub("\\n", "\n")
 key  = ENV['SSL_KEY_PEM']&.gsub("\\n", "\n")
 
-if cert.present? && key.present?
-  puts "SSL_CERT present? #{cert.present?}"
-  puts "SSL_KEY present? #{key.present?}"
-  puts "SSL_PORT: #{ENV['SSL_PORT']}"
-
+if cert.to_s != "" && key.to_s != ""
   ssl_bind '0.0.0.0', ENV.fetch('SSL_PORT', 8443),
            cert_pem: cert,
            key_pem: key

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,7 +32,7 @@ threads threads_count, threads_count
 environment ENV['RACK_ENV'] || 'development'
 
 # Explicit HTTP bind,  default is 3000.
-bind "tcp://0.0.0.0:8080"
+bind "tcp://0.0.0.0:8081"
 
 # Explicit HTTPS bind
 cert = ENV['SSL_CERT_PEM']&.gsub("\\n", "\n")

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,7 +32,7 @@ threads threads_count, threads_count
 environment ENV['RACK_ENV'] || 'development'
 
 # Explicit HTTP bind,  default is 3000.
-bind "tcp://0.0.0.0:8081"
+bind "tcp://0.0.0.0:8080"
 
 # Explicit HTTPS bind
 cert = ENV['SSL_CERT_PEM']&.gsub("\\n", "\n")

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -26,17 +26,17 @@
 # threads. This includes Active Record's `pool` parameter in `database.yml`.
 workers Integer(ENV['WEB_CONCURRENCY'] || 1)
 
-threads_count = ENV.fetch("MAX_THREADS", 3)
+threads_count = ENV.fetch('MAX_THREADS', 3)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT", 3000)
+port ENV.fetch('PORT', 3000)
 environment ENV['RACK_ENV'] || 'development'
 
 if ENV['SSL_CERT_PEM'].present? && ENV['SSL_KEY_PEM'].present?
   ssl_bind '0.0.0.0', ENV['SSL_PORT'],
            cert_pem: ENV['SSL_CERT_PEM'],
-           key_pem:  ENV['SSL_KEY_PEM']
+           key_pem: ENV['SSL_KEY_PEM']
 end
 
 # Allow puma to be restarted by `bin/rails restart` command.
@@ -44,4 +44,4 @@ plugin :tmp_restart
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
-pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
+pidfile ENV['PIDFILE'] if ENV['PIDFILE']

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -30,6 +30,7 @@ Terraform to deploy the service into AWS.
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_secretsmanager_secret.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret_version.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_sns_topic.slack_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -28,6 +28,7 @@ Terraform to deploy the service into AWS.
 | [aws_iam_policy.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_document.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
+| [aws_secretsmanager_secret.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -33,6 +33,10 @@ data "aws_secretsmanager_secret" "ecs_tls_certificate" {
   name = "ecs-tls-certificate"
 }
 
+data "aws_secretsmanager_secret_version" "ecs_tls_certificate" {
+  secret_id = data.aws_secretsmanager_secret.ecs_tls_certificate.id
+}
+
 data "aws_sns_topic" "slack_topic" {
   name = "slack-topic"
 }

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -29,6 +29,10 @@ data "aws_secretsmanager_secret_version" "this" {
   secret_id = data.aws_secretsmanager_secret.this.id
 }
 
+data "aws_secretsmanager_secret" "ecs_tls_certificate" {
+  name = "ecs-tls-certificate"
+}
+
 data "aws_sns_topic" "slack_topic" {
   name = "slack-topic"
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -9,23 +9,22 @@ locals {
     }
   ]
 
+  tls_secret = jsondecode(data.aws_secretsmanager_secret_version.ecs_tls_certificate.secret_string)
+
   ecs_tls_env_vars = [
     {
       name      = "SSL_KEY_PEM"
-      valueFrom = "${data.aws_secretsmanager_secret.ecs_tls_certificate.arn}:private_key::"
+      value = local.tls_secret.private_key
     },
     {
       name      = "SSL_CERT_PEM"
-      valueFrom = "${data.aws_secretsmanager_secret.ecs_tls_certificate.arn}:certificate::"
-    }
-  ]
-
-  ssl_port = [
+      value = local.tls_secret.certificate
+    },
     {
       name  = "SSL_PORT"
       value = "8443"
     }
   ]
 
-  frontend_service_env_vars = concat(local.secret_env_vars, local.ecs_tls_env_vars, local.ssl_port)
+  frontend_service_env_vars = concat(local.secret_env_vars, local.ecs_tls_env_vars)
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -17,12 +17,15 @@ locals {
     {
       name      = "SSL_CERT_PEM"
       valueFrom = "${data.aws_secretsmanager_secret.ecs_tls_certificate.arn}:certificate::"
-    },
+    }
+  ]
+
+  ssl_port = [
     {
       name  = "SSL_PORT"
       value = "8443"
     }
   ]
 
-  frontend_service_env_vars = concat(local.secret_env_vars, local.ecs_tls_env_vars)
+  frontend_service_env_vars = concat(local.secret_env_vars, local.ecs_tls_env_vars, local.ssl_port)
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -13,11 +13,11 @@ locals {
 
   ecs_tls_env_vars = [
     {
-      name      = "SSL_KEY_PEM"
+      name  = "SSL_KEY_PEM"
       value = local.tls_secret.private_key
     },
     {
-      name      = "SSL_CERT_PEM"
+      name  = "SSL_CERT_PEM"
       value = local.tls_secret.certificate
     },
     {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -8,4 +8,21 @@ locals {
       value = value
     }
   ]
+
+  ecs_tls_env_vars = [
+    {
+      name      = "SSL_KEY_PEM"
+      valueFrom = "${data.aws_secretsmanager_secret.ecs_tls_certificate.arn}:private_key::"
+    },
+    {
+      name      = "SSL_CERT_PEM"
+      valueFrom = "${data.aws_secretsmanager_secret.ecs_tls_certificate.arn}:certificate::"
+    },
+    {
+      name      = "SSL_PORT"
+      value     = "8443"
+    }
+  ]
+
+  frontend_service_env_vars = concat(local.secret_env_vars, local.ecs_tls_env_vars)
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -19,8 +19,8 @@ locals {
       valueFrom = "${data.aws_secretsmanager_secret.ecs_tls_certificate.arn}:certificate::"
     },
     {
-      name      = "SSL_PORT"
-      value     = "8443"
+      name  = "SSL_PORT"
+      value = "8443"
     }
   ]
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,7 +16,7 @@ module "service" {
   docker_tag   = var.docker_tag
   skip_destroy = true
 
-  container_port = 8080
+  container_port = 8084
 
   cpu    = var.cpu
   memory = var.memory

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,7 +24,7 @@ module "service" {
   task_role_policy_arns = [aws_iam_policy.task.arn]
   enable_ecs_exec       = true
 
-  service_environment_config = local.secret_env_vars
+  service_environment_config = local.frontend_service_env_vars
 
   has_autoscaler = local.has_autoscaler
   min_capacity   = var.min_capacity

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,7 +16,7 @@ module "service" {
   docker_tag   = var.docker_tag
   skip_destroy = true
 
-  container_port = 8081
+  container_port = 8080
 
   cpu    = var.cpu
   memory = var.memory

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,7 +16,7 @@ module "service" {
   docker_tag   = var.docker_tag
   skip_destroy = true
 
-  container_port = 8080
+  container_port = 8081
 
   cpu    = var.cpu
   memory = var.memory

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,7 +16,7 @@ module "service" {
   docker_tag   = var.docker_tag
   skip_destroy = true
 
-  container_port = 8084
+  container_port = 8080
 
   cpu    = var.cpu
   memory = var.memory


### PR DESCRIPTION
### Jira link

[HMRC-1963](https://transformuk.atlassian.net/browse/HMRC-1963)

### What?

I have 
- Updated config/puma.rb to add an SSL bind on port 8443 when SSL_CERT_PEM and SSL_KEY_PEM environment variables are present
- Added SSL_CERT_PEM and SSL_KEY_PEM to service_secrets_config referencing the secret from Story 1
- Added SSL_PORT=8443 to service_environment_config

### Why?

I am doing this because
- All ECS services need to serving HTTPS on port 8443 alongside existing HTTP on 8080 to encrypt internal ecs communication
