### PR TITLE
Use govuk-clearfix

### DIFF
--- a/app/assets/stylesheets/print.sass.scss
+++ b/app/assets/stylesheets/print.sass.scss
@@ -200,12 +200,7 @@ article.tariff {
     margin: 15px;
     color: govuk-functional-colour(secondary-text);
     font-size: 14px;
-
-    &:after {
-      content: "";
-      display: block;
-      clear: both;
-    }
+    @include govuk-clearfix;
 
     span {
       position: absolute;
@@ -297,7 +292,7 @@ article.tariff {
   }
 
   ul.commodities {
-    @include contain-float;
+    @include govuk-clearfix;
     margin: 1em;
     position: relative;
     font-size: 14px;
@@ -307,7 +302,7 @@ article.tariff {
     }
 
     li {
-      @include contain-float;
+      @include govuk-clearfix;
       @include indented-list(13);
       display: block;
       margin: 0;
@@ -350,6 +345,7 @@ article.tariff {
         position: absolute;
         right: 0;
         bottom: 0;
+        @include govuk-clearfix;
 
         @media (orientation: portrait) {
           width: 200px;
@@ -358,13 +354,6 @@ article.tariff {
 
         .lte-ie8 & {
           float: none !important;
-        }
-
-        &:after {
-          clear: both;
-          content: " ";
-          display: table;
-          zoom: 1;
         }
 
         .vat,
@@ -424,7 +413,7 @@ article.tariff {
       article & a,
       .js-enabled article & a {
         display: block;
-        @include contain-float;
+        @include govuk-clearfix;
         margin-left: 0;
         padding-left: 0;
       }

--- a/app/assets/stylesheets/src/_commodity-tree.scss
+++ b/app/assets/stylesheets/src/_commodity-tree.scss
@@ -77,15 +77,10 @@ article.tariff {
     margin: 15px;
     color: govuk-functional-colour(secondary-text);
     font-size: 14px;
+    @include govuk-clearfix;
 
     @include govuk-media-query($until: tablet) {
       margin-bottom: 0;
-    }
-
-    &:after {
-      content: "";
-      display: block;
-      clear: both;
     }
 
     span {

--- a/app/assets/stylesheets/src/_commodity-tree.scss
+++ b/app/assets/stylesheets/src/_commodity-tree.scss
@@ -182,7 +182,7 @@ article.tariff {
   }
 
   ul.commodities {
-    @include contain-float;
+    @include govuk-clearfix;
     padding: 0;
     margin: 1em;
     position: relative;
@@ -198,7 +198,7 @@ article.tariff {
     }
 
     li {
-      @include contain-float;
+      @include govuk-clearfix;
       @include indented-list(13);
       display: block;
       margin: 0;
@@ -267,6 +267,7 @@ article.tariff {
 
   .commodity__info {
     font-size: 16px;
+    @include govuk-clearfix;
 
     @include govuk-media-query($from: tablet) {
       float: right;
@@ -275,13 +276,6 @@ article.tariff {
 
     .lte-ie8 & {
       float: none !important;
-    }
-
-    &:after {
-      clear: both;
-      content: " ";
-      display: table;
-      zoom: 1;
     }
 
     .vat,
@@ -365,7 +359,7 @@ article.tariff {
   article & a,
   .js-enabled article & a {
     display: block;
-    @include contain-float;
+    @include govuk-clearfix;
     margin-left: 0;
     padding-left: 0;
     min-height: 1.6rem;

--- a/app/assets/stylesheets/src/_functions.scss
+++ b/app/assets/stylesheets/src/_functions.scss
@@ -1,14 +1,3 @@
 @function px($value) {
   @return $value * 1px;
 }
-
-@mixin contain-float {
-  zoom: 1;
-  &:after {
-    content: ".";
-    display: block;
-    height: 0;
-    clear: both;
-    visibility: hidden;
-  }
-}

--- a/app/assets/stylesheets/src/_search-results.scss
+++ b/app/assets/stylesheets/src/_search-results.scss
@@ -57,13 +57,7 @@
     .full-code {
       right: 1em;
       height: 30px;
-
-      &:after {
-        content: " ";
-        display: table;
-        clear: both;
-        zoom: 1;
-      }
+      @include govuk-clearfix;
     }
 
     .line-text {

--- a/app/assets/stylesheets/src/_tariff-breadcrumbs.scss
+++ b/app/assets/stylesheets/src/_tariff-breadcrumbs.scss
@@ -6,14 +6,9 @@
   position: relative;
   padding: 1em;
   margin: 20px 0 40px 0;
+  @include govuk-clearfix;
 
   background-color: govuk-colour("black", $variant: "tint-95");
-
-  &::after {
-    content: "";
-    display: block;
-    clear: both;
-  }
 
   .full-code {
     width: 171px;


### PR DESCRIPTION
### What?

govuk-frontend provides a [clearfix class](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-clearfix). Replace all clearfix classes and the contain-float helper with this.
