### PR TITLE
Add NON_GROUPING_PRODUCTLINE_SUFFIX constant

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -39,7 +39,7 @@ module CommoditiesHelper
 
   def format_commodity_code_based_on_level(commodity)
     code = commodity.code.to_s
-    display_full_code = commodity.producline_suffix == '80'
+    display_full_code = commodity.producline_suffix == GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX
 
     if commodity.number_indents > 1 || display_full_code
       # remove trailing pairs of zeros for non declarable

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -80,6 +80,6 @@ class Commodity < GoodsNomenclature
   end
 
   def umbrella_code?
-    producline_suffix != '80' && has_children?
+    producline_suffix != NON_GROUPING_PRODUCTLINE_SUFFIX && has_children?
   end
 end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -5,6 +5,7 @@ class GoodsNomenclature
   include ApiEntity
   include Classifiable
 
+  NON_GROUPING_PRODUCTLINE_SUFFIX = '80'.freeze
   CHAPTER_SUFFIX = '00000000'.freeze
   HEADING_SUFFIX = '000000'.freeze
 

--- a/app/models/green_lanes/goods_nomenclature.rb
+++ b/app/models/green_lanes/goods_nomenclature.rb
@@ -34,7 +34,7 @@ class GreenLanes::GoodsNomenclature
   end
 
   def declarable?
