### PR TITLE
MYOTT-515 Add route to download commodities spreadsheet

### DIFF
--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -47,8 +47,20 @@ module Myott
       @new_subscriber = params[:new_subscriber] == 'true'
     end
 
-    def download
+    def download_changes
       file_data = TariffChanges::TariffChange.download_file(user_id_token, { as_of: as_of.to_fs(:dashed) })
+
+      send_data(
+        file_data[:body],
+        filename: file_data[:filename],
+        type: file_data[:type],
+        disposition: 'attachment',
+      )
+      response.headers['Cache-Control'] = 'no-cache'
+    end
+
+    def download_commodities
+      file_data = SubscriptionTarget.download_file(subscription.resource_id, user_id_token)
 
       send_data(
         file_data[:body],

--- a/app/models/subscription_target.rb
+++ b/app/models/subscription_target.rb
@@ -15,4 +15,21 @@ class SubscriptionTarget
   rescue Faraday::UnauthorizedError
     nil
   end
+
+  def self.download_file(id, token)
+    return nil if token.nil? && !Rails.env.development?
+
+    path = "/uk/user/subscriptions/#{id}/targets/download"
+    get(path, headers(token))
+
+    response = api.get(path, {}, headers(token))
+
+    {
+      body: response.body,
+      filename: response.headers['content-disposition'][/filename="?([^"]*)"?/, 1],
+      type: response.headers['content-type'],
+    }
+  rescue Faraday::UnauthorizedError
+    nil
+  end
 end

--- a/app/views/myott/mycommodities/_download_changes.html.erb
+++ b/app/views/myott/mycommodities/_download_changes.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-6">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full govuk-!-font-weight-bold">
-      <%= link_to download_myott_mycommodities_path(as_of: as_of.to_fs(:dashed)), class: "download_link govuk-link--no-visited-state" do %>
+      <%= link_to download_changes_myott_mycommodities_path(as_of: as_of.to_fs(:dashed)), class: "download_link govuk-link--no-visited-state" do %>
         <%= inline_svg_tag("download_icon.svg", class: "download_icon", aria: { hidden: true }) %>
         <span>Download tariff changes as spreadsheet</span>
       <% end %>

--- a/app/views/myott/mycommodities/_download_commodities.html.erb
+++ b/app/views/myott/mycommodities/_download_commodities.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-6">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full govuk-!-font-weight-bold">
-      <%= link_to download_myott_mycommodities_path(as_of: as_of.to_fs(:dashed)), class: "download-link govuk-link--inverse" do %>
+      <%= link_to download_commodities_myott_mycommodities_path, class: "download-link govuk-link--inverse" do %>
         <%= inline_svg_tag("download_icon.svg", class: "download_icon", aria: { hidden: true }) %>
         <span>Download all your commodities as spreadsheet</span>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,8 @@ Rails.application.routes.draw do
         get :expired
         get :invalid
         get :confirmation
-        get :download
+        get :download_changes
+        get :download_commodities
       end
     end
 

--- a/spec/features/myott_my_commodities_spec.rb
+++ b/spec/features/myott_my_commodities_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe 'Myott my commodities subscription', type: :feature do
       end
 
       it 'has a link to download tariff changes as a spreadsheet' do
-        expect(page).to have_link('Download tariff changes as spreadsheet', href: %r{/subscriptions/mycommodities/download\?as_of=#{as_of}})
+        expect(page).to have_link('Download tariff changes as spreadsheet', href: %r{/subscriptions/mycommodities/download_changes\?as_of=#{as_of}})
       end
 
       it 'no commodity changes are shown' do

--- a/spec/models/subscription_target_spec.rb
+++ b/spec/models/subscription_target_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe SubscriptionTarget, type: :model do
+  describe '.download_file' do
+    let(:subscription_id) { 'subscription-id' }
+    let(:token) { 'test_token' }
+    let(:response_body) { 'file content' }
+    let(:response_content_type) { 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }
+    let(:api_client) { instance_double(Faraday::Connection) }
+    let(:path) { "/uk/user/subscriptions/#{subscription_id}/targets/download" }
+
+    before do
+      allow(described_class).to receive(:api).and_return(api_client)
+      allow(described_class).to receive(:get)
+    end
+
+    context 'when file is downloaded successfully' do
+      before do
+        faraday_response = instance_double(
+          Faraday::Response,
+          headers: { 'content-disposition' => 'attachment; filename="my_watch_list.xlsx"', 'content-type' => response_content_type },
+          body: response_body,
+        )
+        allow(api_client).to receive(:get).and_return(faraday_response)
+      end
+
+      it 'calls endpoints with auth headers', :aggregate_failures do
+        described_class.download_file(subscription_id, token)
+
+        expect(described_class).to have_received(:get).with(path, described_class.headers(token))
+        expect(api_client).to have_received(:get).with(path, {}, described_class.headers(token))
+      end
+
+      it 'returns filename parsed from content-disposition' do
+        result = described_class.download_file(subscription_id, token)
+
+        expect(result[:filename]).to eq('my_watch_list.xlsx')
+      end
+
+      it 'returns type and body', :aggregate_failures do
+        result = described_class.download_file(subscription_id, token)
+
+        expect(result[:type]).to eq(response_content_type)
+        expect(result[:body]).to eq(response_body)
+      end
+    end
+
+    context 'when token is nil and not in development environment' do
+      before do
+        allow(Rails.env).to receive(:development?).and_return(false)
+      end
+
+      it 'returns nil' do
+        expect(described_class.download_file(subscription_id, nil)).to be_nil
+      end
+    end
+
+    context 'when API returns unauthorized' do
+      before do
+        allow(api_client).to receive(:get).and_raise(Faraday::UnauthorizedError.new('Unauthorized'))
+      end
+
+      it 'returns nil' do
+        expect(described_class.download_file(subscription_id, token)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[MYOTT-515](https://transformuk.atlassian.net/browse/MYOTT-515)

### What?

The backend now has an API for downloading a user's subscribed commodities. This adds a route to the frontend.
