### PR TITLE
AI-461: Support comma-separated passwords in BASIC_PASSWORD

### DIFF
--- a/app/models/basic_session.rb
+++ b/app/models/basic_session.rb
@@ -3,5 +3,13 @@ class BasicSession
 
   attr_accessor :return_url, :password
 
-  validates :password, inclusion: { in: [TradeTariffFrontend.basic_session_password] }
+  validate :password_recognised
+
+  private
+
+  def password_recognised
+    return if TradeTariffFrontend.basic_session_passwords.include?(password)
+
+    errors.add(:password, :inclusion)
+  end
 end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -110,10 +110,6 @@ module TradeTariffFrontend
     ENV['ROO_WIZARD'] == 'true' && TradeTariffFrontend::ServiceChooser.uk?
   end
 
-  def basic_auth?
-    ENV['BASIC_AUTH'].to_s == 'true'
-  end
-
   def webchat_enabled?
     webchat_url.present?
   end
@@ -148,6 +144,10 @@ module TradeTariffFrontend
 
   def basic_session_password
     @basic_session_password ||= ENV['BASIC_PASSWORD']
+  end
+
+  def basic_session_passwords
+    @basic_session_passwords ||= basic_session_password.to_s.split(',').map(&:strip).reject(&:blank?)
   end
 
   class FilterBadURLEncoding

--- a/spec/models/basic_session_spec.rb
+++ b/spec/models/basic_session_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe BasicSession do
+  subject(:basic_session) { described_class.new(password:) }
+
+  before do
+    allow(TradeTariffFrontend).to receive(:basic_session_passwords).and_return(passwords)
+  end
+
+  let(:passwords) { %w[existing-password uat-password] }
+
+  describe 'validations' do
+    context 'with a valid password' do
+      let(:password) { 'existing-password' }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with the second configured password' do
+      let(:password) { 'uat-password' }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with an invalid password' do
+      let(:password) { 'wrong-password' }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'with a blank password' do
+      let(:password) { '' }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-461](https://transformuk.atlassian.net/browse/AI-461)

### What?

- [x] Add `basic_session_passwords` method that splits `BASIC_PASSWORD` on commas
- [x] Update `BasicSession` validation to accept any of the configured passwords
- [x] Remove unused `basic_auth?` method
- [x] Add spec coverage for `BasicSession` model

### Why?

UAT testers need access to the staging frontend without sharing the internal employee credentials. Splitting `BASIC_PASSWORD` on commas means we can add a temporary UAT password alongside the existing one via config, and revoke it after UAT by removing it from the env var - no code deploy needed.