### PR TITLE
[HMRC-1997] Remove hardcoded default for secret

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -19,8 +19,8 @@ PERMUTATIONS=true
 PORT=3001
 ROO_WIZARD=true
 SEARCH_BANNER=false
-SECRET_KEY_BASE=DRP57/m3nTx1UEQ0qAo0IsCKZgKDvu8W+U/8hTO7jPY=
-SECRET_TOKEN=gJmgFBMkeWAjfSwced562+kyfFrndAqYiGR59Su2va4=
+SECRET_KEY_BASE=XXXX
+SECRET_TOKEN=XXXX
 SERVICE_DEFAULT=uk
 STW_ENABLED=false
 STW_URI='https://check-how-to-import-export-goods.service.gov.uk/manage-this-trade/check-licences-certificates-and-other-restrictions'

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -5,5 +5,5 @@
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
 
-TradeTariffFrontend::Application.config.secret_token = ENV['SECRET_TOKEN']
-TradeTariffFrontend::Application.config.secret_key_base = ENV.fetch('SECRET_KEY_BASE', 'DRP57/m3nTx1UEQ0qAo0IsCKZgKDvu8W+U/8hTO7jPY=')
+TradeTariffFrontend::Application.config.secret_token = ENV.fetch('SECRET_TOKEN')
+TradeTariffFrontend::Application.config.secret_key_base = ENV.fetch('SECRET_KEY_BASE')


### PR DESCRIPTION
### Jira link

[HMRC-1997](https://transformuk.atlassian.net/browse/HMRC-1997)

### What?

- Removes hardcoded fallback default for `SECRET_KEY_BASE`
- Requires ENV loaded with `ENV.fetch` to ensure an error is raised if the env var is not set
- Use `XXXX` in `.env.development` to be explicit and scrub the old key (we should rotate this in production just to be safe too)

### Why?

AMR CyberSecurity recommends removing the default hardcoded secret and requiring environment variables to be explicitly configured.

The application should fail to start if required secrets are not configured, rather than falling back to insecure defaults.
