### PR TITLE
Allow unauthenticated MyOTT user to return to specific page

### DIFF
--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -1,5 +1,7 @@
 module Myott
   class MyottController < ApplicationController
+    RETURN_KEY = :myott_return_url
+
     before_action :authenticate,
                   :disable_search_form,
                   :disable_switch_service_banner,
@@ -11,17 +13,26 @@ module Myott
 
     def authenticate
       if current_user.nil?
+        set_return_url
         redirect_to myott_start_path
-      elsif session[:myott_return_url]
-        redirect_to(session.delete(:myott_return_url))
+      elsif (path = return_url)
+        redirect_to(path)
       end
     end
 
     def handle_authentication_error(error)
       clear_authentication_cookies if error.should_clear_cookies?
 
-      session[:myott_return_url] = request.fullpath
+      set_return_url
       redirect_to(URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s, allow_other_host: true)
+    end
+
+    def return_url
+      session.delete(RETURN_KEY)
+    end
+
+    def set_return_url
+      session[RETURN_KEY] = request.fullpath
     end
 
     def clear_authentication_cookies

--- a/spec/controllers/myott/myott_controller_spec.rb
+++ b/spec/controllers/myott/myott_controller_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Myott::MyottController, type: :controller do
   include MyottAuthenticationHelpers
 
+  let(:return_key) { described_class::RETURN_KEY }
+
   describe '#current_user' do
     let(:user) { build(:user) }
     let(:id_token) { 'encrypted_token' }
@@ -94,8 +96,17 @@ RSpec.describe Myott::MyottController, type: :controller do
     end
 
     context 'when current_user is nil' do
+      let(:request_fullpath) { '/myott/commodities/123' }
+
       before do
         allow(controller).to receive(:current_user).and_return(nil)
+        allow(controller.request).to receive(:fullpath).and_return(request_fullpath)
+      end
+
+      it 'stores the current path in session' do
+        controller.send(:authenticate)
+
+        expect(controller.session[return_key]).to eq(request_fullpath)
       end
 
       it 'redirects to the start page' do
@@ -111,7 +122,7 @@ RSpec.describe Myott::MyottController, type: :controller do
 
       before do
         allow(controller).to receive(:current_user).and_return(user)
-        controller.session[:myott_return_url] = return_url
+        controller.session[return_key] = return_url
       end
 
       it 'redirects to the stored return URL' do
@@ -123,7 +134,7 @@ RSpec.describe Myott::MyottController, type: :controller do
       it 'removes the return URL from session' do
         controller.send(:authenticate)
 
-        expect(controller.session[:myott_return_url]).to be_nil
+        expect(controller.session[return_key]).to be_nil
       end
     end
 
@@ -132,7 +143,7 @@ RSpec.describe Myott::MyottController, type: :controller do
 
       before do
         allow(controller).to receive(:current_user).and_return(user)
-        controller.session[:myott_return_url] = nil
+        controller.session[return_key] = nil
       end
 
       it 'does not redirect' do
@@ -149,7 +160,7 @@ RSpec.describe Myott::MyottController, type: :controller do
     let(:error) { AuthenticationError.new('Authentication failed', reason: error_reason) }
 
     before do
-      allow(controller).to receive(:request).and_return(instance_double(ActionDispatch::Request, fullpath: request_fullpath))
+      allow(controller.request).to receive(:fullpath).and_return(request_fullpath)
       allow(TradeTariffFrontend).to receive(:identity_base_url).and_return(identity_base_url)
       allow(controller).to receive(:redirect_to)
       allow(controller).to receive(:clear_authentication_cookies)
@@ -167,7 +178,7 @@ RSpec.describe Myott::MyottController, type: :controller do
       it 'stores the current URL in session' do
         controller.send(:handle_authentication_error, error)
 
-        expect(controller.session[:myott_return_url]).to eq(request_fullpath)
+        expect(controller.session[return_key]).to eq(request_fullpath)
       end
 
       it 'redirects to identity service' do
@@ -190,7 +201,7 @@ RSpec.describe Myott::MyottController, type: :controller do
       it 'stores the current URL in session' do
         controller.send(:handle_authentication_error, error)
 
-        expect(controller.session[:myott_return_url]).to eq(request_fullpath)
+        expect(controller.session[return_key]).to eq(request_fullpath)
       end
 
       it 'redirects to identity service' do


### PR DESCRIPTION
### What?

When a user's myott auth cookie is no longer valid we store their location so they can return to the same page after logging in.
This should also happen if the user does not have a cookie.
