### PR TITLE
OTTIMP-474: Live issues status sorting

### DIFF
--- a/app/controllers/live_issues_controller.rb
+++ b/app/controllers/live_issues_controller.rb
@@ -5,34 +5,10 @@ class LiveIssuesController < ApplicationController
 
   def index
     @sort_direction = sort_direction
-    @live_issues = sorted_live_issues
+    @live_issues = LiveIssue.sorted_by_status(@sort_direction)
   end
 
 private
-
-  def sorted_live_issues
-    LiveIssue.all.sort_by do |live_issue|
-      [status_sort_rank(live_issue), -updated_at_sort_value(live_issue)]
-    end
-  end
-
-  def status_sort_rank(live_issue)
-    active_status = live_issue.status.to_s.casecmp('active').zero?
-
-    if @sort_direction == 'desc'
-      active_status ? 1 : 0
-    else
-      active_status ? 0 : 1
-    end
-  end
-
-  def updated_at_sort_value(live_issue)
-    return 0 if live_issue.updated_at.blank?
-
-    live_issue.updated_at.to_time.to_i
-  rescue ArgumentError, NoMethodError
-    0
-  end
 
   def sort_direction
     params[:sort] == 'desc' ? 'desc' : 'asc'

--- a/app/controllers/live_issues_controller.rb
+++ b/app/controllers/live_issues_controller.rb
@@ -4,6 +4,37 @@ class LiveIssuesController < ApplicationController
                 :disable_search_form
 
   def index
-    @live_issues = LiveIssue.all
+    @sort_direction = sort_direction
+    @live_issues = sorted_live_issues
+  end
+
+private
+
+  def sorted_live_issues
+    LiveIssue.all.sort_by do |live_issue|
+      [status_sort_rank(live_issue), -updated_at_sort_value(live_issue)]
+    end
+  end
+
+  def status_sort_rank(live_issue)
+    active_status = live_issue.status.to_s.casecmp('active').zero?
+
+    if @sort_direction == 'desc'
+      active_status ? 1 : 0
+    else
+      active_status ? 0 : 1
+    end
+  end
+
+  def updated_at_sort_value(live_issue)
+    return 0 if live_issue.updated_at.blank?
+
+    live_issue.updated_at.to_time.to_i
+  rescue ArgumentError, NoMethodError
+    0
+  end
+
+  def sort_direction
+    params[:sort] == 'desc' ? 'desc' : 'asc'
   end
 end

--- a/app/helpers/live_issue_helper.rb
+++ b/app/helpers/live_issue_helper.rb
@@ -3,10 +3,33 @@ module LiveIssueHelper
     raw Kramdown::Document.new(markdown).to_html
   end
 
+  def live_issue_status_sort_link(sort_direction)
+    current_direction = sort_direction == 'desc' ? 'desc' : 'asc'
+    next_direction = current_direction == 'asc' ? 'desc' : 'asc'
+
+    link_to live_issues_path(sort: next_direction), class: 'govuk-link govuk-link--no-visited-state' do
+      safe_join([
+        'Status',
+        tag.span(sort_arrow(current_direction), aria: { hidden: true }),
+        tag.span("sorted #{sort_direction_label(current_direction)}", class: 'govuk-visually-hidden'),
+      ], ' ')
+    end
+  end
+
   def live_issue_from_to_date(live_issue)
     from = live_issue.date_discovered.to_date.to_formatted_s(:long)
     to = live_issue.date_resolved ? live_issue.date_resolved&.to_date&.to_formatted_s(:long) : 'Present'
 
     "#{from} - #{to}"
+  end
+
+private
+
+  def sort_arrow(direction)
+    (direction == 'desc' ? '&#8595;' : '&#8593;').html_safe
+  end
+
+  def sort_direction_label(direction)
+    direction == 'desc' ? 'descending' : 'ascending'
   end
 end

--- a/app/models/live_issue.rb
+++ b/app/models/live_issue.rb
@@ -9,4 +9,32 @@ class LiveIssue
                 :date_discovered,
                 :date_resolved,
                 :updated_at
