### PR TITLE
restore old feedback method for the /subscription pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -180,4 +180,16 @@ module ApplicationHelper
     # Output examples: "March 2022", "2022"
     month.present? ? "#{Date::MONTHNAMES[month.to_i]} #{year}" : year.to_s
   end
+
+  def subscriptions_page?
+    request.path.start_with?('/subscriptions')
+  end
+
+  def feedback_link_url
+    if subscriptions_page?
+      feedback_path
+    else
+      'https://surveys.transformuk.com/s3/17fead99a348'
+    end
+  end
 end

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -67,7 +67,7 @@
       <ul class="govuk-footer__list">
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods">Ask HMRC for advice on classifying your goods</a></li>
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries">Imports and exports: general enquiries</a></li>
-        <li class="govuk-footer__list-item"><%= link_to 'Feedback', 'https://surveys.transformuk.com/s3/17fead99a348', class: "govuk-footer__link", target: '_blank', rel: 'noopener noreferrer' %></li>
+        <li class="govuk-footer__list-item"><%= link_to 'Feedback', feedback_link_url, class: "govuk-footer__link", **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener noreferrer' }) %></li>
         <li class="govuk-footer__list-item"><%= link_to 'Enquiry Form', product_experience_enquiry_form_path, class: "govuk-footer__link" %></li>
       </ul>
     </div>

--- a/app/views/myott/unsubscribes/confirmation.html.erb
+++ b/app/views/myott/unsubscribes/confirmation.html.erb
@@ -18,7 +18,7 @@
             You can now close this window.
           </p>
           <p class="govuk-body">
-            <%= link_to 'What did you think of this service?', 'https://surveys.transformuk.com/s3/17fead99a348', class: 'govuk-link govuk-link--no-visited-state', target: '_blank', rel: 'noopener noreferrer' %>
+            <%= link_to 'What did you think of this service?', feedback_path, class: 'govuk-link govuk-link--no-visited-state' %>
             (takes 30 seconds)
           </p>
         <% end %>

--- a/app/views/shared/_feedback_banner.html.erb
+++ b/app/views/shared/_feedback_banner.html.erb
@@ -6,7 +6,7 @@
         FEEDBACK
       </strong>
       <span class="govuk-phase-banner__text">
-        Help us improve this service and <%= link_to 'give your feedback (opens in new tab)', 'https://surveys.transformuk.com/s3/d95fad286fcd', class: 'govuk-link', target: '_blank' %>.
+        Help us improve this service and <%= link_to 'give your feedback (opens in new tab)', feedback_link_url, class: 'govuk-link', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener noreferrer' }) %>.
       </span>
     </p>
   </div>

--- a/app/views/shared/_feedback_useful_banner.html.erb
+++ b/app/views/shared/_feedback_useful_banner.html.erb
@@ -5,7 +5,7 @@
       <p class="govuk-body govuk-!-margin-bottom-0">Tell us about your experience using this service to help us improve it.</p>
     </div>
     <div class="govuk-footer__meta-item">
-      <%= link_to 'Share your feedback', 'https://surveys.transformuk.com/s3/17fead99a348', class: 'govuk-button govuk-button--secondary', target: '_blank', rel: 'noopener' %>
+      <%= link_to 'Share your feedback', feedback_link_url, class: 'govuk-button govuk-button--secondary', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_interactive_feedback_banner.html.erb
+++ b/app/views/shared/_interactive_feedback_banner.html.erb
@@ -6,7 +6,7 @@
         BETA
       </strong>
       <span class="govuk-phase-banner__text">
-        Help us improve this service and <%= link_to 'give your feedback', 'https://surveys.transformuk.com/s3/17fead99a348', class: 'govuk-link', target: '_blank', rel: 'noopener noreferrer' %> (opens in a new tab).
+        Help us improve this service and <%= link_to 'give your feedback', feedback_link_url, class: 'govuk-link', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener noreferrer' }) %> (opens in a new tab).
       </span>
     </p>
   </div>

--- a/app/views/shared/_interactive_feedback_useful_banner.html.erb
+++ b/app/views/shared/_interactive_feedback_useful_banner.html.erb
@@ -6,7 +6,7 @@
         <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Give feedback about this service</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Tell us about your experience using this service to help us improve it.</p>
       </div>
