### PR TITLE
BAU: Replace rtCamp slack-notify with trade-tariff-tools action

### DIFF
--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -93,14 +93,15 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Notify Slack
-          uses: rtCamp/action-slack-notify@v2
-          env:
-            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-            SLACK_USERNAME: GitHub Actions
-            SLACK_CHANNEL: '#non-production-alerts'
-            SLACK_TITLE: 'Preview Deploy Failed'
-            SLACK_ICON_EMOJI: ':warning:'
-            SLACK_MESSAGE: |
+          uses: trade-tariff/trade-tariff-tools/.github/actions/slack-notify@main
+          with:
+            webhook: ${{ secrets.SLACK_WEBHOOK }}
+            username: GitHub Actions
+            channel: non-production-alerts
+            icon_emoji: ':warning:'
+            color: danger
+            title: Preview Deploy Failed
+            message: |
               *Repository:* ${{ github.repository }}
               *PR:* <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}>
               *Commit:* <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>


### PR DESCRIPTION
### What?

- [x] Replace `rtCamp/action-slack-notify@v2` with `trade-tariff/trade-tariff-tools/.github/actions/slack-notify@main` in `preview-up.yml`

### Why?

Removes the third-party rtCamp dependency and its "Powered By rtCamp's GitHub Actions Library" branding from Slack notifications. Uses our own standalone action added in https://github.com/trade-tariff/trade-tariff-tools/pull/97.