+
+  class << self
+    def sorted_by_status(sort_direction = 'asc')
+      all.sort_by do |live_issue|
+        [status_sort_rank(live_issue, sort_direction), -updated_at_sort_value(live_issue)]
+      end
+    end
+
+  private
+
+    def status_sort_rank(live_issue, sort_direction)
+      active_status = live_issue.status.to_s.casecmp('active').zero?
+
+      if sort_direction == 'desc'
+        active_status ? 1 : 0
+      else
+        active_status ? 0 : 1
+      end
+    end
+
+    def updated_at_sort_value(live_issue)
+      return 0 if live_issue.updated_at.blank?
+
+      live_issue.updated_at.to_time.to_i
+    rescue ArgumentError, NoMethodError
+      0
+    end
+  end
 end

--- a/app/views/live_issues/index.html.erb
+++ b/app/views/live_issues/index.html.erb
@@ -14,13 +14,13 @@
       <th scope="col" class="govuk-table__header">Issue</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Description</th>
       <th scope="col" class="govuk-table__header">Commodities</th>
-      <th scope="col" class="govuk-table__header">Status</th>
+      <th scope="col" class="govuk-table__header"><%= live_issue_status_sort_link(@sort_direction) %></th>
       <th scope="col" class="govuk-table__header">Dates</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Suggested action</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% @live_issues.sort{|l| l.updated_at.to_date}.each do |live_issue| %>
+  <% @live_issues.each do |live_issue| %>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header"> <%= live_issue.title %>
         <div class="govuk-!-font-size-14 govuk-!-margin-top-5 govuk-!-text-colour-muted">

--- a/spec/controllers/live_issues_controller_spec.rb
+++ b/spec/controllers/live_issues_controller_spec.rb
@@ -2,19 +2,10 @@ RSpec.describe LiveIssuesController, type: :controller do
   subject(:perform_request) { get :index, params: params }
 
   let(:params) { {} }
-  let(:live_issues) do
-    [
-      attributes_for(:live_issue, title: 'Resolved newer', status: 'Resolved', updated_at: '2025-07-16T12:00:00Z'),
-      attributes_for(:live_issue, title: 'Active older', status: 'Active', updated_at: '2025-07-14T12:00:00Z'),
-      attributes_for(:live_issue, title: 'Resolved older', status: 'Resolved', updated_at: '2025-07-13T12:00:00Z'),
-      attributes_for(:live_issue, title: 'Active newer', status: 'Active', updated_at: '2025-07-15T12:00:00Z'),
-    ]
-  end
+  let(:sorted_live_issues) { build_list(:live_issue, 2) }
 
   before do
-    stub_api_request('live_issues')
-      .to_return jsonapi_response(:live_issues, live_issues)
-
+    allow(LiveIssue).to receive(:sorted_by_status).and_return(sorted_live_issues)
     perform_request
   end
 
@@ -26,41 +17,29 @@ RSpec.describe LiveIssuesController, type: :controller do
     expect(response).to render_template(:index)
   end
 
-  it 'assigns live issues sorted with active issues first and updated_at descending', :aggregate_failures do
-    expect(assigns(:live_issues)).to all(be_a(LiveIssue))
-    expect(assigns(:live_issues).map(&:title)).to eq([
-      'Active newer',
-      'Active older',
-      'Resolved newer',
-      'Resolved older',
-    ])
+  it 'assigns the sorted live issues with the default sort direction', :aggregate_failures do
+    expect(assigns(:live_issues)).to eq(sorted_live_issues)
     expect(assigns(:sort_direction)).to eq('asc')
+    expect(LiveIssue).to have_received(:sorted_by_status).with('asc')
   end
 
   context 'when sorting the status column descending' do
     let(:params) { { sort: 'desc' } }
 
-    it 'moves active issues to the end and still sorts updated_at descending within each status', :aggregate_failures do
-      expect(assigns(:live_issues).map(&:title)).to eq([
-        'Resolved newer',
-        'Resolved older',
-        'Active newer',
-        'Active older',
-      ])
+    it 'passes the descending sort direction to the model', :aggregate_failures do
+      expect(assigns(:live_issues)).to eq(sorted_live_issues)
       expect(assigns(:sort_direction)).to eq('desc')
+      expect(LiveIssue).to have_received(:sorted_by_status).with('desc')
     end
   end
 
   context 'when an unknown sort direction is provided' do
     let(:params) { { sort: 'sideways' } }
 
