### PR TITLE
HMRC-2043: undefined local variable or method 'from_cache' for class GeographicalArea

### DIFF
--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -31,7 +31,6 @@ class GeographicalArea
               id: eu.id,
               description: eu.description,
               messages: "EU description is '#{eu.description}' instead of 'European Union'",
-              cache: from_cache,
             }
             Rails.logger.warn info.to_json
           end


### PR DESCRIPTION
### Jira link

[HMRC-2043](https://transformuk.atlassian.net/browse/HMRC-2043)

### What?

I have removed obvious log info that cause an error

### Why?

I am doing this because it is not defined and also it is obvious that it is not from cache
