### PR TITLE
MYOTT-525 Redirect new users to start page

### DIFF
--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -11,8 +11,7 @@ module Myott
 
     def authenticate
       if current_user.nil?
-        session[:myott_return_url] = request.fullpath
-        redirect_to(URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s, allow_other_host: true)
+        redirect_to myott_start_path
       elsif session[:myott_return_url]
         redirect_to(session.delete(:myott_return_url))
       end

--- a/spec/controllers/myott/myott_controller_spec.rb
+++ b/spec/controllers/myott/myott_controller_spec.rb
@@ -89,13 +89,7 @@ RSpec.describe Myott::MyottController, type: :controller do
   end
 
   describe '#authenticate' do
-    let(:request_fullpath) { '/myott/commodities/123' }
-    let(:identity_base_url) { 'https://auth.example.com' }
-    let(:expected_redirect_url) { 'https://auth.example.com/myott' }
-
     before do
-      allow(controller).to receive(:request).and_return(instance_double(ActionDispatch::Request, fullpath: request_fullpath))
-      allow(TradeTariffFrontend).to receive(:identity_base_url).and_return(identity_base_url)
       allow(controller).to receive(:redirect_to)
     end
 
@@ -104,16 +98,10 @@ RSpec.describe Myott::MyottController, type: :controller do
         allow(controller).to receive(:current_user).and_return(nil)
       end
 
-      it 'stores the current URL in session' do
+      it 'redirects to the start page' do
         controller.send(:authenticate)
 
-        expect(controller.session[:myott_return_url]).to eq(request_fullpath)
-      end
-
-      it 'redirects to identity service' do
-        controller.send(:authenticate)
-
-        expect(controller).to have_received(:redirect_to).with(expected_redirect_url, allow_other_host: true)
+        expect(controller).to have_received(:redirect_to).with(myott_start_path)
       end
     end
 

--- a/spec/controllers/myott/preferences_controller_spec.rb
+++ b/spec/controllers/myott/preferences_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Myott::PreferencesController, type: :controller do
         post :create, params: { preference: 'selectChapters' }
       end
 
-      it { is_expected.to redirect_to 'http://localhost:3005/myott' }
+      it { is_expected.to redirect_to myott_start_path }
     end
 
     context 'when current_user is valid' do

--- a/spec/support/shared_examples/a_protected_myott_page.rb
+++ b/spec/support/shared_examples/a_protected_myott_page.rb
@@ -5,6 +5,6 @@ RSpec.shared_examples 'a protected myott page' do |action|
       get action
     end
 
-    it { is_expected.to redirect_to 'http://localhost:3005/myott' }
+    it { is_expected.to redirect_to myott_start_path }
   end
 end


### PR DESCRIPTION
### Jira link

[MYOTT-525](https://transformuk.atlassian.net/browse/MYOTT-525)

### What?

If a user does not have an auth cookie then we should assume they are a new user and redirect them to the start page for the service instead of the login page.

### Why?

Gives new users information about what the service is before they try and sign up.