### PR TITLE
Use govuk-colours

### DIFF
--- a/app/assets/stylesheets/src/_cards.scss
+++ b/app/assets/stylesheets/src/_cards.scss
@@ -16,7 +16,7 @@
 }
 
 .gem-c-cards__list-item {
-  border-bottom: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid govuk-functional-colour(border);
   padding: govuk-spacing(1) 0 govuk-spacing(4) 0;
 }
 
@@ -43,8 +43,8 @@
     $dimension: 7px;
     $width: 3px;
 
-    border-right: $width solid $govuk-brand-colour;
-    border-top: $width solid $govuk-brand-colour;
+    border-right: $width solid govuk-functional-colour(brand);
+    border-top: $width solid govuk-functional-colour(brand);
     content: "";
     display: block;
     height: $dimension;
@@ -57,11 +57,11 @@
   }
 
   &:hover::before {
-    border-color: $govuk-link-hover-colour;
+    border-color: govuk-functional-colour(link-hover);
   }
 
   &:focus::before {
-    border-color: $govuk-focus-text-colour;
+    border-color: govuk-functional-colour(focus-text);
   }
 }
 

--- a/app/assets/stylesheets/src/_colors.scss
+++ b/app/assets/stylesheets/src/_colors.scss
@@ -1,8 +1,3 @@
-// GOV.UK elements style guide specifies that 25% or 50% tints
-@function tint($color) {
-  @return mix($color, #fff, 25%);
-}
-
 $tariff-white: #f0f0f0;
 $chapter-code-bg: #d1d2e6;
 $heading-code-bg: #b3d9ee;

--- a/app/assets/stylesheets/src/_commodity-buttons.scss
+++ b/app/assets/stylesheets/src/_commodity-buttons.scss
@@ -1,7 +1,7 @@
 .commodity-action-button {
   display: inline-flex;
   align-items: center;
-  color: rgb(29, 112, 184);
+  color: govuk-colour("blue");
   cursor: pointer;
   font-family: "GDS Transport", arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -19,7 +19,7 @@
 
 .commodity-action-button:link,
 .commodity-action-button:visited {
-  color: rgb(29, 112, 184);
+  color: govuk-colour("blue");
   text-decoration: none;
 }
 
@@ -35,36 +35,36 @@
 
 .commodity-action-button:active {
   background-color: rgb(243, 242, 241);
-  box-shadow: inset 0 -4px 0 #0b0c0c;
-  color: #0b0c0c;
+  box-shadow: inset 0 -4px 0 govuk-colour("black");
+  color: govuk-functional-colour(text);
 }
 
 .commodity-action-button:focus,
 .commodity-action-button:focus-visible {
   outline: 3px solid transparent;
-  background-color: #fd0;
-  box-shadow: inset 0 -4px 0 #0b0c0c;
-  color: #0b0c0c;
+  background-color: govuk-functional-colour(focus);
+  box-shadow: inset 0 -4px 0 govuk-colour("black");
+  color: govuk-functional-colour(focus-text);
   text-decoration: none;
 }
 
 .commodity-action-button--copied,
 .commodity-action-button--copied:focus,
 .commodity-action-button--copied:focus-visible {
-  background-color: #fd0;
-  box-shadow: inset 0 -4px 0 #0b0c0c;
-  color: #0b0c0c;
+  background-color: govuk-functional-colour(focus);
+  box-shadow: inset 0 -4px 0 govuk-colour("black");
+  color: govuk-functional-colour(focus-text);
 }
 
 .commodity-action-button--copied:hover,
 .commodity-action-button--copied:active {
   background-color: rgb(243, 242, 241);
-  box-shadow: inset 0 -4px 0 #0b0c0c;
-  color: #0b0c0c;
+  box-shadow: inset 0 -4px 0 govuk-colour("black");
+  color: govuk-functional-colour(text);
 }
 
 .commodity-action-button__icon {
-  color: #0b0c0c;
+  color: govuk-functional-colour(text);
   vertical-align: top;
   margin-right: 5px;
 }

--- a/app/assets/stylesheets/src/_commodity-tree.scss
+++ b/app/assets/stylesheets/src/_commodity-tree.scss
@@ -496,7 +496,7 @@ li.has_children {
   padding: px($top-level-padding);
   z-index: 1;
   font-size: em(14, 16);
-  background: #fff;
+  background: govuk-functional-colour(body-background);
   border: solid 1px #bbb;
 
   p {

--- a/app/assets/stylesheets/src/_exchange_rates.scss
+++ b/app/assets/stylesheets/src/_exchange_rates.scss
@@ -12,7 +12,7 @@
 
 .document-download a {
   margin-right: 0.25em;
-  border-right: 1px govuk-colour("blue") solid;
+  border-right: 1px govuk-functional-colour(brand) solid;
   padding-right: 0.5em;
 }
 

--- a/app/assets/stylesheets/src/_feedback_banner.scss
+++ b/app/assets/stylesheets/src/_feedback_banner.scss
@@ -1,5 +1,5 @@
 .tariff-feedback-banner {
-  background-color: govuk-colour("white");
+  background-color: govuk-functional-colour(body-background);
 
   .govuk-width-container {
     padding-top: govuk-spacing(4);

--- a/app/assets/stylesheets/src/_feedback_banner_beta.scss
+++ b/app/assets/stylesheets/src/_feedback_banner_beta.scss
@@ -1,5 +1,5 @@
 // Modifier for panel: blue left border and light blue background (GOV.UK notice style)
 .panel--feedback {
-  border-left-color: govuk-colour("blue");
-  background-color: govuk-tint(govuk-colour("blue"), 90%);
+  border-left-color: govuk-functional-colour(brand);
+  background-color: govuk-colour("blue", $variant: "tint-95");
 }

--- a/app/assets/stylesheets/src/_feedback_useful_banner.scss
+++ b/app/assets/stylesheets/src/_feedback_useful_banner.scss
@@ -4,7 +4,7 @@
 
   &__inner {
     background-color: govuk-colour("black", $variant: "tint-95");
-    border-bottom: 1px solid $govuk-border-colour;
+    border-bottom: 1px solid govuk-functional-colour(border);
     padding: govuk-spacing(4);
     // Reapply footer meta flex layout (normally scoped under .govuk-footer)
     display: flex;

--- a/app/assets/stylesheets/src/_form_customisations.scss
+++ b/app/assets/stylesheets/src/_form_customisations.scss
@@ -68,7 +68,7 @@
 }
 
 .custom-select:focus {
-  outline: 3px solid #ffdd00;
+  outline: 3px solid govuk-colour("yellow");
   outline-offset: 0;
   box-shadow: inset 0 0 0 2px;
 }

--- a/app/assets/stylesheets/src/_header.scss
+++ b/app/assets/stylesheets/src/_header.scss
@@ -27,7 +27,7 @@
   height: 2.5rem !important;
   margin-top: 0 !important;
   padding: 0 5px !important;
-  border: 2px solid #0b0c0c !important;
+  border: 2px solid govuk-functional-colour(input-border) !important;
   border-radius: 0 !important;
 
   .select2-selection__placeholder,
@@ -69,7 +69,7 @@
   height: 2.5rem !important;
   margin-top: 0 !important;
   padding: 0 5px !important;
-  border: 2px solid #0b0c0c !important;
+  border: 2px solid govuk-functional-colour(input-border) !important;
   border-radius: 0 !important;
 }
 
@@ -81,7 +81,7 @@
 
 .select2-container--open .select2-dropdown--below {
   border-width: 2px !important;
-  border-color: #0b0c0c !important;
+  border-color: govuk-functional-colour(input-border) !important;
 }
 
 a.back-to-previous {
@@ -89,7 +89,7 @@ a.back-to-previous {
   font-size: 14px;
   display: block;
   text-decoration: none;
-  border-bottom: #0b0c0c 1px solid;
+  border-bottom: govuk-colour("black") 1px solid;
   width: 2.25em;
   background: url('/icon-caret-left.png') left 0.2em no-repeat;
   padding-left: 0.75em;

--- a/app/assets/stylesheets/src/_help_find_commodity.scss
+++ b/app/assets/stylesheets/src/_help_find_commodity.scss
@@ -9,8 +9,8 @@
 }
 
 .gem-c-related-navigation {
-  color: #0b0c0c;
-  border-top: 2px solid #1d70b8;
+  color: govuk-functional-colour(text);
+  border-top: 2px solid govuk-functional-colour(brand);
 }
 
 .gem-c-related-navigation__nav-section {

--- a/app/assets/stylesheets/src/_help_popup.scss
+++ b/app/assets/stylesheets/src/_help_popup.scss
@@ -1,5 +1,5 @@
 #help_popup {
-  background-color: govuk-colour("white");
+  background-color: govuk-functional-colour(body-background);
   border: 1px #333 solid;
   border-radius: 0.5em;
   padding: 0.3em 0.5em;

--- a/app/assets/stylesheets/src/_interactive-search.scss
+++ b/app/assets/stylesheets/src/_interactive-search.scss
@@ -2,7 +2,7 @@
 
 // Blue left-border variant of govuk-inset-text for interactive search feedback
 .app-inset-text--blue {
-  border-left-color: $govuk-brand-colour;
+  border-left-color: govuk-functional-colour(brand);
 }
 
 // Interactive search Q&A styles
@@ -55,7 +55,7 @@
 // Interactive feedback useful banner - full-width grey banner with blue bottom border
 .app-feedback-useful-banner {
   background: govuk-colour("black", $variant: "tint-95");
-  border-bottom: 4px solid $govuk-brand-colour;
+  border-bottom: 4px solid govuk-functional-colour(brand);
 
   .app-feedback-useful-banner__content {
     display: flex;
@@ -71,8 +71,8 @@
     width: auto;
     margin-bottom: 0;
     background-color: govuk-functional-colour(body-background);
-    color: $govuk-text-colour;
-    border: 1px solid $govuk-text-colour;
+    color: govuk-functional-colour(text);
+    border: 1px solid govuk-functional-colour(text);
     border-bottom-width: 3px;
     box-shadow: none;
     flex-shrink: 0;
@@ -80,12 +80,12 @@
     &:link,
     &:visited,
     &:active {
-      color: $govuk-text-colour;
+      color: govuk-functional-colour(text);
       background-color: govuk-functional-colour(body-background);
     }
 
     &:hover {
-      color: $govuk-text-colour;
+      color: govuk-functional-colour(text);
       background-color: color.adjust(govuk-colour("black", $variant: "tint-95"), $lightness: -3%);
     }
   }
@@ -93,7 +93,7 @@
 
 // Feedback banner - thin blue top line, heading and button on same line
 .app-feedback-banner {
-  border-top: 2px solid $govuk-brand-colour;
+  border-top: 2px solid govuk-functional-colour(brand);
   padding-top: govuk-spacing(4);
   display: flex;
   justify-content: space-between;
@@ -108,8 +108,8 @@
   width: auto;
   margin-bottom: 0;
   background-color: govuk-functional-colour(body-background);
-  color: $govuk-text-colour;
-  border: 1px solid $govuk-text-colour;
+  color: govuk-functional-colour(text);
+  border: 1px solid govuk-functional-colour(text);
   border-bottom-width: 3px;
   box-shadow: none;
   flex-shrink: 0;
@@ -118,7 +118,7 @@
   &:visited,
   &:hover,
   &:active {
-    color: $govuk-text-colour;
+    color: govuk-functional-colour(text);
   }
 
   &:hover {
@@ -133,7 +133,7 @@
 
 // Thick blue section break matching GOV.UK prototype kit style
 .app-section-break--thick {
-  border-bottom: 4px solid $govuk-brand-colour;
+  border-bottom: 4px solid govuk-functional-colour(brand);
 }
 
 // Devolved nations panel - grey background matching gem-c-devolved-nations

--- a/app/assets/stylesheets/src/_interactive-search.scss
+++ b/app/assets/stylesheets/src/_interactive-search.scss
@@ -44,11 +44,11 @@
   font-family: "GDS Transport", arial, sans-serif;
   font-size: 14px;
   font-weight: bold;
-  color: #0b0c0c;
+  color: govuk-functional-colour(text);
 }
 
 .app-related-items {
-  border-top: 2px solid #1d70b8;
+  border-top: 2px solid govuk-functional-colour(brand);
   padding-top: 15px;
 }
 
@@ -70,7 +70,7 @@
   .app-feedback-useful-banner__button {
     width: auto;
     margin-bottom: 0;
-    background-color: govuk-colour("white");
+    background-color: govuk-functional-colour(body-background);
     color: $govuk-text-colour;
     border: 1px solid $govuk-text-colour;
     border-bottom-width: 3px;
@@ -81,7 +81,7 @@
     &:visited,
     &:active {
       color: $govuk-text-colour;
-      background-color: govuk-colour("white");
+      background-color: govuk-functional-colour(body-background);
     }
 
     &:hover {
@@ -107,7 +107,7 @@
 .app-feedback-banner__button {
   width: auto;
   margin-bottom: 0;
-  background-color: govuk-colour("white");
+  background-color: govuk-functional-colour(body-background);
   color: $govuk-text-colour;
   border: 1px solid $govuk-text-colour;
   border-bottom-width: 3px;

--- a/app/assets/stylesheets/src/_lists.scss
+++ b/app/assets/stylesheets/src/_lists.scss
@@ -67,7 +67,7 @@ ol.legislative-list {
   padding: 0;
 
   ol li {
-    color: #0b0c0c;
+    color: govuk-functional-colour(text);
     font-weight: 400;
   }
 

--- a/app/assets/stylesheets/src/_modal.scss
+++ b/app/assets/stylesheets/src/_modal.scss
@@ -41,7 +41,7 @@
   zoom: 1;
   z-index: 1050;
   overflow-y: scroll;
-  background-color: #fff;
+  background-color: govuk-functional-colour(body-background);
   border-radius: 5px;
   box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
 
@@ -88,7 +88,7 @@
   }
 
   .info-content {
-    background-color: #fff;
+    background-color: govuk-functional-colour(body-background);
     padding: 2.4em px($top-level-padding) px($top-level-padding) px($top-level-padding);
   }
 

--- a/app/assets/stylesheets/src/_mycommodities.scss
+++ b/app/assets/stylesheets/src/_mycommodities.scss
@@ -22,7 +22,7 @@
   }
 
   .category_container {
-    background-color: govuk-colour(white);
+    background-color: govuk-functional-colour(body-background);
     padding: govuk-spacing(3) + 1px;
     border: 2px solid  govuk-functional-colour(border);
     @include govuk-media-query($until: tablet) {
@@ -39,7 +39,7 @@
   .download_icon {
     margin: govuk-spacing(1) - 1px;
     vertical-align: middle;
-    color: govuk-colour(black);
+    color: govuk-functional-colour(text);
   }
 
   .govuk-link--inverse {

--- a/app/assets/stylesheets/src/_switch_uk_xi_panel.scss
+++ b/app/assets/stylesheets/src/_switch_uk_xi_panel.scss
@@ -8,13 +8,13 @@
 
   .arrow:before {
     content: "\2192";
-    color: govuk-colour("blue");
+    color: govuk-functional-colour(brand);
   }
 
   @include govuk-media-query($from: tablet) {
     display: inline-block;
     padding-left: 0.75em;
-    background-color: govuk-colour("blue");
+    background-color: govuk-functional-colour(brand);
 
     a {
       color: govuk-colour("white");

--- a/app/assets/stylesheets/src/index-page-right-column.scss
+++ b/app/assets/stylesheets/src/index-page-right-column.scss
@@ -1,7 +1,7 @@
 .index-page-right-column {
   margin-top: 40px;
   padding-top: 5px;
-  border-top: 10px solid govuk-colour("blue");
+  border-top: 10px solid govuk-functional-colour(brand);
 
   h2 {
     font-size: 24px;


### PR DESCRIPTION
### What?

Replaces hard-coded hex values with values from GOV.UK colour palette. Where appropriate semantic functional colour names have been used. Changes have only been made where there is an exact match so there will be no visible change on the frontend.

Also:
- Replaced deprecated colour variables (e.g. $govuk-text-colour)
- The unused tint function has been removed
- Removes usage of `govuk-tint` function which was removed in [govuk-frontend 6.0](https://github.com/alphagov/govuk-frontend/pull/6639).

### Why?

These colour changes standardise the codebase on GOV.UK design tokens so colour usage is semantic and maintainable.
