### PR TITLE
Handle invalid as_of values

### DIFF
--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -121,11 +121,11 @@ module Myott
     end
 
     def as_of
-      if params[:as_of].present?
-        Date.parse(params[:as_of])
-      else
-        Time.zone.yesterday
-      end
+      return Time.zone.yesterday if params[:as_of].blank?
+
+      Date.parse(params[:as_of])
+    rescue ArgumentError, TypeError
+      Time.zone.yesterday
     end
 
     def commodity_code_counts

--- a/spec/controllers/myott/commodity_changes_controller_spec.rb
+++ b/spec/controllers/myott/commodity_changes_controller_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Myott::CommodityChangesController, type: :controller do
         get :ending
         expect(response).to render_template(:ending)
       end
+
+      it 'falls back to yesterday when as_of is invalid' do
+        allow(controller).to receive(:as_of).and_call_original
+
+        get :ending, params: { as_of: 'not-a-date' }
+
+        expect(TariffChanges::CommodityChange).to have_received(:find).with(
+          'ending',
+          anything,
+          hash_including(as_of: Time.zone.yesterday.to_fs(:dashed)),
+        )
+      end
     end
   end
 

--- a/spec/controllers/myott/grouped_measure_changes_controller_spec.rb
+++ b/spec/controllers/myott/grouped_measure_changes_controller_spec.rb
@@ -53,5 +53,18 @@ RSpec.describe Myott::GroupedMeasureChangesController, type: :controller do
       get :show, params: { id: '1' }
       expect(assigns(:commodity_changes)).to eq(commodity_changes)
     end
+
+    it 'falls back to yesterday when as_of is invalid' do
+      allow(controller).to receive(:as_of).and_call_original
+      allow(TariffChanges::GroupedMeasureChange).to receive(:find).and_return(grouped_measure_change)
+
+      get :show, params: { id: '1', as_of: 'not-a-date' }
+
+      expect(TariffChanges::GroupedMeasureChange).to have_received(:find).with(
+        '1',
+        user_id_token,
+        hash_including(as_of: Time.zone.yesterday.to_fs(:dashed)),
+      )
+    end
   end
 end

--- a/spec/controllers/myott/mycommodities_controller_spec.rb
+++ b/spec/controllers/myott/mycommodities_controller_spec.rb
@@ -246,6 +246,15 @@ RSpec.describe Myott::MycommoditiesController, type: :controller do
       it 'returns file body' do
         expect(response.body).to eq(file_data[:body])
       end
+
+      it 'falls back to yesterday when as_of is invalid' do
+        get :download_changes, params: { as_of: 'not-a-date' }
+
+        expect(TariffChanges::TariffChange).to have_received(:download_file).with(
+          user_id_token,
+          hash_including(as_of: Time.zone.yesterday.to_fs(:dashed)),
+        ).at_least(:once)
+      end
     end
 
     context 'when user does not have a my commodities subscription' do


### PR DESCRIPTION
### What?

If the as_of value can't be parsed then default to yesterday's date.

### Why?

An invalid as_of value causes an exception
