### PR TITLE
Build hash index for JSONAPI included resources to fix O(n²) parse timeout

### DIFF
--- a/lib/tariff_jsonapi_parser.rb
+++ b/lib/tariff_jsonapi_parser.rb
@@ -85,14 +85,21 @@ class TariffJsonapiParser
   def find_and_parse_included(name, id, type)
     return nil if id.blank? || type.blank?
 
+    key = [type.to_s, id.to_s]
+    return parsed_included_cache[key] if parsed_included_cache.key?(key)
+
     found_resource = find_included(id, type)
+    result = found_resource.blank? ? {} : parse_resource(found_resource)
 
-    return {} if found_resource.blank?
-
-    parse_resource(found_resource)
+    parsed_included_cache[key] = result
+    result
   rescue NoMethodError
     raise ParsingError,
-          "Error finding relationship - '#{name}', '#{id}', '#{type}': #{record.inspect}"
+          "Error finding relationship - '#{name}', '#{id}', '#{type}'"
+  end
+
+  def parsed_included_cache
+    @parsed_included_cache ||= {}
   end
 
   def parse_meta!(resource, parent)
@@ -100,6 +107,12 @@ class TariffJsonapiParser
   end
 
   def find_included(id, type)
-    @attributes['included']&.find { |r| r['id'].to_s == id.to_s && r['type'].to_s == type.to_s } || {}
+    included_index[[type.to_s, id.to_s]] || {}
+  end
+
+  def included_index
+    @included_index ||= (@attributes['included'] || []).index_by do |resource|
+      [resource['type'].to_s, resource['id'].to_s]
+    end
   end
 end

--- a/spec/lib/tariff_jsonapi_parser_spec.rb
+++ b/spec/lib/tariff_jsonapi_parser_spec.rb
@@ -131,5 +131,60 @@ RSpec.describe TariffJsonapiParser do
         end
       end
     end
+
+    context 'with a large included array referenced many times' do
+      # Builds a response with 100 included resources and a data array of 50
+      # items each referencing the same single included resource (id "1",
+      # type "shared_thing"). This exercises both the O(1) index (finding
+      # the right resource among 100) and the memoisation of its parsed form.
+      subject(:parsed) { described_class.new(payload).parse }
+
+      let(:shared_included_resource) do
+        {
+          'id' => '1',
+          'type' => 'shared_thing',
+          'attributes' => { 'label' => 'erga omnes' },
+        }
+      end
+
+      let(:other_included_resources) do
+        (2..100).map do |n|
+          { 'id' => n.to_s, 'type' => 'shared_thing', 'attributes' => { 'label' => "other #{n}" } }
+        end
+      end
+
+      let(:data_items) do
+        (1..50).map do |n|
+          {
+            'id' => n.to_s,
+            'type' => 'measure',
+            'attributes' => { 'description' => "measure #{n}" },
+            'relationships' => {
+              'shared_thing' => { 'data' => { 'id' => '1', 'type' => 'shared_thing' } },
+            },
+          }
+        end
+      end
+
+      let(:payload) do
+        {
+          'data' => data_items,
+          'included' => [shared_included_resource] + other_included_resources,
+        }
+      end
+
+      it 'resolves the shared relationship correctly for every data item' do
+        expect(parsed).to all(include('shared_thing' => include('label' => 'erga omnes')))
+      end
+
+      it 'returns the identical parsed object for every reference to the same included resource' do
+        # All 50 measures reference the same included resource. With memoisation
+        # every call to find_and_parse_included for ["shared_thing","1"] must
+        # return the exact same Ruby object (not just an equal one).
+        shared_things = parsed.map { |item| item['shared_thing'] }
+        first = shared_things.first
+        expect(shared_things).to all(equal(first))
+      end
+    end
   end
 end


### PR DESCRIPTION
`find_included` was doing an O(n) linear scan of the `included` array on every call. `parse_resource` calls `find_and_parse_included` for every relationship of every resource, so for a commodity response with 50+ measures each having ~10 relationships and hundreds of included objects the total work scaled as O(n²). This matches the `execution expired` `Timeout::Error` seen in production.

**Fix 1 — O(1) index for included resources**

A hash index (`included_index`) is built once per parser instance, keyed by `[type, id]`. Every call to `find_included` now does a single hash lookup instead of a full array scan.

**Fix 2 — memoize parsed included resources**

`find_and_parse_included` now stores its result in `parsed_included_cache` (also keyed by `[type, id]`) before returning. Subsequent calls for the same resource return the cached object immediately without re-parsing. Shared resources such as the erga omnes geographical area (referenced by every measure) are now parsed exactly once rather than once per reference. The cache check uses `key?` rather than a nil/falsy check so that a legitimately missing resource (cached as `{}`) is returned from cache correctly on repeat calls.