### PR TITLE
Avoid repeated import_measures calls in measures partial

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -1,3 +1,5 @@
+<% declarable_import_measures = declarable.import_measures %>
+<% uk_import_measures = uk_declarable&.import_measures %>
 <div class="govuk-tabs govuk-!-margin-top-0" data-module="govuk-tabs">
   <ul class="govuk-tabs__list">
     <li class="govuk-tabs__list-item">
@@ -32,7 +34,7 @@
 
     <%= render 'declarables/consigned', declarable: declarable %>
 
-    <% if declarable.import_measures.any? %>
+    <% if declarable_import_measures.any? %>
       <%= render 'measures/grouped/navigation',
                  uk_declarable: uk_declarable,
                  xi_declarable: xi_declarable %>
@@ -120,7 +122,7 @@
 
   <div id="import-measure-references">
     <%= render partial: 'measures/measure_references',
-               collection: declarable.import_measures,
+               collection: declarable_import_measures,
                as: 'measure',
                locals: {
                  declarable: declarable,
@@ -130,7 +132,7 @@
 
     <% if TradeTariffFrontend::ServiceChooser.xi? && uk_declarable.present? %>
       <%= render partial: 'measures/measure_references',
-                 collection: uk_declarable.import_measures.import_controls,
+                 collection: uk_import_measures.import_controls,
                  as: 'measure',
                  locals: {
                    declarable: declarable,
@@ -139,7 +141,7 @@
                  } %>
 
       <%= render partial: 'measures/measure_references',
-                 collection: uk_declarable.import_measures.vat_excise,
+                 collection: uk_import_measures.vat_excise,
                  as: 'measure',
                  locals: {
                    declarable: declarable,


### PR DESCRIPTION
## Summary

- `has_many` accessors in `ApiEntity` (lib/api_entity.rb) have no memoization — every call allocates a new `MeasureCollection` and re-runs the `:without_excluded` filter pass over the full measures array.
- `app/views/measures/_measures.html.erb` called `import_measures` on `declarable` and `uk_declarable` four times per render (lines 35, 122, 133, 142), creating redundant object allocations and array traversals on every page load.
- This change assigns the result to local variables (`declarable_import_measures`, `uk_import_measures`) at the top of the partial and uses those throughout, eliminating the repeated work.
- `_uk.html.erb` already applied this pattern correctly (`uk_import_measures = uk_declarable.import_measures` on line 1); this brings `_measures.html.erb` into line with that approach.
