### PR TITLE
MyOTT-530 updated wording for expired commodity codes

### DIFF
--- a/app/views/myott/mycommodities/_counts.html.erb
+++ b/app/views/myott/mycommodities/_counts.html.erb
@@ -16,7 +16,7 @@
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="category_container">
-      Expired commodity codes:
+      Expired commodities:
       <br />
       <%= link_to number_with_delimiter(commodity_codes.expired), expired_myott_mycommodities_path, class:"govuk-link--no-visited-state" %>
     </div>


### PR DESCRIPTION
### Jira link

[MyOTT-530](https://transformuk.atlassian.net/browse/myott-530)

### What?

I have updated the wording from **expired commodity codes** to **expired commodities**

### Why?

I am doing this because it was incorrect

BEFORE
<img width="207" height="72" alt="image" src="https://github.com/user-attachments/assets/00288ae3-6166-419f-a9ec-7661d830d7e1" />

AFTER
<img width="216" height="78" alt="image" src="https://github.com/user-attachments/assets/d6af892e-075f-4032-bc4e-9d6bfba3ca63" />
