### PR TITLE
OTTIMP-501 Refactor errors and replace unprocessable entity

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -9,62 +9,37 @@ class ErrorsController < ApplicationController
                 :skip_news_banner
 
   ERROR_RESPONSES = {
-    unprocessable_entity: {
-      status: :unprocessable_entity,
-      header: 'Unprocessable entity',
+    unprocessable_content: {
       message: "We're sorry, but we cannot process your request at this time.<br>
-               Please contact support for assistance or try a different request.",
-      html_safe: true,
-      json_error: 'Unprocessable entity',
+               Please contact support for assistance or try a different request.".html_safe,
     },
     internal_server_error: {
-      status: :internal_server_error,
       header: 'We are experiencing technical difficulties',
       message: 'We are experiencing technical difficulties',
-      json_error: 'Internal server error',
     },
     bad_request: {
-      status: :bad_request,
-      header: 'Bad request',
       message: "The request you made is not valid.<br>
-               Please contact support for assistance or try a different request.",
-      html_safe: true,
-      json_error: 'Bad request',
+               Please contact support for assistance or try a different request.".html_safe,
     },
     method_not_allowed: {
-      status: :method_not_allowed,
-      header: 'Method not allowed',
       message: "We're sorry, but this request method is not supported.<br>
-               Please contact support for assistance or try a different request.",
-      html_safe: true,
-      json_error: 'Method not allowed',
+               Please contact support for assistance or try a different request.".html_safe,
     },
     not_acceptable: {
-      status: :not_acceptable,
-      header: 'Not acceptable',
       message: "Unfortunately, we cannot fulfill your request as it is not in a format we can accept.<br>
-               Please contact support for assistance or try a different request.",
-      html_safe: true,
-      json_error: 'Not acceptable',
+               Please contact support for assistance or try a different request.".html_safe,
     },
     not_implemented: {
-      status: :not_implemented,
-      header: 'Not implemented',
       message: "We're sorry, but the requested action is not supported by our server at this time.<br>
-               Please contact support for assistance or try a different request.",
-      html_safe: true,
-      json_error: 'Not implemented',
+               Please contact support for assistance or try a different request.".html_safe,
     },
     too_many_requests: {
-      status: :too_many_requests,
-      header: 'Too Many Requests',
       message: 'You are rate limited. Please try again later.',
-      json_error: 'Too many requests',
     },
   }.freeze
 
   ERROR_RESPONSES.each_key do |action|
-    define_method(action) { render_error(**ERROR_RESPONSES[action]) }
+    define_method(action) { render_error(status: action, **ERROR_RESPONSES[action]) }
   end
 
   def not_found
@@ -89,8 +64,9 @@ class ErrorsController < ApplicationController
 
   private
 
-  def render_error(status:, header:, message:, json_error:, html_safe: false)
-    message = message.html_safe if html_safe
+  def render_error(status:, message:, header: nil, json_error: nil)
+    header ||= status.to_s.humanize
+    json_error ||= status.to_s.humanize
 
     respond_to do |format|
       format.html { render 'error', status:, locals: { header:, message: } }

--- a/app/controllers/green_lanes/applicable_exemptions_controller.rb
+++ b/app/controllers/green_lanes/applicable_exemptions_controller.rb
@@ -26,7 +26,7 @@ module GreenLanes
       else
         @back_link_path = back_link_path_for_current_page
 
-        render_exemptions_questions(:unprocessable_entity)
+        render_exemptions_questions(:unprocessable_content)
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,7 +245,7 @@ Rails.application.routes.draw do
   match '/404', to: 'errors#not_found', via: :all, as: :not_found
   match '/405', to: 'errors#method_not_allowed', via: :all
   match '/406', to: 'errors#not_acceptable', via: :all
-  match '/422', to: 'errors#unprocessable_entity', via: :all
+  match '/422', to: 'errors#unprocessable_content', via: :all
   match '/429', to: 'errors#too_many_requests', via: :all
   match '/500', to: 'errors#internal_server_error', via: :all
   match '/501', to: 'errors#not_implemented', via: :all

--- a/public/422.html
+++ b/public/422.html
@@ -4,7 +4,7 @@
 
   <head>
 
-    <title>The change you wanted was rejected (422 Unprocessable Entity)</title>
+    <title>The change you wanted was rejected (422 Unprocessable Content)</title>
 
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1, width=device-width">

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationController, type: :request do
       let(:exception) { ActionController::InvalidAuthenticityToken }
 
       it { is_expected.to have_http_status(422) }
-      it { expect(do_response.body).to include('Unprocessable entity') }
+      it { expect(do_response.body).to include('Unprocessable content') }
     end
   end
 end

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ErrorsController, type: :request do
   describe 'GET /429' do
     let(:make_request) { get '/429' }
 
-    it { expect(body).to include 'Too Many Requests' }
+    it { expect(body).to include 'Too many requests' }
   end
 
   describe 'GET /500' do


### PR DESCRIPTION
### Jira link

[OTTIMP-501](https://transformuk.atlassian.net/browse/OTTIMP-501)

### What?

Several of the arguments used by the render_error method can be derived from the status.

The unprocessable_entity symbol for HTTP status 422 has been deprecated and replaced by unprocessable_content.
