### PR TITLE
MYOTT-525 Redirect user to login when not logged in.

### DIFF
--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -2,7 +2,13 @@ module Myott
   class SubscriptionsController < MyottController
     skip_before_action :authenticate, only: %i[start invalid]
 
-    def start; end
+    def start
+      @continue_url = if current_user.present?
+                        myott_path
+                      else
+                        URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s
+                      end
+    end
 
     def invalid
       redirect_to myott_path if current_user.present?

--- a/app/views/myott/subscriptions/start.html.erb
+++ b/app/views/myott/subscriptions/start.html.erb
@@ -31,7 +31,7 @@
     </p>
 
 
-    <a href="<%= myott_path %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+    <a href="<%= @continue_url %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
       Start now
       <%= render 'shared/start_arrow' %>
     </a>
@@ -45,7 +45,7 @@
       change your preferences or unsubscribe from all emails.
     </p>
 
-    <a href="<%= myott_path %>" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+    <a href="<%= @continue_url %>" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
       Continue
     </a>
   </div>

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -12,6 +12,29 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
       get :start
       expect(controller).not_to have_received(:authenticate)
     end
+
+    context 'when a user is authenticated' do
+      before do
+        stub_authenticated_user(user)
+        get :start
+      end
+
+      it 'assigns @continue_url to myott_path' do
+        expect(assigns(:continue_url)).to eq(myott_path)
+      end
+    end
+
+    context 'when a user is not authenticated' do
+      before do
+        stub_unauthenticated_user
+        get :start
+      end
+
+      it 'assigns @continue_url to the identity base url' do
+        expected_url = URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s
+        expect(assigns(:continue_url)).to eq(expected_url)
+      end
+    end
   end
 
   describe 'GET #invalid' do


### PR DESCRIPTION
### Jira link

[MYOTT-525](https://transformuk.atlassian.net/browse/MYOTT-525)

### What?

Previously the start page would send the user to the service, and if they were not logged in then the service would redirect to the login page. Now that the service redirects to the start page in that instance, the redirect needs to be done directly on this page.