-    it 'falls back to the default status sort' do
-      expect(assigns(:live_issues).map(&:title)).to eq([
-        'Active newer',
-        'Active older',
-        'Resolved newer',
-        'Resolved older',
-      ])
+    it 'falls back to the default status sort', :aggregate_failures do
+      expect(assigns(:live_issues)).to eq(sorted_live_issues)
+      expect(assigns(:sort_direction)).to eq('asc')
+      expect(LiveIssue).to have_received(:sorted_by_status).with('asc')
     end
   end
 end

--- a/spec/controllers/live_issues_controller_spec.rb
+++ b/spec/controllers/live_issues_controller_spec.rb
@@ -1,21 +1,66 @@
 RSpec.describe LiveIssuesController, type: :controller do
-  subject { response }
+  subject(:perform_request) { get :index, params: params }
+
+  let(:params) { {} }
+  let(:live_issues) do
+    [
+      attributes_for(:live_issue, title: 'Resolved newer', status: 'Resolved', updated_at: '2025-07-16T12:00:00Z'),
+      attributes_for(:live_issue, title: 'Active older', status: 'Active', updated_at: '2025-07-14T12:00:00Z'),
+      attributes_for(:live_issue, title: 'Resolved older', status: 'Resolved', updated_at: '2025-07-13T12:00:00Z'),
+      attributes_for(:live_issue, title: 'Active newer', status: 'Active', updated_at: '2025-07-15T12:00:00Z'),
+    ]
+  end
 
   before do
     stub_api_request('live_issues')
       .to_return jsonapi_response(:live_issues, live_issues)
 
-    get :index
+    perform_request
   end
 
-  let(:live_issues) { attributes_for_list(:live_issue, 2) }
+  it 'returns a successful response' do
+    expect(response).to have_http_status(:success)
+  end
 
-  it { is_expected.to have_http_status(:success) }
-  it { is_expected.to render_template(:index) }
+  it 'renders the index template' do
+    expect(response).to render_template(:index)
+  end
 
-  it 'assigns @live_issues', :aggregate_failures do
-    expect(assigns(:live_issues)).to be_present
-    expect(assigns(:live_issues).length).to eq(2)
-    expect(assigns(:live_issues).first).to be_a(LiveIssue)
+  it 'assigns live issues sorted with active issues first and updated_at descending', :aggregate_failures do
+    expect(assigns(:live_issues)).to all(be_a(LiveIssue))
+    expect(assigns(:live_issues).map(&:title)).to eq([
+      'Active newer',
+      'Active older',
+      'Resolved newer',
+      'Resolved older',
+    ])
+    expect(assigns(:sort_direction)).to eq('asc')
+  end
+
+  context 'when sorting the status column descending' do
+    let(:params) { { sort: 'desc' } }
+
+    it 'moves active issues to the end and still sorts updated_at descending within each status', :aggregate_failures do
+      expect(assigns(:live_issues).map(&:title)).to eq([
+        'Resolved newer',
+        'Resolved older',
+        'Active newer',
+        'Active older',
+      ])
+      expect(assigns(:sort_direction)).to eq('desc')
+    end
+  end
+
+  context 'when an unknown sort direction is provided' do
+    let(:params) { { sort: 'sideways' } }
+
+    it 'falls back to the default status sort' do
+      expect(assigns(:live_issues).map(&:title)).to eq([
+        'Active newer',
+        'Active older',
+        'Resolved newer',
+        'Resolved older',
+      ])
+    end
   end
 end

--- a/spec/helpers/live_issue_helper_spec.rb
+++ b/spec/helpers/live_issue_helper_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe LiveIssue, type: :helper do
+RSpec.describe LiveIssueHelper, type: :helper do
   describe '#markdown_field' do
     subject(:markdown_field) { helper.markdown_field(markdown) }
 
@@ -25,6 +25,46 @@ RSpec.describe LiveIssue, type: :helper do
       let(:date_resolved) { nil }
 
       it { is_expected.to eq('15 July 2025 - Present') }
