### PR TITLE
[HMRC-2185] Remove tariff last updated

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,6 @@ class ApplicationController < ActionController::Base
   before_action :maintenance_mode_if_active
 
   before_action :set_cache
-  before_action :set_last_updated
   before_action :set_path_info
   before_action :set_search
   before_action :bots_no_index_if_historical
@@ -42,12 +41,6 @@ class ApplicationController < ActionController::Base
                 :meursing_lookup_result,
                 :is_switch_service_banner_enabled?
 
-  def set_last_updated
-    # rubocop:disable Naming/MemoizedInstanceVariableName
-    @tariff_last_updated ||= TariffUpdate.latest_applied_import_date
-    # rubocop:enable Naming/MemoizedInstanceVariableName
-  end
-
   def disable_switch_service_banner
     @disable_switch_service_banner = true
   end
@@ -62,10 +55,6 @@ class ApplicationController < ActionController::Base
 
   def skip_news_banner
     @skip_news_banner = true
-  end
-
-  def disable_last_updated_footnote
-    @tariff_last_updated = nil
   end
 
   def search_invoked?

--- a/app/controllers/basic_sessions_controller.rb
+++ b/app/controllers/basic_sessions_controller.rb
@@ -2,7 +2,6 @@ class BasicSessionsController < ApplicationController
   skip_before_action :require_authentication, only: %i[new create]
 
   before_action :disable_switch_service_banner,
-                :disable_last_updated_footnote,
                 :disable_search_form
 
   def new

--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -121,7 +121,6 @@ module InteractiveSearchable
 
   def render_interactive_question
     disable_switch_service_banner
-    disable_last_updated_footnote
     disable_search_form
     mark_interactive_search_page
     render :interactive_question
@@ -129,7 +128,6 @@ module InteractiveSearchable
 
   def render_interactive_no_results
     disable_switch_service_banner
-    disable_last_updated_footnote
     disable_search_form
     mark_interactive_search_page
     render :interactive_no_results
@@ -137,7 +135,6 @@ module InteractiveSearchable
 
   def render_interactive_results
     disable_switch_service_banner
-    disable_last_updated_footnote
     disable_search_form
     mark_interactive_search_page
     render :interactive_results

--- a/app/controllers/duty_calculator/application_controller.rb
+++ b/app/controllers/duty_calculator/application_controller.rb
@@ -1,6 +1,6 @@
 module DutyCalculator
   class ApplicationController < ::ApplicationController
-    before_action :user_session, :disable_switch_service_banner, :disable_search_form, :disable_last_updated_footnote
+    before_action :user_session, :disable_switch_service_banner, :disable_search_form
 
     after_action :no_store_cache
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,5 @@
 class ErrorsController < ApplicationController
   skip_before_action :maintenance_mode_if_active
-  skip_before_action :set_last_updated
   skip_before_action :set_path_info
   skip_before_action :set_search
   skip_before_action :bots_no_index_if_historical

--- a/app/controllers/exchange_rates_controller.rb
+++ b/app/controllers/exchange_rates_controller.rb
@@ -1,5 +1,5 @@
 class ExchangeRatesController < ApplicationController
-  before_action :disable_search_form, :disable_switch_service_banner, :disable_last_updated_footnote
+  before_action :disable_search_form, :disable_switch_service_banner
   before_action :validate_rate_type!
 
   def index

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,7 +1,6 @@
 class FeedbackController < ApplicationController
   before_action :disable_search_form,
-                :disable_switch_service_banner,
-                :disable_last_updated_footnote
+                :disable_switch_service_banner
 
   def new
     session[:feedback_referrer] = request.referer

--- a/app/controllers/geographical_areas_controller.rb
+++ b/app/controllers/geographical_areas_controller.rb
@@ -1,7 +1,6 @@
 class GeographicalAreasController < ApplicationController
   before_action :disable_search_form,
                 :disable_switch_service_banner,
-                :disable_last_updated_footnote,
                 :set_goods_nomenclature_code
 
   def show

--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -10,12 +10,7 @@ class GoodsNomenclaturesController < ApplicationController
   end
 
   def find_relevant_goods_code_or_fallback
-    @search = Search.new(
-      q: goods_code_id,
-      day: @tariff_last_updated.try(:day),
-      month: @tariff_last_updated.try(:month),
-      year: @tariff_last_updated.try(:year),
-    )
+    @search = Search.new(q: goods_code_id)
     results = @search.perform
 
     if results.exact_match?

