### PR TITLE
HMRC-1964: Switch ALB target groups from HTTP to HTTPS

### DIFF
--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -28,11 +28,16 @@ class ClientBuilder
 
   def call
     if TradeTariffFrontend::ServiceChooser.service_choices.present?
+      cert_path = '/tmp/backend.crt'
+      File.write(cert_path, ENV['SSL_CERT_PEM']&.gsub('\\n', "\n"))
+
       Faraday.new(host) do |conn|
         conn.request :url_encoded
         conn.request :retry, RETRY_DEFAULTS.merge(Rails.configuration.x.http.retry_options)
         conn.use :http_cache, store: @cache, logger: Rails.logger if @cache
         conn.response :raise_error
+        conn.ssl.verify = false
+        conn.ssl.ca_file = cert_path
         conn.adapter :net_http_persistent
         conn.response :json, content_type: /\bjson$/
         conn.headers['User-Agent'] = user_agent

--- a/app/services/duty_calculator/client_builder.rb
+++ b/app/services/duty_calculator/client_builder.rb
@@ -1,17 +1,61 @@
 module DutyCalculator
   class ClientBuilder
+    ACCEPT = 'application/vnd.hmrc.2.0+json'.freeze
+
+    RETRY_DEFAULTS = {
+      methods: %i[get head],
+      max: 1,
+      interval: 0.5,
+      interval_randomness: 0.5,
+      backoff_factor: 2,
+      exceptions: (
+        Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS +
+        Faraday::Error.descendants -
+        [
+          # ClientError is needed because the following three inherit from it and
+          # ClientError is in Error's descendants list
+          Faraday::ClientError,
+          Faraday::ResourceNotFound,
+          Faraday::ForbiddenError,
+          Faraday::UnauthorizedError,
+        ]
+      ),
+    }.freeze
+
     def initialize(service)
       @service = service
     end
 
     def call
-      Uktt::Http.build(host)
+      Uktt::Http.new(connection, host:)
     end
 
   private
 
+    def connection
+      cert_path = '/tmp/backend.crt'
+      File.write(cert_path, ENV['SSL_CERT_PEM']&.gsub('\\n', "\n"))
+
+      Faraday.new(url: host) do |faraday|
+        faraday.use Faraday::Response::RaiseError
+        faraday.use Faraday::FollowRedirects::Middleware
+        faraday.response :logger if ENV['DEBUG_REQUESTS']
+        faraday.request :retry, RETRY_DEFAULTS.merge(Rails.configuration.x.http.retry_options)
+        faraday.ssl.verify = false
+        faraday.ssl.ca_file = cert_path
+        faraday.adapter :net_http_persistent
+
+        faraday.headers['User-Agent'] = user_agent
+        faraday.headers['Accept'] = ACCEPT
+      end
+    end
+
     def host
       Rails.application.config.api_options[@service]
+    end
+
+    def user_agent
+      @user_agent ||= "TradeTariffFrontend/#{TradeTariffFrontend.revision}"
     end
   end
 end

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -158,12 +158,16 @@ private
 
     def collection(collection_path, opts = {}, headers = {})
       resp = api.get(collection_path, opts, headers)
+
       collection = parse_jsonapi(resp)
       collection = collection.map { |entry_data| new(entry_data) }
       if resp.body.is_a?(Hash) && resp.body.dig('meta', 'pagination').present?
         collection = paginate_collection(collection, resp.body.dig('meta', 'pagination'))
       end
       collection
+    rescue Faraday::Error => e
+      Rails.logger.error("Faraday error: #{e.class} - #{e.message}")
+      raise
     end
 
     def has_one(association, opts = {})

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,7 +19,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.19.2 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
 
 ## Resources
 
@@ -28,6 +28,7 @@ Terraform to deploy the service into AWS.
 | [aws_iam_policy.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_document.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
+| [aws_lb_target_group.this_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_secretsmanager_secret.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret_version.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -17,6 +17,10 @@ data "aws_lb_target_group" "this" {
   name = "frontend"
 }
 
+data "aws_lb_target_group" "this_https" {
+  name = "frontend-https"
+}
+
 data "aws_security_group" "this" {
   name = "trade-tariff-ecs-security-group-${var.environment}"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,22 +1,30 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.19.2"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.21.0"
 
   region = var.region
 
   service_name  = "frontend"
   service_count = var.service_count
 
-  cluster_name              = "trade-tariff-cluster-${var.environment}"
-  subnet_ids                = data.aws_subnets.private.ids
-  security_groups           = [data.aws_security_group.this.id]
-  target_group_arn          = data.aws_lb_target_group.this.arn
+  cluster_name    = "trade-tariff-cluster-${var.environment}"
+  subnet_ids      = data.aws_subnets.private.ids
+  security_groups = [data.aws_security_group.this.id]
+  target_group_mappings = [
+    {
+      target_group_arn = data.aws_lb_target_group.this.arn
+      container_port   = 8080
+    },
+    {
+      target_group_arn = data.aws_lb_target_group.this_https.arn
+      container_port   = 8443
+    },
+  ]
+
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
 
   docker_image = "382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-frontend-production"
   docker_tag   = var.docker_tag
   skip_destroy = true
-
-  container_port = 8080
 
   cpu    = var.cpu
   memory = var.memory


### PR DESCRIPTION
### Jira link

[HMRC-1964](https://transformuk.atlassian.net/browse/HMRC-1964)

### What?

I have 
- Changed container port to 8443

### Why?

I am doing this because
- As ALB target groups switch from HTTP on port 8080 to HTTPS on port 8443, all the services should serve on 8443 over SSL