### PR TITLE
Remove unnecessary gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ end
 
 gem 'rails', '~> 8.1'
 
-gem 'csv'
 gem 'faraday'
 gem 'faraday-http-cache'
 gem 'faraday-net_http_persistent'
@@ -18,7 +17,6 @@ gem 'inline_svg'
 gem 'jwt'
 gem 'kaminari'
 gem 'multi_json'
-gem 'net-http-persistent'
 gem 'newrelic_rpm'
 gem 'roo'
 gem 'routing-filter', github: 'trade-tariff/routing-filter'
@@ -36,7 +34,6 @@ gem 'turbo-rails'
 gem 'govspeak'
 gem 'govuk_design_system_formbuilder'
 gem 'nokogiri'
-gem 'plek'
 gem 'wizard_steps'
 
 # Logging
@@ -52,11 +49,9 @@ gem 'redis'
 
 # AWS
 gem 'aws-actionmailer-ses'
-gem 'aws-sdk-rails'
 
 group :development do
   gem 'letter_opener'
-  gem 'rubocop-capybara'
   gem 'rubocop-govuk'
   gem 'ruby-lsp-rails'
   gem 'ruby-lsp-rspec'
@@ -76,7 +71,6 @@ group :test do
   gem 'cuprite'
   gem 'factory_bot_rails'
   gem 'forgery'
-  gem 'rack-test'
   gem 'rails-controller-testing', github: 'rails/rails-controller-testing', branch: 'master'
   gem 'rspec-rails'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,9 +122,6 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-rails (5.1.0)
-      aws-sdk-core (~> 3)
-      railties (>= 7.1.0)
     aws-sdk-ses (1.97.0)
       aws-sdk-core (~> 3, >= 3.244.0)
       aws-sigv4 (~> 1.5)
@@ -606,12 +603,10 @@ PLATFORMS
 DEPENDENCIES
   amazing_print
   aws-actionmailer-ses
-  aws-sdk-rails
   bootsnap
   brakeman
   capybara
   cssbundling-rails
-  csv
   cuprite
   dotenv-rails
   factory_bot_rails
@@ -632,16 +627,13 @@ DEPENDENCIES
   lograge
   logstash-event
   multi_json
-  net-http-persistent
   newrelic_rpm
   nokogiri
-  plek
   propshaft
   pry-rails
   puma
   rack-attack
   rack-cors
-  rack-test
   rack-timeout
   rails (~> 8.1)
   rails-controller-testing!
@@ -649,7 +641,6 @@ DEPENDENCIES
   roo
   routing-filter!
   rspec-rails
-  rubocop-capybara
   rubocop-govuk
   ruby-lsp-rails
   ruby-lsp-rspec


### PR DESCRIPTION
### What?

I have removed the following from the Gemfile:
- `csv` - not used directly and is pulled in as a dependency of roo anyway
- `net-http-persistent` - already included as a dependency of `faraday-net_http_persistent`
- `plek` - is not used anywhere but is loaded as a transitive dependency anyway
- `aws-sdk-rails` - not required since actionmailer delivery was changed to :ses_v2
- `rubocop-capybara` - already included as a dependency of `govuk-rubocop` 
-  `rack-test` - not used
