### PR TITLE
BAU: Fix max length handling

### DIFF
--- a/app/forms/interactive_search_form.rb
+++ b/app/forms/interactive_search_form.rb
@@ -2,7 +2,7 @@ class InteractiveSearchForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  MAX_QUERY_LENGTH = 100
+  MAX_QUERY_LENGTH = 500
   MIN_QUERY_LENGTH = 2
 
   attribute :q, :string
@@ -22,6 +22,6 @@ class InteractiveSearchForm
   def sanitise_query(value)
     return nil if value.blank?
 
-    value.to_s.strip.gsub(/[\[\]]/, '').first(MAX_QUERY_LENGTH)
+    value.to_s.strip.gsub(/[\[\]]/, '')
   end
 end

--- a/app/javascript/controllers/guided_search_validation_controller.js
+++ b/app/javascript/controllers/guided_search_validation_controller.js
@@ -32,7 +32,7 @@ export default class extends Controller {
     } else if (value.length < MIN_QUERY_LENGTH) {
       errors.push('Search term must be at least 2 characters')
     } else if (value.length > MAX_QUERY_LENGTH) {
-      errors.push('Search term must be 100 characters or fewer')
+      errors.push(`Search term must be ${MAX_QUERY_LENGTH} characters or fewer`)
     }
 
     return errors

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -352,7 +352,7 @@ en:
             q:
               blank: Enter a search term
               too_short: Search term must be at least 2 characters
-              too_long: Search term must be 100 characters or fewer
+              too_long: Search term must be 500 characters or fewer
             answer:
               blank: Select an option
         duty_calculator/steps/import_date:

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773628058,
-        "narHash": "sha256-hpXH0z3K9xv0fHaje136KY872VT2T5uwxtezlAskQgY=",
+        "lastModified": 1777270315,
+        "narHash": "sha256-yKB4G6cKsQsWN7M6rZGk6gkJPDNPIzT05y4qzRyCDlI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f8573b9c935cfaa162dd62cc9e75ae2db86f85df",
+        "rev": "6368eda62c9775c38ef7f714b2555a741c20c72d",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773816537,
-        "narHash": "sha256-k8PjAB0b587qg+k7hmlKf20RzR5aU7Io8JYIsWzXIRY=",
+        "lastModified": 1776289224,
+        "narHash": "sha256-23ThpEISX0mQhkFl6U+sY03IFgEPoLyS4kG7xGzoJgA=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "12cf042cd3902ed2df3b9a7b988128fc07b05c3f",
+        "rev": "72dc1140cea40ef216f6566b272d5b44bdf95ab3",
         "type": "github"
       },
       "original": {

--- a/spec/forms/interactive_search_form_spec.rb
+++ b/spec/forms/interactive_search_form_spec.rb
@@ -29,14 +29,28 @@ RSpec.describe InteractiveSearchForm, type: :model do
       it { is_expected.to be_valid }
     end
 
-    context 'when query exceeds maximum length' do
+    context 'when query is over 100 characters' do
       subject(:form) { described_class.new(q: 'a' * 150) }
 
-      it 'truncates to 100 characters' do
-        expect(form.q.length).to eq(100)
-      end
+      it { is_expected.to be_valid }
+    end
+
+    context 'when query is at maximum length' do
+      subject(:form) { described_class.new(q: 'a' * 500) }
 
       it { is_expected.to be_valid }
+    end
+
+    context 'when query exceeds maximum length' do
+      subject(:form) { described_class.new(q: 'a' * 501) }
+
+      it { is_expected.not_to be_valid }
+
+      it 'adds a length error' do
+        form.valid?
+
+        expect(form.errors[:q]).to include('Search term must be 500 characters or fewer')
+      end
     end
   end
 
@@ -53,8 +67,10 @@ RSpec.describe InteractiveSearchForm, type: :model do
       expect(described_class.new(q: '  [leather] bag  ').q).to eq('leather bag')
     end
 
-    it 'truncates to 100 characters' do
-      expect(described_class.new(q: 'x' * 200).q.length).to eq(100)
+    it 'does not truncate long queries before validation' do
+      query = 'x' * 501
+
+      expect(described_class.new(q: query).q).to eq(query)
     end
   end
 

--- a/spec/javascript/controllers/guided_search_validation_controller_spec.js
+++ b/spec/javascript/controllers/guided_search_validation_controller_spec.js
@@ -49,6 +49,7 @@ function buildHTML({hiddenFieldValue = 'true', textareaValue = '', serverErrors 
 
 describe('GuidedSearchValidationController', () => {
   let application;
+  let submitSpy;
 
   async function setup(options) {
     document.body.innerHTML = buildHTML(options);
@@ -65,8 +66,13 @@ describe('GuidedSearchValidationController', () => {
     return form;
   }
 
+  beforeEach(() => {
+    submitSpy = jest.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation(() => {});
+  });
+
   afterEach(() => {
     if (application) application.stop();
+    submitSpy.mockRestore();
   });
 
   describe('keyword search', () => {
@@ -106,11 +112,11 @@ describe('GuidedSearchValidationController', () => {
       expect(document.querySelector('.govuk-error-summary').textContent).toContain('Search term must be at least 2 characters');
     });
 
-    it('shows error when input exceeds 100 characters', async () => {
-      await setup({textareaValue: 'a'.repeat(101)});
+    it('shows error when input exceeds 500 characters', async () => {
+      await setup({textareaValue: 'a'.repeat(501)});
       submitForm();
 
-      expect(document.querySelector('.govuk-error-summary').textContent).toContain('Search term must be 100 characters or fewer');
+      expect(document.querySelector('.govuk-error-summary').textContent).toContain('Search term must be 500 characters or fewer');
     });
 
     it('accepts exactly 2 characters', async () => {
@@ -121,8 +127,8 @@ describe('GuidedSearchValidationController', () => {
       expect(form.querySelector('[data-guided-search-validation-target="formContent"]').classList.contains('govuk-!-display-none')).toBe(true);
     });
 
-    it('accepts exactly 100 characters', async () => {
-      await setup({textareaValue: 'a'.repeat(100)});
+    it('accepts exactly 500 characters', async () => {
+      await setup({textareaValue: 'a'.repeat(500)});
       submitForm();
 
       expect(document.querySelector('.govuk-error-summary')).toBeNull();

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -5,26 +5,26 @@ Terraform to deploy the service into AWS.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.97.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_policy.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_document.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_lb_target_group.this_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
@@ -40,7 +40,7 @@ Terraform to deploy the service into AWS.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_enable_service_count_alarm"></a> [enable\_service\_count\_alarm](#input\_enable\_service\_count\_alarm) | Whether to create a CloudWatch alarm for the service that alarms when there are no running tasks for the service. Defaults to `true`. | `bool` | `true` | no |


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Increase interactive search maximum query length from 100 to 500 characters.
- [x] Stop sanitising interactive search input by truncating before validation.
- [x] Update guided search validation copy to use the configured maximum length.
- [x] Add Ruby and JavaScript specs for 500 character boundary handling.

### Why?

Frontend validation should match the backend limit and allow the form validation layer to reject queries above 500 characters instead of silently truncating them at 100 characters.