### PR TITLE
Fix: Revert set secret token

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -5,5 +5,5 @@
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
 
-TradeTariffFrontend::Application.config.secret_token = ENV.fetch('SECRET_TOKEN')
+TradeTariffFrontend::Application.config.secret_token = ENV['SECRET_TOKEN']
 TradeTariffFrontend::Application.config.secret_key_base = ENV.fetch('SECRET_KEY_BASE', 'DRP57/m3nTx1UEQ0qAo0IsCKZgKDvu8W+U/8hTO7jPY=')


### PR DESCRIPTION
https://github.com/trade-tariff/trade-tariff-frontend/pull/2818 made the secret token required by default, but this breaks the build

PR to revert