### PR TITLE
Remove govuk-text-colour usage

### DIFF
--- a/app/assets/stylesheets/src/vendor/govuk_publishing_components/metadata.scss
+++ b/app/assets/stylesheets/src/vendor/govuk_publishing_components/metadata.scss
@@ -1,5 +1,5 @@
 .gem-c-metadata {
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include govuk-font(16);
   @include govuk-clearfix;
 

--- a/app/assets/stylesheets/src/vendor/step-by-step-nav.scss
+++ b/app/assets/stylesheets/src/vendor/step-by-step-nav.scss
@@ -286,7 +286,7 @@ $top-border: solid 2px govuk-colour("black", $variant: "tint-80");
 }
 
 .app-step-nav__title {
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include step-nav-font(19, $weight: bold, $line-height: 1.4);
   margin: 0;
 
@@ -307,7 +307,7 @@ $top-border: solid 2px govuk-colour("black", $variant: "tint-80");
 }
 
 .app-step-nav__panel {
-  @include govuk-text-colour;
+  color: govuk-functional-colour(text);
   @include step-nav-font(16);
 
   .app-step-nav--large & {


### PR DESCRIPTION
### What?

`govuk-text-colour` helper is deprecated - https://frontend.design-system.service.gov.uk/sass-api-reference/#helpers-typography-govuk-text-colour 