### PR TITLE
OTTIMP-270: Add accessible autocomplete to Green Lanes country select

### DIFF
--- a/app/javascript/controllers/country_select_box_controller.js
+++ b/app/javascript/controllers/country_select_box_controller.js
@@ -5,6 +5,7 @@ import Utility from 'utility';
 
 export default class extends Controller {
   static targets = ['countrySelect'];
+  static values = { autoSubmit: { type: Boolean, default: true } };
 
   clearSelect(event) {
     event.currentTarget.value = '';
@@ -56,7 +57,14 @@ export default class extends Controller {
       source: function(query, populateResults) {
         populateResults(matcher(query, element));
       },
-      onConfirm: (confirmed) => Utility.countrySelectorOnConfirm(confirmed, this.selectElement),
+      onConfirm: (confirmed) => {
+        if (this.autoSubmitValue) {
+          Utility.countrySelectorOnConfirm(confirmed, this.selectElement);
+        } else {
+          const matchedOption = [...this.selectElement.options].find((o) => o.text === confirmed);
+          if (matchedOption) this.selectElement.value = matchedOption.value;
+        }
+      },
     });
   }
 

--- a/app/views/green_lanes/moving_requirements/new.html.erb
+++ b/app/views/green_lanes/moving_requirements/new.html.erb
@@ -26,17 +26,21 @@
                                    },
                              style: "width:330px" %>
 
-      <%= f.govuk_collection_select :country_of_origin,
-                              GreenLanes::CategoryAssessmentSearch.country_options,
-                              :long_description,
-                              :long_description,
-                              options: { include_blank: '' },
-                              label: { text: "What is the non-preferential origin of your goods?", size: 'm' },
-                              hint: { text: "The non-preferential origin will affect the category your goods are assigned. " \
-                                            "If you are unsure, <a href='https://www.trade-tariff.service.gov.uk/howto/origin' target='_blank' rel='noopener noreferrer'>" \
-                                            "find out how to determine the non-preferential origin of goods (opens in a new tab).</a>".html_safe
-                                    },
-                              style: "width:330px" %>
+      <div data-controller="country-select-box" data-country-select-box-auto-submit-value="false">
+        <div data-country-select-box-target="countrySelect">
+          <%= f.govuk_collection_select :country_of_origin,
+                                  GreenLanes::CategoryAssessmentSearch.country_options,
+                                  :long_description,
+                                  :long_description,
+                                  options: { include_blank: '' },
+                                  label: { text: "What is the non-preferential origin of your goods?", size: 'm' },
+                                  hint: { text: "The non-preferential origin will affect the category your goods are assigned. " \
+                                                "If you are unsure, <a href='https://www.trade-tariff.service.gov.uk/howto/origin' target='_blank' rel='noopener noreferrer'>" \
+                                                "find out how to determine the non-preferential origin of goods (opens in a new tab).</a>".html_safe
+                                        },
+                                  style: "width:330px" %>
+        </div>
+      </div>
 
       <%= f.label :commodity_code, "When is the internal movement of goods taking place?", class: 'govuk-heading-m',
                   for: 'green_lanes_moving_requirements_form_moving_date_3' %>

--- a/spec/features/green_lanes_category_assessments_spec.rb
+++ b/spec/features/green_lanes_category_assessments_spec.rb
@@ -268,7 +268,9 @@ RSpec.describe 'Green lanes category assessments', :js, vcr: { cassette_name: 'g
     expect(page).to have_selector('#new_green_lanes_moving_requirements_form')
 
     fill_in 'green-lanes-moving-requirements-form-commodity-code-field', with: commodity_code
-    select country, from: 'green-lanes-moving-requirements-form-country-of-origin-field'
+    fill_in 'green-lanes-moving-requirements-form-country-of-origin-field', with: country
+    option = find('.autocomplete__option', text: country, exact_text: true)
+    execute_script('arguments[0].click()', option)
     fill_in 'green_lanes_moving_requirements_form_moving_date_3', with: date[:day]
     fill_in 'green_lanes_moving_requirements_form_moving_date_2', with: date[:month]
     fill_in 'green_lanes_moving_requirements_form_moving_date_1', with: date[:year]


### PR DESCRIPTION
## Context

[OTTIMP-270](https://transformuk.atlassian.net/browse/OTTIMP-270) explored whether the commodity page country picker and the Green Lanes moving requirements country select could share a common component.


## Why the components can't be shared

The two selects are fundamentally different in purpose:

| | Commodity `_country_picker` | Green Lanes select |
|---|---|---|
| Form type | Standalone GET filter form | Multi-field POST form bound to `MovingRequirementsForm` |
| On confirm | Auto-navigates/submits via `Utility.countrySelectorOnConfirm` | User fills other fields then clicks Continue — must not auto-submit |
| Data source | `GeographicalArea.country_options` → `[label, id]` pairs | XI-service `GeographicalArea` objects, `long_description` as both value and text |
| GDS compliant? | Fixed in #2884 | Already compliant via `govuk_collection_select` |

The `Utility.countrySelectorOnConfirm` callback reads `.commodity-header` from the DOM (commodity-page-specific) and immediately navigates. Wiring this into the Green Lanes multi-field form would be wrong behaviour — the user should complete all fields before submitting.

A shared ERB partial or ViewComponent would need to be so heavily parameterised (different field names, data sources, submit behaviours, form contexts) that it would share nothing meaningful.

## What this PR does

Adds the accessible autocomplete enhancement to the Green Lanes country of origin select, keeping the components independent:

**`country_select_box_controller.js`**
- Adds a Stimulus `autoSubmit` value (default: `true`) so the controller can be used in contexts where auto-submit on confirm is not desired
- When `autoSubmit` is `false`, `onConfirm` syncs the selected value back to the underlying select element only — no navigation, no form submission
- Commodity page behaviour is completely unchanged (default remains `true`)

**`green_lanes/moving_requirements/new.html.erb`**
- Wraps `govuk_collection_select` in the Stimulus controller divs with `data-country-select-box-auto-submit-value="false"`
- `govuk_collection_select` continues to own GDS compliance (label, hint, error state)

## Test plan

- [ ] Green Lanes moving requirements form — accessible autocomplete typeahead appears on the country of origin field
- [ ] Selecting a country populates the field without submitting the form
- [ ] Form validation on `country_of_origin` still works (leave blank, submit, error appears)
- [ ] Commodity page country picker — autocomplete and auto-submit behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


https://github.com/user-attachments/assets/2de45841-513f-49f7-96b9-972ecbbd123c