+    end
+  end
+
+  describe '#live_issue_status_sort_link' do
+    subject(:sort_link) { Capybara.string(helper.live_issue_status_sort_link(sort_direction)) }
+
+    context 'when the status column is sorted ascending' do
+      let(:sort_direction) { 'asc' }
+
+      it 'links to the descending sort direction' do
+        expect(sort_link).to have_link(href: live_issues_path(sort: 'desc'))
+      end
+
+      it 'shows the status label' do
+        expect(sort_link).to have_link('Status', href: live_issues_path(sort: 'desc'))
+      end
+
+      it 'shows the ascending arrow' do
+        expect(sort_link).to have_css('span[aria-hidden="true"]', text: '↑')
+      end
+
+      it 'shows the ascending helper text' do
+        expect(sort_link).to have_css('.govuk-visually-hidden', text: 'sorted ascending')
+      end
+    end
+
+    context 'when the status column is sorted descending' do
+      let(:sort_direction) { 'desc' }
+
+      it 'links to the ascending sort direction' do
+        expect(sort_link).to have_link(href: live_issues_path(sort: 'asc'))
+      end
+
+      it 'shows the descending arrow' do
+        expect(sort_link).to have_css('span[aria-hidden="true"]', text: '↓')
+      end
+
+      it 'shows the descending helper text' do
+        expect(sort_link).to have_css('.govuk-visually-hidden', text: 'sorted descending')
+      end
     end
   end
 end

--- a/spec/models/live_issue_spec.rb
+++ b/spec/models/live_issue_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe LiveIssue do
+  describe '.sorted_by_status' do
+    let(:resolved_newer) { build(:live_issue, title: 'Resolved newer', status: 'Resolved', updated_at: '2025-07-16T12:00:00Z') }
+    let(:active_older) { build(:live_issue, title: 'Active older', status: 'Active', updated_at: '2025-07-14T12:00:00Z') }
+    let(:resolved_older) { build(:live_issue, title: 'Resolved older', status: 'Resolved', updated_at: '2025-07-13T12:00:00Z') }
+    let(:active_newer) { build(:live_issue, title: 'Active newer', status: 'Active', updated_at: '2025-07-15T12:00:00Z') }
+    let(:active_without_timestamp) { build(:live_issue, title: 'Active without timestamp', status: 'Active', updated_at: nil) }
+    let(:live_issues) do
+      [
+        resolved_newer,
+        active_older,
+        resolved_older,
+        active_newer,
+        active_without_timestamp,
+      ]
+    end
+
+    before do
+      allow(described_class).to receive(:all).and_return(live_issues)
+    end
+
+    it 'sorts active issues first and updated_at descending within each status for ascending sort' do
+      expect(described_class.sorted_by_status('asc').map(&:title)).to eq([
+        'Active newer',
+        'Active older',
+        'Active without timestamp',
+        'Resolved newer',
+        'Resolved older',
+      ])
+    end
+
+    it 'sorts active issues last and updated_at descending within each status for descending sort' do
+      expect(described_class.sorted_by_status('desc').map(&:title)).to eq([
+        'Resolved newer',
+        'Resolved older',
+        'Active newer',
+        'Active older',
+        'Active without timestamp',
+      ])
+    end
+  end
+end

--- a/spec/views/live_issues/index.html.erb_spec.rb
+++ b/spec/views/live_issues/index.html.erb_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe 'live_issues/index', type: :view do
         updated_at: Time.zone.parse('2025-07-15'),
       ),
     ]
+    assign :sort_direction, 'asc'
   end
 
   it { is_expected.to have_css 'th > div', text: '15 July 2025' }
   it { is_expected.to have_css 'h1#kramdown', text: 'Kramdown' }
+  it { is_expected.to have_link 'Status', href: live_issues_path(sort: 'desc') }
   it { is_expected.to render_template 'live_issues/_commodities' }
 end


### PR DESCRIPTION
### Jira link

[OTTIMP-474](https://transformuk.atlassian.net/browse/OTTIMP-474)

### What?

Server-side sorting for the Live Issues log: default order is **Active** issues first, then **Resolved**, with **newest `updated_at` first** within each group. The **Status** column header links between that order and the inverse (**Resolved** first, still newest-within-group for Active). Uses `?sort=desc` to toggle; no client-side table sorting.

### Why?

So users can see open issues at the top by default and switch to resolved-first when they need it