### PR TITLE
Fix empty CSP nonce when request has no session

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   end
 
   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w[script-src style-src]
 
   # Report violations without enforcing the policy.


### PR DESCRIPTION
When a request arrives with no existing session — bots, crawlers, first visits, or any cookie-less request — `request.session.id` returns `nil`. Calling `.to_s` on `nil` produces an empty string, so the CSP header contains `'nonce-'` (empty nonce). Browsers reject an empty nonce unconditionally, which means every nonce-gated inline script is blocked and a CSP violation report fires for each such request.

The fix replaces the session-based generator with `SecureRandom.base64(16)`. This always produces a valid, non-empty nonce. Rails memoises the generator result once per request, so the nonce injected into the CSP header and the nonce produced by `javascript_tag nonce: true` remain identical within a single request. 