### PR TITLE
Use govuk-media-query and variables

### DIFF
--- a/app/assets/stylesheets/print.sass.scss
+++ b/app/assets/stylesheets/print.sass.scss
@@ -129,15 +129,6 @@ table.measures {
   }
 }
 
-
-
-
-
-
-
-
-
-
 @mixin indented-item($level) {
   $left-pos: -984px;
 
@@ -145,7 +136,7 @@ table.measures {
     padding-left: 0;
     font-weight: bold;
 
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       background-position: $left-pos + $token-width 1em;
     }
   }
@@ -155,7 +146,7 @@ table.measures {
     padding-left: px(($token-width * 2) + (math.div($token-width, 3) * ($level - 1)));
     font-weight: normal;
 
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       margin-left: px(($token-width * 2) + ($token-width * ($level - 2))) * -1;
       padding-left: px(($token-width * 2) + ($token-width * ($level - 1)));
       background-position: $left-pos + ($token-width * $level) 1em;
@@ -183,7 +174,7 @@ article.tariff {
     font-size: 14px;
     padding: 6px 16px;
 
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       font-size: 16px;
       padding: 8px 16px;
     }
@@ -193,7 +184,7 @@ article.tariff {
       margin: 5px 0 0 0.5em;
       font-size: 14px;
 
-      @media (min-width: $desktop-min-width) {
+      @include govuk-media-query($from: tablet) {
         margin: 5px 0 0 0.5em;
       }
     }
@@ -230,7 +221,7 @@ article.tariff {
       width: px(($token-width - $token-padding) + $token-space);
       display: none;
 
-      @media (min-width: $desktop-min-width) {
+      @include govuk-media-query($from: tablet) {
         display: block;
       }
     }
@@ -299,7 +290,7 @@ article.tariff {
       display: inline-block;
       font-size: 14px;
 
-      @media (min-width: $desktop-min-width) {
+      @include govuk-media-query($from: tablet) {
         font-size: 16px;
       }
     }
@@ -311,7 +302,7 @@ article.tariff {
     position: relative;
     font-size: 14px;
 
-    @media(min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       font-size: 16px;
     }
 

--- a/app/assets/stylesheets/src/_a-z-index.scss
+++ b/app/assets/stylesheets/src/_a-z-index.scss
@@ -2,7 +2,7 @@
   ol.index {
     margin-bottom: 1.25em;
 
-    @media (max-width: $mobile-max-width) {
+    @include govuk-media-query($until: tablet) {
       margin-bottom: govuk-spacing(6);
     }
 

--- a/app/assets/stylesheets/src/_commodity-codes.scss
+++ b/app/assets/stylesheets/src/_commodity-codes.scss
@@ -4,7 +4,7 @@
   position: relative;
   height: 1.5625em;
   float: left;
-  @media (min-width: $desktop-min-width) {
+  @include govuk-media-query($from: tablet) {
     font-size: 16px;
   }
   > .code-text {

--- a/app/assets/stylesheets/src/_commodity-tree.scss
+++ b/app/assets/stylesheets/src/_commodity-tree.scss
@@ -110,7 +110,7 @@ article.tariff {
 
   .commodity-tree__additional-info {
     float: right;
-    width: 514px;
+    width: $commodity-tree-info-width-desktop;
 
     em {
       font-style: normal;
@@ -270,7 +270,7 @@ article.tariff {
 
     @media (min-width: 641px) {
       float: right;
-      width: 514px;
+      width: $commodity-tree-info-width-desktop;
     }
 
     .lte-ie8 & {

--- a/app/assets/stylesheets/src/_commodity-tree.scss
+++ b/app/assets/stylesheets/src/_commodity-tree.scss
@@ -8,7 +8,7 @@
     padding-left: 0;
     font-weight: bold;
 
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       padding-left: 0;
       background-position: $left-pos + $token-width 1em;
     }
@@ -19,7 +19,7 @@
     padding-left: px(($token-width * 2) + (math.div($token-width, 3) * ($level - 1)));
     font-weight: normal;
 
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       margin-left: px(($token-width * 2) + ($token-width * ($level - 2))) * -1;
       padding-left: px(($token-width * 2) + ($token-width * ($level - 1)));
       background-position: $left-pos + ($token-width * $level) 1em;
@@ -47,7 +47,7 @@ article.tariff {
     font-size: 14px;
     padding: 6px 16px;
 
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       font-size: 16px;
       padding: 8px 16px;
     }
@@ -57,7 +57,7 @@ article.tariff {
       margin: 5px 0 0 0.5em;
       font-size: 14px;
 
-      @media (min-width: $desktop-min-width) {
+      @include govuk-media-query($from: tablet) {
         margin: 5px 0 0 0.5em;
       }
     }
@@ -78,7 +78,7 @@ article.tariff {
     color: govuk-functional-colour(secondary-text);
     font-size: 14px;
 
-    @media (max-width: $mobile-max-width) {
+    @include govuk-media-query($until: tablet) {
       margin-bottom: 0;
     }
 
@@ -102,7 +102,7 @@ article.tariff {
       width: px(($token-width - $token-padding) + $token-space);
       display: none;
 
-      @media (min-width: $desktop-min-width) {
+      @include govuk-media-query($from: tablet) {
         display: block;
       }
     }
@@ -127,7 +127,7 @@ article.tariff {
       display: none;
       text-align: left;
 
-      @media (min-width: $headings-large-viewport) {
+      @include govuk-media-query($from: $headings-large-viewport) {
         display: block;
       }
     }
@@ -137,7 +137,7 @@ article.tariff {
       display: none;
       text-align: left;
 
-      @media (min-width: $headings-large-viewport) {
+      @include govuk-media-query($from: $headings-large-viewport) {
         display: block;
       }
     }
@@ -147,7 +147,7 @@ article.tariff {
       display: none;
       text-align: left;
 
-      @media (min-width: $headings-large-viewport) {
+      @include govuk-media-query($from: $headings-large-viewport) {
         display: block;
       }
     }
@@ -158,7 +158,7 @@ article.tariff {
       text-align: left;
       display: none;
 
-      @media (min-width: $headings-large-viewport) {
+      @include govuk-media-query($from: $headings-large-viewport) {
         display: block;
       }
     }
@@ -175,7 +175,7 @@ article.tariff {
       display: inline-block;
       font-size: 14px;
 
-      @media (min-width: $desktop-min-width) {
+      @include govuk-media-query($from: tablet) {
         font-size: 16px;
       }
     }
@@ -188,11 +188,11 @@ article.tariff {
     position: relative;
     font-size: 14px;
 
-    @media(min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       font-size: 16px;
     }
 
-    @media(max-width: $mobile-max-width) {
+    @include govuk-media-query($until: tablet) {
       margin-top: 1.5em;
       margin-bottom: 1.5em;
     }
@@ -206,7 +206,7 @@ article.tariff {
       word-wrap: break-word;
 
       // Create Hyphen sequences for the commodity tree views
-      @media (min-width: $desktop-min-width) {
+      @include govuk-media-query($from: tablet) {
         $max_level: 20;
         $dashes_spacing: $token-width;
 
@@ -244,7 +244,7 @@ article.tariff {
   a {
     padding-top: 0.5em;
 
-    @media (max-width: $mobile-max-width) {
+    @include govuk-media-query($until: tablet) {
       &:first-child {
         padding-top: 0;
       }
@@ -268,7 +268,7 @@ article.tariff {
   .commodity__info {
     font-size: 16px;
 
-    @media (min-width: 641px) {
+    @include govuk-media-query($from: tablet) {
       float: right;
       width: $commodity-tree-info-width-desktop;
     }
@@ -294,7 +294,7 @@ article.tariff {
       font-weight: normal;
       font-size: 0.9em;
 
-      @media (min-width: $headings-large-viewport) {
+      @include govuk-media-query($from: $headings-large-viewport) {
         display: block;
       }
     }
@@ -326,7 +326,7 @@ article.tariff {
     padding: 0;
     margin-top: 0.5em;
 
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       color: govuk-functional-colour(text);
       position: absolute;
       right: 0;
@@ -341,14 +341,14 @@ article.tariff {
 
   // service-uk includes a vat column so needs to be shunted further right by its width
   .service-uk.identifier {
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       width: $identifier-width-desktop-uk;
     }
   }
 
   // service-xi excludes a vat column so needs to be shunted further right by its width
   .service-xi.identifier {
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       width: $identifier-width-desktop-xi;
     }
   }
@@ -393,12 +393,12 @@ li:not(.has_children) .description {
   position: relative;
   /* to give z-index */
 
-  @media (min-width: 641px) {
+  @include govuk-media-query($from: tablet) {
     float: left;
     width: calc(100% - 165px);
   }
 
-  @media (min-width: $headings-large-viewport) {
+  @include govuk-media-query($from: $headings-large-viewport) {
     width: calc(100% - #{$identifier-width-desktop - 10px});
   }
 
@@ -416,12 +416,12 @@ li.has_children {
     position: relative;
     /* to give z-index */
 
-    @media (min-width: 641px) {
+    @include govuk-media-query($from: tablet) {
       float: left;
       width: calc(100% - 165px);
     }
 
-    @media (min-width: $headings-large-viewport) {
+    @include govuk-media-query($from: $headings-large-viewport) {
       width: calc(100% - #{$identifier-width-desktop - 10px});
     }
 

--- a/app/assets/stylesheets/src/_commodity-tree.scss
+++ b/app/assets/stylesheets/src/_commodity-tree.scss
@@ -123,7 +123,7 @@ article.tariff {
     }
 
     .vat {
-      width: 80px;
+      width: $vat-width-desktop;
       display: none;
       text-align: left;
 
@@ -133,7 +133,7 @@ article.tariff {
     }
 
     .duty {
-      width: 145px;
+      width: $duty-width-desktop;
       display: none;
       text-align: left;
 
@@ -143,7 +143,7 @@ article.tariff {
     }
 
     .supplementary-units {
-      width: 120px;
+      width: $supplementary-units-width-desktop;
       display: none;
       text-align: left;
 
@@ -153,7 +153,7 @@ article.tariff {
     }
 
     .commcode {
-      width: 110px;
+      width: $commodity-code-width-desktop;
       float: left;
       text-align: left;
       display: none;

--- a/app/assets/stylesheets/src/_country-picker.scss
+++ b/app/assets/stylesheets/src/_country-picker.scss
@@ -1,7 +1,7 @@
 .country-picker {
   margin-bottom: 30px;
   .country-picker-container {
-    @media (min-width: 641px) {
+    @include govuk-media-query($from: tablet) {
       display: table;
       label {
         display: table-cell;
@@ -10,7 +10,7 @@
         vertical-align: middle;
         padding-right: 0.5em;
         float: left;
-        @media (min-width: $desktop-min-width) {
+        @include govuk-media-query($from: tablet) {
           float: none;
         }
       }
@@ -19,7 +19,7 @@
     .autocomplete__wrapper {
       margin-bottom: 10px;
 
-      @media (min-width: 641px) {
+      @include govuk-media-query($from: tablet) {
         margin-bottom: 0;
       }
     }
@@ -36,7 +36,7 @@
       vertical-align: bottom;
       margin-top: 10px;
 
-      @media (min-width: $desktop-min-width) {
+      @include govuk-media-query($from: tablet) {
         padding-left: 1em;
         padding-bottom: 0;
         vertical-align: middle;
@@ -44,7 +44,7 @@
       }
       .long-text {
         display: none;
-        @media (min-width: 540px) {
+        @include govuk-media-query($from: 540px) {
           display: inline;
         }
       }

--- a/app/assets/stylesheets/src/_form_customisations.scss
+++ b/app/assets/stylesheets/src/_form_customisations.scss
@@ -103,7 +103,7 @@
     right: 0.5em;
     pointer-events: none; // HW allows element behind arrow (ie select element) to react to pointer events
 
-    @media (max-width: 640px) {
+    @include govuk-media-query($until: tablet) {
       top: 8px;
     }
   }

--- a/app/assets/stylesheets/src/_grid_extensions.scss
+++ b/app/assets/stylesheets/src/_grid_extensions.scss
@@ -19,31 +19,31 @@ $govuk-grid-widths: map.merge($govuk-grid-widths, (one-eighth: 12.5%, seven-eigh
 }
 
 .column-one-quarter-desktop-only {
-  @media (min-width: $desktop-min-width) {
+  @include govuk-media-query($from: tablet) {
     @include govuk-grid-column(one-quarter, $at: desktop);
   }
 }
 
 .column-three-quarters-desktop-only {
-  @media (min-width: $desktop-min-width) {
+  @include govuk-media-query($from: tablet) {
     @include govuk-grid-column(three-quarters, $at: desktop);
   }
 }
 
 .column-full-mobile-only {
-  @include govuk-media-query(false, $desktop-min-width - 1px) {
+  @include govuk-media-query($until: tablet) {
     @include govuk-grid-column(full, $at: mobile);
   }
 }
 
 .column-one-quarter-mobile-only {
-  @include govuk-media-query(false, $desktop-min-width - 1px) {
+  @include govuk-media-query($until: tablet) {
     @include govuk-grid-column(one-quarter, $at: mobile);
   }
 }
 
 .column-three-quarters-mobile-only {
-  @include govuk-media-query(false, $desktop-min-width - 1px) {
+  @include govuk-media-query($until: tablet) {
     @include govuk-grid-column(three-quarters, $at: mobile);
   }
 }

--- a/app/assets/stylesheets/src/_header.scss
+++ b/app/assets/stylesheets/src/_header.scss
@@ -103,7 +103,7 @@ a.back-to-previous {
     color: govuk-functional-colour(text);
   }
 
-  @media (min-width: $desktop-min-width) {
+  @include govuk-media-query($from: tablet) {
     font-size: 16px;
   }
 }

--- a/app/assets/stylesheets/src/_legacy-grid-layout-conditionals.scss
+++ b/app/assets/stylesheets/src/_legacy-grid-layout-conditionals.scss
@@ -14,10 +14,6 @@
 //   div.columns {
 //     border: 1px solid;
 //
-//     @include media(desktop){
-//       width: 30%;
-//       float: left;
-//     }
 //     @include ie-lte(8) {
 //       something to fix visual bugs in old IE
 //     }
@@ -28,46 +24,6 @@
 
 
 $is-ie: false !default;
-$mobile-ie6: true !default;
-
-$tablet-breakpoint: 641px !default;
-$desktop-breakpoint: 769px !default;
-
-@mixin media($size: false, $max-width: false, $min-width: false, $ignore-for-ie: false) {
-  @if $is-ie and ($ignore-for-ie == false) {
-    @if $size != mobile {
-      @if ($ie-version == 6 and $mobile-ie6 == false) or $ie-version > 6 {
-        @content;
-      }
-    }
-  } @else {
-    @if $size == desktop {
-      @media (min-width: $desktop-breakpoint){
-        @content;
-      }
-    } @else if $size == tablet {
-      @media (min-width: $tablet-breakpoint){
-        @content;
-      }
-    } @else if $size == mobile {
-      @media (max-width: $tablet-breakpoint - 1px){
-        @content;
-      }
-    } @else if $max-width != false {
-      @media (max-width: $max-width){
-        @content;
-      }
-    } @else if $min-width != false {
-      @media (min-width: $min-width){
-        @content;
-      }
-    } @else {
-      @media (min-width: $size){
-        @content
-      }
-    }
-  }
-}
 
 @mixin ie-lte($version) {
   @if $is-ie {

--- a/app/assets/stylesheets/src/_measures.scss
+++ b/app/assets/stylesheets/src/_measures.scss
@@ -1,5 +1,5 @@
 .import-and-export-boxes {
-  @media (min-width: $desktop-min-width) {
+  @include govuk-media-query($from: tablet) {
     display: flex;
     .column-one-half {
       margin-bottom: 45px;
@@ -8,7 +8,7 @@
   .import, .export {
     height: 100%;
     background-color: $highlight-colour;
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       margin-bottom: -30px;
     }
   }
@@ -26,7 +26,7 @@
     margin: 1em 0;
     padding: 0 0 0 1.25em;
     list-style: none;
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       padding: 0 0 0 2.5em;
     }
   }

--- a/app/assets/stylesheets/src/_modal.scss
+++ b/app/assets/stylesheets/src/_modal.scss
@@ -45,7 +45,7 @@
   border-radius: 5px;
   box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
 
-  @media (min-width: $desktop-min-width) {
+  @include govuk-media-query($from: tablet) {
     top: 30px;
     width: 80%;
   }
@@ -101,7 +101,7 @@
     min-height: 0;
     overflow: hidden;
 
-    @media(max-width: $mobile-max-width) {
+    @include govuk-media-query($until: tablet) {
       overflow-x: scroll;
     }
 

--- a/app/assets/stylesheets/src/_quota-search.scss
+++ b/app/assets/stylesheets/src/_quota-search.scss
@@ -2,7 +2,7 @@
   .govuk-grid-row {
     margin-bottom: 0.5em;
 
-    @media (min-width: 641px) {
+    @include govuk-media-query($from: tablet) {
       margin-bottom: 1em;
     }
   }
@@ -19,7 +19,7 @@
   input[type="submit"] {
     margin-top: 1.5em;
 
-    @media (min-width: 641px) {
+    @include govuk-media-query($from: tablet) {
       margin-top: 0;
     }
   }

--- a/app/assets/stylesheets/src/_search-results.scss
+++ b/app/assets/stylesheets/src/_search-results.scss
@@ -18,7 +18,7 @@
   .chapter-results {
     padding-left: 3.1rem;
 
-    @media (max-width: $mobile-max-width) {
+    @include govuk-media-query($until: tablet) {
       padding-left: 0rem;
     }
   }
@@ -48,7 +48,7 @@
     font-size: 1.25em;
 
     .chapter > .full-code {
-      @media (max-width: $mobile-max-width) {
+      @include govuk-media-query($until: tablet) {
         margin: 0 1em;
         padding: 1em 0 0.5em;
       }
@@ -97,7 +97,7 @@
 
       .line-text {
         padding-left: 1em;
-        @media (min-width: $desktop-min-width) {
+        @include govuk-media-query($from: tablet) {
           padding-right: 200px;
         }
       }
@@ -120,7 +120,7 @@
           .line-text {
             padding-left: 0 !important;
 
-            @media (min-width: $desktop-min-width) {
+            @include govuk-media-query($from: tablet) {
               padding-left: 0;
               padding-top: 0em;
               padding-bottom: 0em;
@@ -132,7 +132,7 @@
             bottom: 0;
             right: 0;
 
-            @media (max-width: $mobile-max-width) {
+            @include govuk-media-query($until: tablet) {
               margin-top: 0.5em;
             }
           }

--- a/app/assets/stylesheets/src/_sections-list.scss
+++ b/app/assets/stylesheets/src/_sections-list.scss
@@ -1,5 +1,5 @@
 .sections {
-  @media (max-width: $mobile-max-width) {
+  @include govuk-media-query($until: tablet) {
     tr {
       display: block;
       padding-top: 0.63158em;
@@ -37,7 +37,7 @@
 }
 
 .all-sections {
-  @media (max-width: $mobile-max-width) {
+  @include govuk-media-query($until: tablet) {
     margin-bottom: 5px;
   }
 }

--- a/app/assets/stylesheets/src/_tables.scss
+++ b/app/assets/stylesheets/src/_tables.scss
@@ -23,13 +23,13 @@ table.small-table {
       }
     }
 
-    @media (min-width: $small-table-breakpoint) {
+    @include govuk-media-query($from: $small-table-breakpoint) {
       .measure-type-col {
         min-width: 40%;
       }
     }
 
-    @media (max-width: $small-table-breakpoint - 1) {
+    @include govuk-media-query(false, $small-table-breakpoint - 1) {
       caption,
       thead,
       tbody,

--- a/app/assets/stylesheets/src/_tariff-breadcrumbs.scss
+++ b/app/assets/stylesheets/src/_tariff-breadcrumbs.scss
@@ -19,7 +19,7 @@
     width: 171px;
     margin-top: 5px;
 
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       margin-top: 0;
     }
 
@@ -35,7 +35,7 @@
       padding-left: $breadcrumb-indent;
       margin: 5px 0 0;
 
-      @media (min-width: $desktop-min-width) {
+      @include govuk-media-query($from: tablet) {
         padding-left: $breadcrumb-indent-desktop;
       }
 
@@ -59,7 +59,7 @@
             padding-top: 0 !important;
           }
 
-          @media (min-width: $desktop-min-width) {
+          @include govuk-media-query($from: tablet) {
             font-size: 1em;
             min-height: 30px;
             padding-right: 200px;
@@ -110,7 +110,7 @@
         ul.commodities {
           padding-left: $breadcrumb-indent;
 
-          @media (min-width: $desktop-min-width) {
+          @include govuk-media-query($from: tablet) {
             padding-left: $breadcrumb-indent-desktop;
           }
         }
@@ -126,7 +126,7 @@
       }
     }
 
-    @media (max-width: $mobile-max-width) {
+    @include govuk-media-query($until: tablet) {
       .chapter-code~ul ul {
         padding-left: 0;
       }
@@ -147,7 +147,7 @@
         content: ')';
       }
 
-      @media (min-width: $desktop-min-width) {
+      @include govuk-media-query($from: tablet) {
         float: right;
         margin-top: 2em;
 
@@ -168,7 +168,7 @@
         padding-right: 0 !important;
         min-height: 0 !important;
 
-        @media (min-width: $desktop-min-width) {
+        @include govuk-media-query($from: tablet) {
           background-image: url('/feed-icon-black.png');
           background-position: 0.2em center;
           background-repeat: no-repeat;
@@ -187,7 +187,7 @@
   font-size: 16px;
   font-size: 1rem;
 
-  @media (min-width: $desktop-min-width) {
+  @include govuk-media-query($from: tablet) {
     position: absolute;
     right: 0;
     top: 0;

--- a/app/assets/stylesheets/src/_variables.scss
+++ b/app/assets/stylesheets/src/_variables.scss
@@ -6,10 +6,6 @@ $mobile-max-width: $desktop-min-width - 1;
 $headings-large-viewport: 1100px;
 
 $standard-margin: 16px;
-<<<<<<< HEAD
-$small-margin: math.div($standard-margin, 2);
-=======
->>>>>>> 0b157e8de (Remove unused)
 
 $token-width: 20;
 $token-padding: 5;

--- a/app/assets/stylesheets/src/_variables.scss
+++ b/app/assets/stylesheets/src/_variables.scss
@@ -6,7 +6,10 @@ $mobile-max-width: $desktop-min-width - 1;
 $headings-large-viewport: 1100px;
 
 $standard-margin: 16px;
+<<<<<<< HEAD
 $small-margin: math.div($standard-margin, 2);
+=======
+>>>>>>> 0b157e8de (Remove unused)
 
 $token-width: 20;
 $token-padding: 5;
@@ -14,8 +17,6 @@ $token-space: $token-width+$token-padding;
 /* Uses above values */
 $top-level-padding: 10;
 
-$commodity-padding: $token-width;
-$expand-arrow-width: 11;
 $expand-arrow-space: 11+$token-padding;
 
 $chapter-code-width: 30px;
@@ -24,10 +25,8 @@ $heading-code-width: $chapter-code-width;
 $commodity-code-width: 110px;
 $commodity-code-width-desktop: 110px;
 
-$breadcrumb-v-margin: 5px;
 $breadcrumb-indent: 15px;
 $breadcrumb-indent-desktop: 25px;
-$breadcrumb-changes-link-width: 70px;
 
 $vat-width-desktop: 105px;
 $duty-width-desktop: 145px;
@@ -42,6 +41,5 @@ $table-row-standard-height: 1.31579em;
 $small-table-breakpoint: 840px;
 
 // deprecated colours
-$page-colour: #fff;
 $highlight-colour: #f8f8f8;
 $panel-colour: #dee0e2;

--- a/app/assets/stylesheets/src/_variables.scss
+++ b/app/assets/stylesheets/src/_variables.scss
@@ -1,8 +1,6 @@
 @use "sass:math";
 
 /* global variables */
-$desktop-min-width: 641px;
-$mobile-max-width: $desktop-min-width - 1;
 $headings-large-viewport: 1100px;
 
 $standard-margin: 16px;

--- a/app/assets/stylesheets/src/_variables.scss
+++ b/app/assets/stylesheets/src/_variables.scss
@@ -31,6 +31,7 @@ $breadcrumb-indent-desktop: 25px;
 $vat-width-desktop: 105px;
 $duty-width-desktop: 145px;
 $supplementary-units-width-desktop: 120px;
+$commodity-tree-info-width-desktop: 514px;
 
 $identifier-width: $chapter-code-width+$heading-code-width+$commodity-code-width + 10px;
 $identifier-width-desktop: $chapter-code-width+$heading-code-width+$commodity-code-width-desktop+$vat-width-desktop+$duty-width-desktop+$supplementary-units-width-desktop;

--- a/app/assets/stylesheets/src/index-page.scss
+++ b/app/assets/stylesheets/src/index-page.scss
@@ -6,7 +6,7 @@
     font-weight: 700;
     margin: 1.2em 0 0.4em 0;
 
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       font-size: 24px;
       line-height: 1.25;
     }
@@ -19,7 +19,7 @@
     line-height: 1.25;
     margin-bottom: 0.75em;
 
-    @media (min-width: $desktop-min-width) {
+    @include govuk-media-query($from: tablet) {
       font-size: 19px;
       line-height: 1.31579;
     }

--- a/app/assets/stylesheets/src/tariff-custom.scss
+++ b/app/assets/stylesheets/src/tariff-custom.scss
@@ -2,7 +2,7 @@
   display: none;
 }
 
-@media (min-width: $desktop-min-width) {
+@include govuk-media-query($from: tablet) {
   .mobile-only {
     display: none;
   }


### PR DESCRIPTION
### What?

- Replaces use of `@media` with `@include govuk-media-query`. The default breakpoints matched what was already being used.
- Removes legacy media function
- Cleans up variables file by removing unused, adding `$commodity-tree-info-width-desktop` and using other variables where appropriate.
