### PR TITLE
Remove redundant requires

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include TradeTariffFrontend::ViewContext::Controller

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,4 +1,3 @@
-require 'api_entity'
 # rubocop:disable Rails/ApplicationController
 class HealthcheckController < ActionController::Base
   # rubocop:enable Rails/ApplicationController

--- a/app/decorators/myott/session_chapters_decorator.rb
+++ b/app/decorators/myott/session_chapters_decorator.rb
@@ -1,5 +1,3 @@
-require 'action_view/helpers'
-
 module Myott
   class SessionChaptersDecorator < SimpleDelegator
     include ActionView::Helpers::TextHelper

--- a/app/models/additional_code.rb
+++ b/app/models/additional_code.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class AdditionalCode
   include ApiEntity
 

--- a/app/models/additional_code_type.rb
+++ b/app/models/additional_code_type.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class AdditionalCodeType
   include ApiEntity
 

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class Certificate
   include ApiEntity
 

--- a/app/models/certificate_type.rb
+++ b/app/models/certificate_type.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class CertificateType
   include ApiEntity
 

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class Change
   include ApiEntity
   extend  ActiveModel::Naming

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class Chapter < GoodsNomenclature
   include ApiEntity
   include Changeable

--- a/app/models/chemical.rb
+++ b/app/models/chemical.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class Chemical
   include ApiEntity
 

--- a/app/models/chemical_substance.rb
+++ b/app/models/chemical_substance.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class ChemicalSubstance
   include ApiEntity
 

--- a/app/models/duty_expression.rb
+++ b/app/models/duty_expression.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class DutyExpression
   include ApiEntity
 

--- a/app/models/exchange_rate_collection.rb
+++ b/app/models/exchange_rate_collection.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class ExchangeRateCollection
   include ApiEntity
 

--- a/app/models/exchange_rates/exchange_rate.rb
+++ b/app/models/exchange_rates/exchange_rate.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class ExchangeRates::ExchangeRate
   include ApiEntity
 

--- a/app/models/exchange_rates/file.rb
+++ b/app/models/exchange_rates/file.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class ExchangeRates::File
   include ApiEntity
 

--- a/app/models/exchange_rates/period.rb
+++ b/app/models/exchange_rates/period.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class ExchangeRates::Period
   include ApiEntity
 

--- a/app/models/exchange_rates/period_list.rb
+++ b/app/models/exchange_rates/period_list.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class ExchangeRates::PeriodList
   include ApiEntity
 

--- a/app/models/exchange_rates/year.rb
+++ b/app/models/exchange_rates/year.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class ExchangeRates::Year
   include ApiEntity
 

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,5 +1,3 @@
-require 'active_model'
-
 class Feedback
   TOKEN_TRACKING_PREFIX = 'feedback-delivery'.freeze
   TOKEN_TRACKING_LIFETIME = 1.hour

--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class Footnote
   include ApiEntity
 

--- a/app/models/footnote_type.rb
+++ b/app/models/footnote_type.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class FootnoteType
   include ApiEntity
 

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class GeographicalArea
   EUROPEAN_UNION_ID = '1013'.freeze
   REFERENCING_EUROPEAN_UNION_ID = 'EU'.freeze

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -1,6 +1,3 @@
-require 'api_entity'
-require 'null_object'
-
 class GoodsNomenclature
   include ApiEntity
   include Classifiable

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class GreenLanes::CategoryAssessment
   include XiOnlyApiEntity
 

--- a/app/models/green_lanes/category_assessment_search.rb
+++ b/app/models/green_lanes/category_assessment_search.rb
@@ -1,5 +1,3 @@
-require 'active_model'
-
 class GreenLanes::CategoryAssessmentSearch
   include ActiveModel::Model
 

--- a/app/models/green_lanes/faq_feedback.rb
+++ b/app/models/green_lanes/faq_feedback.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 module GreenLanes
   class FaqFeedback
     include XiOnlyApiEntity

--- a/app/models/green_lanes/goods_nomenclature.rb
+++ b/app/models/green_lanes/goods_nomenclature.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class GreenLanes::GoodsNomenclature
   include XiOnlyApiEntity
   include Classifiable

--- a/app/models/import_trade_summary.rb
+++ b/app/models/import_trade_summary.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class ImportTradeSummary
   include ApiEntity
 

