### PR TITLE
HMRC-2141: Force UK geographical area links for XI UK measures

### DIFF
--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -25,6 +25,21 @@ module MeasuresHelper
     sanitize(link, attributes: %w[href target role rel class title])
   end
 
+  def measure_geographical_area_path(measure, service: nil)
+    path_options = {
+      id: measure.geographical_area.id,
+      goods_nomenclature_code: current_goods_nomenclature_code,
+    }
+
+    if service.present?
+      TradeTariffFrontend::ServiceChooser.with_source(service) do
+        geographical_area_path(path_options)
+      end
+    else
+      geographical_area_path(path_options)
+    end
+  end
+
   def measure_type_description_or_link(measure)
     description = measure.measure_type.description
 

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -1,7 +1,7 @@
 <tr id="measure-<%= measure.id %>" class=" govuk-table__row <%= measure.geographical_area.id %>" tabIndex="-1">
   <td class="country-col govuk-table__cell">
     <% if measure.has_children_geographical_areas? %>
-      <%= link_to measure.geographical_area.long_description, geographical_area_path(id: measure.geographical_area.id, goods_nomenclature_code: current_goods_nomenclature_code), class: 'govuk-link' %>
+      <%= link_to measure.geographical_area.long_description, measure_geographical_area_path(measure, service: local_assigns[:geographical_area_link_service]), class: 'govuk-link' %>
     <% else %>
       <%= measure.geographical_area.long_description %>
     <% end %>

--- a/app/views/measures/grouped/_table.html.erb
+++ b/app/views/measures/grouped/_table.html.erb
@@ -39,6 +39,7 @@
                collection: collection,
                locals: {
                  hide_duty_rate: local_assigns[:hide_duty_rate],
+                 geographical_area_link_service: local_assigns[:geographical_area_link_service],
                  roo_schemes: local_assigns[:roo_schemes],
                } %>
   </tbody>

--- a/app/views/measures/grouped/_xi.html.erb
+++ b/app/views/measures/grouped/_xi.html.erb
@@ -47,6 +47,7 @@
     css_id: 'vat_excise',
     uk_declarable: uk_declarable,
     vat_excise: true,
+    geographical_area_link_service: :uk,
     roo_schemes: rules_of_origin_schemes } %>
 <% end %>
 
@@ -65,5 +66,6 @@
     collection: uk_import_measures.import_controls.sort_by(&:key),
     hide_duty_rate: true,
     css_id: 'uk_import_controls',
+    geographical_area_link_service: :uk,
     roo_schemes: rules_of_origin_schemes } %>
 <% end %>

--- a/spec/helpers/measures_helper_spec.rb
+++ b/spec/helpers/measures_helper_spec.rb
@@ -57,6 +57,37 @@ RSpec.describe MeasuresHelper, type: :helper do
     end
   end
 
+  describe '#measure_geographical_area_path' do
+    let(:measure) do
+      build(
+        :measure,
+        geographical_area: attributes_for(:geographical_area, id: '1013', geographical_area_id: '1013', child_area_ids: %w[FR DE]),
+      )
+    end
+
+    context 'when a geographical area link service override is provided' do
+      before do
+        allow(TradeTariffFrontend::ServiceChooser).to receive(:with_source).and_call_original
+      end
+
+      it 'uses the override service when building the path' do
+        helper.measure_geographical_area_path(measure, service: :uk)
+
+        expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:uk)
+      end
+
+      it 'returns the overridden service path' do
+        expect(helper.measure_geographical_area_path(measure, service: :uk)).to eq('/geographical_areas/1013')
+      end
+    end
+
+    context 'when no geographical area link service override is provided' do
+      it 'uses the current service path' do
+        expect(helper.measure_geographical_area_path(measure)).to eq('/geographical_areas/1013')
+      end
+    end
+  end
+
   describe '#measure_type_description_or_link' do
     context 'when preference code is present' do
       before do

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe 'Commodity page', type: :request do
 
   shared_examples_for 'loads the correct uk declarables' do
     it { expect(TradeTariffFrontend::ServiceChooser).not_to have_received(:with_source).with(:xi) }
-    it { expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:uk) }
+    it { expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:uk).at_least(:once) }
   end
 
   shared_examples_for 'loads the correct xi declarables' do
-    it { expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:xi) }
-    it { expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:uk) }
+    it { expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:xi).at_least(:once) }
+    it { expect(TradeTariffFrontend::ServiceChooser).to have_received(:with_source).with(:uk).at_least(:once) }
   end
 
   it_behaves_like 'loads the correct uk declarables' do

--- a/spec/views/measures/_measure.html.erb_spec.rb
+++ b/spec/views/measures/_measure.html.erb_spec.rb
@@ -31,6 +31,31 @@ RSpec.describe 'measures/_measure', type: :view, vcr: { cassette_name: 'geograph
     it { expect(rendered).to match(/Hectokilogram/) }
   end
 
+  context 'when rendering a UK geographical area link override on the XI service' do
+    let(:measure) do
+      build(
+        :measure,
+        :eu,
+        geographical_area: attributes_for(:geographical_area, id: '1013', geographical_area_id: '1013', description: 'European Union', child_area_ids: %w[FR DE]),
+      )
+    end
+
+    before do
+      TradeTariffFrontend::ServiceChooser.with_source(:xi) do
+        render 'measures/measure',
+               measure: MeasurePresenter.new(measure),
+               roo_schemes: [],
+               geographical_area_link_service: :uk
+      end
+    end
+
+    it 'links to the UK geographical area page' do
+      href = Capybara.string(rendered).find('td.country-col a.govuk-link', text: 'European Union', match: :first).native['href']
+
+      expect(href).to eq('/geographical_areas/1013')
+    end
+  end
+
   context 'with a prohibitive measure that has an additional code' do
     let(:measure) { build(:measure, :prohibitive, :with_additional_code) }
 


### PR DESCRIPTION
### Jira link

[HMRC-2141](https://transformuk.atlassian.net/browse/HMRC-2141)

<img width="633" height="595" alt="image" src="https://github.com/user-attachments/assets/a1dc51b9-b69f-43f1-8c10-281b1b18b4b5" />


### What?

- [x] add a helper that forces UK geographical area paths for UK measures when rendered on the XI service
- [x] switch measure-row geographical area links to use that helper
- [x] cover the helper behaviour with spec coverage

### Why?

UK measures shown on XI commodity pages were linking to XI geographical area pages, which breaks for groups that only exist on the UK service.