### PR TITLE
HMRC:-1965: Remove HTTP fallback and tighten security groups - change docker port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN apk add --no-cache \
 
 ENV RAILS_SERVE_STATIC_FILES=true \
     RAILS_ENV=production \
-    PORT=8080 \
+    SSL_PORT=8443 \
     TZ=Europe/London
 
 RUN addgroup -S tariff && \
@@ -62,11 +62,10 @@ USER tariff
 COPY --chown=tariff:tariff --from=builder /build .
 COPY --chown=tariff:tariff --from=builder /usr/local/bundle/ /usr/local/bundle/
 
-EXPOSE 8080
+EXPOSE 8443
 
-HEALTHCHECK CMD nc -z 0.0.0.0 $PORT
+HEALTHCHECK CMD nc -z 0.0.0.0 $SSL_PORT
 
-#CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 
 #### End production image #####


### PR DESCRIPTION
# Jira link
[HMRC-1965](https://transformuk.atlassian.net/browse/HMRC-1965)

## What?
Remove the HTTP listener from all services and close port 8080 in security groups. After this, only encrypted HTTPS traffic reaches the containers.

I have:
- Update Dockerfile HEALTHCHECK to check port 8443

## Why?

I am doing this because:

- Only encrypted HTTPS traffic allowed in ecs cluster
