### PR TITLE
Remove incorrect API call

### DIFF
--- a/app/models/subscription_target.rb
+++ b/app/models/subscription_target.rb
@@ -20,8 +20,6 @@ class SubscriptionTarget
     return nil if token.nil? && !Rails.env.development?
 
     path = "/uk/user/subscriptions/#{id}/targets/download"
-    get(path, headers(token))
-
     response = api.get(path, {}, headers(token))
 
     {

--- a/spec/models/subscription_target_spec.rb
+++ b/spec/models/subscription_target_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe SubscriptionTarget, type: :model do
       it 'calls endpoints with auth headers', :aggregate_failures do
         described_class.download_file(subscription_id, token)
 
-        expect(described_class).to have_received(:get).with(path, described_class.headers(token))
         expect(api_client).to have_received(:get).with(path, {}, described_class.headers(token))
       end
 


### PR DESCRIPTION
### What?

Method to download commodities spreadsheet has an incorrect api call that is being removed

