### PR TITLE
Fix: Add `secret_token` to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ ENV CORS_HOST="localhost" \
     GOVUK_APP_DOMAIN="localhost" \
     GOVUK_WEBSITE_ROOT="http://localhost/" \
     RAILS_ENV=production \
-    NODE_OPTIONS="--openssl-legacy-provider"
+    NODE_OPTIONS="--openssl-legacy-provider" \
+    SECRET_TOKEN="secret-token"
 
 RUN bundle exec rails assets:precompile
 


### PR DESCRIPTION
https://github.com/trade-tariff/trade-tariff-frontend/pull/2818 makes the `secret_token` env var required.

Add this to the build step in Docker