### PR TITLE
OTTIMP-367 Corrected 6 links to the new feedback method

### DIFF
--- a/app/views/commodities/_interactive_search_feedback.html.erb
+++ b/app/views/commodities/_interactive_search_feedback.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-inset-text app-inset-text--blue">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Give feedback about this service</h2>
     <p class="govuk-body">Help us improve this service by <%= link_to "giving your feedback (opens in a new tab)",
-        feedback_path(request_id: params[:request_id]),
+        'https://surveys.transformuk.com/s3/17fead99a348',
         class: "govuk-link",
         target: "_blank",
         rel: "noopener noreferrer" %>.</p>

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -67,7 +67,7 @@
       <ul class="govuk-footer__list">
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods">Ask HMRC for advice on classifying your goods</a></li>
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries">Imports and exports: general enquiries</a></li>
-        <li class="govuk-footer__list-item"><%= link_to 'Feedback', feedback_path, class: "govuk-footer__link" %></li>
+        <li class="govuk-footer__list-item"><%= link_to 'Feedback', 'https://surveys.transformuk.com/s3/17fead99a348', class: "govuk-footer__link", target: '_blank', rel: 'noopener noreferrer' %></li>
         <li class="govuk-footer__list-item"><%= link_to 'Enquiry Form', product_experience_enquiry_form_path, class: "govuk-footer__link" %></li>
       </ul>
     </div>

--- a/app/views/myott/unsubscribes/confirmation.html.erb
+++ b/app/views/myott/unsubscribes/confirmation.html.erb
@@ -18,7 +18,7 @@
             You can now close this window.
           </p>
           <p class="govuk-body">
-            <%= link_to 'What did you think of this service?', feedback_path, class: 'govuk-link govuk-link--no-visited-state' %>
+            <%= link_to 'What did you think of this service?', 'https://surveys.transformuk.com/s3/17fead99a348', class: 'govuk-link govuk-link--no-visited-state', target: '_blank', rel: 'noopener noreferrer' %>
             (takes 30 seconds)
           </p>
         <% end %>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -62,7 +62,7 @@
     </ol>
 
     <h2 class="govuk-heading-s" id="leave-feedback">Leave feedback</h2>
-    <p><%= link_to 'Leave feedback or suggestions for improvements to this service.', feedback_path %></p>
+    <p><%= link_to 'Leave feedback or suggestions for improvements to this service.', 'https://surveys.transformuk.com/s3/17fead99a348', target: '_blank', rel: 'noopener noreferrer' %></p>
 
     <h2 class="govuk-heading-s" id="getting-help">Getting help from HMRC if you need to find a commodity code</h2>
     <p>If you <%= link_to 'cannot find the right commodity code for your goods', help_find_commodity_path %>, you can contact HMRC for advice or for a decision on your goods.</p>

--- a/app/views/shared/_interactive_feedback_banner.html.erb
+++ b/app/views/shared/_interactive_feedback_banner.html.erb
@@ -6,7 +6,7 @@
         BETA
       </strong>
       <span class="govuk-phase-banner__text">
-        Help us improve this service and <%= link_to 'give your feedback', feedback_path, class: 'govuk-link', target: '_blank', rel: 'noopener noreferrer' %> (opens in a new tab).
+        Help us improve this service and <%= link_to 'give your feedback', 'https://surveys.transformuk.com/s3/17fead99a348', class: 'govuk-link', target: '_blank', rel: 'noopener noreferrer' %> (opens in a new tab).
       </span>
     </p>
   </div>

--- a/app/views/shared/_interactive_feedback_useful_banner.html.erb
+++ b/app/views/shared/_interactive_feedback_useful_banner.html.erb
@@ -6,7 +6,7 @@
         <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Give feedback about this service</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Tell us about your experience using this service to help us improve it.</p>
       </div>
-      <%= link_to 'Share your feedback', feedback_path, class: 'govuk-button app-feedback-useful-banner__button', target: '_blank', rel: 'noopener noreferrer' %>
+      <%= link_to 'Share your feedback', 'https://surveys.transformuk.com/s3/17fead99a348', class: 'govuk-button app-feedback-useful-banner__button', target: '_blank', rel: 'noopener noreferrer' %>
     </div>
   </div>
 </div>

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -13,14 +13,15 @@ RSpec.feature 'Feedback', type: :feature do
     visit '/404'
     expect(page).to have_css 'h1', text: 'Page not found'
 
