### PR TITLE
Handle 500 error when loading user

### DIFF
--- a/app/models/concerns/authenticatable_api_entity.rb
+++ b/app/models/concerns/authenticatable_api_entity.rb
@@ -9,6 +9,8 @@ module AuthenticatableApiEntity
       super(id, options, headers(token))
     rescue Faraday::UnauthorizedError => e
       handle_unauthorized_error(e)
+    rescue StandardError => e
+      raise AuthenticationError.new(e.message, reason: 'invalid_token')
     end
 
     def all(token, params = {})

--- a/spec/models/concerns/authenticatable_api_entity_spec.rb
+++ b/spec/models/concerns/authenticatable_api_entity_spec.rb
@@ -191,9 +191,12 @@ RSpec.describe AuthenticatableApiEntity do
           .and_raise(Faraday::ServerError.new('Server Error'))
       end
 
-      it 'allows error to bubble up' do
+      it 'raises invalid token error', :aggregate_failures do
         expect { test_class.find(entity_id, token) }
-          .to raise_error(Faraday::ServerError)
+          .to raise_error(AuthenticationError) do |error|
+            expect(error.reason).to eq('invalid_token')
+            expect(error.message).to eq('Server Error')
+          end
       end
     end
   end


### PR DESCRIPTION
### What?

A 500 error from the backend when loading a user was not being handled.
Now, an invalid_token error will be raised to force a new login.
