### PR TITLE
Memoize ApiEntity has_many and has_one association getters

### DIFF
--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -178,7 +178,12 @@ private
 
       relationships << association
 
-      attr_reader association.to_sym
+      define_method(association) do
+        cache_ivar = "@_#{association}"
+        return instance_variable_get(cache_ivar) if instance_variable_defined?(cache_ivar)
+
+        instance_variable_set(cache_ivar, instance_variable_get("@#{association}"))
+      end
 
       define_method("#{association}=") do |attributes|
         entity = if attributes.nil?
@@ -195,6 +200,7 @@ private
                  end
 
         instance_variable_set("@#{association}", entity)
+        remove_instance_variable("@_#{association}") if instance_variable_defined?("@_#{association}")
       end
     end
 
@@ -207,14 +213,14 @@ private
       relationships << association
 
       define_method(association) do
+        cache_ivar = "@_#{association}"
+        return instance_variable_get(cache_ivar) if instance_variable_defined?(cache_ivar)
+
         collection = instance_variable_get("@#{association}").presence || []
         collection = options[:wrapper].new(collection) if options[:wrapper]
+        collection = collection.public_send(options[:filter]) if options[:filter].present?
 
-        if options[:filter].present?
-          collection.public_send(options[:filter])
-        else
-          collection
-        end
+        instance_variable_set(cache_ivar, collection)
       end
 
       define_method("#{association}=") do |data|
@@ -239,11 +245,13 @@ private
         end
 
         instance_variable_set("@#{association}", collection)
+        remove_instance_variable("@_#{association}") if instance_variable_defined?("@_#{association}")
       end
 
       define_method("add_#{association.to_s.singularize}") do |entity|
         instance_variable_set("@#{association}", []) unless instance_variable_defined?("@#{association}")
         instance_variable_get("@#{association}").public_send('<<', entity)
+        remove_instance_variable("@_#{association}") if instance_variable_defined?("@_#{association}")
       end
     end
 

--- a/spec/lib/api_entity_spec.rb
+++ b/spec/lib/api_entity_spec.rb
@@ -428,6 +428,73 @@ RSpec.describe ApiEntity do
     end
   end
 
+  describe 'association memoization' do
+    before do
+      stub_const 'Part', (Class.new do
+        include ApiEntity
+
+        attr_accessor :name
+
+        def self.name = 'Part'
+      end)
+    end
+
+    describe 'has_many getter' do
+      subject(:instance) { mock_entity.new(parts: [{ name: 'wheel' }]) }
+
+      it 'returns the same object on repeated calls' do
+        expect(instance.parts).to equal(instance.parts)
+      end
+
+      it 'invalidates the cache when the setter is called' do
+        original = instance.parts
+        instance.parts = [{ name: 'door' }]
+
+        expect(instance.parts).not_to equal(original)
+      end
+
+      it 'reflects the new values after the setter is called' do
+        instance.parts = [{ name: 'door' }]
+
+        expect(instance.parts.first.name).to eq('door')
+      end
+
+      it 'includes the added item after add_part is called' do
+        instance.add_part(Part.new(name: 'mirror'))
+
+        expect(instance.parts.map(&:name)).to include('mirror')
+      end
+    end
+
+    describe 'has_one getter' do
+      subject(:instance) { mock_entity.new(part: { name: 'engine' }) }
+
+      it 'returns the same object on repeated calls' do
+        expect(instance.part).to equal(instance.part)
+      end
+
+      it 'invalidates the cache when the setter is called' do
+        original = instance.part
+        instance.part = { name: 'gearbox' }
+
+        expect(instance.part).not_to equal(original)
+      end
+
+      it 'reflects the new value after the setter is called' do
+        instance.part = { name: 'gearbox' }
+
+        expect(instance.part.name).to eq('gearbox')
+      end
+
+      it 'accepts nil and invalidates the cache' do
+        instance.part
+        instance.part = nil
+
+        expect(instance.part).to be_nil
+      end
+    end
+  end
+
   describe '#update' do
     subject(:result) do
       mock_entity.update(


### PR DESCRIPTION
Every call to a `has_many` or `has_one` accessor was constructing a new wrapper object and re-running the filter against the raw collection on each invocation. Because the cost was invisible at the definition site, call sites had been patched individually — capturing accessor results in local variables in views and presenters — to avoid repeated work.

The root fix is in `lib/api_entity.rb`:

- **`has_many` getter**: caches the wrapped-and-filtered result in `@_<name>` (distinct from `@<name>`, which holds the raw array populated by the setter). On subsequent calls the cached value is returned immediately.
- **`has_many` setter** and **`add_<singular>` method**: both invalidate `@_<name>` so the cache is never stale if data is written after first access.
- **`has_one` getter**: same pattern — caches the entity in `@_<name>` on first access.
- **`has_one` setter**: invalidates `@_<name>` on write.

Existing call-site local-variable captures remain valid as defensive coding but are no longer load-bearing. No behaviour change is observable through the public API.

Note, now that ApiEntity memoizes associations at the source, the local-variable patches in the earlier PRs (#2907, #2908, #2909) remain valid as defensive coding but are no longer strictly necessary for performance. They don't hurt though.