### PR TITLE
Silence Faraday::ResourceNotFound from duty calculator commodity lookups

### DIFF
--- a/app/controllers/duty_calculator/steps/base_controller.rb
+++ b/app/controllers/duty_calculator/steps/base_controller.rb
@@ -6,6 +6,11 @@ module DutyCalculator
       include UkimsHelper
 
       rescue_from Errors::SessionIntegrityError, with: :handle_session_integrity_error
+      # Must be declared before rescue_from StandardError so it is matched first.
+      # Rails stores handlers in definition order and picks the first match. A missing
+      # commodity is an expected condition — the API returns 404 when a code doesn't
+      # exist or isn't declarable. We redirect silently rather than surfacing it in NewRelic.
+      rescue_from Faraday::ResourceNotFound, with: :handle_commodity_not_found
       rescue_from StandardError, with: :handle_exception
 
       default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
@@ -56,6 +61,10 @@ module DutyCalculator
           NewRelic::Agent.notice_error(exception)
           redirect_to sections_url, allow_other_host: true
         end
+      end
+
+      def handle_commodity_not_found(_exception)
+        redirect_to sections_url, allow_other_host: true
       end
 
       def ensure_session_integrity

--- a/spec/controllers/duty_calculator/steps/base_controller_spec.rb
+++ b/spec/controllers/duty_calculator/steps/base_controller_spec.rb
@@ -27,6 +27,39 @@ RSpec.describe DutyCalculator::Steps::BaseController, :user_session do
     allow(Rails.configuration).to receive(:trade_tariff_frontend_url).and_return(trade_tariff_host)
   end
 
+  describe 'Faraday::ResourceNotFound rescue_from registration' do
+    it 'is registered as the rescue handler for Faraday::ResourceNotFound' do
+      registered = described_class.rescue_handlers.detect { |klass, _| klass == 'Faraday::ResourceNotFound' }
+
+      expect(registered).not_to be_nil
+    end
+
+    it 'delegates to handle_commodity_not_found' do
+      registered = described_class.rescue_handlers.detect { |klass, _| klass == 'Faraday::ResourceNotFound' }
+
+      expect(registered[1]).to eq(:handle_commodity_not_found)
+    end
+
+    it 'is positioned before the StandardError handler so it takes priority' do
+      handlers = described_class.rescue_handlers
+      not_found_index = handlers.index { |klass, _| klass == 'Faraday::ResourceNotFound' }
+      standard_error_index = handlers.index { |klass, _| klass == 'StandardError' }
+
+      expect(not_found_index).to be < standard_error_index
+    end
+
+    it 'does not notify NewRelic for a commodity not found error' do
+      exception = Faraday::ResourceNotFound.new('commodity not found')
+      allow(NewRelic::Agent).to receive(:notice_error)
+      allow(controller).to receive(:sections_url).and_return('/sections')
+      allow(controller).to receive(:redirect_to)
+
+      controller.rescue_with_handler(exception)
+
+      expect(NewRelic::Agent).not_to have_received(:notice_error)
+    end
+  end
+
   describe 'GET #index' do
     subject(:response) { get :index }
 


### PR DESCRIPTION
## Problem

`/duty-calculator/<code>/import-date` (and other duty calculator steps) was generating a stream of `ActionView::Template::Error` alerts in NewRelic. The root cause:

1. The view renders `_commodity_details`, which calls the `commodity` helper
2. `commodity` calls `Api::Commodity.build` via `CommodityContextService`
3. When the commodity code doesn't exist (stale URL, non-declarable code, etc.) the API returns 404 → `Faraday::ResourceNotFound`
4. `BaseController` had `rescue_from StandardError, with: :handle_exception` which **re-raises** every exception, so it all ended up in NewRelic

## Fix

Add `rescue_from Faraday::ResourceNotFound, with: :handle_commodity_not_found` **before** the `StandardError` handler. Rails matches handlers in definition order (first match wins), so the specific handler takes priority.

`handle_commodity_not_found` redirects silently to `/sections` — a missing commodity is an expected condition (code retired, wrong service, stale bookmark), not an application bug, so there's nothing for NewRelic to track.

## Tests

- Handler is registered for `Faraday::ResourceNotFound` → `handle_commodity_not_found`
- Handler is positioned before `StandardError` in the rescue chain
- `NewRelic::Agent.notice_error` is **not** called when the handler fires