### PR TITLE
[HMRC-2185] Cache tariff last updated

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,9 @@ class ApplicationController < ActionController::Base
 
   def set_last_updated
     # rubocop:disable Naming/MemoizedInstanceVariableName
-    @tariff_last_updated ||= TariffUpdate.latest_applied_import_date
+    @tariff_last_updated ||= Rails.cache.fetch('tariff_last_updated', expires_in: 1.day) do
+      TariffUpdate.latest_applied_import_date
+    end
     # rubocop:enable Naming/MemoizedInstanceVariableName
   end
 


### PR DESCRIPTION
### Jira link

[HMRC-2185](https://transformuk.atlassian.net/browse/HMRC-2185)

### What?

When reviewing the apps for performance optimisations, I noticed the `/updates/latest` endpoint was called on every request to set the `@tariff_last_updated` timestamp. This should not be necessary when the timestamp should only change after an import (once a day)

This PR caches the timestamp for 1 day.

Expiring the cache in 1 day is safe because `ClearCacheWorker` calls `frontend_redis.flushdb` after every tariff import so the `tariff_last_updated` key should be invalidated automatically after an import regardless of TTL.

### Why?

Setting this on every request when it should only change whenever a new update is processed causes a large amount of wasted requests to `/updates/latest`. Caching reduces those requests and reduces resource, and speeds things up for everyone.