### PR TITLE
Fix commodity/heading caching so cache hits skip template rendering

### DIFF
--- a/app/presenters/grouped_measures_presenter.rb
+++ b/app/presenters/grouped_measures_presenter.rb
@@ -213,11 +213,11 @@ class GroupedMeasuresPresenter
   private
 
   def uk_import_measures
-    uk_declarable&.import_measures
+    @uk_import_measures ||= uk_declarable&.import_measures
   end
 
   def xi_import_measures
-    xi_declarable.import_measures
+    @xi_import_measures ||= xi_declarable.import_measures
   end
 
   def sorted_by_key(measures)

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -1,12 +1,13 @@
 <% cacheable = params.values.compact.none? { |v| v.is_a?(ActionController::Parameters) } %>
 
-<% content = capture do %>
-  <% content_for :head do %>
-    <meta name="description" content="<%= declarable.description_plain %>">
-  <% end %>
+<%# These are always needed regardless of cache state — set them before the cache block. %>
+<% content_for :title, strip_tags(commodity_title(declarable)) %>
+<% content_for :head do %>
+  <meta name="description" content="<%= declarable.description_plain %>">
+<% end %>
+<% content_for :bodyClasses, "page--wide" %>
 
-  <% content_for :bodyClasses, "page--wide" %>
-
+<% cache_if(cacheable, commodity_cache_key) do %>
   <%= render 'commodities/header', commodity_code: declarable.code %>
 
   <% declarable.critical_footnotes.each do |footnote| %>
@@ -41,10 +42,4 @@
             roo_all_schemes: @roo_all_schemes %>
 
   <%= render 'commodities/help_popup' %>
-<% end %>
-
-<% if cacheable %>
-  <%= cache(commodity_cache_key) { concat(content) } %>
-<% else %>
-  <%= content %>
 <% end %>

--- a/app/views/declarables/_declarable.html.erb
+++ b/app/views/declarables/_declarable.html.erb
@@ -1,5 +1,3 @@
-<% content_for :title, strip_tags(commodity_title(declarable)) %>
-
 <article class="tariff commodity">
   <%= render partial: 'shared/country_picker' %>
   <%= render 'measures/measures',

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -1,12 +1,14 @@
 <% cacheable = params.values.compact.none? { |v| v.is_a?(ActionController::Parameters) } %>
 
-<% content = capture do %>
-  <% content_for :title, goods_nomenclature_title(@heading) %>
+<%# Always set content_for outside the cache block so it is populated on cache hits too. %>
+<% content_for :title, goods_nomenclature_title(@heading) %>
+<% content_for :head do %>
+  <meta name="description" content="<%= @heading %>">
+<% end %>
 
-  <% content_for :head do %>
-    <meta name="description" content="<%= @heading %>">
-  <% end %>
+<% heading_cache_key = ['headings#show', cache_key, cache_params.values.compact.map(&:to_s).sort.join('/')] %>
 
+<% cache_if(cacheable, heading_cache_key) do %>
   <%= page_header do %>
     <% @heading.critical_footnotes.each do |footnote| %>
       <%= render 'footnotes/critical_warning', footnote: footnote %>
@@ -26,11 +28,4 @@
 
   <%= render 'shared/notes', section_note: @heading.section.section_note,
                             chapter_note: @heading.chapter.chapter_note %>
-<% end %>
-
-<% if cacheable %>
-  <% heading_cache_key = ['headings#show', cache_key, cache_params.values.compact.map(&:to_s).sort.join('/')] %>
-  <%= cache(heading_cache_key) { concat(content) } %>
-<% else %>
-  <%= content %>
 <% end %>


### PR DESCRIPTION
## Problem

`commodities#show` (and `headings#show`) were reporting thousands of renders of `_declarable.html.erb` in NewRelic. For a popular commodity like `/commodities/6912002310` this showed up as 4253+ calls to the partial — one per request rather than one per cache miss.

The root cause was a broken caching pattern:

```erb
<%# capture ALWAYS runs — renders full template tree on every request %>
<% content = capture do %>
  ...all the templates, including hundreds of measure rows...
<% end %>

<% if cacheable %>
  <%# cache block just stores the already-rendered string — rendering already happened %>
  <%= cache(commodity_cache_key) { concat(content) } %>
<% else %>
  <%= content %>
<% end %>
```

The `cache` block only controlled where the pre-rendered HTML string was stored/retrieved. The template rendering happened unconditionally on every request.

## Fix

Replace `capture` + `cache` with `cache_if(cacheable, key) do … end`, which skips the block entirely on a cache hit:

```erb
<% cache_if(cacheable, commodity_cache_key) do %>
  ...all the templates...
<% end %>
```

`content_for` calls cannot live inside the block (they would not fire on cache hits), so `:title`, `:head`, and `:bodyClasses` are now set before the `cache_if` block. The `:title` assignment is removed from `_declarable.html.erb` where it was previously set, and moved to `commodities/show.html.erb` directly.

The same pattern is applied to `headings/show.html.erb`.

`GroupedMeasuresPresenter#uk_import_measures` and `#xi_import_measures` are also memoized — both methods were called many times per render (once per section/navigation item check) but delegated to `declarable.import_measures` on every call.

## Test plan

- [ ] Smoke test `/commodities/6912002310` — page renders correctly on first load (cache cold) and on repeat load (cache warm)
- [ ] Verify page title, meta description, and body class are set correctly on both cold and warm cache loads
- [ ] Smoke test a heading page (e.g. `/headings/6912`) — same checks
- [ ] Check NewRelic after deploy — `View/declarables/_declarable.html.erb/Partial` call count should drop to match cache miss rate only