### PR TITLE
MyOTT-572 Fix Nil Subscription on Create

### DIFF
--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -39,7 +39,10 @@ module Myott
       end
 
       new_subscriber = subscription.nil?
-      update_user_commodity_codes(result.codes)
+      unless update_user_commodity_codes(result.codes, new_subscriber)
+        @upload_form.errors.add(:file, 'We could not create your subscription. Please try again.')
+        return render(:new)
+      end
       redirect_to confirmation_myott_mycommodities_path params: { new_subscriber: new_subscriber } and return
     end
 
@@ -83,12 +86,19 @@ module Myott
       end
     end
 
-    def update_user_commodity_codes(commodity_codes)
-      User.update(user_id_token, my_commodities_subscription: 'true') if subscription.nil?
+    def update_user_commodity_codes(commodity_codes, new_subscriber)
+      if new_subscriber
+        User.update(user_id_token, my_commodities_subscription: 'true')
+        reload_subscription
+      end
+      return false if subscription.nil?
 
       Subscription.batch(subscription.resource_id,
                          user_id_token,
                          targets: TariffJsonapiParser.new(commodity_codes.uniq).parse)
+      true
+    rescue StandardError
+      false
     end
 
     def get_subscription_targets(category)

--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -56,5 +56,11 @@ module Myott
       subscription_id = current_user[:subscriptions]&.find { |s| s['subscription_type'] == subscription_type && s['active'] }&.fetch('id', nil)
       Subscription.find(subscription_id, user_id_token) if subscription_id
     end
+
+    def reload_subscription
+      @current_user = nil
+      @current_subscriptions = nil
+      @subscription = nil
+    end
   end
 end

--- a/spec/support/shared_examples/a_valid_commodity_file_upload.rb
+++ b/spec/support/shared_examples/a_valid_commodity_file_upload.rb
@@ -41,11 +41,17 @@ RSpec.shared_examples 'a valid commodity file upload' do |fixture_path, content_
                        .with('my_commodities')
                        .and_return(nil, subscription)
 
+      allow(User).to receive(:update).and_return(true)
+
       post :create, params: { myott_commodity_upload_form: { file: valid_file } }
     end
 
     it 'does not set an alert' do
       expect(assigns(:alert)).to be_nil
+    end
+
+    it 'calls User.update with my_commodities_subscription set to true' do
+      expect(User).to have_received(:update).with(token, my_commodities_subscription: 'true')
     end
 
     it 'calls Subscription.batch with parsed commodity codes' do
@@ -60,6 +66,33 @@ RSpec.shared_examples 'a valid commodity file upload' do |fixture_path, content_
 
     it 'redirects to the index page' do
       expect(response).to redirect_to(confirmation_myott_mycommodities_path(params: { new_subscriber: true }))
+    end
+  end
+
+  context 'when user subscription update succeeds but subscription is still missing' do
+    before do
+      cookies[:id_token] = token
+
+      allow(User).to receive(:update).and_return(true)
+      allow(Subscription).to receive(:batch)
+
+      allow(controller).to receive(:current_subscription)
+        .with('my_commodities')
+        .and_return(nil, nil)
+
+      post :create, params: { myott_commodity_upload_form: { file: valid_file } }
+    end
+
+    it 'does not call Subscription.batch' do
+      expect(Subscription).not_to have_received(:batch)
+    end
+
+    it 'sets the error' do
+      expect(assigns(:upload_form).errors[:file]).to include('We could not create your subscription. Please try again.')
+    end
+
+    it 'renders the new template' do
+      expect(response).to render_template(:new)
     end
   end
 end


### PR DESCRIPTION
### Jira link

[MyOTT-572](https://transformuk.atlassian.net/browse/MyOTT-572)

### What?

I have ensured stale memoized instance variables refresh following a user subscription update for new subscribers and display an error if subscription still does not exist  for any reason.

### Why?

I am doing this because stale instance variables were throwing a 500 error in production as the controller didn't have a fresh subscription.  If for ever reason there is still no subscription we can receive helpful feedback from the users instead of getting the 500 error page.

**500 errors received in cloudwatch caused by stale memoized subscription instance variable**
<img width="1604" height="558" alt="image (20)" src="https://github.com/user-attachments/assets/492cb803-22ca-4043-b7f5-54e105ba0e86" />

**If subscription doesn't exist**
<img width="551" height="867" alt="image" src="https://github.com/user-attachments/assets/e6207820-facf-4395-b029-a408af4369ea" />

