### PR TITLE
Extract shared initialisation logic from search presenters into SearchResultsPresenter

### DIFF
--- a/app/presenters/certificate_search_presenter.rb
+++ b/app/presenters/certificate_search_presenter.rb
@@ -1,11 +1,3 @@
-class CertificateSearchPresenter
-  attr_reader :search_form, :search_result, :with_errors
-
-  def initialize(search_form)
-    @with_errors = false
-    @search_form = search_form
-    @search_result = Certificate.search(search_form.to_params) if search_form.present?
-  rescue StandardError
-    @with_errors = true
-  end
+class CertificateSearchPresenter < SearchResultsPresenter
+  def self.model_class = Certificate
 end

--- a/app/presenters/chemical_search_presenter.rb
+++ b/app/presenters/chemical_search_presenter.rb
@@ -1,13 +1,9 @@
-class ChemicalSearchPresenter
-  attr_reader :search_form, :search_result, :with_errors
+class ChemicalSearchPresenter < SearchResultsPresenter
+  def self.model_class = Chemical
 
-  def initialize(search_form)
-    @with_errors = false
-    @search_form = search_form
-    @search_result = Chemical.search(search_form.to_params) if search_form.present?
-  rescue Faraday::ResourceNotFound
+  private
+
+  def handle_resource_not_found
     # noop - swallow a 404 here so that the UI can display a message to the user
-  rescue StandardError
-    @with_errors = true
   end
 end

--- a/app/presenters/footnote_search_presenter.rb
+++ b/app/presenters/footnote_search_presenter.rb
@@ -1,11 +1,3 @@
-class FootnoteSearchPresenter
-  attr_reader :search_form, :search_result, :with_errors
-
-  def initialize(search_form)
-    @with_errors = false
-    @search_form = search_form
-    @search_result = Footnote.search(search_form.to_params) if search_form.present?
-  rescue StandardError
-    @with_errors = true
-  end
+class FootnoteSearchPresenter < SearchResultsPresenter
+  def self.model_class = Footnote
 end

--- a/app/presenters/quota_search_presenter.rb
+++ b/app/presenters/quota_search_presenter.rb
@@ -1,11 +1,4 @@
-class QuotaSearchPresenter
-  attr_reader :search_form, :search_result, :with_errors
-
-  def initialize(search_form)
-    @with_errors = false
-    @search_form = search_form
-    @search_result = search_form.present? ? OrderNumber::Definition.search(search_form.to_params) : []
-  rescue StandardError
-    @with_errors = true
-  end
+class QuotaSearchPresenter < SearchResultsPresenter
+  def self.model_class = OrderNumber::Definition
+  def self.empty_result = []
 end

--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -1,0 +1,27 @@
+class SearchResultsPresenter
+  attr_reader :search_form, :search_result, :with_errors
+
+  def initialize(search_form)
+    @with_errors = false
+    @search_form = search_form
+    @search_result = search_form.present? ? self.class.model_class.search(search_form.to_params) : self.class.empty_result
+  rescue Faraday::ResourceNotFound
+    handle_resource_not_found
+  rescue StandardError
+    @with_errors = true
+  end
+
+  class << self
+    def model_class
+      raise NotImplementedError, "#{name} must define model_class"
+    end
+
+    def empty_result = nil
+  end
+
+  private
+
+  def handle_resource_not_found
+    @with_errors = true
+  end
+end


### PR DESCRIPTION
## Summary

- Introduces a new `SearchResultsPresenter` base class that captures the repeated `attr_reader`, `with_errors` flag, and `search` call shared by all four search presenters
- `CertificateSearchPresenter`, `FootnoteSearchPresenter`, `QuotaSearchPresenter`, and `ChemicalSearchPresenter` are each reduced to a minimal subclass declaring only what makes them unique
- Subclass variation is handled via two override points: `model_class` (required), `empty_result` (defaults to `nil`; Quota overrides to `[]`), and `handle_resource_not_found` (defaults to setting `with_errors = true`; Chemical overrides to noop to allow the UI to display a message on 404)

## Test plan

- [x] `spec/controllers/search_chemical_search_controller_spec.rb` — 21 examples, 0 failures
- [x] `spec/controllers/search_controller_quotas_spec.rb` — included in above run
- [x] `spec/controllers/search_controller_search_spec.rb` — 55 examples, 0 failures
- [x] All 76 examples across the three spec files pass with no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)