### PR TITLE
BAU: Fix literal br tags in interactive search classification descriptions

### DIFF
--- a/app/views/search/_interactive_results_content.html.erb
+++ b/app/views/search/_interactive_results_content.html.erb
@@ -45,7 +45,7 @@
         <div class="interactive-result">
           <div class="interactive-result__content">
             <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
-              <%= result.classification_description %>
+              <%= sanitize result.classification_description %>
             </h3>
             <p class="govuk-body-s govuk-!-margin-bottom-2 govuk-!-text-colour-secondary">
               <%= result.self_text %>

--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -62,7 +62,7 @@
         <ul class="govuk-list govuk-list--bullet">
           <% @results.all.first(@results.result_limit).each do |result| %>
             <li>
-              <%= result.formatted_description %>
+              <%= sanitize result.formatted_description %>
               (<%= result.goods_nomenclature_item_id %>)
             </li>
           <% end %>

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
           'description' => 'Containing less than 70% by weight of sugar',
           'formatted_description' => 'Containing less than 70% by weight of sugar',
           'self_text' => 'Citrus marmalade and jam products',
-          'classification_description' => 'Citrus fruit jam with less than 70% sugar',
+          'classification_description' => 'Citrus fruit jam<br>with less than 70% sugar',
           'full_description' => 'Citrus fruit jam with less than 70% sugar',
           'heading_description' => 'Jams and marmalades',
           'declarable' => true,
@@ -65,8 +65,14 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
   end
 
   describe 'result descriptions' do
-    it { is_expected.to have_css('h3', text: 'Citrus fruit jam with less than 70% sugar') }
+    it { is_expected.to have_css('h3', text: /Citrus fruit jam.*with less than 70% sugar/) }
     it { is_expected.to have_css('p.govuk-body-s', text: 'Citrus marmalade and jam products') }
+
+    it 'renders br tags as HTML rather than escaping them' do
+      render partial: 'search/interactive_results_content'
+
+      expect(rendered).not_to include('&lt;br&gt;')
+    end
   end
 
   describe 'commodity links' do


### PR DESCRIPTION
### What?

- [x] Sanitize `classification_description` in interactive search results so `<br>` tags render as HTML
- [x] Sanitize `formatted_description` in the interactive question "Current best matches" list
- [x] Add spec coverage for HTML rendering in classification descriptions

### Why?

Classification descriptions from the API contain `<br>` tags for line breaks. The interactive search results and question pages were rendering these as literal text (`&lt;br&gt;`) because ERB auto-escapes by default. Every other view rendering `classification_description` already uses `sanitize` - these two templates were missed.