### PR TITLE
MYOTT-594 Improve normalisation of upload data

### DIFF
--- a/app/services/commodity_codes_extraction_service.rb
+++ b/app/services/commodity_codes_extraction_service.rb
@@ -29,8 +29,17 @@ class CommodityCodesExtractionService
       end
 
     rows.filter_map do |value|
-      code = value.to_s.gsub(/[^0-9]/, '')
+      code = normalize_code_value(value)
       code if code.present? && code.length.between?(1, 20)
+    end
+  end
+
+  def normalize_code_value(value)
+    case value
+    when Numeric
+      value.floor.to_s if value.finite?
+    else
+      value.to_s.sub(/\.0+\z/, '').gsub(/[^0-9]/, '') # Remove trailing .0 and any non-numeric characters
     end
   end
 end

--- a/spec/services/commodity_codes_extraction_service_spec.rb
+++ b/spec/services/commodity_codes_extraction_service_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe CommodityCodesExtractionService do
       it { expect(result.error_message).to eq('Selected file has no valid commodity codes in column A') }
     end
 
+    context 'when CSV values are decimal-suffixed numeric strings' do
+      let(:file) { instance_double(ActionDispatch::Http::UploadedFile, content_type: 'text/csv', read: "1023456789.0\n") }
+
+      it { is_expected.to be_success }
+      it { expect(result.codes).to eq(%w[1023456789]) }
+    end
+
     context 'when the file is a valid Excel file with valid codes' do
       let(:file) do
         fixture_file_upload(
@@ -69,6 +76,22 @@ RSpec.describe CommodityCodesExtractionService do
       it { is_expected.not_to be_success }
       it { expect(result.codes).to eq([]) }
       it { expect(result.error_message).to eq('Selected file has no valid commodity codes in column A') }
+    end
+
+    context 'when Excel cell values are integer-like floats' do
+      let(:file) { instance_double(ActionDispatch::Http::UploadedFile, content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet') }
+      let(:sheet) { instance_double(Roo::Excelx::Sheet) }
+      let(:spreadsheet) { instance_double(Roo::Excelx) }
+
+      before do
+        allow(Roo::Spreadsheet).to receive(:open).with(file).and_return(spreadsheet)
+        allow(spreadsheet).to receive(:sheet).with(0).and_return(sheet)
+        allow(sheet).to receive(:last_row).and_return(1)
+        allow(sheet).to receive(:column).with('A').and_return([1_023_456_789.0])
+      end
+
+      it { is_expected.to be_success }
+      it { expect(result.codes).to eq(%w[1023456789]) }
     end
   end
 


### PR DESCRIPTION
### Jira link

[MYOTT-594](https://transformuk.atlassian.net/browse/MYOTT-594)

### What?

Some values were being loaded as floats e.g. 9876543210.0 and the code was converting to a string and stripping the decimal point which incorrectly left an 11 digit commodity code.

The value type is now checked and converted to an integer first.