### PR TITLE
Extract shared code search form logic into CodeSearchForm base class

### DIFF
--- a/app/forms/additional_code_search_form.rb
+++ b/app/forms/additional_code_search_form.rb
@@ -1,58 +1,20 @@
-class AdditionalCodeSearchForm
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
+class AdditionalCodeSearchForm < CodeSearchForm
   OPTIONAL_PARAMS = [:@page].freeze
   EXCLUDED_TYPES = %w[6 7 9 D F P].freeze
 
-  attribute :code, :string
-  attribute :description, :string
-
-  validate :validate_code
-  validate :validate_description
-
   attr_writer :page
-
-  def initialize(*args)
-    super(*args)
-
-    sanitize_code!
-  end
-
-  def validate_code
-    if code.present?
-      errors.add(:code, :length) unless code.length == 4
-      errors.add(:code, :invalid_characters) unless code =~ /\A([A-Z]|[0-9]){4}\z/
-      errors.add(:code, :wrong_type) unless type.in?(self.class.possible_types)
-    elsif description.blank?
-      errors.add(:code, :blank)
-    end
-  end
-
-  def validate_description
-    unless description.present? || code.present?
-      errors.add(:description, :blank)
-    end
-  end
 
   def type
     code.to_s[0]
   end
 
-  def to_params
-    {
-      code: code.to_s[1..],
-      type: code.to_s[0],
-      description:,
-    }
-  end
-
   class << self
+    def code_length = 4
+    def type_length = 1
+    def valid_types = possible_types
+
     def possible_types
-      additional_code_type_ids
-        .reject do |additional_code_type_id|
-          EXCLUDED_TYPES.include?(additional_code_type_id)
-        end
+      additional_code_type_ids.reject { |id| EXCLUDED_TYPES.include?(id) }
     end
 
     private
@@ -60,14 +22,5 @@ class AdditionalCodeSearchForm
     def additional_code_type_ids
       @additional_code_type_ids ||= AdditionalCodeType.all.map(&:additional_code_type_id).sort
     end
-  end
-
-  private
-
-  def sanitize_code!
-    return if code.nil?
-
-    code.strip!
-    code.upcase!
   end
 end

--- a/app/forms/certificate_search_form.rb
+++ b/app/forms/certificate_search_form.rb
@@ -1,49 +1,13 @@
-class CertificateSearchForm
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
-  attribute :code, :string
-  attribute :description, :string
-
-  validate :validate_code
-  validate :validate_description
-
-  def validate_code
-    if code.present?
-      sanitize_code!
-
-      errors.add(:code, :length) unless code.length == 4
-      errors.add(:code, :invalid_characters) unless code =~ /\A([A-Z]|[0-9]){4}\z/
-      errors.add(:code, :wrong_type) unless type.in?(self.class.certificate_types)
-    elsif description.blank?
-      errors.add(:code, :blank)
-    end
-  end
-
-  def validate_description
-    errors.add(:description, :blank) if description.blank? && code.blank?
-  end
-
+class CertificateSearchForm < CodeSearchForm
   def type
     code.to_s[0]
   end
 
-  def to_params
-    {
-      code: code.to_s[1..],
-      type:,
-      description:,
-    }
-  end
-
-  private
-
-  def sanitize_code!
-    code.strip!
-    code.upcase!
-  end
-
   class << self
+    def code_length = 4
+    def type_length = 1
+    def valid_types = certificate_types
+
     def certificate_types
       @certificate_types ||= CertificateType.all.map(&:certificate_type_code).sort
     end

--- a/app/forms/code_search_form.rb
+++ b/app/forms/code_search_form.rb
@@ -1,0 +1,52 @@
+class CodeSearchForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :code, :string
+  attribute :description, :string
+
+  validate :validate_code
+  validate :validate_description
+
+  def initialize(attributes = {})
+    super
+    sanitize_code!
+  end
+
+  def type
+    code.to_s[0, self.class.type_length]
+  end
+
+  def to_params
+    {
+      code: code.to_s[self.class.type_length..],
+      type:,
+      description:,
+    }
+  end
+
+  private
+
+  def validate_code
+    if code.present?
+      sanitize_code!
+
+      errors.add(:code, :length) unless code.length == self.class.code_length
+      errors.add(:code, :invalid_characters) unless code.match?(/\A[A-Z0-9]{#{self.class.code_length}}\z/)
+      errors.add(:code, :wrong_type) unless type.in?(self.class.valid_types)
+    elsif description.blank?
+      errors.add(:code, :blank)
+    end
+  end
+
+  def validate_description
+    errors.add(:description, :blank) if description.blank? && code.blank?
+  end
+
+  def sanitize_code!
+    return if code.nil?
+
+    code.strip!
+    code.upcase!
+  end
+end

--- a/app/forms/footnote_search_form.rb
+++ b/app/forms/footnote_search_form.rb
@@ -1,53 +1,9 @@
-class FootnoteSearchForm
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-
-  attribute :code, :string
-  attribute :description, :string
-
-  validate :validate_code
-  validate :validate_description
-
-  def validate_code
-    if code.present?
-      sanitize_code!
-
-      errors.add(:code, :length) unless code.length == 5
-      errors.add(:code, :invalid_characters) unless code =~ /\A([A-Z]|[0-9]){5}\z/
-      errors.add(:code, :wrong_type) unless type.in?(self.class.footnote_types)
-    elsif description.blank?
-      errors.add(:code, :blank)
-    end
-  end
-
-  def validate_description
-    errors.add(:description, :blank) if description.blank? && code.blank?
-  end
-
-  def type
-    code.to_s[0..1]
-  end
-
-  def id
-    code.to_s[2..]
-  end
-
-  def to_params
-    {
-      code: id,
-      type:,
-      description:,
-    }
-  end
-
-  private
-
-  def sanitize_code!
-    code.strip!
-    code.upcase!
-  end
-
+class FootnoteSearchForm < CodeSearchForm
   class << self
+    def code_length = 5
+    def type_length = 2
+    def valid_types = footnote_types
+
     def footnote_types
       @footnote_types ||= FootnoteType.all.map(&:footnote_type_id).sort
     end


### PR DESCRIPTION
## Summary

- `CertificateSearchForm`, `AdditionalCodeSearchForm`, and `FootnoteSearchForm` shared identical attribute declarations, validation logic, `sanitize_code!`, and `to_params` structure
- Extract the common parts into a new `CodeSearchForm` base class, parameterised by three class-level hooks: `code_length`, `type_length`, and `valid_types`
- Each subclass now only declares what is specific to it (its type lookup, any extra attributes like `page`, constants like `EXCLUDED_TYPES`)
- `FootnoteSearchForm#id` removed as dead code — it was only called internally by `to_params`, which now lives in the base class

## Test plan

- [x] All 56 existing form specs pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)