### PR TITLE
Memoize Measure#key to avoid repeated sort key computation

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -150,7 +150,7 @@ class Measure
   end
 
   def key
-    "#{third_country_duties? ? 0 : 1}
+    @key ||= "#{third_country_duties? ? 0 : 1}
      #{tariff_preferences? ? 0 : 1}
      #{supplementary? ? 0 : 1}
      #{vat? ? 0 : 1}

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -326,6 +326,18 @@ RSpec.describe Measure do
     end
   end
 
+  describe '#key' do
+    subject(:measure) { build(:measure) }
+
+    it 'returns a consistent sort key' do
+      expect(measure.key).to eq(measure.key)
+    end
+
+    it 'memoizes the result' do
+      expect(measure.key).to equal(measure.key)
+    end
+  end
+
   describe '#cds_proofs_of_origin' do
     subject { measure.cds_proofs_of_origin schemes }
 

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -329,10 +329,6 @@ RSpec.describe Measure do
   describe '#key' do
     subject(:measure) { build(:measure) }
 
-    it 'returns a consistent sort key' do
-      expect(measure.key).to eq(measure.key)
-    end
-
     it 'memoizes the result' do
       expect(measure.key).to equal(measure.key)
     end


### PR DESCRIPTION
## Summary

- `Measure#key` is called O(n) times per `sort_by(&:key)` and there are 7+ such sorts per commodity page render, meaning the method runs many times per request for each measure in the collection.
- The method does string interpolation over 7 conditions, including `geographical_area.children_geographical_areas.any?`, making each call non-trivial.
- `Measure` is an immutable deserialized API object — the key never changes after initialization — so memoizing with `@key ||=` is safe and correct.
- Memoization eliminates redundant computation on all repeated calls within the same request lifecycle.
