### PR TITLE
MYOTT-518 Enable commodities download for all

### DIFF
--- a/app/assets/stylesheets/src/_mycommodities.scss
+++ b/app/assets/stylesheets/src/_mycommodities.scss
@@ -31,13 +31,13 @@
     }
   }
 
-  .download-commodities-top {
+  .myott-mycommodities__download-desktop {
     @include govuk-media-query($until: tablet) {
       display: none;
     }
   }
 
-  .download-commodities-bottom {
+  .myott-mycommodities__download-mobile {
     display: none;
     @include govuk-media-query($until: tablet) {
       display: block;

--- a/app/views/myott/mycommodities/_counts.html.erb
+++ b/app/views/myott/mycommodities/_counts.html.erb
@@ -2,8 +2,8 @@
   <div class="govuk-grid-column-one-half ">
     <h2 class="govuk-heading-l myott-mycommodities__counts-heading">Your commodities</h2>
   </div>
-  <div class="govuk-grid-column-one-half download-commodities-top govuk-!-text-align-right">
-      <%= render 'download_commodities' if @commodity_code_counts.total <= 5000 %>
+  <div class="govuk-grid-column-one-half myott-mycommodities__download-desktop govuk-!-text-align-right">
+      <%= render 'download_commodities' %>
   </div>
 </div>
 <div class="govuk-grid-row govuk-!-font-weight-bold">
@@ -11,14 +11,14 @@
     <div class="category_container">
       Errors from upload:
       <br />
-      <%= link_to number_with_delimiter(commodity_codes.invalid), invalid_myott_mycommodities_path, class:"govuk-link--no-visited-state" %>
+      <%= link_to number_with_delimiter(commodity_codes.invalid), invalid_myott_mycommodities_path, class: "govuk-link--no-visited-state" %>
     </div>
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="category_container">
       Expired commodities:
       <br />
-      <%= link_to number_with_delimiter(commodity_codes.expired), expired_myott_mycommodities_path, class:"govuk-link--no-visited-state" %>
+      <%= link_to number_with_delimiter(commodity_codes.expired), expired_myott_mycommodities_path, class: "govuk-link--no-visited-state" %>
     </div>
   </div>
   <div class="govuk-grid-column-one-third">
@@ -28,11 +28,11 @@
       <% if commodity_codes.active.zero? %>
         0
       <% else %>
-        <%= link_to number_with_delimiter(commodity_codes.active), active_myott_mycommodities_path, class:"govuk-link--no-visited-state" %>
+        <%= link_to number_with_delimiter(commodity_codes.active), active_myott_mycommodities_path, class: "govuk-link--no-visited-state" %>
       <% end %>
     </div>
   </div>
-  <div class="govuk-grid-column-one-half download-commodities-bottom">
-    <%= render 'download_commodities' if @commodity_code_counts.total <= 5000 %>
+  <div class="govuk-grid-column-one-half myott-mycommodities__download-mobile">
+    <%= render 'download_commodities' %>
   </div>
 </div>


### PR DESCRIPTION
### Jira link

[MYOTT-518](https://transformuk.atlassian.net/browse/MYOTT-518)

### What?

Issues with the commodities download for large watch lists have been resolved so it can be made available to all users.

The link appears in different places depending on screen size so I've updated the style names to clarify this.