--- a/app/controllers/import_export_dates_controller.rb
+++ b/app/controllers/import_export_dates_controller.rb
@@ -3,7 +3,6 @@ class ImportExportDatesController < ApplicationController
 
   before_action :disable_search_form,
                 :disable_switch_service_banner,
-                :disable_last_updated_footnote,
                 :set_goods_nomenclature_code
 
   def show

--- a/app/controllers/live_issues_controller.rb
+++ b/app/controllers/live_issues_controller.rb
@@ -1,6 +1,5 @@
 class LiveIssuesController < ApplicationController
   before_action :disable_switch_service_banner,
-                :disable_last_updated_footnote,
                 :disable_search_form
 
   def index

--- a/app/controllers/measure_types/preference_codes_controller.rb
+++ b/app/controllers/measure_types/preference_codes_controller.rb
@@ -1,7 +1,6 @@
 module MeasureTypes
   class PreferenceCodesController < ApplicationController
     before_action :disable_search_form,
-                  :disable_last_updated_footnote,
                   :set_goods_nomenclature_code
 
     def show

--- a/app/controllers/meursing_lookup/steps_controller.rb
+++ b/app/controllers/meursing_lookup/steps_controller.rb
@@ -2,7 +2,6 @@ module MeursingLookup
   class StepsController < ApplicationController
     before_action do
       disable_search_form
-      disable_last_updated_footnote
       disable_switch_service_banner
 
       clear_meursing_lookup_session

--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -4,8 +4,7 @@ module Myott
 
     before_action :authenticate,
                   :disable_search_form,
-                  :disable_switch_service_banner,
-                  :disable_last_updated_footnote
+                  :disable_switch_service_banner
 
     rescue_from AuthenticationError, with: :handle_authentication_error
 

--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -1,6 +1,5 @@
 class NewsItemsController < ApplicationController
   before_action :disable_search_form,
-                :disable_last_updated_footnote,
                 :disable_switch_service_banner
 
   def index

--- a/app/controllers/pages/glossary_controller.rb
+++ b/app/controllers/pages/glossary_controller.rb
@@ -1,7 +1,6 @@
 module Pages
   class GlossaryController < ApplicationController
-    before_action :disable_search_form,
-                  :disable_last_updated_footnote
+    before_action :disable_search_form
 
     def index
       @terms = Pages::Glossary.all

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,5 @@
 class PagesController < ApplicationController
-  before_action :disable_search_form,
-                :disable_last_updated_footnote
+  before_action :disable_search_form
   before_action :disable_switch_service_banner, only: %i[changes_999l terms privacy]
 
   def glossary

--- a/app/controllers/product_experience/enquiry_form_controller.rb
+++ b/app/controllers/product_experience/enquiry_form_controller.rb
@@ -1,7 +1,6 @@
 module ProductExperience
   class EnquiryFormController < ApplicationController
     before_action :disable_switch_service_banner,
-                  :disable_last_updated_footnote,
                   :disable_search_form,
                   :initialize_enquiry_data
 

--- a/app/controllers/rules_of_origin/steps_controller.rb
+++ b/app/controllers/rules_of_origin/steps_controller.rb
@@ -7,7 +7,6 @@ module RulesOfOrigin
 
     before_action do
       disable_search_form
-      disable_last_updated_footnote
       disable_switch_service_banner
     end
 

--- a/app/controllers/simplified_procedural_values_controller.rb
+++ b/app/controllers/simplified_procedural_values_controller.rb
@@ -1,6 +1,5 @@
 class SimplifiedProceduralValuesController < ApplicationController
   before_action :disable_search_form,
-                :disable_last_updated_footnote,
                 :disable_switch_service_banner
 
   def index

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -2,7 +2,7 @@ module CacheHelper
   CACHE_EXCLUDED_PARAMS = %w[request_id].freeze
 
   def cache_key
-    [TradeTariffFrontend::ServiceChooser.cache_prefix, @tariff_last_updated, TradeTariffFrontend.revision].join('/')
+    [TradeTariffFrontend::ServiceChooser.cache_prefix, TradeTariffFrontend.revision].join('/')
   end
 
   def commodity_cache_key

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -61,7 +61,7 @@ class Search
   end
 
   def filtered_by_date?
