### PR TITLE
[HMRC-2111] Geographic areas fallback

### DIFF
--- a/app/controllers/geographical_areas_controller.rb
+++ b/app/controllers/geographical_areas_controller.rb
@@ -6,10 +6,20 @@ class GeographicalAreasController < ApplicationController
 
   def show
     render 'errors/not_found', status: :not_found if params[:id] == 'countries'
-    @geographical_area = GeographicalArea.find(params[:id], query_params)
+    @geographical_area = find_geographical_area
   end
 
   private
+
+  def find_geographical_area
+    GeographicalArea.find(params[:id], query_params)
+  rescue Faraday::ResourceNotFound
+    raise if TradeTariffFrontend::ServiceChooser.uk?
+
+    TradeTariffFrontend::ServiceChooser.with_source(:uk) do
+      GeographicalArea.find(params[:id], query_params)
+    end
+  end
 
   def set_goods_nomenclature_code
     @goods_nomenclature_code = params[:goods_nomenclature_code]

--- a/spec/controllers/geographical_areas_controller_spec.rb
+++ b/spec/controllers/geographical_areas_controller_spec.rb
@@ -7,4 +7,30 @@ RSpec.describe GeographicalAreasController, type: :controller do
     it { is_expected.to render_template('geographical_areas/show') }
     it { is_expected.to have_http_status(:success) }
   end
+
+  describe 'GET show on XI service' do
+    before { TradeTariffFrontend::ServiceChooser.service_choice = 'xi' }
+
+    context 'when the geo area exists on XI', vcr: { cassette_name: 'geographical_areas_show_xi_1013' } do
+      it 'renders successfully without falling back to UK' do
+        get :show, params: { id: '1013' }
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'when the geo area does not exist on XI but exists on UK', vcr: { cassette_name: 'geographical_areas_1400_xi_fallback' } do
+      it 'renders successfully using UK data' do
+        get :show, params: { id: '1400' }
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'when the geo area does not exist on XI or UK', vcr: { cassette_name: 'geographical_areas_1400_not_found' } do
+      it 'raises Faraday::ResourceNotFound' do
+        expect { get :show, params: { id: '1400' } }.to raise_error(Faraday::ResourceNotFound)
+      end
+    end
+  end
 end

--- a/spec/vcr/geographical_areas_1400_not_found.yml
+++ b/spec/vcr/geographical_areas_1400_not_found.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3019/api/xi/geographical_areas/1400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - TradeTariffFrontend/a4d021c2
+      Accept:
+      - application/vnd.hmrc.2.0+json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"title":"The resource you were looking for was not found."}]}'
+  recorded_at: Wed, 18 Mar 2026 10:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:3018/api/uk/geographical_areas/1400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - TradeTariffFrontend/a4d021c2
+      Accept:
+      - application/vnd.hmrc.2.0+json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"title":"The resource you were looking for was not found."}]}'
+  recorded_at: Wed, 18 Mar 2026 10:00:00 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr/geographical_areas_1400_xi_fallback.yml
+++ b/spec/vcr/geographical_areas_1400_xi_fallback.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3019/api/xi/geographical_areas/1400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - TradeTariffFrontend/a4d021c2
+      Accept:
+      - application/vnd.hmrc.2.0+json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"title":"The resource you were looking for was not found."}]}'
+  recorded_at: Wed, 18 Mar 2026 10:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:3018/api/uk/geographical_areas/1400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - TradeTariffFrontend/a4d021c2
+      Accept:
+      - application/vnd.hmrc.2.0+json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"1400","type":"geographical_area","attributes":{"id":"1400","description":"Areas
+        subject to VAT or Excise","geographical_area_id":"1400","hjid":12345},"relationships":{"children_geographical_areas":{"data":[{"id":"JE","type":"geographical_area"},{"id":"GG","type":"geographical_area"}]}}},"included":[{"id":"JE","type":"geographical_area","attributes":{"id":"JE","description":"Jersey","geographical_area_id":"JE","hjid":23001},"relationships":{"children_geographical_areas":{"data":[]}}},{"id":"GG","type":"geographical_area","attributes":{"id":"GG","description":"Guernsey","geographical_area_id":"GG","hjid":23002},"relationships":{"children_geographical_areas":{"data":[]}}}]}'
+  recorded_at: Wed, 18 Mar 2026 10:00:00 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr/geographical_areas_show_xi_1013.yml
+++ b/spec/vcr/geographical_areas_show_xi_1013.yml
@@ -1,0 +1,26 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3019/api/xi/geographical_areas/1013
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - TradeTariffFrontend/a4d021c2
+      Accept:
+      - application/vnd.hmrc.2.0+json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"1013","type":"geographical_area","attributes":{"id":"1013","description":"European
+        Union","geographical_area_id":"1013","hjid":23537},"relationships":{"children_geographical_areas":{"data":[{"id":"DE","type":"geographical_area"},{"id":"FR","type":"geographical_area"}]}}},"included":[{"id":"DE","type":"geographical_area","attributes":{"id":"DE","description":"Germany","geographical_area_id":"DE","hjid":23726},"relationships":{"children_geographical_areas":{"data":[]}}},{"id":"FR","type":"geographical_area","attributes":{"id":"FR","description":"France","geographical_area_id":"FR","hjid":23621},"relationships":{"children_geographical_areas":{"data":[]}}}]}'
+  recorded_at: Wed, 18 Mar 2026 10:00:00 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
### Jira link

[HMRC-2111](https://transformuk.atlassian.net/browse/HMRC-2111)

Also see support query [HMRC-1984](https://transformuk.atlassian.net/browse/HMRC-1984) for the original issue

### What?

Geographic areas usually exist in both XI and UK tariffs. Geographic area 1400 is UK only and does not exist in the XI tariff database. When a user viewing the XI tariff clicks the link to view this area, the user gets a 404 because we’re trying to get it from XI data. If they switch to viewing the UK tariff they can see the area, but we want them to see this without redirecting to the UK space and taking them out of their current XI space.

Instead of hardcoding a rule around this one area, I've implemented fallback behaviour that works like this:

1. We try get the area from wherever it's requested (in this case XI),
2. If it doesn't exist in XI, we try get the area from UK
3. if it doesn't exist in either, we raise an error and 404 as normal

### Why?

The user should be able to see the geographic area without leaving the XI tariff space.
