### PR TITLE
HMRC:-1965: Remove HTTP fallback and tighten security groups - change container port

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -27,7 +27,6 @@ Terraform to deploy the service into AWS.
 |------|------|
 | [aws_iam_policy.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_document.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_lb_target_group.this_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_secretsmanager_secret.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -13,10 +13,6 @@ data "aws_subnets" "private" {
   }
 }
 
-data "aws_lb_target_group" "this" {
-  name = "frontend"
-}
-
 data "aws_lb_target_group" "this_https" {
   name = "frontend-https"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,16 +9,9 @@ module "service" {
   cluster_name    = "trade-tariff-cluster-${var.environment}"
   subnet_ids      = data.aws_subnets.private.ids
   security_groups = [data.aws_security_group.this.id]
-  target_group_mappings = [
-    {
-      target_group_arn = data.aws_lb_target_group.this.arn
-      container_port   = 8080
-    },
-    {
-      target_group_arn = data.aws_lb_target_group.this_https.arn
-      container_port   = 8443
-    },
-  ]
+
+  target_group_arn = data.aws_lb_target_group.this_https.arn
+  container_port   = 8443
 
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
 


### PR DESCRIPTION
# Jira link
[HMRC-1965](https://transformuk.atlassian.net/browse/HMRC-1965)

## What?
Remove the HTTP listener from all services and close port 8080 in security groups. After this, only encrypted HTTPS traffic reaches the containers.

I have:
- Update PORT environment variable to 8443

## Why?

I am doing this because:

- Only encrypted HTTPS traffic allowed in ecs cluster
