### PR TITLE
BAU: Disable interactive search for XI and restore hero banner

### DIFF
--- a/app/views/find_commodities/show_interactive.html.erb
+++ b/app/views/find_commodities/show_interactive.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'news_items/hero_story', news_item: @hero_story if @hero_story %>
 
-<%= render 'find_commodities/devolved_nations' %>
+<%= render 'news_items/hero_spimm' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -127,7 +127,7 @@ module TradeTariffFrontend
   end
 
   def interactive_search_enabled?
-    !production?
+    !production? && !ServiceChooser.xi?
   end
 
   def green_lanes_api_token

--- a/spec/views/find_commodities/show_interactive.html.erb_spec.rb
+++ b/spec/views/find_commodities/show_interactive.html.erb_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe 'find_commodities/show_interactive', type: :view do
     it { is_expected.to have_text('Steps for searching the tariff') }
   end
 
-  describe 'devolved nations banner' do
-    it { is_expected.to have_css('.app-devolved-nations', text: /Applies to England, Scotland and Wales/) }
-    it { is_expected.to have_link('Guidance for Northern Ireland') }
+  describe 'hero spimm banner' do
+    it { is_expected.to have_css('.govuk-notification-banner', text: /Importing goods into Northern Ireland/) }
+    it { is_expected.to have_link('Check eligibility') }
   end
 
   describe 'other ways to search' do


### PR DESCRIPTION
### What?

- [x] Restore the "Importing goods into Northern Ireland?" hero banner on the interactive search homepage (replacing the newer "Applies to England, Scotland and Wales" devolved nations banner)
- [x] Disable interactive/guided search when the service is XI (Northern Ireland)

### Why?

Robert flagged that the interactive search view shouldn't be shown for XI, and the devolved nations banner should be reverted to the existing hero SPIMM banner used on the non-interactive homepage.

The `interactive_search_enabled?` toggle is the single check point used by the controller, `InteractiveSearchable` concern, and search suggestions - so adding `!ServiceChooser.xi?` there disables interactive search everywhere for XI users.