### PR TITLE
AI-523: Fix interactive search description links

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -49,25 +49,18 @@ module CommoditiesHelper
   end
 
   def convert_text_to_links(text)
-    starting_characters = /(\s|^|\A|<br>|<\/br>)/
-    terminating_characters = /(\s|;|,|$|\.|\z|<br>|<\/br>)/
+    fragment = Nokogiri::HTML::DocumentFragment.parse(text.to_s)
 
-    text = text.gsub( # Match subheading longer-syntax
-      /#{starting_characters}(\d{4})\s(\d{2})\s(\d{2})#{terminating_characters}/,
-      " <a href='/search?q=\\2\\3\\4#{query}'>\\2 \\3 \\4</a>\\5",
-    )
-    text = text.gsub( # Match subheading short syntax
-      /#{starting_characters}(\d{4})\s(\d{2})#{terminating_characters}/,
-      " <a href='/search?q=\\2\\3#{query}'>\\2 \\3</a>\\4",
-    )
-    text = text.gsub( # Match heading short syntax
-      /#{starting_characters}(\d{4})#{terminating_characters}/,
-      " <a href='/search?q=\\2#{query}'>\\2</a>\\3",
-    )
-    text.gsub( # Match chapter short syntax
-      /(chapter)\s(\d{2})#{terminating_characters}/i,
-      "<a href='/search?q=\\2#{query}'>\\1 \\2</a>\\3",
-    )
+    fragment.xpath('.//text()[normalize-space()] | ./text()[normalize-space()]').each do |node|
+      next if node.ancestors.any? { |ancestor| ancestor.name == 'a' }
+
+      replacement = linkify_code_references(node.text)
+      next if replacement == node.text
+
+      node.replace(Nokogiri::HTML::DocumentFragment.parse(replacement))
+    end
+
+    CGI.unescapeHTML(fragment.to_html)
   end
 
   def query
@@ -154,6 +147,33 @@ module CommoditiesHelper
   end
 
   private