--- a/app/models/legal_act.rb
+++ b/app/models/legal_act.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class LegalAct
   include ApiEntity
 

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class Measure
   include ApiEntity
   include HasExcludedCountries

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class MeasureCondition
   OVERRIDDEN_ACTION_CODES = {
     '01' => 'Apply the duty',

--- a/app/models/measure_condition_permutation.rb
+++ b/app/models/measure_condition_permutation.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class MeasureConditionPermutation
   include ApiEntity
 

--- a/app/models/measure_condition_permutation_group.rb
+++ b/app/models/measure_condition_permutation_group.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class MeasureConditionPermutationGroup
   include ApiEntity
 

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class MeasureType
   RENDERED_MEASURE_TYPE_DETAILS = { 'xi' => {}, 'uk' => {} }.freeze
 

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class MeasurementUnit
   include ApiEntity
 

--- a/app/models/measurement_unit_qualifier.rb
+++ b/app/models/measurement_unit_qualifier.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class MeasurementUnitQualifier
   include ApiEntity
 

--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 module News
   class Collection
     include UkOnlyApiEntity

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 module News
   class Item
     include UkOnlyApiEntity

--- a/app/models/news/year.rb
+++ b/app/models/news/year.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 module News
   class Year
     include UkOnlyApiEntity

--- a/app/models/order_number.rb
+++ b/app/models/order_number.rb
@@ -1,6 +1,3 @@
-require 'api_entity'
-require 'order_number/definition'
-
 class OrderNumber
   include ApiEntity
 

--- a/app/models/order_number/definition.rb
+++ b/app/models/order_number/definition.rb
@@ -1,6 +1,3 @@
-require 'api_entity'
-require 'null_object'
-
 class OrderNumber
   class Definition
     include ApiEntity

--- a/app/models/preference_code.rb
+++ b/app/models/preference_code.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class PreferenceCode
   include ApiEntity
 

--- a/app/models/quota_closed_and_transferred_event.rb
+++ b/app/models/quota_closed_and_transferred_event.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class QuotaClosedAndTransferredEvent
   include ApiEntity
 

--- a/app/models/rules_of_origin/article.rb
+++ b/app/models/rules_of_origin/article.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class RulesOfOrigin::Article
   include ApiEntity
 

--- a/app/models/rules_of_origin/link.rb
+++ b/app/models/rules_of_origin/link.rb
@@ -1,4 +1,3 @@
-require 'api_entity'
 require 'digest'
 
 class RulesOfOrigin::Link

--- a/app/models/rules_of_origin/proof.rb
+++ b/app/models/rules_of_origin/proof.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class RulesOfOrigin::Proof
   include ApiEntity
 

--- a/app/models/rules_of_origin/rule.rb
+++ b/app/models/rules_of_origin/rule.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class RulesOfOrigin::Rule
   include ApiEntity
 

--- a/app/models/rules_of_origin/rule_set.rb
+++ b/app/models/rules_of_origin/rule_set.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class RulesOfOrigin::RuleSet
   include ApiEntity
 

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class RulesOfOrigin::Scheme
   include ApiEntity
 

--- a/app/models/rules_of_origin/v2_rule.rb
+++ b/app/models/rules_of_origin/v2_rule.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class RulesOfOrigin::V2Rule
   include ApiEntity
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class Search
   include ApiEntity
   include CacheHelper

--- a/app/models/search/base_match.rb
+++ b/app/models/search/base_match.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class Search
   class BaseMatch
     include ApiEntity

--- a/app/models/search/goods_nomenclature_match.rb
+++ b/app/models/search/goods_nomenclature_match.rb
@@ -1,6 +1,4 @@
-require 'api_entity'
 require 'ostruct'
-require 'search/base_match'
 
 class Search
   class GoodsNomenclatureMatch < BaseMatch

--- a/app/models/search/outcome.rb
+++ b/app/models/search/outcome.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class Search
   class Outcome
     include ApiEntity

--- a/app/models/search/reference_match.rb
+++ b/app/models/search/reference_match.rb
@@ -1,6 +1,4 @@
-require 'api_entity'
 require 'ostruct'
-require 'search/base_match'
 
 class Search
   include ApiEntity

--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class SearchReference
   include ApiEntity
 

--- a/app/models/search_suggestion.rb
+++ b/app/models/search_suggestion.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class SearchSuggestion
   include ApiEntity
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class Section
   include ApiEntity
 

--- a/app/models/simplified_procedural_code_measure.rb
+++ b/app/models/simplified_procedural_code_measure.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class SimplifiedProceduralCodeMeasure
   include ApiEntity
 

--- a/app/models/validity_period.rb
+++ b/app/models/validity_period.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 class ValidityPeriod
   include ApiEntity
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,3 @@
-require 'trade_tariff_frontend'
-require 'routing_filter/service_path_prefix_handler'
-
 Rails.application.routes.draw do
   filter :service_path_prefix_handler
   default_url_options(host: TradeTariffFrontend.host)

--- a/lib/api_entity.rb
+++ b/lib/api_entity.rb
@@ -1,8 +1,3 @@
-require 'multi_json'
-require 'active_model'
-require 'tariff_jsonapi_parser'
-require 'unparseable_response_error'
-
 module ApiEntity
   extend ActiveSupport::Concern
 

--- a/lib/routing_filter/service_path_prefix_handler.rb
+++ b/lib/routing_filter/service_path_prefix_handler.rb
@@ -1,5 +1,3 @@
-require 'trade_tariff_frontend'
-
 module RoutingFilter
   class ServicePathPrefixHandler < Filter
     SERVICE_CHOICE_PREFIXES =

--- a/spec/factories/measurement_unit_qualifier_factory.rb
+++ b/spec/factories/measurement_unit_qualifier_factory.rb
@@ -1,5 +1,3 @@
-require 'api_entity'
-
 FactoryBot.define do
   factory :measurement_unit_qualifier do
     resource_id { 'E' }

--- a/spec/lib/trade_tariff_frontend/service_timeout_spec.rb
+++ b/spec/lib/trade_tariff_frontend/service_timeout_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'trade_tariff_frontend/service_timeout'
 
 RSpec.describe TradeTariffFrontend::ServiceTimeout do
   subject(:middleware) { described_class.new(app) }


### PR DESCRIPTION
### What?

Classes in the lib directory are autoloaded (https://github.com/trade-tariff/trade-tariff-frontend/blob/main/config/application.rb#L70) so it is not necessary to require them when used.

Validated this works by running `bundle exec rails zeitwerk:check`
