### PR TITLE
AI-524: Submit interactive search via POST

### DIFF
--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -16,7 +16,7 @@
 
     <%= form_with model: (@form || InteractiveSearchForm.new),
                   url: perform_search_path,
-                  method: :get,
+                  method: :post,
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder,
                   id: "interactive_search_form",
                   data: { action: "submit->interactive-question#submitWithThinking" } do |f| %>

--- a/app/views/shared/search/_interactive_search_form.html.erb
+++ b/app/views/shared/search/_interactive_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag perform_search_path, method: :get, id: "new_search",
+<%= form_tag perform_search_path, method: :post, id: "new_search",
     data: { controller: "guided-search-validation",
             action: "submit->guided-search-validation#validateAndSubmit" } do %>
 

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770812194,
-        "narHash": "sha256-OH+lkaIKAvPXR3nITO7iYZwew2nW9Y7Xxq0yfM/UcUU=",
+        "lastModified": 1773628058,
+        "narHash": "sha256-hpXH0z3K9xv0fHaje136KY872VT2T5uwxtezlAskQgY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8482c7ded03bae7550f3d69884f1e611e3bd19e8",
+        "rev": "f8573b9c935cfaa162dd62cc9e75ae2db86f85df",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770273217,
-        "narHash": "sha256-biMRh5KRKwtDbyHaBTmdrQxB0Ua2SlMEF+krGH1tPt0=",
+        "lastModified": 1773816537,
+        "narHash": "sha256-k8PjAB0b587qg+k7hmlKf20RzR5aU7Io8JYIsWzXIRY=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "8b840328105a5d6d5c0aac9d3d12d7e2213aac33",
+        "rev": "12cf042cd3902ed2df3b9a7b988128fc07b05c3f",
         "type": "github"
       },
       "original": {

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -270,8 +270,8 @@ RSpec.describe SearchController, type: :controller do
       end
     end
 
-    context 'with internal interactive search' do
-      subject(:do_response) { get :search, params: }
+    context 'with internal interactive search via POST' do
+      subject(:do_response) { post :search, params: }
 
       let(:commodity_data) do
         {


### PR DESCRIPTION
### Jira link

[AI-524](https://transformuk.atlassian.net/browse/AI-524)

### What?

- [x] Submit the guided interactive search form to `/search` via POST instead of GET
- [x] Submit the follow-up interactive question form to `/search` via POST instead of GET
- [x] Update the controller spec and add view coverage so the interactive flow stays on POST

### Why?

The browser-side interactive search journey was resubmitting the full answer tree back to `/search` in the URL on every step.

That meant repeated guided answers could grow the query string until CloudFront WAF blocked the request before the app saw it. The internal search API was already called with a JSON POST body, so the real problem was the frontend form method rather than the backend integration.

Switching the browser submission to POST keeps the answers in the request body, which is the shape this flow should have had all along.

### Deployment risks

- Low risk route-level change: `/search` already accepts both GET and POST
- We still need to run the frontend specs in a Ruby 4.0.1 environment, because this shell only has Ruby 3.4.7
