### PR TITLE
Add linux-headers dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} AS builder
 
 WORKDIR /build
 
-RUN apk add --no-cache build-base git yarn tzdata yaml-dev openssl-dev && \
+RUN apk add --no-cache build-base linux-headers git yarn tzdata yaml-dev openssl-dev && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 


### PR DESCRIPTION
### What?

A recent update of Puma caused raindrops gem to be added as a dependency. This could not compile on Alpine because of missing kernel headers. The linux-headers package has been added to fix this.

---
The new dependency is caused by having to downgrade govuk_app_config as recent versions specify the version of puma as <8. 
