### PR TITLE
[HMRC-2129] - Add critical footnotes to import/export tabs

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -23,8 +23,11 @@
 
   <!-- Import tab -->
   <div class="govuk-tabs__panel" id="import">
-
     <h2 class="govuk-heading-m"><%= measures_heading(anchor: 'import') %></h2>
+
+    <% declarable.critical_footnotes.each do |footnote| %>
+      <%= render "footnotes/critical_warning", footnote: footnote %>
+    <% end %>
 
     <p>Select a country to view country-specific import information.</p>
 
@@ -56,7 +59,12 @@
 
   <!-- Export tab -->
   <div class="govuk-tabs__panel" id="export">
-    <h2 class="govuk-heading-l"><%= measures_heading(anchor: 'export') %></h2>
+    <h2 class="govuk-heading-m"><%= measures_heading(anchor: 'export') %></h2>
+
+    <% declarable.critical_footnotes.each do |footnote| %>
+      <%= render "footnotes/critical_warning", footnote: footnote %>
+    <% end %>
+
     <p>The commodity code for exporting and <%= link_to 'Intrastat reporting', 'https://www.gov.uk/intrastat', target: "_blank" %> is <%= declarable.display_export_code %>.</p>
 
     <%= render 'declarables/consigned', declarable: declarable %>


### PR DESCRIPTION
### Jira link

[HMRC-2129](https://transformuk.atlassian.net/browse/HMRC-2129)

### What?

- Adds critical footnotes to the import and export tabs
- Corrects "export" tab heading to be consistent font size with import tab heading

### Why?
CDS has made the changes so we can amend of Banner for CCs in Chapter 99

We need to add the same critical footnote to the export tab as requested in the request above. The banner should reflect the message below on the export tab.
