### PR TITLE
Eliminate duplicate iteration in rules of origin and permutation group partials

### DIFF
--- a/app/views/measure_conditions/_permutation_group.html.erb
+++ b/app/views/measure_conditions/_permutation_group.html.erb
@@ -1,6 +1,8 @@
+<% permutations = permutation_group.permutations %>
+<% conditions_with_guidance = permutations.flat_map(&:measure_conditions).select(&:has_guidance?).uniq(&:resource_id) %>
 <div class="permutation-group">
   <p>
-    <% if permutation_group.permutations.many? %>
+    <% if permutations.many? %>
       Meet one of the following conditions
     <% else %>
       Meet the following condition
@@ -20,15 +22,11 @@
 
     <tbody class="govuk-table__body">
       <%= render partial: 'measure_conditions/permutation',
-                 collection: permutation_group.permutations %>
+                 collection: permutations %>
     </tbody>
   </table>
 
   <%= render 'measures/guidance_table',
              include_chief_guidance: anchor == 'export',
-             measure_conditions_with_guidance: permutation_group
-                                                 .permutations
-                                                 .flat_map(&:measure_conditions)
-                                                 .select(&:has_guidance?)
-                                                 .uniq(&:resource_id) %>
+             measure_conditions_with_guidance: conditions_with_guidance %>
 </div>

--- a/app/views/rules_of_origin/_tab_uk.html.erb
+++ b/app/views/rules_of_origin/_tab_uk.html.erb
@@ -40,8 +40,9 @@
 
     <nav role="navigation">
       <ul class="govuk-list govuk-list-s">
-        <% if rules_of_origin_schemes.flat_map(&:links).any? %>
-          <% rules_of_origin_schemes.flat_map(&:links).uniq(&:id).each do |link| %>
+        <% scheme_links = rules_of_origin_schemes.flat_map(&:links).uniq(&:id) %>
+        <% if scheme_links.any? %>
+          <% scheme_links.each do |link| %>
             <p>
               <li>
                 <%= link_to link.text, link.url %>

--- a/app/views/rules_of_origin/_tab_xi.html.erb
+++ b/app/views/rules_of_origin/_tab_xi.html.erb
@@ -71,8 +71,9 @@
 
   <nav role="navigation">
     <ul class="govuk-list govuk-list-s">
-      <% if rules_of_origin_schemes.flat_map(&:links).any? %>
-        <% rules_of_origin_schemes.flat_map(&:links).uniq(&:id).each do |link| %>
+      <% scheme_links = rules_of_origin_schemes.flat_map(&:links).uniq(&:id) %>
+      <% if scheme_links.any? %>
+        <% scheme_links.each do |link| %>
           <li>
             <%= link_to link.text, link.url %>
           </li>

--- a/app/views/rules_of_origin/legacy/_tab.html.erb
+++ b/app/views/rules_of_origin/legacy/_tab.html.erb
@@ -19,7 +19,8 @@
   <%= render 'rules_of_origin/non_preferential_xi' %>
 <% end %>
 
-<% if rules_of_origin_schemes.flat_map(&:links).any? %>
+<% scheme_links = rules_of_origin_schemes.flat_map(&:links).uniq(&:id) %>
+<% if scheme_links.any? %>
 <div id="rules-of-origin__related-content">
   <h2 class="govuk-heading-m">
     Related content
@@ -27,7 +28,7 @@
 
   <nav role="navigation">
     <ul class="govuk-list govuk-list-s">
-      <% rules_of_origin_schemes.flat_map(&:links).uniq(&:id).each do |link| %>
+      <% scheme_links.each do |link| %>
         <li>
           <%= link_to link.text, link.url %>
         </li>


### PR DESCRIPTION
## Summary

- In the three rules-of-origin tab partials (`legacy/_tab`, `_tab_uk`, `_tab_xi`), `flat_map(&:links)` was being called twice on `rules_of_origin_schemes` — once for the `.any?` guard and a second time to iterate with `.uniq(&:id).each`. Each call traverses all schemes and their links collections. This is fixed by extracting the result to a `scheme_links` local before the guard, so the traversal happens once.

- In `measure_conditions/_permutation_group.html.erb`, `permutation_group.permutations` was accessed twice and the guidance-condition chain (`flat_map(&:measure_conditions).select(&:has_guidance?).uniq(&:resource_id)`) was inlined at the render call site. This is fixed by extracting `permutations` and `conditions_with_guidance` locals at the top of the partial so both chains execute exactly once per render.