-    producline_suffix == '80'
+    producline_suffix == ::GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX
   end
 
   def get_declarable

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe CommoditiesController, type: :controller do
               jsonapi_response :subheading,
                                attributes_for(:subheading,
                                               goods_nomenclature_item_id: '0101999999',
-                                              producline_suffix: '80')
+                                              producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
         end
 
         it { is_expected.to redirect_to subheading_path('0101999999-80') }

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe SearchController, type: :controller do
           'type' => 'commodity',
           'attributes' => {
             'goods_nomenclature_item_id' => '0101210000',
-            'producline_suffix' => '80',
+            'producline_suffix' => GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
             'goods_nomenclature_class' => 'Commodity',
             'description' => 'Pure-bred breeding animals',
             'formatted_description' => 'Pure-bred breeding animals',
@@ -330,7 +330,7 @@ RSpec.describe SearchController, type: :controller do
             'type' => 'commodity',
             'attributes' => {
               'goods_nomenclature_item_id' => '0101210000',
-              'producline_suffix' => '80',
+              'producline_suffix' => GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
               'goods_nomenclature_class' => 'Commodity',
               'description' => 'Pure-bred breeding animals',
               'formatted_description' => 'Pure-bred breeding animals',

--- a/spec/factories/chemical_substance_factory.rb
+++ b/spec/factories/chemical_substance_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     cas_rn { '102-28-3' }
     goods_nomenclature_sid { 101_368 }
     goods_nomenclature_item_id { '2924297099' }
-    producline_suffix { '80' }
+    producline_suffix { GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
     name { "3'-aminoacetanilide" }
     nomen { 'INN' }
   end

--- a/spec/factories/duty_calculator/api/commodity.rb
+++ b/spec/factories/duty_calculator/api/commodity.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
     end
 
     id { generate(:goods_nomenclature_sid) }
-    producline_suffix { '80' }
+    producline_suffix { GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
     number_indents { 4 }
     description { 'Cherry tomatoes' }
     goods_nomenclature_item_id { '0702000007' }

--- a/spec/factories/search_outcome_factory.rb
+++ b/spec/factories/search_outcome_factory.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
               "_source": {
                 "id": 54_631,
                 "goods_nomenclature_item_id": '9603210000',
-                "producline_suffix": '80',
+                "producline_suffix": GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
                 "validity_start_date": '1972-01-01T00:00:00.000Z',
                 "validity_end_date": nil,
                 "description": 'Toothbrushes, including dental-plate brushes',
@@ -34,7 +34,7 @@ FactoryBot.define do
                 "chapter": {
                   "goods_nomenclature_sid": 54_615,
                   "goods_nomenclature_item_id": '9600000000',
-                  "producline_suffix": '80',
+                  "producline_suffix": GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
                   "validity_start_date": '1971-12-31T00:00:00.000Z',
                   "validity_end_date": nil,
                   "description": 'Miscellaneous manufactured articles',
@@ -43,7 +43,7 @@ FactoryBot.define do
                 "heading": {
                   "goods_nomenclature_sid": 54_628,
                   "goods_nomenclature_item_id": '9603000000',
-                  "producline_suffix": '80',
+                  "producline_suffix": GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
                   "validity_start_date": '1972-01-01T00:00:00.000Z',
                   "validity_end_date": nil,
                   "description": 'Brooms, brushes (including brushes constituting parts of machines, appliances or vehicles), hand-operated mechanical floor sweepers, not motorised, mops and feather dusters; prepared knots and tufts for broom or brush making; paint pads and rollers; squeegees (other than roller squeegees)',
@@ -72,7 +72,7 @@ FactoryBot.define do
                 "reference": {
                   "id": 49_912,
                   "goods_nomenclature_item_id": '8509800000',
-                  "producline_suffix": '80',
+                  "producline_suffix": GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
                   "validity_start_date": '1972-01-01T00:00:00.000Z',
                   "validity_end_date": nil,
                   "description": 'Other appliances',
@@ -92,7 +92,7 @@ FactoryBot.define do
                   "chapter": {
                     "goods_nomenclature_sid": 49_496,
                     "goods_nomenclature_item_id": '8500000000',
-                    "producline_suffix": '80',
+                    "producline_suffix": GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
                     "validity_start_date": '1971-12-31T00:00:00.000Z',
                     "validity_end_date": nil,
                     "description": 'Electrical machinery and equipment and parts thereof; sound recorders and reproducers, television image and sound recorders and reproducers, and parts and accessories of such articles',
@@ -101,7 +101,7 @@ FactoryBot.define do
                   "heading": {
                     "goods_nomenclature_sid": 49_905,
                     "goods_nomenclature_item_id": '8509000000',
-                    "producline_suffix": '80',
+                    "producline_suffix": GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
                     "validity_start_date": '1972-01-01T00:00:00.000Z',
                     "validity_end_date": nil,
                     "description": 'Electromechanical domestic appliances, with self-contained electric motor, other than vacuum cleaners of heading 8508',

--- a/spec/factories/search_reference_factory.rb
+++ b/spec/factories/search_reference_factory.rb
@@ -9,13 +9,13 @@ FactoryBot.define do
     trait :with_chapter do
       referenced_id { '20' }
       referenced_class { 'Chapter' }
-      productline_suffix { '80' }
+      productline_suffix { GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
     end
 
     trait :with_heading do
       referenced_id { '2001' }
       referenced_class { 'Heading' }
-      productline_suffix { '80' }
+      productline_suffix { GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
     end
 
     trait :with_subheading do
@@ -27,7 +27,7 @@ FactoryBot.define do
     trait :with_commodity do
       referenced_id { '8418690000' }
       referenced_class { 'Commodity' }
-      productline_suffix { '80' }
+      productline_suffix { GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
     end
   end
 end

--- a/spec/factories/search_result_factory.rb
+++ b/spec/factories/search_result_factory.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
     end
 
     trait :redirect do
-      direct_hit { attributes_for(:heading, goods_nomenclature_item_id: '0101000000', producline_suffix: '80') }
+      direct_hit { attributes_for(:heading, goods_nomenclature_item_id: '0101000000', producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX) }
     end
 
     trait :multiple_headings_view do

--- a/spec/factories/validity_period_factory.rb
+++ b/spec/factories/validity_period_factory.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
 
     trait :subheading do
       goods_nomenclature_item_id { '0101999999' }
-      producline_suffix { '80' }
+      producline_suffix { GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
       goods_nomenclature_class { 'Subheading' }
 
       to_param { "#{goods_nomenclature_item_id}-#{producline_suffix}" }
@@ -48,7 +48,7 @@ FactoryBot.define do
 
     trait :commodity do
       goods_nomenclature_item_id { '0101999999' }
-      producline_suffix { '80' }
+      producline_suffix { GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
       goods_nomenclature_class { 'Commodity' }
 
       to_param { goods_nomenclature_item_id }

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Commodity do
       end
 
       context 'with producline_suffix of 80' do
-        let(:producline_suffix) { '80' }
+        let(:producline_suffix) { GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
 
         it { is_expected.to be false }
       end
@@ -201,7 +201,7 @@ RSpec.describe Commodity do
       end
 
       context 'with producline_suffix of 80' do
-        let(:producline_suffix) { '80' }
+        let(:producline_suffix) { GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
 
         it { is_expected.to be false }
       end

--- a/spec/models/duty_calculator/api/commodity_spec.rb
+++ b/spec/models/duty_calculator/api/commodity_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DutyCalculator::Api::Commodity, :user_session, type: :model do
 
   it_behaves_like 'a resource that has attributes',
                   id: 'flibble',
-                  producline_suffix: '80',
+                  producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
                   number_indents: 1,
                   description: 'Cherry Tomatoes',
                   goods_nomenclature_item_id: '0702000007',

--- a/spec/models/green_lanes/goods_nomenclature_spec.rb
+++ b/spec/models/green_lanes/goods_nomenclature_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe GreenLanes::GoodsNomenclature do
     subject { goods_nomenclature.declarable? }
 
     context 'when producline_suffix is 80' do
-      before { goods_nomenclature.producline_suffix = '80' }
+      before { goods_nomenclature.producline_suffix = GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
 
       it { is_expected.to be true }
     end
@@ -61,7 +61,7 @@ RSpec.describe GreenLanes::GoodsNomenclature do
     subject { goods_nomenclature.get_declarable }
 
     context 'when the goods_nomenclature is declarable' do
-      before { goods_nomenclature.producline_suffix = '80' }
+      before { goods_nomenclature.producline_suffix = GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
 
       it { is_expected.to eq(goods_nomenclature) }
     end

--- a/spec/models/search/internal_search_result_spec.rb
+++ b/spec/models/search/internal_search_result_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Search::InternalSearchResult do
   def commodity_attrs(overrides = {})
     {
       'goods_nomenclature_item_id' => '0101210000',
-      'producline_suffix' => '80',
+      'producline_suffix' => GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
       'goods_nomenclature_class' => 'Commodity',
       'description' => 'Pure-bred breeding animals',
       'formatted_description' => 'Pure-bred breeding animals',
@@ -16,7 +16,7 @@ RSpec.describe Search::InternalSearchResult do
   def heading_attrs(overrides = {})
     {
       'goods_nomenclature_item_id' => '0101000000',
-      'producline_suffix' => '80',
+      'producline_suffix' => GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
       'goods_nomenclature_class' => 'Heading',
       'description' => 'Live horses',
       'formatted_description' => 'Live horses',
@@ -28,7 +28,7 @@ RSpec.describe Search::InternalSearchResult do
   def chapter_attrs(overrides = {})
     {
       'goods_nomenclature_item_id' => '0100000000',
-      'producline_suffix' => '80',
+      'producline_suffix' => GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
       'goods_nomenclature_class' => 'Chapter',
       'description' => 'Live animals',
       'formatted_description' => 'Live animals',

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Search do
               'type' => 'commodity',
               'attributes' => {
                 'goods_nomenclature_item_id' => '0101210000',
-                'producline_suffix' => '80',
+                'producline_suffix' => GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
                 'goods_nomenclature_class' => 'Commodity',
                 'description' => 'Pure-bred breeding animals',
                 'formatted_description' => 'Pure-bred breeding animals',

--- a/spec/presenters/internal_results_presenter_spec.rb
+++ b/spec/presenters/internal_results_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe InternalResultsPresenter do
         Search::InternalSearchResult.new([
           {
             'goods_nomenclature_item_id' => '0101210000',
-            'producline_suffix' => '80',
+            'producline_suffix' => GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
             'goods_nomenclature_class' => 'Commodity',
             'description' => 'Pure-bred breeding animals',
             'formatted_description' => 'Pure-bred breeding animals',
@@ -20,7 +20,7 @@ RSpec.describe InternalResultsPresenter do
           },
           {
             'goods_nomenclature_item_id' => '0101000000',
-            'producline_suffix' => '80',
+            'producline_suffix' => GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
             'goods_nomenclature_class' => 'Heading',
             'description' => 'Live horses',
             'formatted_description' => 'Live horses',

--- a/spec/views/commodities/_commodity.html.erb_spec.rb
+++ b/spec/views/commodities/_commodity.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'commodities/_commodity', type: :view do
     let(:commodity) { build(:heading, :with_subheading_and_commodity, producline_suffix:).commodities.first }
 
     context 'with producline_suffix of 80' do
-      let(:producline_suffix) { '80' }
+      let(:producline_suffix) { GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX }
 
       it 'shows the commodity code' do
         expect(rendered_page).to have_css \

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
       [
         {
           'goods_nomenclature_item_id' => '2007919930',
-          'producline_suffix' => '80',
+          'producline_suffix' => GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
           'goods_nomenclature_class' => 'Commodity',
           'description' => 'Containing less than 70% by weight of sugar',
           'formatted_description' => 'Containing less than 70% by weight of sugar',


### PR DESCRIPTION
### What?

Use a constant to represent the productline suffix value that means non-grouping.
Matches the constant that exists in the backend
