### PR TITLE
Always return a Date from ImportDate#import_date

### DIFF
--- a/app/models/duty_calculator/steps/import_date.rb
+++ b/app/models/duty_calculator/steps/import_date.rb
@@ -30,7 +30,10 @@ module DutyCalculator
       end
 
       def import_date
-        super || user_session.import_date || Time.zone.now.strftime('%Y-%m-%d')
+        date = super || user_session.import_date || Time.zone.today
+        date.is_a?(Date) ? date : Date.parse(date.to_s)
+      rescue Date::Error, ArgumentError
+        Time.zone.today
       end
 
       def save!

--- a/app/models/duty_calculator/steps/import_date.rb
+++ b/app/models/duty_calculator/steps/import_date.rb
@@ -32,7 +32,7 @@ module DutyCalculator
       def import_date
         date = super || user_session.import_date || Time.zone.today
         date.is_a?(Date) ? date : Date.parse(date.to_s)
-      rescue Date::Error, ArgumentError
+      rescue ArgumentError
         Time.zone.today
       end
 

--- a/spec/models/duty_calculator/steps/import_date_spec.rb
+++ b/spec/models/duty_calculator/steps/import_date_spec.rb
@@ -147,7 +147,6 @@ RSpec.describe DutyCalculator::Steps::ImportDate, :step, :user_session do
   describe '#import_date' do
     context 'when super returns a Date (form params present)' do
       it 'returns the Date unchanged' do
-        date = Date.new(2024, 6, 15)
         expect(step.import_date).to be_a(Date)
       end
     end

--- a/spec/models/duty_calculator/steps/import_date_spec.rb
+++ b/spec/models/duty_calculator/steps/import_date_spec.rb
@@ -144,6 +144,69 @@ RSpec.describe DutyCalculator::Steps::ImportDate, :step, :user_session do
     end
   end
 
+  describe '#import_date' do
+    context 'when super returns a Date (form params present)' do
+      it 'returns the Date unchanged' do
+        date = Date.new(2024, 6, 15)
+        expect(step.import_date).to be_a(Date)
+      end
+    end
+
+    context 'when super is nil and the session holds a String date' do
+      subject(:step) do
+        build(:duty_calculator_import_date, user_session:, day: '', month: '', year: '')
+      end
+
+      before do
+        allow(user_session).to receive(:import_date).and_return('2023-06-19')
+      end
+
+      it 'returns a Date' do
+        expect(step.import_date).to be_a(Date)
+      end
+
+      it 'returns the correct date' do
+        expect(step.import_date).to eq(Date.new(2023, 6, 19))
+      end
+    end
+
+    context 'when both super and session are nil' do
+      subject(:step) do
+        build(:duty_calculator_import_date, user_session:, day: '', month: '', year: '')
+      end
+
+      before do
+        allow(user_session).to receive(:import_date).and_return(nil)
+      end
+
+      it 'returns a Date' do
+        expect(step.import_date).to be_a(Date)
+      end
+
+      it 'returns today' do
+        expect(step.import_date).to eq(Time.zone.today)
+      end
+    end
+
+    context 'when the session holds an unparseable string' do
+      subject(:step) do
+        build(:duty_calculator_import_date, user_session:, day: '', month: '', year: '')
+      end
+
+      before do
+        allow(user_session).to receive(:import_date).and_return('not-a-date')
+      end
+
+      it 'returns a Date' do
+        expect(step.import_date).to be_a(Date)
+      end
+
+      it 'falls back to today' do
+        expect(step.import_date).to eq(Time.zone.today)
+      end
+    end
+  end
+
   describe '#save!' do
     let(:expected_date) { Date.parse("#{1.year.from_now.year}-12-12") }
 


### PR DESCRIPTION
Session cookies deserialise dates as strings. When a user had previously stored an import date in their session, `user_session.import_date` returned a `String` (e.g. `"2019-06-19"`) rather than a `Date`. The previous fallback of `Time.zone.now.strftime('%Y-%m-%d')` also produced a `String`.

The controller then called `.strftime('%Y-%m-%d')` on whatever `import_date` returned, causing:

```
NoMethodError: undefined method 'strftime' for an instance of String
```

The `import_date` override now coerces any string value to a `Date` via `Date.parse`, uses `Time.zone.today` (which is a `Date`) as the final fallback instead of `strftime`, and rescues `Date::Error`/`ArgumentError` to handle any unparseable garbage that may have been stored in the session.