### PR TITLE
MYOTT-565 Add quota order number and use presenter

### DIFF
--- a/app/presenters/myott/impacted_measures_presenter.rb
+++ b/app/presenters/myott/impacted_measures_presenter.rb
@@ -1,0 +1,23 @@
+module Myott
+  class ImpactedMeasuresPresenter
+    include Enumerable
+
+    attr_reader :changes
+
+    def initialize(changes)
+      @changes = changes
+    end
+
+    def each(&block)
+      @changes.each(&block)
+    end
+
+    def has_additional_code?
+      @changes.any? { |change| change['additional_code'].present? }
+    end
+
+    def has_quota_order_number?
+      @changes.any? { |change| change['quota_order_number'].present? }
+    end
+  end
+end

--- a/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
+++ b/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
@@ -1,5 +1,3 @@
-<% has_additional_code = changes.any? { |change| change['additional_code'].present? } %>
-
 <h2 class="govuk-heading-l">Measure affected: <%= measure_type %></h2>
 <p>The following links open in a new tab</p>
 
@@ -7,21 +5,27 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Change type</th>
-      <% if has_additional_code %>
+      <% if presenter.has_additional_code? %>
         <th class="govuk-table__header">Additional code</th>
+      <% end %>
+      <% if presenter.has_quota_order_number? %>
+        <th class="govuk-table__header">Quota order number</th>
       <% end %>
       <th class="govuk-table__header">Date of effect</th>
       <th class="govuk-table__header">Action
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% changes.each do |change| %>
+    <% presenter.each do |change| %>
       <% date = Date.parse(change['date_of_effect']) %>
       <% date_visible = Date.parse(change['date_of_effect_visible']) %>
       <tr class="govuk-table__row">
         <th class="govuk-table__header"><%= change['change_type'] %></th>
-        <% if has_additional_code %>
+        <% if presenter.has_additional_code? %>
           <td class="govuk-table__cell"><%= sanitize change['additional_code'].presence || 'N/A' %></td>
+        <% end %>
+        <% if presenter.has_quota_order_number? %>
+          <td class="govuk-table__cell"><%= sanitize change['quota_order_number'].presence || 'N/A' %></td>
         <% end %>
         <td class="govuk-table__cell"><%= date.to_fs %></td>
         <td class="govuk-table__cell">

--- a/app/views/myott/grouped_measure_commodity_changes/show.html.erb
+++ b/app/views/myott/grouped_measure_commodity_changes/show.html.erb
@@ -72,7 +72,7 @@
       </dl>
 
       <% @grouped_measure_commodity_changes.impacted_measures.each do |measure_type, changes| %>
-        <%= render 'impacted_measures', measure_type: measure_type, changes: changes %>
+        <%= render 'impacted_measures', measure_type: measure_type, presenter: Myott::ImpactedMeasuresPresenter.new(changes) %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
### Jira link

[MYOTT-565](https://transformuk.atlassian.net/browse/MYOTT-565)

### What?

Shows quota order number for a measure when it is available. 
Methods for this and whether there is an additional code have been moved to a presenter

### Why?

Sometimes measures are very similar and can only be identified by the different quota order number.