-      <%= link_to 'Share your feedback', 'https://surveys.transformuk.com/s3/17fead99a348', class: 'govuk-button app-feedback-useful-banner__button', target: '_blank', rel: 'noopener noreferrer' %>
+      <%= link_to 'Share your feedback', feedback_link_url, class: 'govuk-button app-feedback-useful-banner__button', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener noreferrer' }) %>
     </div>
   </div>
 </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -461,4 +461,38 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { is_expected.to have_css 'a[href="/xi/duty-calculator/1704909991/import-date"]' }
     end
   end
+
+  describe '#subscriptions_page?' do
+    context 'when request path starts with /subscriptions' do
+      before { allow(helper).to receive(:request).and_return(double(path: '/subscriptions')) }
+
+      it { expect(helper.subscriptions_page?).to be true }
+    end
+
+    context 'when request path is /subscriptions/start' do
+      before { allow(helper).to receive(:request).and_return(double(path: '/subscriptions/start')) }
+
+      it { expect(helper.subscriptions_page?).to be true }
+    end
+
+    context 'when request path is not under /subscriptions' do
+      before { allow(helper).to receive(:request).and_return(double(path: '/feedback')) }
+
+      it { expect(helper.subscriptions_page?).to be false }
+    end
+  end
+
+  describe '#feedback_link_url' do
+    context 'when on a subscriptions page' do
+      before { allow(helper).to receive(:subscriptions_page?).and_return(true) }
+
+      it { expect(helper.feedback_link_url).to eq(feedback_path) }
+    end
+
+    context 'when not on a subscriptions page' do
+      before { allow(helper).to receive(:subscriptions_page?).and_return(false) }
+
+      it { expect(helper.feedback_link_url).to eq('https://surveys.transformuk.com/s3/17fead99a348') }
+    end
+  end
 end

--- a/spec/views/myott/unsubscribes/confirmation.html.erb_spec.rb
+++ b/spec/views/myott/unsubscribes/confirmation.html.erb_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe 'myott/unsubscribes/confirmation.html.erb', type: :view do
+  context 'when subscription type is stop_press' do
+    before do
+      assign(:title, 'You have unsubscribed')
+      assign(:header, 'Unsubscribe successful')
+      assign(:message, 'You will no longer receive these updates.')
+      assign(:subscription_type, 'stop_press')
+      render
+    end
+
+    it 'links "What did you think of this service?" to the in-app feedback path' do
+      expect(rendered).to have_link('What did you think of this service?', href: feedback_path)
+    end
+  end
+end

--- a/spec/views/shared/_interactive_feedback_banner.html.erb_spec.rb
+++ b/spec/views/shared/_interactive_feedback_banner.html.erb_spec.rb
@@ -5,10 +5,30 @@ RSpec.describe 'shared/_interactive_feedback_banner', type: :view do
   it { is_expected.to have_text('Help us improve this service') }
   it { is_expected.to have_link('give your feedback') }
 
-  it 'opens feedback link in a new tab' do
+  it 'opens feedback link in a new tab when not on a subscriptions page' do
+    allow(view).to receive_messages(subscriptions_page?: false, feedback_link_url: 'https://surveys.transformuk.com/s3/17fead99a348')
+
     render partial: 'shared/interactive_feedback_banner'
 
     expect(rendered).to have_css('a[target="_blank"][rel="noopener noreferrer"]')
+  end
+
+  context 'when on a subscriptions page' do
+    before do
+      allow(view).to receive_messages(subscriptions_page?: true, feedback_link_url: feedback_path)
+    end
+
+    it 'links to the in-app feedback path' do
+      render partial: 'shared/interactive_feedback_banner'
+
+      expect(rendered).to have_link('give your feedback', href: feedback_path)
+    end
+
+    it 'does not open the feedback link in a new tab' do
+      render partial: 'shared/interactive_feedback_banner'
+
+      expect(rendered).not_to have_css('a[target="_blank"]')
+    end
   end
 
   context 'when @feedback is set' do


### PR DESCRIPTION
### Jira link

[OTTIMP-440](https://transformuk.atlassian.net/browse/OTTIMP-440)

### What?

I have a change that keeps feedback on `/subscriptions` pages on the existing in-app feedback flow. On those pages, the header banner, “was this page useful” banner, and main footer “Feedback” link use `feedback_path`; everywhere else they still go to the Alchemer survey. A `subscriptions_page?` helper and a single `feedback_link_url` helper control this.

### Why?

I am doing this because OTTIMP-367 moved feedback to the survey everywhere, which would stop us tracking feedback from subscriptions. Excluding `/subscriptions` keeps the old mechanism there so we can still get user insight in the early go-live period (e.g. from Tuesday 17 Mar 2026).