### PR TITLE
MYOTT-564 Reduce table sizes on mobile devices

### DIFF
--- a/app/views/myott/grouped_measure_changes/show.html.erb
+++ b/app/views/myott/grouped_measure_changes/show.html.erb
@@ -27,7 +27,7 @@
 
       <h2 class="govuk-heading-m">Total commodities affected: <%= @commodity_changes.total_count %></h2>
 
-      <table class="govuk-table">
+      <table class="govuk-table govuk-table--small-text-until-tablet">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header">Commodity</th>

--- a/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
+++ b/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
@@ -3,7 +3,7 @@
 <h2 class="govuk-heading-l">Measure affected: <%= measure_type %></h2>
 <p>The following links open in a new tab</p>
 
-<table class="govuk-table">
+<table class="govuk-table govuk-table--small-text-until-tablet">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Change type</th>

--- a/app/views/myott/mycommodities/_commodity_changes.html.erb
+++ b/app/views/myott/mycommodities/_commodity_changes.html.erb
@@ -3,7 +3,7 @@
 <% if changes.empty? %>
   <p class="govuk-body">No changes published</p>
 <% else %>
-  <table class="govuk-table">
+  <table class="govuk-table govuk-table--small-text-until-tablet">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header">Change type</th>

--- a/app/views/myott/mycommodities/_grouped_measure_changes.html.erb
+++ b/app/views/myott/mycommodities/_grouped_measure_changes.html.erb
@@ -3,7 +3,7 @@
 <% if changes.empty? %>
   <p class="govuk-body">No changes published</p>
 <% else %>
-  <table class="govuk-table">
+  <table class="govuk-table govuk-table--small-text-until-tablet">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header">Import/Export</th>

--- a/app/views/myott/mycommodities/active.html.erb
+++ b/app/views/myott/mycommodities/active.html.erb
@@ -20,7 +20,7 @@
           <%= link_to "Replace all commodities (upload)", new_myott_mycommodity_path, class: "govuk-button govuk-button--secondary" %>
         </div>
       </div>
-       <table class="govuk-table">
+       <table class="govuk-table govuk-table--small-text-until-tablet">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header">Commodity</th>

--- a/app/views/myott/mycommodities/expired.html.erb
+++ b/app/views/myott/mycommodities/expired.html.erb
@@ -36,7 +36,7 @@
             <%= link_to "Replace all commodities (upload)", new_myott_mycommodity_path, class: "govuk-button govuk-button--secondary" %>
           </div>
         </div>
-        <table class="govuk-table">
+        <table class="govuk-table govuk-table--small-text-until-tablet">
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th class="govuk-table__header">Commodity</th>


### PR DESCRIPTION
### Jira Link

[MYOTT-564](https://transformuk.atlassian.net/browse/MYOTT-564)

### What?

Some of the data on tables does not fit well on a mobile screen. 
The class 'govuk-table--small-text-until-tablet' has been added which reduces the text size - https://design-system.service.gov.uk/components/table#tables-with-a-lot-of-data

| Before | After |
|-------|------|
|<img width="274" height="328" alt="Screenshot 2026-03-12 at 13 59 26" src="https://github.com/user-attachments/assets/2e85fdaf-ca99-4201-b360-2a8762d9879b" /> | <img width="274" height="293" alt="Screenshot 2026-03-12 at 13 59 49" src="https://github.com/user-attachments/assets/d9d5b9d5-02af-4524-b3d1-e2d5076a8de0" />|

### Why?

Make content fit better on small devices