-    date != TariffUpdate.latest_applied_import_date
+    date != Time.zone.today
   end
 
   def day_month_and_year_set?

--- a/spec/helpers/cache_helper_spec.rb
+++ b/spec/helpers/cache_helper_spec.rb
@@ -3,10 +3,9 @@ RSpec.describe CacheHelper, type: :helper do
     let(:cacheable) do
       Class.new do
         include CacheHelper
-        attr_accessor :tariff_last_updated, :params
+        attr_accessor :params
 
-        def initialize(last_updated, params_hash)
-          @tariff_last_updated = last_updated
+        def initialize(params_hash)
           @params = ActionController::Parameters.new(params_hash)
         end
 
@@ -22,21 +21,21 @@ RSpec.describe CacheHelper, type: :helper do
     end
 
     context 'when date params are available, builds the correct commodity cache key' do
-      let(:instance) { cacheable.new('2025-01-01', { day: '04', month: '01', year: '2025', id: '2008605010' }) }
+      let(:instance) { cacheable.new({ day: '04', month: '01', year: '2025', id: '2008605010' }) }
 
-      it { expect(instance.commodity_cache_key).to eq(%w[commodities#show uk/2025-01-01/1 100 04/2008605010/01/2025]) }
+      it { expect(instance.commodity_cache_key).to eq(%w[commodities#show uk/1 100 04/2008605010/01/2025]) }
     end
 
     context 'when date and month swapped for subsequent requests, cache keys are different' do
-      let(:instance) { cacheable.new('2025-01-01', { day: '04', month: '01', year: '2025', id: '2008605010' }) }
-      let(:instance2) { cacheable.new('2025-01-01', { day: '01', month: '04', year: '2025', id: '2008605010' }) }
+      let(:instance) { cacheable.new({ day: '04', month: '01', year: '2025', id: '2008605010' }) }
+      let(:instance2) { cacheable.new({ day: '01', month: '04', year: '2025', id: '2008605010' }) }
 
       it { expect(instance.commodity_cache_key).not_to eq(instance2.commodity_cache_key) }
     end
 
     context 'when request_id is present, it is excluded from the cache key' do
-      let(:without_request_id) { cacheable.new('2025-01-01', { day: '04', month: '01', year: '2025', id: '2008605010' }) }
-      let(:with_request_id) { cacheable.new('2025-01-01', { day: '04', month: '01', year: '2025', id: '2008605010', request_id: SecureRandom.uuid }) }
+      let(:without_request_id) { cacheable.new({ day: '04', month: '01', year: '2025', id: '2008605010' }) }
+      let(:with_request_id) { cacheable.new({ day: '04', month: '01', year: '2025', id: '2008605010', request_id: SecureRandom.uuid }) }
 
       it { expect(with_request_id.commodity_cache_key).to eq(without_request_id.commodity_cache_key) }
     end

--- a/spec/models/tariff_update_spec.rb
+++ b/spec/models/tariff_update_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe TariffUpdate do
+  before do
+    allow(described_class).to receive(:all).and_return([build(:tariff_update)])
+  end
+
   describe '#applied_at' do
     subject(:applied_at) { build(:tariff_update).applied_at }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,7 +81,6 @@ RSpec.configure do |config|
   config.include_context 'with switch service banner', type: :view
 
   config.before do
-    allow(TariffUpdate).to receive(:all).and_return([OpenStruct.new(applied_at: Time.zone.today)])
     allow(News::Item).to receive(:latest_banner).and_return build(:news_item, :banner)
     Thread.current[:service_choice] = nil
 


### PR DESCRIPTION
### Jira link

[HMRC-2185](https://transformuk.atlassian.net/browse/HMRC-2185)

### What?

When reviewing the apps for performance optimisations, I noticed the `/updates/latest` endpoint was called on every request to set the @tariff_last_updated timestamp. This should not be necessary when the timestamp should only change after an import (once a day).

More investigating shows that we removed this in an earlier PR: [OTTIMP-439](https://transformuk.atlassian.net/browse/OTTIMP-439) so this is no longer needed.

This PR removed mentions of `tariff_last_updated` almost entirely, but leaves the model intact should we wish to bring this back.

### Why?

We currently make a request to `/updates/latest` on every request but don't actually do anything with this.
Removing this means way fewer requests, faster service, and cleaner code.