+
+  def linkify_code_references(text)
+    starting_characters = /(\s|^|\A)/
+    punctuation_terminators = /(;|,|$|\)|\z)/
+    spaced_terminators = /(\s|;|,|$|\.|\)|\z)/
+
+    text = text.gsub( # Match subheading dotted short syntax
+      /#{starting_characters}(\d{4})\.(\d{2})(?=#{spaced_terminators})/,
+      " <a href='/search?q=\\2\\3#{query}'>\\2.\\3</a>",
+    )
+    text = text.gsub( # Match subheading longer-syntax
+      /#{starting_characters}(\d{4})\s(\d{2})\s(\d{2})(?=#{spaced_terminators})/,
+      " <a href='/search?q=\\2\\3\\4#{query}'>\\2 \\3 \\4</a>",
+    )
+    text = text.gsub( # Match subheading short syntax
+      /#{starting_characters}(\d{4})\s(\d{2})(?=#{spaced_terminators})/,
+      " <a href='/search?q=\\2\\3#{query}'>\\2 \\3</a>",
+    )
+    text = text.gsub( # Match heading short syntax
+      /#{starting_characters}(\d{4})(?=#{punctuation_terminators}|<br>|<\/br>)/,
+      " <a href='/search?q=\\2#{query}'>\\2</a>",
+    )
+    text.gsub( # Match chapter short syntax
+      /(chapter)\s(\d{2})(?=#{spaced_terminators})/i,
+      "<a href='/search?q=\\2#{query}'>\\1 \\2</a>",
+    )
+  end
 
   def chapter_and_heading_codes(code)
     "<div class='chapter-code'>

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -77,6 +77,14 @@ class GoodsNomenclature
     goods_nomenclature_item_id
   end
 
+  def formatted_self_text
+    format_description(self_text)
+  end
+
+  def formatted_classification_description
+    format_description(classification_description)
+  end
+
   def rules_of_origin(*args, **kwargs)
     return nil unless declarable?
 
@@ -89,5 +97,11 @@ class GoodsNomenclature
 
   def self.is_heading_id?(goods_nomenclature_item_id)
     goods_nomenclature_item_id.ends_with?('000000') && goods_nomenclature_item_id.slice(2, 2) != '00'
+  end
+
+  private
+
+  def format_description(text)
+    GoodsNomenclature::DescriptionFormatter.new(text).to_html
   end
 end

--- a/app/models/goods_nomenclature/description_formatter.rb
+++ b/app/models/goods_nomenclature/description_formatter.rb
@@ -1,0 +1,42 @@
+class GoodsNomenclature
+  class DescriptionFormatter
+    include ActionView::Helpers::SanitizeHelper
+    include CommoditiesHelper
+
+    ALLOWED_SOURCE_TAGS = %w[br sub sup].freeze
+    ALLOWED_RESULT_TAGS = %w[a br sub sup].freeze
+    ALLOWED_RESULT_ATTRIBUTES = %w[href rel target].freeze
+
+    def initialize(text)
+      @text = text.to_s
+    end
+
+    def to_html
+      fragment = Nokogiri::HTML::DocumentFragment.parse(linkified_text)
+      add_link_attributes(fragment)
+
+      sanitize(
+        fragment.to_html,
+        tags: ALLOWED_RESULT_TAGS,
+        attributes: ALLOWED_RESULT_ATTRIBUTES,
+      ).html_safe
+    end
+
+    private
+
+    def linkified_text
+      convert_text_to_links(
+        sanitize(@text, tags: ALLOWED_SOURCE_TAGS, attributes: []),
+      )
+    end
+
+    def add_link_attributes(fragment)
+      fragment.css('a').each do |link|
+        link['target'] = '_blank'
+        link['rel'] = 'noopener noreferrer'
+      end
+    end
+
+    def url_options = {}
+  end
+end

--- a/app/views/search/_interactive_results_content.html.erb
+++ b/app/views/search/_interactive_results_content.html.erb
@@ -45,10 +45,10 @@
         <div class="interactive-result">
           <div class="interactive-result__content">
             <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
-              <%= sanitize result.classification_description %>
+              <%= result.formatted_classification_description %>
             </h3>
             <p class="govuk-body-s govuk-!-margin-bottom-2 govuk-!-text-colour-secondary">
-              <%= result.self_text %>
+              <%= result.formatted_self_text %>
             </p>
             <%= link_to "View this commodity code (opens in new tab)",
                 commodity_path(result.goods_nomenclature_item_id, request_id: @search.request_id),

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770812194,
-        "narHash": "sha256-OH+lkaIKAvPXR3nITO7iYZwew2nW9Y7Xxq0yfM/UcUU=",
+        "lastModified": 1773628058,
+        "narHash": "sha256-hpXH0z3K9xv0fHaje136KY872VT2T5uwxtezlAskQgY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8482c7ded03bae7550f3d69884f1e611e3bd19e8",
+        "rev": "f8573b9c935cfaa162dd62cc9e75ae2db86f85df",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770273217,
-        "narHash": "sha256-biMRh5KRKwtDbyHaBTmdrQxB0Ua2SlMEF+krGH1tPt0=",
+        "lastModified": 1773816537,
+        "narHash": "sha256-k8PjAB0b587qg+k7hmlKf20RzR5aU7Io8JYIsWzXIRY=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "8b840328105a5d6d5c0aac9d3d12d7e2213aac33",
+        "rev": "12cf042cd3902ed2df3b9a7b988128fc07b05c3f",
         "type": "github"
       },
       "original": {

--- a/spec/helpers/commodities_helper_spec.rb
+++ b/spec/helpers/commodities_helper_spec.rb
@@ -184,25 +184,50 @@ RSpec.describe CommoditiesHelper, type: :helper do
     context 'with chapter in formatted description' do
       let(:declarable_formatted_description) { ' Chapter 32.' }
 
-      it { is_expected.to eql " <a href='/search?q=32&country=IN&day=01&month=12&year=2022'>Chapter 32</a>." }
+      it { is_expected.to include('/search?q=32&country=IN&day=01&month=12&year=2022') }
+      it { is_expected.to include('>Chapter 32</a>.') }
     end
 
     context 'with heading in formatted description' do
       let(:declarable_formatted_description) { ' 1234<br>' }
 
-      it { is_expected.to eql " <a href='/search?q=1234&country=IN&day=01&month=12&year=2022'>1234</a><br>" }
+      it { is_expected.to include('/search?q=1234&country=IN&day=01&month=12&year=2022') }
+      it { is_expected.to include('>1234</a><br>') }
     end
 
     context 'with 8 digit subheading in formatted description' do
       let(:declarable_formatted_description) { ' 1234 11 22' }
 
-      it { is_expected.to eql " <a href='/search?q=12341122&country=IN&day=01&month=12&year=2022'>1234 11 22</a>" }
+      it { is_expected.to include('/search?q=12341122&country=IN&day=01&month=12&year=2022') }
+      it { is_expected.to include('>1234 11 22</a>') }
+    end
+
+    context 'with dotted 6 digit subheading in formatted description' do
+      let(:declarable_formatted_description) { ' 8703.10)' }
+
+      it { is_expected.to include('/search?q=870310&country=IN&day=01&month=12&year=2022') }
+      it { is_expected.to include('>8703.10</a>)') }
+    end
+
+    context 'with a dotted 6 digit subheading followed by more text' do
+      let(:declarable_formatted_description) { ' subheading 8703.10 and other text' }
+
+      it { is_expected.to include('/search?q=870310&country=IN&day=01&month=12&year=2022') }
+      it { is_expected.to include('subheading <a') }
+      it { is_expected.to include('>8703.10</a> and other text') }
     end
 
     context 'with 6 digit subheading in formatted description' do
       let(:declarable_formatted_description) { ' 1234 11, flibble' }
 
-      it { is_expected.to eql " <a href='/search?q=123411&country=IN&day=01&month=12&year=2022'>1234 11</a>, flibble" }
+      it { is_expected.to include('/search?q=123411&country=IN&day=01&month=12&year=2022') }
+      it { is_expected.to include('>1234 11</a>, flibble') }
+    end
+
+    context 'with a 4 digit quantity followed by a unit' do
+      let(:declarable_formatted_description) { ' cylinder capacity <= 1000 cm3' }
+
+      it { is_expected.to eql ' cylinder capacity <= 1000 cm3' }
     end
   end
 

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -192,4 +192,77 @@ RSpec.describe GoodsNomenclature do
       it { is_expected.not_to be_is_other }
     end
   end
+
+  describe '#formatted_self_text' do
+    subject(:formatted_self_text) { goods_nomenclature.formatted_self_text }
+
+    let(:goods_nomenclature) do
+      described_class.new(
+        'self_text' => self_text,
+      )
+    end
+
+    context 'when the text contains safe inline html and embedded goods codes' do
+      let(:self_text) do
+        'Motor cars for <= 10 persons, cylinder capacity <= 1000 cm<sup>3</sup>, used (excl. vehicles of subheading 8703.10)' \
+          '<script>alert(1)</script>'
+      end
+
+      it 'renders sup tags' do
+        expect(formatted_self_text).to include('cm<sup>3</sup>')
+      end
+
+      it 'strips unsafe tags' do
+        expect(formatted_self_text).not_to include('<script>')
+      end
+
+      it 'linkifies dotted goods codes to a new tab search link' do
+        expect(formatted_self_text).to include('href="/search?q=870310"')
+      end
+
+      it 'opens linkified goods codes in a new tab' do
+        expect(formatted_self_text).to include('target="_blank"')
+      end
+
+      it 'adds a safe rel attribute to generated goods code links' do
+        expect(formatted_self_text).to include('rel="noopener noreferrer"')
+      end
+
+      it 'preserves the displayed dotted goods code text' do
+        expect(formatted_self_text).to include('>8703.10</a>')
+      end
+
+      it 'does not link unrelated numeric values' do
+        expect(formatted_self_text).not_to include('href="/search?q=1000"')
+      end
+
+      it 'keeps dotted goods codes linked to the full code' do
+        expect(formatted_self_text).not_to include('href="/search?q=8703"')
+      end
+    end
+  end
+
+  describe '#formatted_classification_description' do
+    subject(:formatted_classification_description) { goods_nomenclature.formatted_classification_description }
+
+    let(:goods_nomenclature) do
+      described_class.new(
+        'classification_description' => classification_description,
+      )
+    end
+
+    let(:classification_description) { 'Engine output in cm<sub>3</sub><br>chapter 87' }
+
+    it 'renders allowed formatting tags' do
+      expect(formatted_classification_description).to include('cm<sub>3</sub><br>')
+    end
+
+    it 'linkifies recognised code references' do
+      expect(formatted_classification_description).to include('href="/search?q=87"')
+    end
+
+    it 'preserves the displayed chapter reference text' do
+      expect(formatted_classification_description).to include('>chapter 87</a>')
+    end
+  end
 end

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
           'goods_nomenclature_class' => 'Commodity',
           'description' => 'Containing less than 70% by weight of sugar',
           'formatted_description' => 'Containing less than 70% by weight of sugar',
-          'self_text' => 'Citrus marmalade and jam products',
-          'classification_description' => 'Citrus fruit jam<br>with less than 70% sugar',
+          'self_text' => 'Citrus marmalade and jam products with 8703.10 and 1000 cm<sup>3</sup>',
+          'classification_description' => 'Citrus fruit jam<br>with less than 70% sugar and 5 cm<sub>3</sub>',
           'full_description' => 'Citrus fruit jam with less than 70% sugar',
           'heading_description' => 'Jams and marmalades',
           'declarable' => true,
@@ -66,12 +66,48 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
 
   describe 'result descriptions' do
     it { is_expected.to have_css('h3', text: /Citrus fruit jam.*with less than 70% sugar/) }
-    it { is_expected.to have_css('p.govuk-body-s', text: 'Citrus marmalade and jam products') }
+    it { is_expected.to have_css('p.govuk-body-s', text: /Citrus marmalade and jam products with 8703\.10 and 1000 cm3/) }
 
     it 'renders br tags as HTML rather than escaping them' do
       render partial: 'search/interactive_results_content'
 
       expect(rendered).not_to include('&lt;br&gt;')
+    end
+
+    it 'renders sub and sup tags as HTML rather than escaping them' do
+      render partial: 'search/interactive_results_content'
+
+      expect(rendered).to include('<sup>3</sup>')
+    end
+
+    it 'renders sub tags as HTML rather than escaping them' do
+      render partial: 'search/interactive_results_content'
+
+      expect(rendered).to include('<sub>3</sub>')
+    end
+
+    it 'does not escape sup tags' do
+      render partial: 'search/interactive_results_content'
+
+      expect(rendered).not_to include('&lt;sup&gt;')
+    end
+
+    it 'does not escape sub tags' do
+      render partial: 'search/interactive_results_content'
+
+      expect(rendered).not_to include('&lt;sub&gt;')
+    end
+
+    it 'linkifies recognised goods codes in self text' do
+      render partial: 'search/interactive_results_content'
+
+      expect(rendered).to have_link('8703.10', href: '/search?q=870310')
+    end
+
+    it 'opens linkified goods code references in a new tab' do
+      render partial: 'search/interactive_results_content'
+
+      expect(rendered).to have_css('p.govuk-body-s a[target="_blank"][rel="noopener noreferrer"]', text: '8703.10')
     end
   end
 


### PR DESCRIPTION
### Jira link

[AI-523](https://transformuk.atlassian.net/browse/AI-523)

### What?

- [x] render sub and sup markup safely in interactive search descriptions
- [x] reuse commodity linkification for interactive search self text and classification descriptions
- [x] fix dotted goods code linking like 8703.10 without degrading to 8703
- [x] avoid false-positive heading links for numeric quantities like 1000 cm
- [x] update flake.lock

### Why?

Interactive search results were rendering self text too loosely for inline markup, and code references inside those descriptions could link to the wrong search or catch unrelated numeric values.
