### PR TITLE
MyOTT-516 Limit CCWL Download Size

### DIFF
--- a/app/views/myott/mycommodities/_counts.html.erb
+++ b/app/views/myott/mycommodities/_counts.html.erb
@@ -3,7 +3,7 @@
     <h2 class="govuk-heading-l myott-mycommodities__counts-heading">Your commodities</h2>
   </div>
   <div class="govuk-grid-column-one-half download-commodities-top govuk-!-text-align-right">
-    <%= render 'download_commodities' %>
+      <%= render 'download_commodities' if @commodity_code_counts.total <= 5000 %>
   </div>
 </div>
 <div class="govuk-grid-row govuk-!-font-weight-bold">
@@ -33,6 +33,6 @@
     </div>
   </div>
   <div class="govuk-grid-column-one-half download-commodities-bottom">
-    <%= render 'download_commodities' %>
+    <%= render 'download_commodities' if @commodity_code_counts.total <= 5000 %>
   </div>
 </div>


### PR DESCRIPTION
### Jira link

[MyOTT-516](https://transformuk.atlassian.net/browse/myott-516)

### What?

I have limited the download watchlist to 5000 CCs

### Why?

I am doing this because we want to avoid timeouts from large watchlists and 90% of users have < 5000 CCs.  This will allow more time to test and investigate asynchronous download solution.
