### PR TITLE
Avoid redundant association access in MeasurePresenter

### DIFF
--- a/app/presenters/measure_presenter.rb
+++ b/app/presenters/measure_presenter.rb
@@ -48,7 +48,7 @@ class MeasurePresenter < SimpleDelegator
   end
 
   def permutations_enabled?
-    measure_condition_permutation_groups.any? &&
-      measure_condition_permutation_groups.all? { |pg| pg.permutations.any? }
+    groups = measure_condition_permutation_groups
+    groups.any? && groups.all? { |pg| pg.permutations.any? }
   end
 end


### PR DESCRIPTION
`ApiEntity`'s `has_many` and `has_one` macros build a new wrapper collection on every call, so accessing the same association twice in one method doubles the allocation with no benefit. `permutations_enabled?` was calling `measure_condition_permutation_groups` twice — once for `any?` and once for `all?` — so storing the result in a local variable eliminates the redundant allocation.

No functional change; all existing specs pass.