### PR TITLE
Cache repeated association access in measure collection partial

### DIFF
--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -69,7 +69,7 @@
   </td>
 
   <td class="footnotes-col govuk-table__cell govuk-table__header--numeric">
-    <% if measure.has_measure_footnotes? %>
+    <% if footnotes.any? %>
       <div data-controller="anchor">
         <%= link_to footnotes.size == 1 ? footnotes.first.code : "Footnotes", "#", class: 'reference', data: { action: "click->anchor#launchModal", modal_ref: "#{measure.destination}-#{measure.id}-footnotes" }, "aria-label": "Click to open a dialog with the footnotes for this measure", role: "button" %>
         <div id="modal" class="modal tariff-info" data-controller="modal" data-anchor-target="modal"></div>

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -1,9 +1,12 @@
-<tr id="measure-<%= measure.id %>" class=" govuk-table__row <%= measure.geographical_area.id %>" tabIndex="-1">
+<% geo_area = measure.geographical_area %>
+<% measure_type = measure.measure_type %>
+<% footnotes = measure.footnotes %>
+<tr id="measure-<%= measure.id %>" class=" govuk-table__row <%= geo_area.id %>" tabIndex="-1">
   <td class="country-col govuk-table__cell">
     <% if measure.has_children_geographical_areas? %>
-      <%= link_to measure.geographical_area.long_description, geographical_area_path(id: measure.geographical_area.id, goods_nomenclature_code: current_goods_nomenclature_code), class: 'govuk-link' %>
+      <%= link_to geo_area.long_description, geographical_area_path(id: geo_area.id, goods_nomenclature_code: current_goods_nomenclature_code), class: 'govuk-link' %>
     <% else %>
-      <%= measure.geographical_area.long_description %>
+      <%= geo_area.long_description %>
     <% end %>
 
     <% if measure.excluded_country_list.present? %>
@@ -14,7 +17,7 @@
     <% end %>
   </td>
 
-  <td class="measure-type-col govuk-table__cell <%= measure.measure_type.id %>">
+  <td class="measure-type-col govuk-table__cell <%= measure_type.id %>">
     <span class='table-line'><%= measure_type_description_or_link(measure) %></span>
 
     <% if measure.order_number.present? %>
@@ -26,7 +29,7 @@
       </span>
     <% end %>
     <% if measure.additional_code.present? %>
-      <% if measure.measure_type.prohibitive? %>
+      <% if measure_type.prohibitive? %>
         <%= render 'measures/additional_codes/prohibitive', measure: measure %>
       <% else %>
         <%= render 'measures/additional_codes/regular', measure: measure %>
@@ -68,7 +71,7 @@
   <td class="footnotes-col govuk-table__cell govuk-table__header--numeric">
     <% if measure.has_measure_footnotes? %>
       <div data-controller="anchor">
-        <%= link_to measure.footnotes.size == 1 ? measure.footnotes.first.code : "Footnotes", "#", class: 'reference', data: { action: "click->anchor#launchModal", modal_ref: "#{measure.destination}-#{measure.id}-footnotes" }, "aria-label": "Click to open a dialog with the footnotes for this measure", role: "button" %>
+        <%= link_to footnotes.size == 1 ? footnotes.first.code : "Footnotes", "#", class: 'reference', data: { action: "click->anchor#launchModal", modal_ref: "#{measure.destination}-#{measure.id}-footnotes" }, "aria-label": "Click to open a dialog with the footnotes for this measure", role: "button" %>
         <div id="modal" class="modal tariff-info" data-controller="modal" data-anchor-target="modal"></div>
       </div>
     <% end %>


### PR DESCRIPTION
## Why

`ApiEntity#has_many` reconstructs its collection on every call — it reads the raw instance variable, optionally wraps it, and optionally filters it, returning a new object each time. `_measure.html.erb` is rendered once per measure in a collection (20–50 per page), and previously accessed `measure.geographical_area`, `measure.measure_type`, and `measure.footnotes` multiple times each per render, producing 100–200 redundant allocations per request.

## What

Assign the three associations to locals at the top of the partial:

```erb
<% geo_area     = measure.geographical_area %>
<% measure_type = measure.measure_type %>
<% footnotes    = measure.footnotes %>
```

All subsequent uses within the template reference the local variable. The accessor is now called exactly once per measure render with no change to behaviour or output.
