### PR TITLE
BAU: Disable task count alerts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.103.0
+    rev: v1.105.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -25,7 +25,7 @@ repos:
         files: '.env.development|.env.test'
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint-docker
         args:
@@ -40,7 +40,7 @@ repos:
         args: ["--autocorrect"]
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.8
+    rev: v1.7.11
     hooks:
       - id: actionlint-docker
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,7 +19,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.18.2 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.19.2 |
 
 ## Resources
 
@@ -43,6 +43,7 @@ Terraform to deploy the service into AWS.
 |------|-------------|------|---------|:--------:|
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
+| <a name="input_enable_service_count_alarm"></a> [enable\_service\_count\_alarm](#input\_enable\_service\_count\_alarm) | Whether to create a CloudWatch alarm for the service that alarms when there are no running tasks for the service. Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | `5` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -3,3 +3,5 @@ environment  = "development"
 cpu          = 1024
 memory       = 2048
 max_capacity = 1
+
+enable_service_count_alarm = false

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.18.2"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.19.2"
 
   region = var.region
 
@@ -40,6 +40,8 @@ module "service" {
       target_value = 70
     }
   }
+
+  enable_service_count_alarm = var.enable_service_count_alarm
 
   sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,3 +40,9 @@ variable "memory" {
   description = "Memory to allocate in MB. Powers of 2 only."
   type        = number
 }
+
+variable "enable_service_count_alarm" {
+  description = "Whether to create a CloudWatch alarm for the service that alarms when there are no running tasks for the service. Defaults to `true`."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
### Jira link

BAU

### What?

[] Disabled task count alarms in development

### Why?

I am doing this because we don't want the task count alerts to be triggered every time services are stopped in dev