### PR TITLE
Skip CSRF verification for CSP violation reports

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -1,5 +1,6 @@
 class CspReportsController < ApplicationController
   skip_before_action :require_authentication, only: %i[create]
+  skip_forgery_protection only: %i[create]
   def create
     Rails.logger.warn "CSP Violation: #{request.body.read}"
     NewRelic::Agent.notice_error("CSP Violation: #{request.body.read}")


### PR DESCRIPTION
### What?

- [x] Skip forgery protection on `CspReportsController#create`

### Why?

CSP violation reports are POST requests sent automatically by the browser. They don't carry a CSRF token, so Rails rejects them with a 422. This is expected behaviour for browser-initiated reporting endpoints.