-    click_on 'Feedback'
+    visit feedback_path
     expect(page).to have_css 'h1', text: 'Give feedback on Online Trade Tariff'
     fill_in 'feedback[message]', with: 'Some random feedback'
     click_button 'Submit feedback'
 
     expect(page).to have_css 'h1', text: 'Feedback submitted'
-    expect(page).to have_css 'a', text: 'Return to page'
-    expect(page).to have_link nil, href: /404/
+    expect(page).to have_text 'Thank you for your valuable feedback'
+    # "Return to page" link only appears when referrer was set (e.g. when user clicked through from another page).
+    # Feature test driver does not send Referer on visit(), so we don't assert the link here; see request spec.
   end
 
   scenario 'when original page is feedback page' do
@@ -39,7 +40,7 @@ RSpec.feature 'Feedback', type: :feature do
     expect(page).to have_css 'p', text: 'Give feedback about this service'
     expect(page).to have_text 'Tell us about your experience using this service to help us improve it.'
 
-    click_on 'Feedback'
+    visit feedback_path
     expect(page).not_to have_css '.feedback-useful-banner'
     expect(page).not_to have_css 'a', text: 'Share your feedback'
   end
@@ -49,7 +50,7 @@ RSpec.feature 'Feedback', type: :feature do
     expect(page).to have_css 'a', text: 'give your feedback (opens in new tab)'
     expect(page).to have_text 'Help us improve this service'
 
-    click_on 'Feedback'
+    visit feedback_path
     expect(page).not_to have_css '.tariff-feedback-banner'
     expect(page).not_to have_css 'a', text: 'give your feedback (opens in new tab)'
   end

--- a/spec/requests/feedback_controller_spec.rb
+++ b/spec/requests/feedback_controller_spec.rb
@@ -9,6 +9,25 @@ RSpec.describe FeedbackController, type: :request do
     before { get new_feedback_path }
 
     it { is_expected.to have_http_status :success }
+
+    context 'with HTTP_REFERER set' do
+      before do
+        get new_feedback_path, headers: { 'HTTP_REFERER' => 'http://test.host/404' }
+        post feedbacks_path, params: {
+          feedback: { message: },
+          authenticity_token: 'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw',
+        }
+        follow_redirect!
+      end
+
+      it 'shows the thanks page with Return to page link' do
+        expect(response.body).to include('Return to page')
+      end
+
+      it 'links Return to page at the referrer URL' do
+        expect(response.body).to include('http://test.host/404')
+      end
+    end
   end
 
   describe 'POST #create' do

--- a/spec/views/commodities/_interactive_search_feedback.html.erb_spec.rb
+++ b/spec/views/commodities/_interactive_search_feedback.html.erb_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe 'commodities/_interactive_search_feedback', type: :view do
       expect(rendered).to have_css('a[target="_blank"][rel="noopener noreferrer"]')
     end
 
-    it 'passes request_id to the feedback form' do
+    it 'links to the feedback survey' do
       render partial: 'commodities/interactive_search_feedback'
 
-      expect(rendered).to have_link(href: /request_id=test-uuid-123/)
+      expect(rendered).to have_link('giving your feedback (opens in a new tab)', href: 'https://surveys.transformuk.com/s3/17fead99a348')
     end
   end
 


### PR DESCRIPTION
### Jira link

[OTTIMP-367-2](https://transformuk.atlassian.net/browse/OTTIMP-367-2)

### What?

I have a change that makes all in-app “give feedback” links go to the external survey (`https://surveys.transformuk.com/s3/17fead99a348`) instead of the internal feedback page (`/feedback`). Updated in six places: footer, interactive phase banner, interactive useful banner, commodities interactive search feedback, Help page, and MyOTT unsubscribe confirmation. Links open in a new tab with `target="_blank"` and `rel="noopener noreferrer"`. The spec that asserted `request_id` on the commodities feedback link was updated to assert the survey URL instead.

### Why?

I am doing this because we want a single feedback destination (the survey) and to avoid users landing on `/feedback?day=10&month=3&year=2026` when they follow feedback links from dated or search pages. Sending everyone to the same survey URL keeps feedback collection consistent and removes dependence on the in-app feedback form for these entry points.