### PR TITLE
Add Pry debugging tip to README troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ yarn cache clean
 bin/rails setup
 ```
 
+### Debugging Locally with Pry
+
+To drop into a debugger mid-request, add `binding.pry` to any Ruby file and run the server with `bin/rails server`. The terminal where the server is running will pause at that line and drop into a Pry REPL, where you can inspect state and step through logic interactively.
+
 ### Disabling Continuous Deployments
 
 We continuously deploy our frontend application to production after a staging deployment passes some end-to-end tests.


### PR DESCRIPTION
## Summary

- Adds a short **Debugging Locally with Pry** subsection to the Troubleshooting section of the README
- Explains how to use `binding.pry` to pause mid-request and inspect state in a REPL

## Why

The README already covers common setup, running tests, and a known Webpacker error, but has no guidance on interactive debugging. Pry is a standard tool in the Rails/Ruby ecosystem and a likely first port of call for developers working through unfamiliar code paths in this app. Adding this tip makes the README more useful as a day-to-day reference without adding noise.

## Test plan

- [ ] Confirm the new section renders correctly in the GitHub README preview
- [ ] No functional code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)