### PR TITLE
HMRC:-2139: order Geo Area Exclusions by a-z on the description

### DIFF
--- a/app/models/concerns/has_excluded_countries.rb
+++ b/app/models/concerns/has_excluded_countries.rb
@@ -9,7 +9,7 @@ module HasExcludedCountries
                   excluded_countries
                 end
 
-    countries.map(&:description).join(', ').html_safe
+    countries.map(&:description).sort.join(', ').html_safe
   end
 
   def exclusions_include_european_union?

--- a/spec/models/concerns/has_excluded_countries_spec.rb
+++ b/spec/models/concerns/has_excluded_countries_spec.rb
@@ -25,6 +25,25 @@ RSpec.describe HasExcludedCountries do
 
       it { expect(measure.excluded_country_list).to eq(expected_list) }
     end
+
+    context 'when excluded countries are not in alphabetical order' do
+      subject(:measure) { build(:measure) }
+
+      before do
+        allow(measure).to receive(:exclusions_include_european_union?).and_return(false)
+        allow(measure).to receive(:excluded_countries).and_return(
+          [
+            instance_double(GeographicalArea, description: 'Switzerland'),
+            instance_double(GeographicalArea, description: 'Cyprus'),
+            instance_double(GeographicalArea, description: 'Czechia'),
+          ],
+        )
+      end
+
+      it 'sorts the country descriptions alphabetically' do
+        expect(measure.excluded_country_list).to eq('Cyprus, Czechia, Switzerland')
+      end
+    end
   end
 
   describe '#exclusions_include_european_union?' do

--- a/spec/models/concerns/has_excluded_countries_spec.rb
+++ b/spec/models/concerns/has_excluded_countries_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe HasExcludedCountries do
     context 'when the excluded_countries include all eu members' do
       subject(:measure) { build(:measure, :with_eu_member_exclusions) }
 
-      let(:expected_list) { 'European Union, Switzerland, Iceland, Liechtenstein, Norway' }
+      let(:expected_list) { 'European Union, Iceland, Liechtenstein, Norway, Switzerland' }
 
       it { expect(measure.excluded_country_list).to eq(expected_list) }
     end
@@ -13,7 +13,7 @@ RSpec.describe HasExcludedCountries do
     context 'when the excluded_countries do not include all eu members' do
       subject(:measure) { build(:measure, :with_exclusions) }
 
-      let(:expected_list) { 'Switzerland, Cyprus, Czechia' }
+      let(:expected_list) { 'Cyprus, Czechia, Switzerland' }
 
       it { expect(measure.excluded_country_list).to eq(expected_list) }
     end
@@ -24,25 +24,6 @@ RSpec.describe HasExcludedCountries do
       let(:expected_list) { '' }
 
       it { expect(measure.excluded_country_list).to eq(expected_list) }
-    end
-
-    context 'when excluded countries are not in alphabetical order' do
-      subject(:measure) { build(:measure) }
-
-      before do
-        allow(measure).to receive(:exclusions_include_european_union?).and_return(false)
-        allow(measure).to receive(:excluded_countries).and_return(
-          [
-            instance_double(GeographicalArea, description: 'Switzerland'),
-            instance_double(GeographicalArea, description: 'Cyprus'),
-            instance_double(GeographicalArea, description: 'Czechia'),
-          ],
-        )
-      end
-
-      it 'sorts the country descriptions alphabetically' do
-        expect(measure.excluded_country_list).to eq('Cyprus, Czechia, Switzerland')
-      end
     end
   end
 


### PR DESCRIPTION
### Jira link

[HMRC-2139](https://transformuk.atlassian.net/browse/HMRC-2139)

### What?

I have sorted exclusion list by description

### Why?

I am doing this because...
It should be easier to skim read
