### PR TITLE
OTTIMP-525 Unhide legal base for UK on staging

### DIFF
--- a/app/assets/stylesheets/src/_uk_overrides.scss
+++ b/app/assets/stylesheets/src/_uk_overrides.scss
@@ -1,4 +1,4 @@
-body.uk-service {
+body.uk-service:not(.uk-legal-base-column-enabled) {
   table.measures {
     th.legal-base-col {
       display: none;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
   <%= javascript_importmap_tags %>
 </head>
 
-<body class="govuk-template__body <%= service_choice || service_default %>-service">
+<body class="govuk-template__body <%= service_choice || service_default %>-service<%= ' uk-legal-base-column-enabled' if TradeTariffFrontend.uk_legal_base_column_enabled? %>">
   <%= render 'shared/gtm', part: 'body' if analytics_allowed? %>
   <%= content_tag :div, class: 'path_info', data: @path_info do %>
   <% end %>

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -126,6 +126,10 @@ module TradeTariffFrontend
     ENV['GREEN_LANES_ENABLED'].to_s == 'true'
   end
 
+  def uk_legal_base_column_enabled?
+    !production?
+  end
+
   def interactive_search_enabled?
     !production? && !ServiceChooser.xi?
   end


### PR DESCRIPTION
### Jira link

[OTTIMP-525](https://transformuk.atlassian.net/browse/OTTIMP-525)

### What?

We are unhiding the legal base links for UK tariff on non-production environments.

### Why?

Traders need to verify the legal basis for tariff measures affecting their imports and exports. They were previously hidden because post-brexit UK legislation not yet formed, but that is no longer the case.
