### PR TITLE
Memoize Govspeak markdown rendering on MeasureCondition

### DIFF
--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -38,6 +38,15 @@ class MeasureCondition
     guidance_cds.present?
   end
 
+  def guidance_cds_html
+    @guidance_cds_html ||= begin
+      text = guidance_cds.is_a?(Hash) ? guidance_cds['content'] || guidance_cds[:content] : guidance_cds
+      return ''.html_safe if text.nil?
+
+      Govspeak::Document.new(text, sanitize: true).to_html.html_safe
+    end
+  end
+
   def presented_action
     OVERRIDDEN_ACTION_CODES.fetch(action_code.to_s, action)
   end

--- a/app/views/measures/_guidance_table.html.erb
+++ b/app/views/measures/_guidance_table.html.erb
@@ -20,7 +20,7 @@
                 <%= mc.document_code %>
               </td>
               <td class="govuk-table__cell tariff-markdown">
-                <%= govspeak mc.guidance_cds %>
+                <%= mc.guidance_cds_html %>
               </td>
             </tr>
           <% end %>

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -41,6 +41,47 @@ RSpec.describe MeasureCondition do
     end
   end
 
+  describe '#guidance_cds_html' do
+    context 'when guidance_cds is a plain string' do
+      subject(:condition) { build(:measure_condition, :with_guidance) }
+
+      it 'returns an HTML-safe string' do
+        expect(condition.guidance_cds_html).to be_html_safe
+      end
+
+      it 'returns a non-empty string' do
+        expect(condition.guidance_cds_html).to be_present
+      end
+
+      it 'memoizes the result so the same object is returned on repeated calls' do
+        first_call = condition.guidance_cds_html
+        expect(condition.guidance_cds_html).to equal(first_call)
+      end
+    end
+
+    context 'when guidance_cds is nil' do
+      subject(:condition) { build(:measure_condition) }
+
+      it 'returns an empty html-safe string' do
+        expect(condition.guidance_cds_html).to eq('')
+        expect(condition.guidance_cds_html).to be_html_safe
+      end
+    end
+
+    context 'when guidance_cds is a Hash with a content key' do
+      subject(:condition) { build(:measure_condition, guidance_cds: { 'content' => 'Some **bold** text' }) }
+
+      it 'extracts the content and returns an HTML string' do
+        expect(condition.guidance_cds_html).to include('<strong>')
+      end
+
+      it 'memoizes the result so the same object is returned on repeated calls' do
+        first_call = condition.guidance_cds_html
+        expect(condition.guidance_cds_html).to equal(first_call)
+      end
+    end
+  end
+
   describe '#measure_condition_class' do
     subject { condition.measure_condition_class }
 

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -62,8 +62,11 @@ RSpec.describe MeasureCondition do
     context 'when guidance_cds is nil' do
       subject(:condition) { build(:measure_condition) }
 
-      it 'returns an empty html-safe string' do
+      it 'returns an empty string' do
         expect(condition.guidance_cds_html).to eq('')
+      end
+
+      it 'returns an html-safe string' do
         expect(condition.guidance_cds_html).to be_html_safe
       end
     end


### PR DESCRIPTION
## Summary

`Govspeak::Document.new(text, sanitize: true).to_html` is called once per condition inside the loop in `app/views/measures/_guidance_table.html.erb`. Since `MeasureCondition` objects are immutable deserialized API responses, the rendered HTML for a given `guidance_cds` value is the same every time it is requested within a request cycle. Parsing markdown on every iteration is redundant work.

- Adds `guidance_cds_html` to `MeasureCondition` which memoizes the Govspeak parse result in `@guidance_cds_html`. The hash content-extraction and nil-guard that were in the `govspeak` helper are reproduced in the method so behaviour is unchanged.
- Updates `_guidance_table.html.erb` to call `mc.guidance_cds_html` directly, removing the loop's dependency on the view helper.
- Adds specs covering string input, nil input, and hash input, with an `equal` assertion confirming the same object is returned on repeated calls.