### PR TITLE
Use govuk link helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'turbo-rails'
 
 # gov UK
 gem 'govspeak'
+gem 'govuk-components'
 gem 'govuk_design_system_formbuilder'
 gem 'nokogiri'
 gem 'wizard_steps'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,10 @@ GEM
       nokogiri (~> 1.12)
       rinku (~> 2.0)
       sanitize (>= 6, < 8)
+    govuk-components (6.1.0)
+      html-attributes-utils (~> 1.0.0, >= 1.0.0)
+      pagy (>= 6, < 10)
+      view_component (>= 4.0, < 4.7)
     govuk_app_config (3.3.0)
       logstasher (>= 1.2.2, < 2.2.0)
       sentry-raven (~> 3.1.1)
@@ -364,6 +368,7 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     ostruct (0.6.3)
+    pagy (9.4.0)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -577,6 +582,10 @@ GEM
     uri (1.1.1)
     useragent (0.16.11)
     vcr (6.4.0)
+    view_component (4.6.0)
+      actionview (>= 7.1.0)
+      activesupport (>= 7.1.0)
+      concurrent-ruby (~> 1)
     webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -616,6 +625,7 @@ DEPENDENCIES
   faraday-retry
   forgery
   govspeak
+  govuk-components
   govuk_design_system_formbuilder
   guard-rspec
   guard-rubocop

--- a/app/views/basic_sessions/new.html.erb
+++ b/app/views/basic_sessions/new.html.erb
@@ -18,7 +18,7 @@
 
           <p>
             If you need access to either this or the production application, please
-            <a href="mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk">contact</a>
+            <%= govuk_mail_to 'hmrc-trade-tariff-support-g@digital.hmrc.gov.uk', 'contact' %>
             the team.
           </p>
 

--- a/app/views/browse_sections/index.html.erb
+++ b/app/views/browse_sections/index.html.erb
@@ -43,10 +43,8 @@
         </td>
 
         <td class="title govuk-table__cell">
-          <%= link_to section_path(section, request.query_parameters.symbolize_keys) do %>
-            <span class="govuk-visually-hidden">
-              Section <%= section.position %>:
-            </span>
+          <%= govuk_link_to section_path(section, request.query_parameters.symbolize_keys) do %>
+            <%= govuk_visually_hidden "Section #{section.position}:" %>
             <%= section.title %>
           <% end %>
         </td>

--- a/app/views/chapters/_chapter.html.erb
+++ b/app/views/chapters/_chapter.html.erb
@@ -5,8 +5,8 @@
     </div>
   </td>
   <td class="govuk-table__cell">
-    <%= link_to chapter_path(chapter, request.query_parameters.symbolize_keys) do %>
-      <span class="govuk-visually-hidden">Chapter <%= chapter.short_code %>: </span> <%= chapter %>
+    <%= govuk_link_to chapter_path(chapter, request.query_parameters.symbolize_keys) do %>
+      <%= govuk_visually_hidden "Chapter #{chapter.short_code}: " %> <%= chapter %>
     <% end %>
     <%= render partial: 'chapters/chapter_guides', locals: {chapter: chapter} %>
   </td>

--- a/app/views/commodities/_commodity.html.erb
+++ b/app/views/commodities/_commodity.html.erb
@@ -14,7 +14,7 @@
   </li>
 <% else %>
   <li class="<%= commodity_level(commodity, initial_indent) %><%= leaf_position(commodity) %>">
-    <%= link_to commodity_path(commodity, request.query_parameters.symbolize_keys), title: "View complete information for this commodity", "aria-label" => commodity.aria_label do %>
+    <%= govuk_link_to commodity_path(commodity, request.query_parameters.symbolize_keys), title: "View complete information for this commodity", "aria-label" => commodity.aria_label do %>
       <div class="description open" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></div>
 
       <%= overview_measure_duty_amounts_for(commodity) %>

--- a/app/views/commodities/show_404.html.erb
+++ b/app/views/commodities/show_404.html.erb
@@ -24,10 +24,10 @@
       <ul class="govuk-list govuk-list--bullet">
         <% @validity_periods.each do |validity_period| %>
           <li>
-            From <%= link_to validity_period.start_date.to_formatted_s(:long),
+            From <%= govuk_link_to validity_period.start_date.to_formatted_s(:long),
                      commodity_on_date_path(@commodity_code, validity_period.start_date) -%>
             <% if validity_period.end_date.present? -%>
-              to <%= link_to validity_period.end_date.to_formatted_s(:long),
+              to <%= govuk_link_to validity_period.end_date.to_formatted_s(:long),
                      commodity_on_date_path(@commodity_code, validity_period.end_date) -%>
             <% end -%>
           </li>
@@ -43,12 +43,12 @@
 
     <p>
       Alternatively, you can visit
-      <%= link_to "heading #{@heading_code}", heading_path(@heading_code) %>
+      <%= govuk_link_to "heading #{@heading_code}", heading_path(@heading_code) %>
       or
       <% if @search.today? %>
-        <%= link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>.
+        <%= govuk_link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>.
       <% else %>
-        <%= link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>
+        <%= govuk_link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>
         for <%= @search.date.to_formatted_s :long %>.
       <% end %>
     </p>

--- a/app/views/duty_calculator/shared/_commodity_details.html.erb
+++ b/app/views/duty_calculator/shared/_commodity_details.html.erb
@@ -5,6 +5,6 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    Commodity code <strong><%= commodity.formatted_commodity_code %></strong><br><%= commodity.description %><br><br><a class="govuk-link" href="<%= commodity_url(commodity.code) %>">View commodity <%= commodity.code %></a>
+    Commodity code <strong><%= commodity.formatted_commodity_code %></strong><br><%= commodity.description %><br><br><%= govuk_link_to "View commodity #{commodity.code}", commodity_url(commodity.code) %>
   </div>
 </details>

--- a/app/views/duty_calculator/steps/annual_turnover/show.html.erb
+++ b/app/views/duty_calculator/steps/annual_turnover/show.html.erb
@@ -15,7 +15,7 @@
   <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
   <ul class="govuk-list">
     <li>
-      <%= link_to("Check if you can declare goods you bring into Northern Ireland 'not at risk' of moving to the EU", 'https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu', class: 'govuk-link') %>
+      <%= govuk_link_to("Check if you can declare goods you bring into Northern Ireland 'not at risk' of moving to the EU", 'https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu') %>
     </li>
   </ul>
 </div>

--- a/app/views/duty_calculator/steps/confirmation/_entry.html.erb
+++ b/app/views/duty_calculator/steps/confirmation/_entry.html.erb
@@ -2,6 +2,6 @@
   <dt class="govuk-summary-list__key"><%= entry[:label] %></dt>
   <dd class="govuk-summary-list__value"><%= entry[:value] %></dd>
   <dd class="govuk-summary-list__actions">
-    <%= link_to('Change', @decorated_step.path_for(key: entry[:key]), class: 'govuk-link') %>
+    <%= govuk_link_to('Change', @decorated_step.path_for(key: entry[:key])) %>
   </dd>
 </div>

--- a/app/views/duty_calculator/steps/confirmation/show.html.erb
+++ b/app/views/duty_calculator/steps/confirmation/show.html.erb
@@ -7,9 +7,9 @@
     <dt class="govuk-summary-list__key">Commodity code</dt>
     <dd class="govuk-summary-list__value"><%= commodity.formatted_commodity_code %></dd>
     <dd class="govuk-summary-list__actions">
-      <%= link_to('Change', sections_url, class: 'govuk-link') %>
+      <%= govuk_link_to('Change', sections_url) %>
     </dd>
   </div>
   <%= render partial: 'entry', collection: @decorated_step.user_answers, as: :entry %>
 </dl>
-<%= link_to('Calculate import duties', @decorated_step.next_step_path, class: 'govuk-button') %>
+<%= govuk_button_link_to('Calculate import duties', @decorated_step.next_step_path) %>

--- a/app/views/duty_calculator/steps/country_of_origin/show.html.erb
+++ b/app/views/duty_calculator/steps/country_of_origin/show.html.erb
@@ -13,7 +13,7 @@
   <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
   <ul class="govuk-list">
     <li>
-      <%= link_to('Check your goods meet the rules of origin', 'https://www.gov.uk/guidance/check-your-goods-meet-the-rules-of-origin', class: 'govuk-link') %>
+      <%= govuk_link_to('Check your goods meet the rules of origin', 'https://www.gov.uk/guidance/check-your-goods-meet-the-rules-of-origin') %>
     </li>
   </ul>
 </div>

--- a/app/views/duty_calculator/steps/customs_value/show.html.erb
+++ b/app/views/duty_calculator/steps/customs_value/show.html.erb
@@ -10,12 +10,10 @@
     World Trade Organisation (WTO) Valuation Agreement.
   </p>
   <p class="govuk-hint govuk-!-margin-bottom-7">
-    <%= link_to(
+    <%= govuk_link_to(
       'How to calculate the customs value of your goods.',
       'https://www.gov.uk/government/publications/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics',
-      class: 'govuk-link',
-      target: '_blank',
-      rel: 'noopener norefferer',
+      new_tab: govuk_visually_hidden('(opens in new tab)')
     ) %>
   </p>
   <%= f.govuk_text_field :monetary_value, width: 'one-quarter', label: { text: 'What is the value in GBP of the goods being imported?', class: 'govuk-label govuk-label--s' }, prefix_text: '£' %>
@@ -29,7 +27,7 @@
   <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
   <ul class="govuk-list">
     <li>
-      <%= link_to('Valuation of imported goods for customs purposes, VAT and trade statistics', 'https://www.gov.uk/government/publications/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics', class: 'govuk-link') %>
+      <%= govuk_link_to('Valuation of imported goods for customs purposes, VAT and trade statistics', 'https://www.gov.uk/government/publications/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics') %>
     </li>
   </ul>
 </div>

--- a/app/views/duty_calculator/steps/customs_value/show.html.erb
+++ b/app/views/duty_calculator/steps/customs_value/show.html.erb
@@ -13,7 +13,7 @@
     <%= govuk_link_to(
       'How to calculate the customs value of your goods.',
       'https://www.gov.uk/government/publications/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics',
-      new_tab: govuk_visually_hidden('(opens in new tab)')
+      new_tab: govuk_visually_hidden('opens in new tab')
     ) %>
   </p>
   <%= f.govuk_text_field :monetary_value, width: 'one-quarter', label: { text: 'What is the value in GBP of the goods being imported?', class: 'govuk-label govuk-label--s' }, prefix_text: '£' %>

--- a/app/views/duty_calculator/steps/duty/_no_duty.html.erb
+++ b/app/views/duty_calculator/steps/duty/_no_duty.html.erb
@@ -1,6 +1,6 @@
 <% if @user_session.ni_to_gb_route? %>
   <p class="govuk-body govuk-!-margin-top-5">There are no import duties applicable to the movement of goods from Northern Ireland to England, Scotland and Wales.</p>
-  <p class="govuk-body">Find out more about <%= link_to('trading and moving goods in and out of Northern Ireland (opens in a new window)', 'https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland', class: 'govuk-link', target: '_blank') %>.</p>
+  <p class="govuk-body">Find out more about <%= govuk_link_to('trading and moving goods in and out of Northern Ireland', 'https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland', new_tab: true) %>.</p>
 <% elsif @user_session.eu_to_ni_route? %>
   <p class="govuk-body govuk-!-margin-top-5">
   There is no import duty to pay when importing goods into Northern Ireland from a European Union member state.
@@ -12,4 +12,4 @@
   <%= render 'duty_calculator/steps/duty/gb_to_ni/no_duty' %>
 <% end %>
 
-<%= link_to('Start again', import_date_path(commodity_code: user_session.commodity_code), class: 'govuk-button') %>
+<%= govuk_button_link_to('Start again', import_date_path(commodity_code: user_session.commodity_code)) %>

--- a/app/views/duty_calculator/steps/duty/calculations/_options_summary.html.erb
+++ b/app/views/duty_calculator/steps/duty/calculations/_options_summary.html.erb
@@ -4,7 +4,7 @@
     <ul class="app-contents govuk-!-margin-bottom-9">
       <% @duty_options.each.with_index(1) do |option, index| %>
         <li class="govuk-!-margin-bottom-2">
-          <%= link_to(t("duty_calculations.options.heading.#{option.category}.#{option.type}", option_no: index, geographical_area_description: option.geographical_area_description, order_number:  option.order_number), "##{option.type}", class: 'govuk-body') %>
+          <%= govuk_link_to(t("duty_calculations.options.heading.#{option.category}.#{option.type}", option_no: index, geographical_area_description: option.geographical_area_description, order_number:  option.order_number), "##{option.type}") %>
         </li>
       <% end %>
     </ul>

--- a/app/views/duty_calculator/steps/duty/show.html.erb
+++ b/app/views/duty_calculator/steps/duty/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', :back, class: "govuk-back-link") %>
+<%= govuk_back_link(href: :back) %>
 
 <span class="govuk-caption-xl">Calculate import duties</span>
 

--- a/app/views/duty_calculator/steps/duty/show.html.erb
+++ b/app/views/duty_calculator/steps/duty/show.html.erb
@@ -11,7 +11,7 @@
   <%= render 'no_duty' %>
 <% else %>
   <h1 class="govuk-heading-xl">Import duty calculation</h1>
-  <p class="govuk-body">You are importing commodity <%= link_to(commodity.formatted_commodity_code(user_session.additional_codes), commodity_url(commodity.code), class: 'govuk-link') %> from <strong><%= country_of_origin_description %> </strong> on <strong><%= l user_session.import_date %></strong>.</p>
+  <p class="govuk-body">You are importing commodity <%= govuk_link_to(commodity.formatted_commodity_code(user_session.additional_codes), commodity_url(commodity.code)) %> from <strong><%= country_of_origin_description %> </strong> on <strong><%= l user_session.import_date %></strong>.</p>
   <%= render 'duty_calculator/steps/duty/calculations/trade_details' %>
   <%= render 'duty_calculator/steps/duty/calculations/options' %>
 

--- a/app/views/duty_calculator/steps/final_use/show.html.erb
+++ b/app/views/duty_calculator/steps/final_use/show.html.erb
@@ -15,7 +15,7 @@
   <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
   <ul class="govuk-list">
     <li>
-      <%= link_to("Check if you can declare goods you bring into Northern Ireland 'not at risk' of moving to the EU", 'https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu', class: 'govuk-link') %>
+      <%= govuk_link_to("Check if you can declare goods you bring into Northern Ireland 'not at risk' of moving to the EU", 'https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu') %>
     </li>
   </ul>
 </div>

--- a/app/views/duty_calculator/steps/import_date/show.html.erb
+++ b/app/views/duty_calculator/steps/import_date/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', commodity_path(commodity.code), class: "govuk-back-link") %>
+<%= govuk_back_link(href: commodity_path(commodity.code)) %>
 
 <%= form_for @step, url: import_date_path, html: { novalidate: true } do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/duty_calculator/steps/import_destination/show.html.erb
+++ b/app/views/duty_calculator/steps/import_destination/show.html.erb
@@ -15,11 +15,11 @@
   <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
   <ul class="govuk-list">
     <li>
-      <%= link_to('Import goods into the UK: step by step', 'https://www.gov.uk/import-goods-into-uk', class: 'govuk-link') %>
+      <%= govuk_link_to('Import goods into the UK: step by step', 'https://www.gov.uk/import-goods-into-uk') %>
     </li>
     <li>
-      <%= link_to('Trading
-      and moving goods in and out of Northern Ireland', 'https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland-from-1-january-2021', class: 'govuk-link') %>
+      <%= govuk_link_to('Trading
+      and moving goods in and out of Northern Ireland', 'https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland-from-1-january-2021') %>
     </li>
   </ul>
 </div>

--- a/app/views/duty_calculator/steps/interstitial/show.html.erb
+++ b/app/views/duty_calculator/steps/interstitial/show.html.erb
@@ -4,4 +4,4 @@
 
 <%= render interstitial_partial_options %>
 
-<%= link_to('Continue', @step.next_step_path, class: 'govuk-button') %>
+<%= govuk_button_link_to('Continue', @step.next_step_path) %>

--- a/app/views/duty_calculator/steps/measure_amount/show.html.erb
+++ b/app/views/duty_calculator/steps/measure_amount/show.html.erb
@@ -31,7 +31,7 @@
   <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
   <ul class="govuk-list">
     <li>
-      <%= link_to('Valuation of imported goods for customs purposes, VAT and trade statistics ', 'https://www.gov.uk/government/publications/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics', class: 'govuk-link') %>
+      <%= govuk_link_to('Valuation of imported goods for customs purposes, VAT and trade statistics ', 'https://www.gov.uk/government/publications/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics') %>
     </li>
   </ul>
 </div>

--- a/app/views/duty_calculator/steps/planned_processing/show.html.erb
+++ b/app/views/duty_calculator/steps/planned_processing/show.html.erb
@@ -23,10 +23,10 @@
   <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
   <ul class="govuk-list">
     <li>
-      <%= link_to('Additional requirements for when you bring goods into Northern Ireland for processing', 'https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu-from-1-january-2021#processing', class: 'govuk-link') %>
+      <%= govuk_link_to('Additional requirements for when you bring goods into Northern Ireland for processing', 'https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu-from-1-january-2021#processing') %>
     </li>
     <li>
-      <%= link_to('Apply to pay less duty on goods you import for specific uses', 'https://www.gov.uk/guidance/apply-to-pay-less-duty-on-goods-you-import-for-specific-uses', class: 'govuk-link') %>
+      <%= govuk_link_to('Apply to pay less duty on goods you import for specific uses', 'https://www.gov.uk/guidance/apply-to-pay-less-duty-on-goods-you-import-for-specific-uses') %>
     </li>
   </ul>
 </div>

--- a/app/views/duty_calculator/steps/shared/_back_link.html.erb
+++ b/app/views/duty_calculator/steps/shared/_back_link.html.erb
@@ -1,1 +1,1 @@
-<%= link_to('Back', @step.previous_step_path, class: "govuk-back-link") if @step.present? %>
+<%= govuk_back_link(href: @step.previous_step_path) if @step.present? %>

--- a/app/views/duty_calculator/steps/stopping/show.html.erb
+++ b/app/views/duty_calculator/steps/stopping/show.html.erb
@@ -4,14 +4,14 @@
 <h1 class="govuk-heading-xl">Declared subheading not allowed</h1>
 
 <p class="govuk-body">
-  You have chosen a commodity code (<%= link_to(commodity.formatted_commodity_code, commodity_url(commodity.code), class: 'govuk-link')%>) for which you do not have the necessary documentation to proceed.
+  You have chosen a commodity code (<%= govuk_link_to(commodity.formatted_commodity_code, commodity_url(commodity.code))%>) for which you do not have the necessary documentation to proceed.
 </p>
 
 <h2 class="govuk-heading-m">What's next</h2>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>
-    Go back to the previous screen and <%= link_to('select the correct document code', @step.previous_step_path) %>
+    Go back to the previous screen and <%= govuk_link_to('select the correct document code', @step.previous_step_path) %>
   </li>
   <li>
     Try another commodity code

--- a/app/views/duty_calculator/steps/trader_scheme/show.html.erb
+++ b/app/views/duty_calculator/steps/trader_scheme/show.html.erb
@@ -12,7 +12,7 @@
   <%= f.govuk_submit %>
 <% end %>
 
-<p class='govuk-body'>If you are not yet authorised, then you can <%= link_to("find out more about applying for authorisation for the UK Internal Market Scheme", 'https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland', class: 'govuk-link') %>.</p>
+<p class='govuk-body'>If you are not yet authorised, then you can <%= govuk_link_to("find out more about applying for authorisation for the UK Internal Market Scheme", 'https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland') %>.</p>
 
 <%= render 'duty_calculator/shared/commodity_details' %>
 
@@ -20,7 +20,7 @@
   <h2 class="govuk-heading-m govuk-!-margin-top-3"><%= explore_topic_title %></h2>
   <ul class="govuk-list">
     <li>
-      <%= link_to("Apply for authorisation for the #{market_scheme_type}", 'https://www.gov.uk/government/news/windsor-framework-unveiled-to-fix-problems-of-the-northern-ireland-protocol', class: 'govuk-link') %>
+      <%= govuk_link_to("Apply for authorisation for the #{market_scheme_type}", 'https://www.gov.uk/government/news/windsor-framework-unveiled-to-fix-problems-of-the-northern-ireland-protocol') %>
     </li>
   </ul>
 </div>

--- a/app/views/duty_calculator/steps/trader_scheme/show.html.erb
+++ b/app/views/duty_calculator/steps/trader_scheme/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to('Back', @step.previous_step_path, class: "govuk-back-link") %>
+<%= govuk_back_link(href: @step.previous_step_path) %>
 
 <%= form_for @step, url: trader_scheme_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -10,9 +10,9 @@
       <p>You can also:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li><%= link_to 'Search for a commodity', find_commodity_path %></li>
-        <li><%= link_to 'Browse through the goods classification', browse_sections_path %></li>
-        <li><%= link_to 'Use the A-Z of classified goods', a_z_index_path('a') %></li>
+        <li><%= govuk_link_to 'Search for a commodity', find_commodity_path %></li>
+        <li><%= govuk_link_to 'Browse through the goods classification', browse_sections_path %></li>
+        <li><%= govuk_link_to 'Use the A-Z of classified goods', a_z_index_path('a') %></li>
       </ul>
     </div>
   </article>

--- a/app/views/exchange_rates/_document_detail.html.erb
+++ b/app/views/exchange_rates/_document_detail.html.erb
@@ -2,7 +2,7 @@
   <section class="attachment exchange-rates-attachment">
     <div class="attachment-thumb">
       <% if period.has_exchange_rates %>
-        <%= link_to(image_tag("spreadsheet.png", alt: ""), exchange_rate_collection_path("#{period.year}-#{period.month}"), class: 'govuk-link') %>
+        <%= govuk_link_to(image_tag("spreadsheet.png", alt: ""), exchange_rate_collection_path("#{period.year}-#{period.month}")) %>
       <% else %>
         <%= image_tag("spreadsheet.png", alt: "") %>
       <% end %>
@@ -14,7 +14,7 @@
 
       <p class="document-download">
         <% if period.has_exchange_rates %>
-          <%= link_to "<strong>View online</strong>".html_safe, exchange_rate_collection_path("#{period.year}-#{period.month}", type: type), title: "View #{period.month} #{period.year} monthly exchange rates online", class: 'govuk-link' %>
+          <%= govuk_link_to "<strong>View online</strong>".html_safe, exchange_rate_collection_path("#{period.year}-#{period.month}", type: type), title: "View #{period.month} #{period.year} monthly exchange rates online"  %>
         <% end %>
 
         <% if period.files.any? %>
@@ -35,7 +35,7 @@
           </span>
         </summary>
         <div class="govuk-details__text">
-          If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <a href="mailto:different.format@hmrc.gov.uk">different.format@hmrc.gov.uk</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.
+          If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <%= govuk_mail_to 'different.format@hmrc.gov.uk' %>. Please tell us what format you need. It will help us if you say what assistive technology you use.
         </div>
       </details>
     </div>

--- a/app/views/exchange_rates/_download_files.html.erb
+++ b/app/views/exchange_rates/_download_files.html.erb
@@ -8,7 +8,7 @@
 <dt class="gem-c-metadata__term">Download:</dt>
 <dd class="gem-c-metadata__definition">
   <% files.each_with_index do |file, index| %>
-    <%= link_to file.file_size_label, file.adjusted_file_path %>
+    <%= govuk_link_to file.file_size_label, file.adjusted_file_path %>
     <% unless index + 1 == files.length %>
       |
     <% end %>

--- a/app/views/exchange_rates/index.html.erb
+++ b/app/views/exchange_rates/index.html.erb
@@ -42,7 +42,7 @@
       </p>
       <p>
         <ul>
-          <li><p><a href="https://www.gov.uk/guidance/converting-foreign-currency-amounts-to-include-in-the-customs-value" target="_blank">converting foreign currency amounts to include in the customs value (open in new tab)</a></p></li>
+          <li><p><%= govuk_link_to 'converting foreign currency amounts to include in the customs value', 'https://www.gov.uk/guidance/converting-foreign-currency-amounts-to-include-in-the-customs-value', new_tab: true %></p></li>
         </ul>
       </p>
       <p>
@@ -122,7 +122,7 @@
           <ul class="gem-c-related-navigation__link-list" data-module="gem-track-click" data-gem-track-click-module-started="true">
             <% filter_years(@period_list.exchange_rate_years, @period_list.year).each do |year| %>
               <li class="gem-c-related-navigation__link">
-                <%= link_to "#{year.year}", exchange_rates_path(type: @period_list.type, year: year.year) %><br>
+                <%= govuk_link_to year.year, exchange_rates_path(type: @period_list.type, year: year.year) %><br>
               </li>
             <% end %>
           </ul>

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -23,7 +23,7 @@
                             max_chars: 500 %>
 
         <p class="form-hint">
-          If you have any questions or need assistance, use our <%= link_to 'enquiry form', product_experience_enquiry_form_path %>.
+          If you have any questions or need assistance, use our <%= govuk_link_to 'enquiry form', product_experience_enquiry_form_path %>.
         </p>
 
       <div style="display: none;">

--- a/app/views/find_commodities/_devolved_nations.html.erb
+++ b/app/views/find_commodities/_devolved_nations.html.erb
@@ -2,12 +2,12 @@
   <% if TradeTariffFrontend::ServiceChooser.xi? %>
     <h2 class="govuk-heading-s govuk-!-margin-bottom-0">Applies to Northern Ireland</h2>
     <ul class="govuk-list govuk-!-margin-top-1 govuk-!-margin-bottom-0">
-      <li><%= govuk_link_to 'Guidance for England, Scotland and Wales', '/find_commodity'  %></li>
+      <li><%= govuk_link_to 'Guidance for England, Scotland and Wales', '/find_commodity' %></li>
     </ul>
   <% else %>
     <h2 class="govuk-heading-s govuk-!-margin-bottom-0">Applies to England, Scotland and Wales</h2>
     <ul class="govuk-list govuk-!-margin-top-1 govuk-!-margin-bottom-0">
-      <li><%= govuk_link_to 'Guidance for Northern Ireland', '/xi/find_commodity'  %></li>
+      <li><%= govuk_link_to 'Guidance for Northern Ireland', '/xi/find_commodity' %></li>
     </ul>
   <% end %>
 </section>

--- a/app/views/find_commodities/_devolved_nations.html.erb
+++ b/app/views/find_commodities/_devolved_nations.html.erb
@@ -2,12 +2,12 @@
   <% if TradeTariffFrontend::ServiceChooser.xi? %>
     <h2 class="govuk-heading-s govuk-!-margin-bottom-0">Applies to Northern Ireland</h2>
     <ul class="govuk-list govuk-!-margin-top-1 govuk-!-margin-bottom-0">
-      <li><%= link_to 'Guidance for England, Scotland and Wales', '/find_commodity', class: 'govuk-link' %></li>
+      <li><%= govuk_link_to 'Guidance for England, Scotland and Wales', '/find_commodity'  %></li>
     </ul>
   <% else %>
     <h2 class="govuk-heading-s govuk-!-margin-bottom-0">Applies to England, Scotland and Wales</h2>
     <ul class="govuk-list govuk-!-margin-top-1 govuk-!-margin-bottom-0">
-      <li><%= link_to 'Guidance for Northern Ireland', '/xi/find_commodity', class: 'govuk-link' %></li>
+      <li><%= govuk_link_to 'Guidance for Northern Ireland', '/xi/find_commodity'  %></li>
     </ul>
   <% end %>
 </section>

--- a/app/views/find_commodities/show.html.erb
+++ b/app/views/find_commodities/show.html.erb
@@ -21,13 +21,13 @@
           <p>Expect technical language. Commodity code descriptions can be quite formal. For example, a laptop might be described as a "Portable automatic data-processing machines, weighing not more than 10 kg, consisting of at least a central processing unit, a keyboard and a display."</p>
           <p>Use plain English and avoid using foreign words or special characters. The search is also unable to pick up on any spelling mistakes.</p>
           <p>Make sure you're using the correct country's classification. Commodity codes can vary between countries. Make sure you're using the right code for the country you're importing to or from.</p>
-          <p>If you are struggling to understand the duty you may need to pay then this guidance may help you: <%= link_to "Tax and customs for goods sent from abroad: Tax and duty - GOV.UK", "https://www.gov.uk/goods-sent-from-abroad/tax-and-duty" %></p>
+          <p>If you are struggling to understand the duty you may need to pay then this guidance may help you: <%= govuk_link_to "Tax and customs for goods sent from abroad: Tax and duty - GOV.UK", "https://www.gov.uk/goods-sent-from-abroad/tax-and-duty" %></p>
 
           <h3 class="govuk-heading-s">If you're stuck</h3>
           <p>If you can't find what you're looking for:</p>
           <ul class="govuk-list--bullet govuk-list">
-            <li><%= link_to "Try searching using the A to Z", a_z_index_path('a') %></li>
-            <li><%= link_to "Browse the goods classification", browse_sections_path %></li>
+            <li><%= govuk_link_to "Try searching using the A to Z", a_z_index_path('a') %></li>
+            <li><%= govuk_link_to "Browse the goods classification", browse_sections_path %></li>
           </ul>
 
           <h3 class="govuk-heading-s">Steps for searching the tariff</h3>
@@ -44,8 +44,8 @@
 
       <p>Alternatively, you can:</p>
       <ul class="govuk-list--bullet govuk-list">
-        <li><%= link_to 'browse the goods classification', browse_sections_path %> or</li>
-        <li><%= link_to 'look for your product in the A-Z', a_z_index_path('a') %>.</li>
+        <li><%= govuk_link_to 'browse the goods classification', browse_sections_path %> or</li>
+        <li><%= govuk_link_to 'look for your product in the A-Z', a_z_index_path('a') %>.</li>
       </ul>
 
     </div>

--- a/app/views/find_commodities/show_interactive.html.erb
+++ b/app/views/find_commodities/show_interactive.html.erb
@@ -30,7 +30,7 @@
           <li class="gem-c-cards__list-item">
             <div class="gem-c-cards__list-item-wrapper">
               <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-                <%= link_to 'Keyword or commodity code', find_commodity_path, class: 'govuk-link gem-c-cards__link' %>
+                <%= govuk_link_to 'Keyword or commodity code', find_commodity_path, class: 'gem-c-cards__link' %>
               </h3>
               <p class="govuk-body gem-c-cards__description">Search using keywords or use a known commodity code</p>
             </div>
@@ -38,7 +38,7 @@
           <li class="gem-c-cards__list-item">
             <div class="gem-c-cards__list-item-wrapper">
               <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-                <%= link_to 'Goods classifications', browse_sections_path, class: 'govuk-link gem-c-cards__link' %>
+                <%= govuk_link_to 'Goods classifications', browse_sections_path, class: 'gem-c-cards__link' %>
               </h3>
               <p class="govuk-body gem-c-cards__description">Browse the goods classification</p>
             </div>
@@ -46,7 +46,7 @@
           <li class="gem-c-cards__list-item">
             <div class="gem-c-cards__list-item-wrapper">
               <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-                <%= link_to 'A-Z product index', a_z_index_path('a'), class: 'govuk-link gem-c-cards__link' %>
+                <%= govuk_link_to 'A-Z product index', a_z_index_path('a'), class: 'gem-c-cards__link' %>
               </h3>
               <p class="govuk-body gem-c-cards__description">Look for your product in the A-Z</p>
             </div>

--- a/app/views/goods_nomenclatures/_ancestors.html.erb
+++ b/app/views/goods_nomenclatures/_ancestors.html.erb
@@ -5,7 +5,7 @@
     <%# list commodities section %>
     <li id="commodity-ancestors__section"
         aria-owns="commodity-ancestors__chapter">
-      <%= link_to section_path(goods_nomenclature.section) do %>
+      <%= govuk_link_to section_path(goods_nomenclature.section) do %>
         <span class="commodity-ancestors__identifier">
           Section <%= goods_nomenclature.section.numeral %>
         </span>
@@ -19,7 +19,7 @@
     <%# list commodities chapter %>
     <li id="commodity-ancestors__chapter"
         aria-owns="commodity-ancestors__heading">
-      <%= link_to chapter_path(goods_nomenclature.chapter) do %>
+      <%= govuk_link_to chapter_path(goods_nomenclature.chapter) do %>
         <span class="commodity-ancestors__identifier">
           Chapter <%= goods_nomenclature.chapter.short_code %>
         </span>
@@ -51,7 +51,7 @@
       <%# list commodities heading %>
       <li id="commodity-ancestors__heading"
           aria-owns="<%= commodity_ancestor_id 1 %>">
-        <%= link_to heading_path(goods_nomenclature.heading) do %>
+        <%= govuk_link_to heading_path(goods_nomenclature.heading) do %>
           <span class="commodity-ancestors__identifier">
             <%= segmented_commodity_code goods_nomenclature.heading.short_code,
                                          coloured: true %>
@@ -67,7 +67,7 @@
       <% goods_nomenclature.ancestors.each.with_index do |ancestor, index| %>
       <li id="<%= commodity_ancestor_id(index + 1) %>"
           aria-owns="<%= commodity_ancestor_id(index + 2) %>">
-        <%= link_to subheading_path("#{ancestor.code}-#{ancestor.producline_suffix}") do %>
+        <%= govuk_link_to subheading_path("#{ancestor.code}-#{ancestor.producline_suffix}") do %>
           <span class="commodity-ancestors__identifier">
             <%= segmented_commodity_code abbreviate_commodity_code(ancestor), coloured: true %>
           </span>

--- a/app/views/green_lanes/applicable_exemptions/_form.html.erb
+++ b/app/views/green_lanes/applicable_exemptions/_form.html.erb
@@ -26,7 +26,7 @@
           <% if category_assessment.regulation_url.present? %>
           <p>
             <%= govuk_link_to 'View Regulation document',
-                        category_assessment.regulation_url, new_tab: govuk_visually_hidden('(opens in new tab)')
+                        category_assessment.regulation_url, new_tab: govuk_visually_hidden('opens in new tab')
             %>
           </p>
           <% end %>

--- a/app/views/green_lanes/applicable_exemptions/_form.html.erb
+++ b/app/views/green_lanes/applicable_exemptions/_form.html.erb
@@ -25,9 +25,8 @@
 
           <% if category_assessment.regulation_url.present? %>
           <p>
-            <%= link_to 'View Regulation document',
-                        category_assessment.regulation_url,
-                        class: 'govuk-link', target: '_blank', rel: 'noopener noreferrer'
+            <%= govuk_link_to 'View Regulation document',
+                        category_assessment.regulation_url, new_tab: govuk_visually_hidden('(opens in new tab)')
             %>
           </p>
           <% end %>

--- a/app/views/green_lanes/category_assessments/_category.html.erb
+++ b/app/views/green_lanes/category_assessments/_category.html.erb
@@ -34,7 +34,7 @@
     <p><%= category.regulation.description %></p>
     <% if category.regulation.regulation_url.present? %>
     <p>
-      <%= link_to 'Further information', category.regulation.regulation_url, target: '_blank' %>
+      <%= govuk_link_to 'Further information', category.regulation.regulation_url, new_tab: govuk_visually_hidden('opens in new tab') %>
     </p>
     <% end %>
   </div>

--- a/app/views/green_lanes/eligibility_results/_not_eligible.html.erb
+++ b/app/views/green_lanes/eligibility_results/_not_eligible.html.erb
@@ -16,11 +16,11 @@
     </ul>
 
     <p class="govuk-body">
-      <a href="http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland" target="_blank" class="govuk-link">Find out more about Internal Market Movements (opens in new tab)</a>
+      <%= govuk_link_to 'Find out more about Internal Market Movements', 'http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland', new_tab: true %>
     </p>
 
     <p class="govuk-body">
-      You can also <a href="https://www.gov.uk/check-how-to-import-export" target="_blank" class="govuk-link">check how to import or export goods (opens in new tab)</a> or find guidance on <a href="https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland" target="_blank" class="govuk-link">trading and moving goods in and out of Northern Ireland (opens in new tab).</a>
+      You can also <%= govuk_link_to 'check how to import or export goods', 'https://www.gov.uk/check-how-to-import-export', new_tab: true %> or find guidance on <%= govuk_link_to 'trading and moving goods in and out of Northern Ireland', 'https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland', new_tab: true %>
 
     </p>
 

--- a/app/views/green_lanes/eligibility_results/_not_yet_eligible.html.erb
+++ b/app/views/green_lanes/eligibility_results/_not_yet_eligible.html.erb
@@ -11,10 +11,10 @@
 
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>be a <a href="https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland" target="_blank" class="govuk-link">UK Internal Market Scheme (UKIMS) authorised trader (opens in new tab)</a></li>
+      <li>be a <%= govuk_link_to 'UK Internal Market Scheme (UKIMS) authorised trader', 'https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland', new_tab: true %></li>
       <li>be transporting goods directly from Great Britain to Northern Ireland</li>
       <li>confirm goods are in free circulation in the UK</li>
-      <li>confirm goods are intended to be sold to, or used by, end consumers in the UK, and therefore deemed <a href="https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu" target="_blank" class="govuk-link">'not at risk’ of moving to the EU (opens in new tab)</a>, including the Republic of Ireland</li>
+      <li>confirm goods are intended to be sold to, or used by, end consumers in the UK, and therefore deemed <%= govuk_link_to "'not at risk' of moving to the EU", 'https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu', new_tab: true %>, including the Republic of Ireland</li>
       <li>check the category of your goods</li>
     </ul>
 

--- a/app/views/green_lanes/eligibility_results/_you_may_be_eligible.html.erb
+++ b/app/views/green_lanes/eligibility_results/_you_may_be_eligible.html.erb
@@ -11,10 +11,10 @@
 
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>be a <a href="https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland" target="_blank" class="govuk-link">UK Internal Market Scheme (UKIMS) authorised trader (opens in new tab)</a></li>
+      <li>be a <%= govuk_link_to 'UK Internal Market Scheme (UKIMS) authorised trader', 'https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland', new_tab: true %></li>
       <li>be transporting goods directly from Great Britain to Northern Ireland</li>
       <li>confirm goods are in free circulation in the UK</li>
-      <li>confirm goods are intended to be sold to, or used by, end consumers in the UK, and therefore deemed <a href="https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu" target="_blank" class="govuk-link">'not at risk’ of moving to the EU (opens in new tab)</a>, including the Republic of Ireland</li>
+      <li>confirm goods are intended to be sold to, or used by, end consumers in the UK, and therefore deemed <%= govuk_link_to "'not at risk' of moving to the EU", 'https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu', new_tab: true %>, including the Republic of Ireland</li>
       <li>check the category of your goods</li>
     </ul>
 

--- a/app/views/green_lanes/results/_category_assessments_card.erb
+++ b/app/views/green_lanes/results/_category_assessments_card.erb
@@ -17,7 +17,7 @@
             </p>
 
             <% if category_assessment.regulation_url.present? %>
-              <%= govuk_link_to 'View Regulation document', category_assessment.regulation_url  %>
+              <%= govuk_link_to 'View Regulation document', category_assessment.regulation_url %>
             <% end %>
 
             <p class='govuk-!-margin-top-4'>

--- a/app/views/green_lanes/results/_category_assessments_card.erb
+++ b/app/views/green_lanes/results/_category_assessments_card.erb
@@ -17,7 +17,7 @@
             </p>
 
             <% if category_assessment.regulation_url.present? %>
-              <%= link_to 'View Regulation document', category_assessment.regulation_url, class: 'govuk-link' %>
+              <%= govuk_link_to 'View Regulation document', category_assessment.regulation_url  %>
             <% end %>
 
             <p class='govuk-!-margin-top-4'>

--- a/app/views/green_lanes/results/_result_category_1.html.erb
+++ b/app/views/green_lanes/results/_result_category_1.html.erb
@@ -22,9 +22,9 @@
 </ul>
 
 <p>
-  <%= link_to 'Find out more about Internal Market Movements (opens in a new tab)',
+  <%= govuk_link_to 'Find out more about Internal Market Movements',
               'http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland',
-              target: '_blank', rel: 'noopener noreferrer'
+              new_tab: true
   %>
 </p>
 
@@ -40,9 +40,9 @@
 </p>
 
 <p>
-  <%= link_to 'Find out more about trading and moving goods in and out of Northern Ireland (opens in a new tab)',
+  <%= govuk_link_to 'Find out more about trading and moving goods in and out of Northern Ireland',
               'https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland',
-              target: '_blank', rel: 'noopener noreferrer'
+              new_tab: true
   %>
 </p>
 

--- a/app/views/green_lanes/results/_result_category_2.html.erb
+++ b/app/views/green_lanes/results/_result_category_2.html.erb
@@ -19,9 +19,9 @@
 </ul>
 
 <p>
-  <%= link_to 'Find out more about Internal Market Movements (opens in a new tab)',
+  <%= govuk_link_to 'Find out more about Internal Market Movements',
               'http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland',
-              target: '_blank', rel: 'noopener noreferrer'
+              new_tab: true
   %>
 </p>
 

--- a/app/views/green_lanes/results/_result_category_3.html.erb
+++ b/app/views/green_lanes/results/_result_category_3.html.erb
@@ -20,9 +20,9 @@
 </ul>
 
 <p>
-   <%= link_to 'Find out more about Internal Market Movements (opens in a new tab)',
-              'http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland',
-              target: '_blank', rel: 'noopener noreferrer'
+  <%= govuk_link_to 'Find out more about Internal Market Movements',
+                    'http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland',
+                    new_tab: true
   %>
 </p>
 

--- a/app/views/green_lanes/results/create.html.erb
+++ b/app/views/green_lanes/results/create.html.erb
@@ -14,7 +14,6 @@
 
 <%= render partial: "result_category_#{@category}" %>
 
-<%= link_to 'Check the category of other goods',
-             green_lanes_moving_requirements_path,
-             class: 'govuk-button govuk-button--secondary'
-%>
+<%= govuk_button_link_to 'Check the category of other goods',
+                         green_lanes_moving_requirements_path,
+                         secondary: true %>

--- a/app/views/headings/_heading.html.erb
+++ b/app/views/headings/_heading.html.erb
@@ -6,8 +6,8 @@
       </div>
     </td>
     <td class="govuk-table__cell">
-      <%= link_to heading_path(heading, request.query_parameters.symbolize_keys)  do %>
-        <span class="govuk-visually-hidden">Heading <%= heading.display_short_code %>: </span> <%= heading.formatted_description.html_safe %>
+      <%= govuk_link_to heading_path(heading, request.query_parameters.symbolize_keys) do %>
+        <%= govuk_visually_hidden "Heading #{heading.display_short_code}: " %> <%= heading.formatted_description.html_safe %>
       <% end %>
     </td>
   </tr>

--- a/app/views/headings/show_404.html.erb
+++ b/app/views/headings/show_404.html.erb
@@ -20,10 +20,10 @@
       <ul class="govuk-list govuk-list--bullet">
         <% @validity_periods.each do |validity_period| %>
           <li>
-            From <%= link_to validity_period.start_date.to_formatted_s(:long),
+            From <%= govuk_link_to validity_period.start_date.to_formatted_s(:long),
                              heading_on_date_path(@heading_code, validity_period.start_date) -%>
             <% if validity_period.end_date.present? -%>
-              to <%= link_to validity_period.end_date.to_formatted_s(:long),
+              to <%= govuk_link_to validity_period.end_date.to_formatted_s(:long),
                              heading_on_date_path(@heading_code, validity_period.end_date) -%>
             <% end -%>
           </li>
@@ -40,9 +40,9 @@
     <p>
       Alternatively, you can visit
       <% if @search.today? %>
-        <%= link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>.
+        <%= govuk_link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>.
       <% else %>
-        <%= link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>
+        <%= govuk_link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>
         for <%= @search.date.to_formatted_s :long %>.
       <% end %>
     </p>

--- a/app/views/import_export_dates/show.html.erb
+++ b/app/views/import_export_dates/show.html.erb
@@ -21,7 +21,7 @@
 
       <div class="govuk-button-group">
         <%= f.govuk_submit('Update date') %>
-        <%= link_to('Cancel', goods_nomenclature_path, class: 'govuk-link') %>
+        <%= govuk_link_to('Cancel', goods_nomenclature_path) %>
       </div>
     <% end %>
   </div>

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -27,22 +27,22 @@
           </button>
           <ul id="proposition-links" class="govuk-service-navigation__list">
             <%= govuk_service_navigation_item(active_class: search_active_class) do %>
-              <%= link_to 'Search', home_path, class: "govuk-service-navigation__link" %>
+              <%= govuk_link_to 'Search', home_path, class: "govuk-service-navigation__link" %>
             <% end %>
             <%= govuk_service_navigation_item(active_class: browse_active_class) do %>
-              <%= link_to 'Browse', browse_sections_path, class: "govuk-service-navigation__link" %>
+              <%= govuk_link_to 'Browse', browse_sections_path, class: "govuk-service-navigation__link" %>
             <% end %>
             <%= govuk_service_navigation_item(active_class: a_z_active_class) do %>
-              <%= link_to "A-Z", a_z_index_path(letter: "a"), class: "govuk-service-navigation__link" %>
+              <%= govuk_link_to "A-Z", a_z_index_path(letter: "a"), class: "govuk-service-navigation__link" %>
             <% end %>
             <%= govuk_service_navigation_item(active_class: tools_active_class) do %>
-              <%= link_to "Tools", tools_path, class: "govuk-service-navigation__link" %>
+              <%= govuk_link_to "Tools", tools_path, class: "govuk-service-navigation__link" %>
             <% end %>
             <%= govuk_service_navigation_item(active_class: updates_active_class) do %>
-              <%= link_to "News", news_items_path, class: "govuk-service-navigation__link" %>
+              <%= govuk_link_to "News", news_items_path, class: "govuk-service-navigation__link" %>
             <% end %>
             <%= govuk_service_navigation_item(active_class: help_active_class) do %>
-              <%= link_to "Help", help_path, class: "govuk-service-navigation__link" %>
+              <%= govuk_link_to "Help", help_path, class: "govuk-service-navigation__link" %>
             <% end %>
           </ul>
         </nav>
@@ -67,8 +67,8 @@
       <ul class="govuk-footer__list">
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods">Ask HMRC for advice on classifying your goods</a></li>
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries">Imports and exports: general enquiries</a></li>
-        <li class="govuk-footer__list-item"><%= link_to 'Feedback', feedback_link_url, class: "govuk-footer__link", **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %></li>
-        <li class="govuk-footer__list-item"><%= link_to 'Enquiry Form', product_experience_enquiry_form_path, class: "govuk-footer__link" %></li>
+        <li class="govuk-footer__list-item"><%= govuk_link_to 'Feedback', feedback_link_url, class: "govuk-footer__link", **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %></li>
+        <li class="govuk-footer__list-item"><%= govuk_link_to 'Enquiry Form', product_experience_enquiry_form_path, class: "govuk-footer__link" %></li>
       </ul>
     </div>
 
@@ -100,13 +100,13 @@
       <h2 class="govuk-visually-hidden">Support links</h2>
       <ul class="govuk-footer__inline-list">
         <li class="govuk-footer__inline-list-item">
-          <%= link_to 'Privacy', privacy_path, class: 'govuk-footer__link' %>
+          <%= govuk_link_to 'Privacy', privacy_path, class: 'govuk-footer__link' %>
         </li>
         <li class="govuk-footer__inline-list-item">
-          <%= link_to 'Cookies', cookies_policy_path, class: 'govuk-footer__link' %>
+          <%= govuk_link_to 'Cookies', cookies_policy_path, class: 'govuk-footer__link' %>
         </li>
         <li class="govuk-footer__inline-list-item">
-          <%= link_to 'Terms and conditions', terms_path, class: 'govuk-footer__link' %>
+          <%= govuk_link_to 'Terms and conditions', terms_path, class: 'govuk-footer__link' %>
         </li>
       </ul>
 

--- a/app/views/layouts/_cookies_consent.html.erb
+++ b/app/views/layouts/_cookies_consent.html.erb
@@ -7,7 +7,7 @@
         <p>
           You have accepted additional cookies.
 
-          You can <%= link_to('change your cookie settings', cookies_policy_path) %> at any time.
+          You can <%= govuk_link_to('change your cookie settings', cookies_policy_path) %> at any time.
         </p>
 
         <button class="govuk-button hide_cookie_panel" data-action="cookie-banner#hideConfirmCookiesBanner">
@@ -22,7 +22,7 @@
         <p>
           You have rejected additional cookies.
 
-          You can <%= link_to('change your cookie settings', cookies_policy_path) %> at any time.
+          You can <%= govuk_link_to('change your cookie settings', cookies_policy_path) %> at any time.
         </p>
 
         <button class="govuk-button hide_cookie_panel" data-action="cookie-banner#hideConfirmCookiesBanner">

--- a/app/views/layouts/_cookies_consent.html.erb
+++ b/app/views/layouts/_cookies_consent.html.erb
@@ -58,7 +58,7 @@
             Reject additional cookies
           </button>
 
-          <%= link_to('View cookies', cookies_policy_path, class: "govuk-link") %>
+          <%= govuk_link_to('View cookies', cookies_policy_path) %>
         </div>
       </div>
     </div>

--- a/app/views/measures/_measure.html.erb
+++ b/app/views/measures/_measure.html.erb
@@ -1,7 +1,7 @@
 <tr id="measure-<%= measure.id %>" class=" govuk-table__row <%= measure.geographical_area.id %>" tabIndex="-1">
   <td class="country-col govuk-table__cell">
     <% if measure.has_children_geographical_areas? %>
-      <%= link_to measure.geographical_area.long_description, geographical_area_path(id: measure.geographical_area.id, goods_nomenclature_code: current_goods_nomenclature_code), class: 'govuk-link' %>
+      <%= govuk_link_to measure.geographical_area.long_description, geographical_area_path(id: measure.geographical_area.id, goods_nomenclature_code: current_goods_nomenclature_code)  %>
     <% else %>
       <%= measure.geographical_area.long_description %>
     <% end %>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -65,7 +65,7 @@
       <%= render "footnotes/critical_warning", footnote: footnote %>
     <% end %>
 
-    <p>The commodity code for exporting and <%= link_to 'Intrastat reporting', 'https://www.gov.uk/intrastat', target: "_blank" %> is <%= declarable.display_export_code %>.</p>
+    <p>The commodity code for exporting and <%= govuk_link_to 'Intrastat reporting', 'https://www.gov.uk/intrastat', new_tab: govuk_visually_hidden("opens in new tab") %> is <%= declarable.display_export_code %>.</p>
 
     <%= render 'declarables/consigned', declarable: declarable %>
 

--- a/app/views/measures/_meursing_form.html.erb
+++ b/app/views/measures/_meursing_form.html.erb
@@ -1,5 +1,5 @@
-<% meursing_finder_link = link_to 'Meursing code finder', meursing_lookup_step_path('start', goods_nomenclature_code: current_goods_nomenclature_code), class: 'govuk-link' %>
-<% meursing_clear_link = link_to 'Clear additional code', meursing_lookup_result_path(goods_nomenclature_code: current_goods_nomenclature_code), class: 'govuk-link meursing-form-textual-button' %>
+<% meursing_finder_link = govuk_link_to 'Meursing code finder', meursing_lookup_step_path('start', goods_nomenclature_code: current_goods_nomenclature_code)  %>
+<% meursing_clear_link = govuk_link_to 'Clear additional code', meursing_lookup_result_path(goods_nomenclature_code: current_goods_nomenclature_code), class: 'meursing-form-textual-button' %>
 
 <div id="meursing" class="govuk-inset-text govuk-inset-text--s no-inset tariff-inset-meursing">
   <%= form_for MeursingLookup::Result.new, url: meursing_lookup_result_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>

--- a/app/views/measures/_meursing_form.html.erb
+++ b/app/views/measures/_meursing_form.html.erb
@@ -1,4 +1,4 @@
-<% meursing_finder_link = govuk_link_to 'Meursing code finder', meursing_lookup_step_path('start', goods_nomenclature_code: current_goods_nomenclature_code)  %>
+<% meursing_finder_link = govuk_link_to 'Meursing code finder', meursing_lookup_step_path('start', goods_nomenclature_code: current_goods_nomenclature_code) %>
 <% meursing_clear_link = govuk_link_to 'Clear additional code', meursing_lookup_result_path(goods_nomenclature_code: current_goods_nomenclature_code), class: 'meursing-form-textual-button' %>
 
 <div id="meursing" class="govuk-inset-text govuk-inset-text--s no-inset tariff-inset-meursing">

--- a/app/views/measures/grouped/_navigation.html.erb
+++ b/app/views/measures/grouped/_navigation.html.erb
@@ -5,7 +5,7 @@
   <ul class="measure-list-item govuk-!-margin-bottom-0">
     <% grouped_measures_presenter.navigation_items.each do |item| %>
       <li class="govuk-!-margin-bottom-2">
-        <%= link_to(item[:text], item[:anchor], class: 'govuk-link') %>
+        <%= govuk_link_to(item[:text], item[:anchor]) %>
       </li>
     <% end %>
   </ul>

--- a/app/views/meursing_lookup/steps/_end.html.erb
+++ b/app/views/meursing_lookup/steps/_end.html.erb
@@ -26,11 +26,11 @@
           <%= goods_nomenclature_link %>
         </li>
         <li>
-          <%= link_to('Start again', meursing_lookup_step_path(:start, goods_nomenclature_code: current_goods_nomenclature_code)) %>
+          <%= govuk_link_to('Start again', meursing_lookup_step_path(:start, goods_nomenclature_code: current_goods_nomenclature_code)) %>
         </li>
       </ul>
     <% else %>
-      <%= link_to('Start again', meursing_lookup_step_path(:start)) %>
+      <%= govuk_link_to('Start again', meursing_lookup_step_path(:start)) %>
     <% end %>
   </div>
 </div>

--- a/app/views/meursing_lookup/steps/_review_answer.html.erb
+++ b/app/views/meursing_lookup/steps/_review_answer.html.erb
@@ -6,6 +6,6 @@
   <dt class="govuk-summary-list__key"><%= I18n.t("meursing_lookup.steps.#{key}.review_answer_label") %></dt>
   <dd class="govuk-summary-list__value"><%= answer %> %</dd>
   <dd class="govuk-summary-list__actions">
-    <%= link_to('Change', meursing_lookup_step_path(key), class: 'govuk-link') %>
+    <%= govuk_link_to('Change', meursing_lookup_step_path(key)) %>
   </dd>
 </div>

--- a/app/views/meursing_lookup/steps/_start.html.erb
+++ b/app/views/meursing_lookup/steps/_start.html.erb
@@ -42,10 +42,10 @@
     <h2 class="govuk-heading-m">Documents to download</h2>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        <%= link_to('Meursing table (PDF) [opens in new window]', asset_path('Meursing_table.pdf'), target: '_blank', class: 'govuk-link') %>
+        <%= govuk_link_to('Meursing table (PDF)', asset_path('Meursing_table.pdf'), new_tab: true) %>
       </li>
       <li>
-        <%= link_to('Meursing table (ODT) [opens in new window]', asset_path('Meursing_table.odt'), target: '_blank', class: 'govuk-link') %>
+        <%= govuk_link_to('Meursing table (ODT)', asset_path('Meursing_table.odt'), new_tab: true) %>
       </li>
     </ul>
   </div>

--- a/app/views/myott/grouped_measure_changes/show.html.erb
+++ b/app/views/myott/grouped_measure_changes/show.html.erb
@@ -40,7 +40,7 @@
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= commodity_change.commodity.goods_nomenclature_item_id %></td>
               <td class="govuk-table__cell"><%= sanitize commodity_change.commodity.classification_description %></td>
-              <td class="govuk-table__cell"><%= link_to(pluralize(commodity_change.count, 'change'), myott_grouped_measure_commodity_change_path(commodity_change.resource_id, as_of:)) %></td>
+              <td class="govuk-table__cell"><%= govuk_link_to(pluralize(commodity_change.count, 'change'), myott_grouped_measure_commodity_change_path(commodity_change.resource_id, as_of:)) %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
+++ b/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
@@ -27,8 +27,8 @@
         <% end %>
         <td class="govuk-table__cell"><%= change.date_of_effect %></td>
         <td class="govuk-table__cell">
-          <%= link_to(commodity_path(@grouped_measure_commodity_changes.goods_nomenclature_item_id, **change.commodity_link_params), target: '_blank', rel: 'noopener') do %>
-            View commodity on <%= change.date_of_effect_visible %> <span class="govuk-visually-hidden">(opens in new tab)</span>
+          <%= govuk_link_to(commodity_path(@grouped_measure_commodity_changes.goods_nomenclature_item_id, **change.commodity_link_params), target: '_blank', rel: 'noopener') do %>
+            View commodity on <%= change.date_of_effect_visible %> <%= govuk_visually_hidden("(opens in new tab)") %>
           <% end %>
         </td>
       </tr>

--- a/app/views/myott/mycommodities/_commodity_changes.html.erb
+++ b/app/views/myott/mycommodities/_commodity_changes.html.erb
@@ -17,7 +17,7 @@
             <%= change.description %>
           </td>
           <td class="govuk-table__cell">
-            <%= link_to "#{pluralize(change.count, 'commodity')}", send("#{change.resource_id}_myott_commodity_changes_path", as_of:) %>
+            <%= govuk_link_to "#{pluralize(change.count, 'commodity')}", send("#{change.resource_id}_myott_commodity_changes_path", as_of:) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/myott/mycommodities/_counts.html.erb
+++ b/app/views/myott/mycommodities/_counts.html.erb
@@ -11,14 +11,14 @@
     <div class="category_container">
       Errors from upload:
       <br />
-      <%= link_to number_with_delimiter(commodity_codes.invalid), invalid_myott_mycommodities_path, class: "govuk-link--no-visited-state" %>
+      <%= govuk_link_to number_with_delimiter(commodity_codes.invalid), invalid_myott_mycommodities_path, no_visited_state: true %>
     </div>
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="category_container">
       Expired commodities:
       <br />
-      <%= link_to number_with_delimiter(commodity_codes.expired), expired_myott_mycommodities_path, class: "govuk-link--no-visited-state" %>
+      <%= govuk_link_to number_with_delimiter(commodity_codes.expired), expired_myott_mycommodities_path, no_visited_state: true %>
     </div>
   </div>
   <div class="govuk-grid-column-one-third">
@@ -28,7 +28,7 @@
       <% if commodity_codes.active.zero? %>
         0
       <% else %>
-        <%= link_to number_with_delimiter(commodity_codes.active), active_myott_mycommodities_path, class: "govuk-link--no-visited-state" %>
+        <%= govuk_link_to number_with_delimiter(commodity_codes.active), active_myott_mycommodities_path, no_visited_state: true %>
       <% end %>
     </div>
   </div>

--- a/app/views/myott/mycommodities/_download_changes.html.erb
+++ b/app/views/myott/mycommodities/_download_changes.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-6">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full govuk-!-font-weight-bold">
-      <%= link_to download_changes_myott_mycommodities_path(as_of: as_of.to_fs(:dashed)) do %>
+      <%= govuk_link_to download_changes_myott_mycommodities_path(as_of: as_of.to_fs(:dashed)) do %>
         <%= inline_svg_tag("download_icon.svg", class: "download_icon", aria: { hidden: true }) %>
         <span>Download tariff changes (.xlsx)</span>
       <% end %>

--- a/app/views/myott/mycommodities/_download_commodities.html.erb
+++ b/app/views/myott/mycommodities/_download_commodities.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-padding-top-1">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <%= link_to download_commodities_myott_mycommodities_path, class: "govuk-link--inverse" do %>
+      <%= govuk_link_to download_commodities_myott_mycommodities_path, inverse: true do %>
         <span class="myott-mycommodities__download-link">
           <%= inline_svg_tag("download_icon.svg", class: "download_icon", aria: { hidden: true }) %>
           <span class="myott-mycommodities__download-link-text">Download your commodities (.xlsx)</span>

--- a/app/views/myott/mycommodities/_grouped_measure_changes.html.erb
+++ b/app/views/myott/mycommodities/_grouped_measure_changes.html.erb
@@ -21,7 +21,7 @@
             <%= change.geographical_area_description %>
           </td>
           <td class="govuk-table__cell">
-            <%= link_to(pluralize(change.count, 'commodity'), myott_grouped_measure_change_path(change.resource_id, as_of:)) %>
+            <%= govuk_link_to(pluralize(change.count, 'commodity'), myott_grouped_measure_change_path(change.resource_id, as_of:)) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/myott/mycommodities/active.html.erb
+++ b/app/views/myott/mycommodities/active.html.erb
@@ -17,7 +17,7 @@
       <h1 class="govuk-heading-xl">Active commodities: <%= number_with_delimiter(@targets.total_count) %></h1>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <%= link_to "Replace all commodities (upload)", new_myott_mycommodity_path, class: "govuk-button govuk-button--secondary" %>
+          <%= govuk_button_link_to 'Replace all commodities (upload)', new_myott_mycommodity_path, secondary: true %>
         </div>
       </div>
        <table class="govuk-table govuk-table--small-text-until-tablet">

--- a/app/views/myott/mycommodities/confirmation.html.erb
+++ b/app/views/myott/mycommodities/confirmation.html.erb
@@ -17,7 +17,7 @@
           You can also view your subscription to access these updates.
         </p>
         <p class="govuk-body">
-          <%= link_to "View your commodity watch list", myott_mycommodities_path, class: "govuk-button govuk-!-margin-top-4" %>
+          <%= govuk_button_link_to 'View your commodity watch list', myott_mycommodities_path, class: 'govuk-!-margin-top-4' %>
         </p>
       </div>
     </div>

--- a/app/views/myott/mycommodities/expired.html.erb
+++ b/app/views/myott/mycommodities/expired.html.erb
@@ -28,7 +28,7 @@
       <% if @targets.total_count.positive? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-third">
-            <%= link_to "Replace all commodities (upload)", new_myott_mycommodity_path, class: "govuk-button govuk-button--secondary" %>
+            <%= govuk_button_link_to 'Replace all commodities (upload)', new_myott_mycommodity_path, secondary: true %>
           </div>
         </div>
         <h3 class="govuk-heading-m govuk-!-margin-top-4">Your expired commodities</h3>
@@ -55,7 +55,7 @@
                 <%= target.validity_end_date.to_fs %>
               </td>
               <td class="govuk-table__cell">
-                <%= link_to(commodity_path(target.goods_nomenclature_item_id), target: '_blank', rel: 'noopener') do %>
+                <%= govuk_link_to(commodity_path(target.goods_nomenclature_item_id), target: '_blank', rel: 'noopener') do %>
                   Review on tariff <span class="govuk-visually-hidden">(opens in new tab)</span>
                 <% end %>
               </td>

--- a/app/views/myott/mycommodities/invalid.html.erb
+++ b/app/views/myott/mycommodities/invalid.html.erb
@@ -31,7 +31,7 @@
       <% if @targets.total_count.positive? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-third">
-            <%= link_to "Replace all commodities (upload)", new_myott_mycommodity_path, class: "govuk-button govuk-button--secondary" %>
+            <%= govuk_button_link_to 'Replace all commodities (upload)', new_myott_mycommodity_path, secondary: true %>
           </div>
         </div>
         <h3 class="govuk-heading-m govuk-!-margin-top-4">Input errors from your watch list</h3>

--- a/app/views/myott/mycommodities/new.html.erb
+++ b/app/views/myott/mycommodities/new.html.erb
@@ -47,9 +47,9 @@
         <div class="govuk-button-group">
           <%= f.submit "Continue", class: "govuk-button govuk-!-margin-top-4" %>
           <% if current_subscription('my_commodities') %>
-            <%= link_to 'Cancel', myott_mycommodities_path, class: 'govuk-link govuk-!-margin-left-4 govuk-link--no-visited-state' %>
+            <%= govuk_link_to 'Cancel', myott_mycommodities_path, class: 'govuk-!-margin-left-4', no_visited_state: true %>
           <% else %>
-            <%= link_to 'Cancel', myott_path, class: 'govuk-link govuk-!-margin-left-4 govuk-link--no-visited-state' %>
+            <%= govuk_link_to 'Cancel', myott_path, class: 'govuk-!-margin-left-4', no_visited_state: true %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/myott/stop_presses/confirmation.html.erb
+++ b/app/views/myott/stop_presses/confirmation.html.erb
@@ -14,7 +14,7 @@
           When Stop Press updates are published by the UK Trade Tariff Service which relate to the chapters you have chosen, an email will be sent to <strong><%= current_user&.email %></strong>
         </p>
         <p class="govuk-body">
-          <%= link_to "View your tariff watch lists", myott_path, class: "govuk-button govuk-!-margin-top-4" %>
+          <%= govuk_button_link_to 'View your tariff watch lists', myott_path, class: 'govuk-!-margin-top-4' %>
         </p>
       </div>
     </div>

--- a/app/views/myott/stop_presses/show.html.erb
+++ b/app/views/myott/stop_presses/show.html.erb
@@ -20,7 +20,7 @@
 
     <%= render 'details_selected_sections_chapters', selected_sections_chapters: @selected_sections_chapters %>
 
-    <p class="govuk-body"><%= link_to 'Edit your chapter preferences', edit_myott_stop_press_preferences_path, class: 'govuk-link--no-visited-state' %></p>
+    <p class="govuk-body"><%= govuk_link_to 'Edit your chapter preferences', edit_myott_stop_press_preferences_path, no_visited_state: true %></p>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 

--- a/app/views/myott/stop_presses/show.html.erb
+++ b/app/views/myott/stop_presses/show.html.erb
@@ -25,6 +25,6 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m">Unsubscribe</h2>
-    <p class="govuk-body"><%= link_to 'Unsubscribe from all updates', myott_unsubscribe_path(@current_subscription.resource_id) %></p>
+    <p class="govuk-body"><%= govuk_link_to 'Unsubscribe from all updates', myott_unsubscribe_path(@current_subscription.resource_id) %></p>
   </div>
 </div>

--- a/app/views/myott/subscriptions/index.html.erb
+++ b/app/views/myott/subscriptions/index.html.erb
@@ -14,11 +14,11 @@
         <% if @my_commodities.present? %>
           <p class="govuk-body govuk-!-static-margin-bottom-0"><strong>Changes published yesterday: <%= number_with_delimiter(@my_commodities[:meta][:published][:yesterday]) %></strong></p>
           <p class="govuk-body">Total commodities selected: <%= number_with_delimiter(@my_commodities[:meta][:counts][:total]) %></p>
-          <%= link_to 'View commodity watch list', myott_mycommodities_path, class: 'govuk-link--no-visited-state' %>
+          <%= govuk_link_to 'View commodity watch list', myott_mycommodities_path, no_visited_state: true %>
         <% else %>
           <p class="govuk-body govuk-!-static-margin-bottom-0"><strong>No commodities selected</strong></p>
           <p class="govuk-body">You will receive updates on specific commodities</p>
-          <%= link_to 'Create a commodity watch list',  new_myott_mycommodity_path, class: 'govuk-link--no-visited-state' %>
+          <%= govuk_link_to 'Create a commodity watch list',  new_myott_mycommodity_path, no_visited_state: true %>
         <% end %>
       </div>
     </div>
@@ -29,11 +29,11 @@
         <% if @stop_press.present? %>
           <p class="govuk-body govuk-!-static-margin-bottom-0"><strong>Updates published yesterday: <%= @stop_press[:meta][:published][:yesterday] %></strong></p>
           <p class="govuk-body">Total chapters selected: <%= @stop_press[:meta][:chapters] %></p>
-          <%= link_to 'View Stop Press watch list', myott_stop_press_path, class: 'govuk-link--no-visited-state' %>
+          <%= govuk_link_to 'View Stop Press watch list', myott_stop_press_path, no_visited_state: true %>
         <% else %>
           <p class="govuk-body govuk-!-static-margin-bottom-0"><strong>No chapters selected</strong></p>
           <p class="govuk-body">You will receive updates on specific chapters</p>
-          <%= link_to 'Create a Stop Press watch list', myott_stop_press_path, class: 'govuk-link--no-visited-state' %>
+          <%= govuk_link_to 'Create a Stop Press watch list', myott_stop_press_path, no_visited_state: true %>
         <% end %>
       </div>
     </div>

--- a/app/views/myott/unsubscribes/confirmation.html.erb
+++ b/app/views/myott/unsubscribes/confirmation.html.erb
@@ -18,7 +18,7 @@
             You can now close this window.
           </p>
           <p class="govuk-body">
-            <%= link_to 'What did you think of this service?', feedback_path, class: 'govuk-link govuk-link--no-visited-state' %>
+            <%= govuk_link_to 'What did you think of this service?', feedback_path, no_visited_state: true %>
             (takes 30 seconds)
           </p>
         <% end %>

--- a/app/views/news_items/_hero_story.html.erb
+++ b/app/views/news_items/_hero_story.html.erb
@@ -9,7 +9,7 @@
       <%= format_news_item_content news_item.precis_with_fallback %>
 
       <%- if news_item.content_after_precis? -%>
-        <%= link_to 'Show more ...', news_item,
+        <%= govuk_link_to 'Show more ...', news_item,
                     class: 'govuk-notification-banner__link' %>
       <%- end -%>
     </div>

--- a/app/views/news_items/_recent_news.html.erb
+++ b/app/views/news_items/_recent_news.html.erb
@@ -8,19 +8,19 @@
     <% news_items.each do |news_item| %>
       <article class="news-item">
         <p class="govuk-body-s govuk-!-margin-bottom-2">
-          <%= link_to news_item.title, news_item %>
+          <%= govuk_link_to news_item.title, news_item %>
         </p>
 
         <p class="tariff-body-subtext">
           <%= news_item.start_date.to_formatted_s :short %>
           <% news_item.collections.each do |collection| %>
-            | <%= link_to collection.name, collection %>
+            | <%= govuk_link_to collection.name, collection %>
           <% end %>
         </p>
       </article>
     <% end %>
 
-    <%= link_to 'See all latest news', news_items_path %>
+    <%= govuk_link_to 'See all latest news', news_items_path %>
   </nav>
 </div>
 </div>

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -18,14 +18,14 @@
 
     <ul class="govuk-list tariff-list--hyphen" id="news-year-filter">
       <li>
-        <%= @filter_year ? link_to('All years', story_year: nil, page: nil) : 'All years' %>
+        <%= @filter_year ? govuk_link_to('All years', story_year: nil, page: nil) : 'All years' %>
       </li>
       <% @news_years.each do |story_year| %>
       <li>
         <% if @filter_year == story_year.year %>
           <%= story_year.year %>
         <% else %>
-          <%= link_to story_year.year, news_index_params.merge(story_year: story_year.year, page: nil) %>
+          <%= govuk_link_to story_year.year, news_index_params.merge(story_year: story_year.year, page: nil) %>
         <% end %>
       </li>
       <% end %>
@@ -37,14 +37,14 @@
 
     <ul class="govuk-list tariff-list--hyphen" id="news-collection-filter">
       <li>
-        <%= @filter_collection ? link_to('All collections', collection_id: nil, page: nil) : 'All collections' %>
+        <%= @filter_collection ? govuk_link_to('All collections', collection_id: nil, page: nil) : 'All collections' %>
       </li>
       <% @news_collections.each do |collection| %>
       <li>
         <% if collection.id == @filter_collection&.id %>
           <%= collection.name %>
         <% else %>
-          <%= link_to collection.name, news_index_params.merge(collection_id: collection, page: nil, story_year: @filter_year) %>
+          <%= govuk_link_to collection.name, news_index_params.merge(collection_id: collection, page: nil, story_year: @filter_year) %>
         <% end %>
       </li>
       <% end %>
@@ -68,7 +68,7 @@
     <% @news_items.each do |news_item| %>
       <article class="news-item" data-news-item-id="<%= news_item.id %>">
         <h2 class="govuk-heading-s">
-          <%= link_to sanitize(news_item.title), news_item %>
+          <%= govuk_link_to sanitize(news_item.title), news_item %>
         </h2>
 
         <div class="tariff-markdown tariff-markdown--reduced-trailing-margin">

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -55,7 +55,7 @@
     </h3>
     <ul class="govuk-list tariff-list--hyphen">
       <li>
-        <%= link_to 'View live issues log', live_issues_path, class: 'govuk-link govuk-link--no-visited-state' %>
+        <%= govuk_link_to 'View live issues log', live_issues_path, no_visited_state: true %>
       </li>
     </ul>
   </div>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -28,7 +28,7 @@
         <dl>
           <dt class="gem-c-metadata__term">From:</dt>
           <dd class="gem-c-metadata__definition">
-            <%= link_to 'HM Revenue & Customs',
+            <%= govuk_link_to 'HM Revenue & Customs',
                         'https://www.gov.uk/government/organisations/hm-revenue-customs' %>
           </dd>
 
@@ -67,7 +67,7 @@
       </div>
 
       <p>
-        <%= link_to t('navigation.back_to_top'), '#content', class: 'govuk-!-display-none-print' %>
+        <%= govuk_link_to t('navigation.back_to_top'), '#content', class: 'govuk-!-display-none-print' %>
       </p>
 
       <% if @news_collection.description.present? %>
@@ -89,7 +89,7 @@
       <ul class="govuk-list govuk-!-margin-bottom-6">
         <% @collection_items.each do |collection_item| %>
           <li class="govuk-!-padding-top-2">
-            <%= link_to collection_item.title, collection_item %>
+            <%= govuk_link_to collection_item.title, collection_item %>
           </li>
         <% end %>
       </ul>
@@ -102,7 +102,7 @@
     </h3>
 
     <p>
-      <%= link_to @news_collection.name,
+      <%= govuk_link_to @news_collection.name,
                   news_collection_path(collection_id: @news_collection) %>
     <p>
   </div>

--- a/app/views/pages/_howto_sidebar_links.html.erb
+++ b/app/views/pages/_howto_sidebar_links.html.erb
@@ -9,23 +9,23 @@
       <ul class="gem-c-related-navigation__link-list">
 
         <li class="gem-c-related-navigation__link">
-          <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar govuk-link gem-c-related-navigation__section-link--other" href="/howto/commodity-codes">Classifying your goods</a>
+          <%= govuk_link_to 'Classifying your goods', '/howto/commodity-codes', class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
 
         <li class="gem-c-related-navigation__link">
-          <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar govuk-link gem-c-related-navigation__section-link--other" href="/howto/quotas">How to use quotas</a>
+          <%= govuk_link_to 'How to use quotas', '/howto/quotas', class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
 
         <li class="gem-c-related-navigation__link">
-          <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar govuk-link gem-c-related-navigation__section-link--other" href="/howto/valuation">How to value your goods for import or export</a>
+          <%= govuk_link_to 'How to value your goods for import or export', '/howto/valuation', class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
 
         <li class="gem-c-related-navigation__link">
-          <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar govuk-link gem-c-related-navigation__section-link--other" href="/howto/trade-remedies">What are trade remedies, safeguards and retaliatory duties?</a>
+          <%= govuk_link_to 'What are trade remedies, safeguards and retaliatory duties?', '/howto/trade-remedies', class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
 
         <li class="gem-c-related-navigation__link">
-          <a class="govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar govuk-link gem-c-related-navigation__section-link--other" href="/howto/origin">What is origin and why is it important for international trade?</a>
+          <%= govuk_link_to 'What is origin and why is it important for international trade?', '/howto/origin', class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
 
       </ul>

--- a/app/views/pages/changes_999l.html.erb
+++ b/app/views/pages/changes_999l.html.erb
@@ -17,10 +17,10 @@
 
     <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#RemovalofExportWaiverDocumentCode999L">Removal of Export Waiver Document Code 999L</a>
+        <%= govuk_link_to 'Removal of Export Waiver Document Code 999L', '#RemovalofExportWaiverDocumentCode999L', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#MeasureListforImportsPost999L">Measure List for Imports Post 999L</a>
+        <%= govuk_link_to 'Measure List for Imports Post 999L', '#MeasureListforImportsPost999L', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
     </ol>
 

--- a/app/views/pages/cn2021_cn2022.html.erb
+++ b/app/views/pages/cn2021_cn2022.html.erb
@@ -38,11 +38,11 @@
     <div class="downloads" data-module="govspeak">
       <section class="attachment">
         <div class="attachment-thumb">
-          <%= link_to(image_tag("spreadsheet.png", alt: ""), asset_path('UK Trade Tariff 2022 - 2022 01 06.docx')) %>
+          <%= govuk_link_to(image_tag("spreadsheet.png", alt: ""), asset_path('UK Trade Tariff 2022 - 2022 01 06.docx')) %>
         </div>
         <div class="attachment-details">
           <h3 class="govuk-heading-s">
-            <%= link_to('UK goods classification 2021-2022 10-digits (complete)', asset_path('UK Trade Tariff 2022 - 2022 01 06.docx')) %>
+            <%= govuk_link_to('UK goods classification 2021-2022 10-digits (complete)', asset_path('UK Trade Tariff 2022 - 2022 01 06.docx')) %>
           </h3>
           <p class="metadata">
             <span class="type">MS Word</span>,
@@ -55,12 +55,12 @@
       <section class="attachment">
         <div class="attachment-thumb">
 
-          <%= link_to(image_tag("spreadsheet.png", alt: ""), asset_path('UK Trade Tariff 2022 - 2022 01 06.xlsx')) %>
+          <%= govuk_link_to(image_tag("spreadsheet.png", alt: ""), asset_path('UK Trade Tariff 2022 - 2022 01 06.xlsx')) %>
 
         </div>
         <div class="attachment-details">
           <h3 class="govuk-heading-s">
-            <%= link_to('UK goods classification 2021-2022 10-digits (complete)', asset_path('UK Trade Tariff 2022 - 2022 01 06.xlsx')) %>
+            <%= govuk_link_to('UK goods classification 2021-2022 10-digits (complete)', asset_path('UK Trade Tariff 2022 - 2022 01 06.xlsx')) %>
           </h3>
           <p class="metadata">
             <span class="type">MS Excel Spreadsheet</span>,
@@ -76,11 +76,11 @@
       <div class="downloads" data-module="govspeak">
         <section class="attachment">
           <div class="attachment-thumb">
-            <%= link_to(image_tag("spreadsheet.png", alt: ""), asset_path(asset)) %>
+            <%= govuk_link_to(image_tag("spreadsheet.png", alt: ""), asset_path(asset)) %>
           </div>
           <div class="attachment-details">
             <h3 class="govuk-heading-s">
-              <%= link_to(link_text, asset_path(asset)) %>
+              <%= govuk_link_to(link_text, asset_path(asset)) %>
             </h3>
             <p class="metadata">
               <span class="type">MS Excel Spreadsheet</span>,

--- a/app/views/pages/glossary/index.html.erb
+++ b/app/views/pages/glossary/index.html.erb
@@ -16,9 +16,9 @@
       <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
         <% for term in @terms %>
           <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-            <%= link_to term.term_and_title,
+            <%= govuk_link_to term.term_and_title,
                         { anchor: "glossary-#{term.key.dasherize}" },
-                        class: 'gem-c-contents-list__link govuk-link--no-underline' %>
+                        class: 'gem-c-contents-list__link', no_underline: true %>
           </li>
         <% end %>
       </ol>
@@ -42,10 +42,10 @@
       <nav class="gem-c-related-navigation__nav-section">
         <ul class="gem-c-related-navigation__link-list">
           <li class="gem-c-related-navigation__link">
-            <%= link_to 'Rules of origin glossary', glossary_terms_path %>
+            <%= govuk_link_to 'Rules of origin glossary', glossary_terms_path %>
           </li>
           <li class="gem-c-related-navigation__link">
-            <%= link_to 'Duty drawback', rules_of_origin_duty_drawback_path %>
+            <%= govuk_link_to 'Duty drawback', rules_of_origin_duty_drawback_path %>
           </li>
         </ul>
       </nav>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -20,58 +20,57 @@
     <h2 class="gem-c-contents-list__title">Contents</h2>
     <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#leave-feedback">Leave feedback</a>
+        <%= govuk_link_to 'Leave feedback', '#leave-feedback', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="/howto/commodity-codes">How to classify your goods: what are commodity codes?</a>
+        <%= govuk_link_to 'How to classify your goods: what are commodity codes?', '/howto/commodity-codes', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="/howto/quotas">A background to quotas</a>
+        <%= govuk_link_to 'A background to quotas', '/howto/quotas', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="/howto/valuation">How to value your goods for import or export</a>
+        <%= govuk_link_to 'How to value your goods for import or export', '/howto/valuation', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="/howto/trade-remedies">What are trade remedies, safeguards and retaliatory duties?</a>
+        <%= govuk_link_to 'What are trade remedies, safeguards and retaliatory duties?', '/howto/trade-remedies', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="/howto/origin">What is origin and why is it important for international trade?</a>
+        <%= govuk_link_to 'What is origin and why is it important for international trade?', '/howto/origin', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#getting-help">Getting help from HMRC if you need to find a commodity code</a>
+        <%= govuk_link_to 'Getting help from HMRC if you need to find a commodity code', '#getting-help', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#consignment">Goods that cannot be imported in a single consignment</a>
+        <%= govuk_link_to 'Goods that cannot be imported in a single consignment', '#consignment', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#sets">Items packaged as a set</a>
+        <%= govuk_link_to 'Items packaged as a set', '#sets', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#made-of">Checking what your goods are made of</a>
+        <%= govuk_link_to 'Checking what your goods are made of', '#made-of', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#difficult-to-classify">Goods that are difficult to classify</a>
+        <%= govuk_link_to 'Goods that are difficult to classify', '#difficult-to-classify', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#rules-of-origin">Rules
-        of origin</a>
+        <%= govuk_link_to 'Rules of origin', '#rules-of-origin', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
       <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#ask-a-question">Ask a question</a>
+        <%= govuk_link_to 'Ask a question', '#ask-a-question', class: 'gem-c-contents-list__link', no_underline: true %>
       </li>
     </ol>
 
     <h2 class="govuk-heading-s" id="leave-feedback">Leave feedback</h2>
-    <p><%= link_to 'Leave feedback or suggestions for improvements to this service.', feedback_link_url, target: '_blank', rel: 'noopener' %></p>
+    <p><%= govuk_link_to 'Leave feedback or suggestions for improvements to this service.', feedback_link_url, new_tab: govuk_visually_hidden('(opens in new tab)') %></p>
 
     <h2 class="govuk-heading-s" id="getting-help">Getting help from HMRC if you need to find a commodity code</h2>
-    <p>If you <%= link_to 'cannot find the right commodity code for your goods', help_find_commodity_path %>, you can contact HMRC for advice or for a decision on your goods.</p>
+    <p>If you <%= govuk_link_to 'cannot find the right commodity code for your goods', help_find_commodity_path %>, you can contact HMRC for advice or for a decision on your goods.</p>
 
     <%= render 'shared/webchat_message/help' %>
 
     <h2 class="govuk-heading-s" id="consignment">Goods that cannot be imported in a single consignment</h2>
     <p>If you have goods (like large machinery) that cannot be transported in a single consignment, you may need to split them up.</p>
-    <p><a href="https://www.gov.uk/guidance/split-consignments-tariff-classification-and-import-procedures" class="govuk-link">Find out if your goods qualify for import in split consignments</a> and what you need to do to import goods in this way.</p>
+    <p><%= govuk_link_to 'Find out if your goods qualify for import in split consignments', 'https://www.gov.uk/guidance/split-consignments-tariff-classification-and-import-procedures' %> and what you need to do to import goods in this way.</p>
 
     <h2 class="govuk-heading-s" id="sets">Items packaged as a set</h2>
     <p>If your items are packaged in a set to sell and be used together, you should classify them using the most significant item in that set.</p>
@@ -85,7 +84,7 @@
     <h2 class="govuk-heading-s" id="made-of">Checking what your goods are made of</h2>
     <p>For certain types of goods, you may need precise details of what your goods are made up of. For these you may want to get advice from an independent laboratory.</p>
 
-    <p>You can find a list of analysts in the <a rel="external" href="https://www.rsc.org/membership-and-community/directory-of-consultants/" class="govuk-link">directory of consultants for the Royal Society of Chemistry</a>.</p>
+    <p>You can find a list of analysts in the <%= govuk_link_to 'directory of consultants for the Royal Society of Chemistry', 'https://www.rsc.org/membership-and-community/directory-of-consultants/', rel: 'external' %>.</p>
 
     <h2 class="govuk-heading-s" id="difficult-to-classify">Goods that are difficult to classify</h2>
     <p>Some goods are more difficult to classify than others. You can read more on how to classify these goods correctly:</p>
@@ -96,15 +95,15 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        <%= link_to 'Rules of origin glossary', glossary_terms_path %>
+        <%= govuk_link_to 'Rules of origin glossary', glossary_terms_path %>
       </li>
       <li>
-        <%= link_to 'Duty drawback', rules_of_origin_duty_drawback_path %><br>Find out about duty drawback and the Trade
+        <%= govuk_link_to 'Duty drawback', rules_of_origin_duty_drawback_path %><br>Find out about duty drawback and the Trade
         Agreements that include it
       </li>
     </ul>
     <h2 class="govuk-heading-s" id="ask-a-question">Ask a question</h2>
-    <p>If you are unable to find the information you need, you can submit a question using our <%= link_to 'enquiry form', product_experience_enquiry_form_path %>.</p>
+    <p>If you are unable to find the information you need, you can submit a question using our <%= govuk_link_to 'enquiry form', product_experience_enquiry_form_path %>.</p>
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="gem-c-related-navigation">
@@ -114,7 +113,7 @@
         <p class="govuk-body-s">On 1 January 2022, the UK introduced its 2022 Integrated Tariff, which incorporates the WCO's changes to the Harmonised System Nomenclature.</p>
         <ul class="gem-c-related-navigation__link-list" data-module="gem-track-click" data-gem-track-click-module-started="true">
           <li class="gem-c-related-navigation__link">
-            <%= link_to('View the correlation of commodity codes, at 8-digit level, from the 2021 Tariff to that of 2022', cn2021_cn2022_path, class: 'govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other') %>.
+            <%= govuk_link_to('View the correlation of commodity codes, at 8-digit level, from the 2021 Tariff to that of 2022', cn2021_cn2022_path, class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other') %>.
           </li>
         </ul>
       </nav>
@@ -124,7 +123,7 @@
       <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-related_items-40a88cdf" data-module="gem-toggle" data-gem-toggle-module-started="true">
         <ul class="gem-c-related-navigation__link-list" data-module="gem-track-click" data-gem-track-click-module-started="true">
           <li class="gem-c-related-navigation__link">
-            <%= link_to(t('green_lanes_faq.page_title'),  green_lanes_faq_path, class: 'govuk-link govuk-link gem-c-related-navigation__section-link govuk-link gem-c-related-navigation__section-link--sidebar  govuk-link gem-c-related-navigation__section-link--other') %>
+            <%= govuk_link_to(t('green_lanes_faq.page_title'),  green_lanes_faq_path, class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other') %>
           </li>
         </ul>
       </nav>
@@ -135,7 +134,7 @@
         <ul class="gem-c-related-navigation__link-list" data-module="gem-track-click" data-gem-track-click-module-started="true">
 
           <li class="gem-c-related-navigation__link">
-            <%= link_to "Document Code 999L", help_changes_999l_path %>
+            <%= govuk_link_to 'Document Code 999L', help_changes_999l_path %>
           </li>
 
           <li class="gem-c-related-navigation__link">

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -61,7 +61,7 @@
     </ol>
 
     <h2 class="govuk-heading-s" id="leave-feedback">Leave feedback</h2>
-    <p><%= govuk_link_to 'Leave feedback or suggestions for improvements to this service.', feedback_link_url, new_tab: govuk_visually_hidden('(opens in new tab)') %></p>
+    <p><%= govuk_link_to 'Leave feedback or suggestions for improvements to this service.', feedback_link_url, new_tab: govuk_visually_hidden('opens in new tab') %></p>
 
     <h2 class="govuk-heading-s" id="getting-help">Getting help from HMRC if you need to find a commodity code</h2>
     <p>If you <%= govuk_link_to 'cannot find the right commodity code for your goods', help_find_commodity_path %>, you can contact HMRC for advice or for a decision on your goods.</p>

--- a/app/views/pages/help_find_commodity.html.erb
+++ b/app/views/pages/help_find_commodity.html.erb
@@ -22,7 +22,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Informal advice</h2>
-    <p>You can <%= link_to "use HMRC's Tariff Classification Service", "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods", target: '_blank' %> to get non-legally binding classification advice.</p>
+    <p>You can <%= govuk_link_to "use HMRC's Tariff Classification Service", "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods", new_tab: govuk_visually_hidden("opens in new tab") %> to get non-legally binding classification advice.</p>
     <p>HMRC will try to respond to your email within 5 working days.</p>
 
     <div class="govuk-inset-text">

--- a/app/views/pages/help_find_commodity.html.erb
+++ b/app/views/pages/help_find_commodity.html.erb
@@ -41,7 +41,7 @@
     </ul>
 
     <div class="call-to-action">
-      <p>Check what you’ll need to <a href="https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code" class="govuk-link">get a legally binding decision</a>.</p>
+      <p>Check what you’ll need to <%= govuk_link_to 'get a legally binding decision', 'https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code' %>.</p>
     </div>
 
     <p>If you want to check if a decision has already been made on goods that are similar to yours you can search for previous:</p>

--- a/app/views/pages/howtos/_commodity-codes.html.erb
+++ b/app/views/pages/howtos/_commodity-codes.html.erb
@@ -2,22 +2,22 @@
 
 <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#whatarecommoditycodes">What are commodity codes?</a>
+    <%= govuk_link_to 'What are commodity codes?', '#whatarecommoditycodes', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#worldwide">Are commodity codes the same worldwide?</a>
+    <%= govuk_link_to 'Are commodity codes the same worldwide?', '#worldwide', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#digits">How many digits does a commodity code have?</a>
+    <%= govuk_link_to 'How many digits does a commodity code have?', '#digits', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#components">What does the commodity code comprise of and what do the components do?</a>
+    <%= govuk_link_to 'What does the commodity code comprise of and what do the components do?', '#components', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#responsibility">Who is responsible for classifying products?</a>
+    <%= govuk_link_to 'Who is responsible for classifying products?', '#responsibility', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#identifying">How is the right commodity code identified?</a>
+    <%= govuk_link_to 'How is the right commodity code identified?', '#identifying', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
 </ol>
 
@@ -128,7 +128,7 @@
     Using the <%= webchat_link("webchat function") %>, when offered in this service
   </li>
   <li>
-    Sending an <a href="mailto:classification.enquiries@hmrc.gov.uk">email to our classification enquiry team</a>
+    Sending an <%= govuk_mail_to 'classification.enquiries@hmrc.gov.uk', 'email to our classification enquiry team' %>
   </li>
   <li>
     <a href="https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling">Applying for a formal ruling</a>, if you want legal certainty

--- a/app/views/pages/howtos/_commodity-codes.html.erb
+++ b/app/views/pages/howtos/_commodity-codes.html.erb
@@ -115,11 +115,11 @@
 
 <p>The classification process takes account of the characteristics using a series of six legally binding rules, known as the General Interpretative Rules (GIRs), which were set down by the World Customs Organisation (WCO) and are applied by its member countries.</p>
 
-<p>Read the <a href="https://www.wcoomd.org/-/media/wco/public/global/pdf/topics/nomenclature/instruments-and-tools/hs-interpretation-general-rules/0001_2012e_gir.pdf?la=en" target="_blank">full text of the General Interpretative Rules rules</a>, with a simple description of what they do.</p>
+<p>Read the <%= govuk_link_to 'full text of the General Interpretative Rules rules', 'https://www.wcoomd.org/-/media/wco/public/global/pdf/topics/nomenclature/instruments-and-tools/hs-interpretation-general-rules/0001_2012e_gir.pdf?la=en', new_tab: govuk_visually_hidden('opens in new tab') %>, with a simple description of what they do.</p>
 
 <p>As most types of goods have been classified before and many are referred to within the text of the tariff and its notes, the right codes can often be identified using the search function on this service. Although you should always check associated notes and rules to ensure you are content that the proposed classification is correct, this aims to help you through this process by using knowledge and tips from HMRC's classification experts to direct you based on the search terms you have used.</p>
 
-<p>If you find that your goods are difficult to classify, HMRC has published <a href="https://www.gov.uk/guidance/finding-commodity-codes-for-imports-or-exports">a series of guides for certain types of challenging goods</a>
+<p>If you find that your goods are difficult to classify, HMRC has published <%= govuk_link_to 'a series of guides for certain types of challenging goods', 'https://www.gov.uk/guidance/finding-commodity-codes-for-imports-or-exports' %>
   and provides a classification advice service.</p>
 
 <p>You can access this help by:</p>
@@ -131,6 +131,6 @@
     Sending an <%= govuk_mail_to 'classification.enquiries@hmrc.gov.uk', 'email to our classification enquiry team' %>
   </li>
   <li>
-    <a href="https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling">Applying for a formal ruling</a>, if you want legal certainty
+    <%= govuk_link_to 'Applying for a formal ruling', 'https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling' %>, if you want legal certainty
   </li>
 </ul>

--- a/app/views/pages/howtos/_origin.html.erb
+++ b/app/views/pages/howtos/_origin.html.erb
@@ -3,25 +3,25 @@
 <h2 class="gem-c-contents-list__title">Contents</h2>
 <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#definition">What is origin?</a>
+    <%= govuk_link_to 'What is origin?', '#definition', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#worldwide">Are rules of origin used internationally?</a>
+    <%= govuk_link_to 'Are rules of origin used internationally?', '#worldwide', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#non-preferential">How to determine non-preferential origin?</a>
+    <%= govuk_link_to 'How to determine non-preferential origin?', '#non-preferential', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#preferential">How to determine preferential rules of origin?</a>
+    <%= govuk_link_to 'How to determine preferential rules of origin?', '#preferential', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#certified">How is origin certified?</a>
+    <%= govuk_link_to 'How is origin certified?', '#certified', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#responsible">Who is responsible for determining the origin of products?</a>
+    <%= govuk_link_to 'Who is responsible for determining the origin of products?', '#responsible', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#ott">Using the Online Trade Tariff to work out origin</a>
+    <%= govuk_link_to 'Using the Online Trade Tariff to work out origin', '#ott', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
 </ol>
 

--- a/app/views/pages/howtos/_quotas.html.erb
+++ b/app/views/pages/howtos/_quotas.html.erb
@@ -1,25 +1,25 @@
 <h2 class="gem-c-contents-list__title">Contents</h2>
 <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#definition">What are tariff rate and safeguard quotas?</a>
+    <%= govuk_link_to 'What are tariff rate and safeguard quotas?', '#definition', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#worldwide">Are Tariff Rate Quotas used internationally?</a>
+    <%= govuk_link_to 'Are Tariff Rate Quotas used internationally?', '#worldwide', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#restriction">Are Tariff Rate Quotas restricted based on the country of origin of the goods being imported?</a>
+    <%= govuk_link_to 'Are Tariff Rate Quotas restricted based on the country of origin of the goods being imported?', '#restriction', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#application">When are quotas applied and can they be agreed in advance?</a>
+    <%= govuk_link_to 'When are quotas applied and can they be agreed in advance?', '#application', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#availability">How do you find out if there is a TRQ available for your import?</a>
+    <%= govuk_link_to 'How do you find out if there is a TRQ available for your import?', '#availability', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#using">How to use the available Tariff Rate Quota to reduce your import duties?</a>
+    <%= govuk_link_to 'How to use the available Tariff Rate Quota to reduce your import duties?', '#using', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#ott">Quotas on the Online Trade Tariff</a>
+    <%= govuk_link_to 'Quotas on the Online Trade Tariff', '#ott', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
 </ol>
 

--- a/app/views/pages/howtos/_trade-remedies.html.erb
+++ b/app/views/pages/howtos/_trade-remedies.html.erb
@@ -33,14 +33,14 @@
 
 <p>Trade remedies are covered by these WTO agreements:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li><a target="_blank" href="https://www.wto.org/english/tratop_e/adp_e/antidum2_e.htm">the WTO Agreement on the Implementation of Article VI of the GATT (opens in new window)</a></li>
-  <li><a target="_blank" href="https://www.wto.org/english/tratop_e/scm_e/subs_e.htm">the WTO Agreement on Subsidies and Countervailing Measures (opens in new window)</a></li>
-  <li><a target="_blank" href="https://www.wto.org/english/docs_e/legal_e/25-safeg_e.htm">the WTO Agreement on Safeguards (opens in new window)</a></li>
+  <li><%= govuk_link_to 'the WTO Agreement on the Implementation of Article VI of the GATT', 'https://www.wto.org/english/tratop_e/adp_e/antidum2_e.htm', new_tab: true %></li>
+  <li><%= govuk_link_to 'the WTO Agreement on Subsidies and Countervailing Measures', 'https://www.wto.org/english/tratop_e/scm_e/subs_e.htm', new_tab: true %></li>
+  <li><%= govuk_link_to 'the WTO Agreement on Safeguards', 'https://www.wto.org/english/docs_e/legal_e/25-safeg_e.htm', new_tab: true %></li>
 </ul>
 
 <h2 class="govuk-heading-m" id="usage">How does the UK apply trade remedies?</h2>
 
-<p>In the UK, trade remedies investigations are conducted by the Trade Remedies Authority. The <a href="https://www.trade-remedies.service.gov.uk" target="_blank">Trade Remedies Service</a> allows UK companies to participate in ongoing trade remedies cases and request new reviews.</p>
+<p>In the UK, trade remedies investigations are conducted by the Trade Remedies Authority. The <%= govuk_link_to 'Trade Remedies Service', 'https://www.trade-remedies.service.gov.uk', new_tab: govuk_visually_hidden('opens in new tab') %> allows UK companies to participate in ongoing trade remedies cases and request new reviews.</p>
 
 <h2 class="govuk-heading-m" id="impact">How do trade remedies impact UK importers?</h2>
 
@@ -62,7 +62,7 @@
 </ul>
 
 <p class="govuk-!-margin-top-2">In many cases, a safeguard mechanism, which would ordinarily apply a surcharge on your import duties,
-  may be waived via the use of a <a href="/howto/quotas">quota</a>, if the quota has not been exhausted. Quotas are listed in the quota section of the import tab.</p>
+  may be waived via the use of a <%= govuk_link_to 'quota', '/howto/quotas' %>, if the quota has not been exhausted. Quotas are listed in the quota section of the import tab.</p>
 
 <p>For trade remedies, the tariff additionally shows:</p>
 
@@ -75,6 +75,6 @@
       <li>provisional anti-dumping duty</li>
       <li>provisional countervailing duty</li>
     </ul>
-    This notice explains in detail <a href="https://www.gov.uk/government/publications/notice-376-anti-dumping-and-countervailing-duties/notice-376-anti-dumping-and-countervailing-duties" target="_blank">what each remedy measure means (opens in new window)</a>.</li>
+    This notice explains in detail <%= govuk_link_to 'what each remedy measure means', 'https://www.gov.uk/government/publications/notice-376-anti-dumping-and-countervailing-duties/notice-376-anti-dumping-and-countervailing-duties', new_tab: true %>.</li>
   <li>any conditions, such as a requirement for documentation that might influence the duty payable.</li>
 </ul>

--- a/app/views/pages/howtos/_trade-remedies.html.erb
+++ b/app/views/pages/howtos/_trade-remedies.html.erb
@@ -4,13 +4,13 @@
 <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
 
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#worldwide">Are trade remedies used internationally?</a>
+    <%= govuk_link_to 'Are trade remedies used internationally?', '#worldwide', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#usage">How does the UK apply trade remedies?</a>
+    <%= govuk_link_to 'How does the UK apply trade remedies?', '#usage', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#impact">How do trade remedies impact UK importers?</a>
+    <%= govuk_link_to 'How do trade remedies impact UK importers?', '#impact', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
 </ol>
 

--- a/app/views/pages/howtos/_valuation.html.erb
+++ b/app/views/pages/howtos/_valuation.html.erb
@@ -1,19 +1,19 @@
 <h2 class="gem-c-contents-list__title">Contents</h2>
 <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#definition">What is customs valuation?</a>
+    <%= govuk_link_to 'What is customs valuation?', '#definition', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#worldwide">Is customs valuation determined in the same way worldwide?</a>
+    <%= govuk_link_to 'Is customs valuation determined in the same way worldwide?', '#worldwide', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#determination">How is customs value determined?</a>
+    <%= govuk_link_to 'How is customs value determined?', '#determination', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#responsibility">Who is responsible for determining the customs value of products?</a>
+    <%= govuk_link_to 'Who is responsible for determining the customs value of products?', '#responsibility', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#methods">Valuation methods</a>
+    <%= govuk_link_to 'Valuation methods', '#methods', class: 'gem-c-contents-list__link', no_underline: true %>
   </li>
 </ol>
 

--- a/app/views/pages/rules_of_origin_duty_drawback.html.erb
+++ b/app/views/pages/rules_of_origin_duty_drawback.html.erb
@@ -14,15 +14,13 @@
 
       <ol class="gem-c-contents-list__list govuk-!-margin-bottom-6">
         <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-          <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#what-is">What is duty
-          drawback</a>
+          <%= govuk_link_to 'What is duty drawback', '#what-is', class: 'gem-c-contents-list__link', no_underline: true %>
         </li>
         <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-          <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#example">Duty drawback -
-          an example</a>
+          <%= govuk_link_to 'Duty drawback - an example', '#example', class: 'gem-c-contents-list__link', no_underline: true %>
         </li>
         <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-          <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#agreements">Agreements</a>
+          <%= govuk_link_to 'Agreements', '#agreements', class: 'gem-c-contents-list__link', no_underline: true %>
         </li>
       </ol>
 

--- a/app/views/pages/rules_of_origin_duty_drawback.html.erb
+++ b/app/views/pages/rules_of_origin_duty_drawback.html.erb
@@ -84,10 +84,10 @@
         <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-related_items-40a88cdf" data-module="gem-toggle" data-gem-toggle-module-started="true">
             <ul class="gem-c-related-navigation__link-list" data-module="gem-track-click" data-gem-track-click-module-started="true">
                 <li class="gem-c-related-navigation__link">
-                  <%= link_to 'Rules of origin glossary', glossary_terms_path %>
+                  <%= govuk_link_to 'Rules of origin glossary', glossary_terms_path %>
                 </li>
                 <li class="gem-c-related-navigation__link">
-                  <%= link_to 'Duty drawback', rules_of_origin_duty_drawback_path %>
+                  <%= govuk_link_to 'Duty drawback', rules_of_origin_duty_drawback_path %>
                 </li>
             </ul>
         </nav>

--- a/app/views/pages/rules_of_origin_proof_requirements.html.erb
+++ b/app/views/pages/rules_of_origin_proof_requirements.html.erb
@@ -19,6 +19,6 @@
       <%= govspeak @article.section(params[:section]) %>
     </div>
 
-    <%= link_to t('navigation.back_to_top'), '#content' %>
+    <%= govuk_link_to t('navigation.back_to_top'), '#content' %>
   </div>
 </div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -116,7 +116,7 @@
 <h2 class="govuk-heading-m">Data and privacy</h2>
 
 <p>
-  We collect and process information in line with the <%= link_to "Online Trade Tariff Privacy Notice", privacy_path %> and UK data protection law. This may include:
+  We collect and process information in line with the <%= govuk_link_to "Online Trade Tariff Privacy Notice", privacy_path %> and UK data protection law. This may include:
 </p>
 
 <ul class="govuk-list govuk-list--bullet">
@@ -175,4 +175,4 @@
 
 <p>For general enquiries or support, email: <%= mail_to "tariff.management@hmrc.gov.uk" %></p>
 
-<p>When you contact us, we will collect and process your personal information in line with the <%= link_to "Online Trade Tariff Privacy Notice", privacy_path %>. This includes the information you provide in your enquiry, which will be used only for the purposes of responding to and managing your request.</p>
+<p>When you contact us, we will collect and process your personal information in line with the <%= govuk_link_to "Online Trade Tariff Privacy Notice", privacy_path %>. This includes the information you provide in your enquiry, which will be used only for the purposes of responding to and managing your request.</p>

--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -15,7 +15,7 @@
       <% if TradeTariffFrontend::ServiceChooser.uk? %>
         <li>
           <p>
-            <%= link_to t('breadcrumb.exchange_rates'), exchange_rates_path %>
+            <%= govuk_link_to t('breadcrumb.exchange_rates'), exchange_rates_path %>
             <br>
             View official monthly, average and spot exchange rates online, or download in CSV or XML. You can also request accessible formats.
           </p>
@@ -23,7 +23,7 @@
       <% end %>
       <li>
         <p>
-          <%= link_to t('breadcrumb.simplified_procedural_values'), simplified_procedural_values_path %>
+          <%= govuk_link_to t('breadcrumb.simplified_procedural_values'), simplified_procedural_values_path %>
           <br>
           Use simplified procedure value rates for fresh fruit and vegetable goods that you import.
         </p>
@@ -31,7 +31,7 @@
       <% if TradeTariffFrontend::ServiceChooser.uk? %>
         <li>
           <p>
-            <%= link_to t('breadcrumb.quotas'), quota_search_path %>
+            <%= govuk_link_to t('breadcrumb.quotas'), quota_search_path %>
             <br>
             Search for tariff quotas, including daily updated balances.
           </p>
@@ -39,34 +39,34 @@
       <% end %>
       <li>
         <p>
-          <%= link_to "Certificates, licences and documents", certificate_search_path %>
+          <%= govuk_link_to "Certificates, licences and documents", certificate_search_path %>
           <br>
           Search for certificates, licences and other document codes.
         </p>
       </li>
       <li>
         <p>
-          <%= link_to t('breadcrumb.additional_codes'), additional_code_search_path %>
+          <%= govuk_link_to t('breadcrumb.additional_codes'), additional_code_search_path %>
           <br>
           Search for additional codes. Additional codes are used on the tariff for a number of purposes to help you to classify goods accurately on your customs declaration.
         </p>
       </li>
       <li>
         <p>
-          <%= link_to 'Footnotes', footnote_search_path %>
+          <%= govuk_link_to 'Footnotes', footnote_search_path %>
           <br>Search the tariff for footnotes.
         </p>
       </li>
       <li>
         <p>
-          <%= link_to t('breadcrumb.chemicals'), chemical_search_path %>
+          <%= govuk_link_to t('breadcrumb.chemicals'), chemical_search_path %>
           <br>Search the tariff for chemicals by <abbr title="Chemical Abstracts Service">CAS</abbr> Registry Number (RN).
         </p>
       </li>
       <% if TradeTariffFrontend::ServiceChooser.xi? %>
         <li>
           <p>
-            <%= link_to t('breadcrumb.meursing_lookup'), meursing_lookup_step_path('start') %>
+            <%= govuk_link_to t('breadcrumb.meursing_lookup'), meursing_lookup_step_path('start') %>
             <br>
             Find the Meursing code for your composite agrifood.
           </p>

--- a/app/views/product_experience/enquiry_form/check_your_answers.html.erb
+++ b/app/views/product_experience/enquiry_form/check_your_answers.html.erb
@@ -18,7 +18,7 @@
                 <%= simple_format(display_value_for(field, value)) %>
               </dd>
               <dd class="govuk-summary-list__actions">
-                <%= link_to 'Change', product_experience_enquiry_form_field_path(field, editing: true), class: 'govuk-link' %>
+                <%= govuk_link_to 'Change', product_experience_enquiry_form_field_path(field, editing: true)  %>
               </dd>
             </div>
           <% end %>

--- a/app/views/rules_of_origin/_find_out_more.erb
+++ b/app/views/rules_of_origin/_find_out_more.erb
@@ -1,5 +1,5 @@
 <div class="rules-of-origin__find_out_more govuk-!-padding-bottom-2">
   <p>Origin allows for various policy measures to be implemented and for duties to be calculated.</p>
   <p>There are two types of origin, subject to different rules, which may affect your trade.</p>
-  <p><a href="/howto/origin" class="govuk-link">Find out more about origin</a></p>
+  <p><%= govuk_link_to 'Find out more about origin', '/howto/origin' %></p>
 </div>

--- a/app/views/rules_of_origin/_non_preferential_uk.html.erb
+++ b/app/views/rules_of_origin/_non_preferential_uk.html.erb
@@ -14,6 +14,6 @@
     <li>tariff quotas</li>
   </ul>
 
-  <p><a href="https://www.gov.uk/government/publications/reference-document-for-the-customs-origin-of-chargeable-goods-eu-exit-regulations-2020" class="govuk-link" rel="noreferrer noopener" target="_blank">View rules for determining non-preferential origin (opens in new tab)</a></p>
+  <p><%= govuk_link_to 'View rules for determining non-preferential origin', 'https://www.gov.uk/government/publications/reference-document-for-the-customs-origin-of-chargeable-goods-eu-exit-regulations-2020', new_tab: true %></p>
 
 </div>

--- a/app/views/rules_of_origin/_non_preferential_xi.html.erb
+++ b/app/views/rules_of_origin/_non_preferential_xi.html.erb
@@ -4,7 +4,7 @@
   </h3>
 
   <p>
-    <%= link_to "The Customs (Origin of Chargeable Goods) (EU Exit) Regulations 2020 (opens in new tab)", "https://www.gov.uk/government/publications/reference-document-for-the-customs-origin-of-chargeable-goods-eu-exit-regulations-2020", target: 'blank' %>
+    <%= govuk_link_to "The Customs (Origin of Chargeable Goods) (EU Exit) Regulations 2020", "https://www.gov.uk/government/publications/reference-document-for-the-customs-origin-of-chargeable-goods-eu-exit-regulations-2020", new_tab: true %>
   </p>
 
   <p>Non-preferential rules of origin allows the implementation of several commercial policy measures such as:</p>

--- a/app/views/rules_of_origin/_proofs.html.erb
+++ b/app/views/rules_of_origin/_proofs.html.erb
@@ -25,29 +25,28 @@
 
   <% if schemes.many? || schemes.none? %>
     <p>
-      <%= link_to 'See valid proofs of origin for all trade agreements',
-                  rules_of_origin_proofs_path %>
+      <%= govuk_link_to 'See valid proofs of origin for all trade agreements', rules_of_origin_proofs_path %>
     </p>
   <% else %>
     <p>Find out more about proofs of origin:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        <%= link_to 'How proofs are verified',
+        <%= govuk_link_to 'How proofs are verified',
                     rules_of_origin_proof_verification_path(
                       "#{commodity_code}-#{country_code}-#{schemes.first.scheme_code}"
                     ) %>
       </li>
 
       <li>
-        <%= link_to 'Detailed processes and requirements for proving the origin for goods',
+        <%= govuk_link_to 'Detailed processes and requirements for proving the origin for goods',
                     rules_of_origin_proof_requirements_path(
                       "#{commodity_code}-#{country_code}-#{schemes.first.scheme_code}"
                     ) %>
       </li>
 
       <li>
-        <%= link_to 'See valid proofs of origin for all trade agreements',
+        <%= govuk_link_to 'See valid proofs of origin for all trade agreements',
                     rules_of_origin_proofs_path %>
       </li>
     </ul>

--- a/app/views/rules_of_origin/_proofs_uk.html.erb
+++ b/app/views/rules_of_origin/_proofs_uk.html.erb
@@ -33,14 +33,14 @@
 
     <p>
 
-        <%= link_to 'Verification for proving the origin for goods coming from ' + country_name,
+        <%= govuk_link_to 'Verification for proving the origin for goods coming from ' + country_name,
                     rules_of_origin_proof_verification_path(
                       "#{commodity_code}-#{country_code}-#{schemes.first.scheme_code}"
                     ) %>
      </p>
 
       <p>
-        <%= link_to 'Requirements for proving the origin for goods coming from ' + country_name,
+        <%= govuk_link_to 'Requirements for proving the origin for goods coming from ' + country_name,
                     rules_of_origin_proof_requirements_path(
                       "#{commodity_code}-#{country_code}-#{schemes.first.scheme_code}"
                     ) %>
@@ -48,7 +48,7 @@
 
   <% end %>
   <p>
-    <%= link_to 'View valid proofs of origin for all trade agreements',
+    <%= govuk_link_to 'View valid proofs of origin for all trade agreements',
                 rules_of_origin_proofs_path %>
   </p>
 </div>

--- a/app/views/rules_of_origin/_scheme.html.erb
+++ b/app/views/rules_of_origin/_scheme.html.erb
@@ -6,6 +6,6 @@
                                                      commodity_code: %>
 
 <p>
-  <%= link_to 'View product-specific rules for other countries',
+  <%= govuk_link_to 'View product-specific rules for other countries',
               rules_of_origin_product_specific_rules_path(commodity_code) %>
 </p>

--- a/app/views/rules_of_origin/_tab_uk.html.erb
+++ b/app/views/rules_of_origin/_tab_uk.html.erb
@@ -44,7 +44,7 @@
           <% rules_of_origin_schemes.flat_map(&:links).uniq(&:id).each do |link| %>
             <p>
               <li>
-                <%= link_to link.text, link.url %>
+                <%= govuk_link_to link.text, link.url %>
               </li>
             </p>
           <% end %>

--- a/app/views/rules_of_origin/_tab_xi.html.erb
+++ b/app/views/rules_of_origin/_tab_xi.html.erb
@@ -74,7 +74,7 @@
       <% if rules_of_origin_schemes.flat_map(&:links).any? %>
         <% rules_of_origin_schemes.flat_map(&:links).uniq(&:id).each do |link| %>
           <li>
-            <%= link_to link.text, link.url %>
+            <%= govuk_link_to link.text, link.url %>
           </li>
         <% end %>
       <% else %>

--- a/app/views/rules_of_origin/_wizard_link.html.erb
+++ b/app/views/rules_of_origin/_wizard_link.html.erb
@@ -25,9 +25,7 @@
 
   <p>
     This is not a legal binding decision. For certainty, you can
-    <%= link_to 'https://www.gov.uk/guidance/apply-for-an-advance-origin-ruling' do %>
-      apply for an advanced origin ruling (opens in new window)
-    <% end %>.
+    <%= govuk_link_to 'apply for an advanced origin ruling', 'https://www.gov.uk/guidance/apply-for-an-advance-origin-ruling', new_tab: true %>.
   </p>
 
   <%= form_with model: RulesOfOrigin::Wizard.steps.first,

--- a/app/views/rules_of_origin/legacy/_proofs.html.erb
+++ b/app/views/rules_of_origin/legacy/_proofs.html.erb
@@ -31,7 +31,7 @@
     <% proofs.each do |proof| %>
       <ul class="govuk-list govuk-list--bullet govuk-list--spaced rules-of-origin__proofs__content">
         <li>
-          <%= link_to proof.summary, proof.url %>
+          <%= govuk_link_to proof.summary, proof.url %>
         </li>
 
         <% if proof.subtext.present? %>

--- a/app/views/rules_of_origin/legacy/_tab.html.erb
+++ b/app/views/rules_of_origin/legacy/_tab.html.erb
@@ -29,7 +29,7 @@
     <ul class="govuk-list govuk-list-s">
       <% rules_of_origin_schemes.flat_map(&:links).uniq(&:id).each do |link| %>
         <li>
-          <%= link_to link.text, link.url %>
+          <%= govuk_link_to link.text, link.url %>
         </li>
       <% end %>
     </ul>

--- a/app/views/rules_of_origin/steps/_about_commodity.html.erb
+++ b/app/views/rules_of_origin/steps/_about_commodity.html.erb
@@ -8,7 +8,7 @@
   </p>
 
   <p>
-    <%= link_to t('rules_of_origin.steps.about_commodity.link',
+    <%= govuk_link_to t('rules_of_origin.steps.about_commodity.link',
                   commodity_code: commodity_code),
                 commodity_path(commodity_code) %>
   </p>

--- a/app/views/rules_of_origin/steps/_cumulation.html.erb
+++ b/app/views/rules_of_origin/steps/_cumulation.html.erb
@@ -46,7 +46,7 @@
 
   <%= image_tag(asset_path(form.object.map_path)) %>
 
-  <p><%= link_to "View cumulation map in a new browser window", asset_path(form.object.map_path), target: "_blank" %></p>
+  <p><%= govuk_link_to "View cumulation map", asset_path(form.object.map_path), new_tab: true %></p>
 
   <h2 class="govuk-heading-s" id="agreement_text"><%= t '.agreement_title' %></h2>
 

--- a/app/views/rules_of_origin/steps/_import_only.html.erb
+++ b/app/views/rules_of_origin/steps/_import_only.html.erb
@@ -31,6 +31,6 @@
 </div>
 
 <p>
-  <%= link_to t('.export_info_link'),
+  <%= govuk_link_to t('.export_info_link'),
               "https://www.gov.uk/government/publications/reference-document-for-the-customs-origin-of-chargeable-goods-eu-exit-regulations-2020" %>
 </p>

--- a/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
+++ b/app/views/rules_of_origin/steps/_origin_requirements_met.html.erb
@@ -23,30 +23,30 @@
 
 <ul class="govuk-list" id="next-steps">
   <li>
-    <%= link_to t('.links.proofs'), step_path(:proofs_of_origin) %>
+    <%= govuk_link_to t('.links.proofs'), step_path(:proofs_of_origin) %>
   </li>
   <li>
-    <%= link_to t('.links.requirements'), step_path(:proof_requirements) %>
+    <%= govuk_link_to t('.links.requirements'), step_path(:proof_requirements) %>
   </li>
   <li>
-    <%= link_to t('.links.verification'), step_path(:proof_verification) %>
+    <%= govuk_link_to t('.links.verification'), step_path(:proof_verification) %>
   </li>
 
   <% if current_step.duty_drawback_available? %>
     <li>
-      <%= link_to t('.links.duty_drawback'), step_path(:duty_drawback) %>
+      <%= govuk_link_to t('.links.duty_drawback'), step_path(:duty_drawback) %>
     </li>
   <% end %>
 
   <% if current_step.non_alteration_available? %>
     <li>
-      <%= link_to t('.links.non_alteration'), step_path(:non_alteration_rule) %>
+      <%= govuk_link_to t('.links.non_alteration'), step_path(:non_alteration_rule) %>
     </li>
   <% end %>
 
   <% if current_step.direct_transport_available? %>
     <li>
-      <%= link_to t('.links.direct_transport'), step_path(:direct_transport_rule) %>
+      <%= govuk_link_to t('.links.direct_transport'), step_path(:direct_transport_rule) %>
     </li>
   <% end %>
 </ul>

--- a/app/views/rules_of_origin/steps/_proof_requirements.html.erb
+++ b/app/views/rules_of_origin/steps/_proof_requirements.html.erb
@@ -21,4 +21,4 @@
   <%= govspeak current_step.processes_section(params[:section]) %>
 </div>
 
-<%= link_to t('navigation.back_to_top'), '#content' %>
+<%= govuk_link_to t('navigation.back_to_top'), '#content' %>

--- a/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
+++ b/app/views/rules_of_origin/steps/_proofs_of_origin.html.erb
@@ -38,16 +38,16 @@
 
 <ul class="govuk-list" id="next-steps">
   <li>
-    <%= link_to t('.links.requirements'), step_path(:proof_requirements) %>
+    <%= govuk_link_to t('.links.requirements'), step_path(:proof_requirements) %>
   </li>
 
   <li>
-    <%= link_to t('.links.verification'), step_path(:proof_verification) %>
+    <%= govuk_link_to t('.links.verification'), step_path(:proof_verification) %>
   </li>
 
   <% if current_step.duty_drawback_available? %>
     <li>
-      <%= link_to t('.links.duty_drawback'), step_path(:duty_drawback) %>
+      <%= govuk_link_to t('.links.duty_drawback'), step_path(:duty_drawback) %>
     </li>
   <% end %>
 <ul>

--- a/app/views/rules_of_origin/steps/_rules_not_met.html.erb
+++ b/app/views/rules_of_origin/steps/_rules_not_met.html.erb
@@ -28,7 +28,7 @@
   </p>
 
   <p>
-    <%= link_to t('.tolerances.link'), step_path(:tolerances) %>
+    <%= govuk_link_to t('.tolerances.link'), step_path(:tolerances) %>
   </p>
 </div>
 <% end %>
@@ -74,8 +74,7 @@
   </p>
 
   <p>
-    <%= link_to t('.cumulation.link', scheme_title: current_step.scheme_title),
-                step_path(:cumulation) %>.
+    <%= govuk_link_to t('.cumulation.link', scheme_title: current_step.scheme_title), step_path(:cumulation) %>.
   </p>
 </div>
 <% end %>

--- a/app/views/rules_of_origin/steps/_sidebar_section.html.erb
+++ b/app/views/rules_of_origin/steps/_sidebar_section.html.erb
@@ -21,7 +21,7 @@
     <%= t("rules_of_origin.steps.sections.import_or_export_options.#{current_step.trade_direction}_html",
           trade_country: current_step.trade_country_name,
           service_country: current_step.service_country_name,
-          commodity_link: link_to(current_step.commodity_code, return_to_commodity_path),
+          commodity_link: govuk_link_to(current_step.commodity_code, return_to_commodity_path),
           default: nil) if current_step.trade_direction_chosen? %>
 
     <ol class="app-step-nav__list " data-length="<%= sidebar_section.steps.length %>">

--- a/app/views/search/_interactive_dont_know.html.erb
+++ b/app/views/search/_interactive_dont_know.html.erb
@@ -24,8 +24,8 @@
   <button class="govuk-button" data-action="interactive-question#goBack">
     Go back and add more details
   </button>
-  <%= link_to "Start search again", find_commodity_path, class: "govuk-button govuk-button--secondary" %>
-  <%= link_to "Cancel", sections_path, class: "govuk-link" %>
+  <%= govuk_button_link_to 'Start search again', find_commodity_path, secondary: true %>
+  <%= govuk_link_to "Cancel", sections_path  %>
 </div>
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible app-section-break--thick">
@@ -36,7 +36,7 @@
     <li class="gem-c-cards__list-item">
       <div class="gem-c-cards__list-item-wrapper">
         <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= link_to "Keyword or commodity code", find_commodity_path, class: "govuk-link gem-c-cards__link" %>
+          <%= govuk_link_to "Keyword or commodity code", find_commodity_path, class: 'gem-c-cards__link' %>
         </h3>
         <p class="govuk-body gem-c-cards__description">Search using keywords or use a known commodity code</p>
       </div>
@@ -44,7 +44,7 @@
     <li class="gem-c-cards__list-item">
       <div class="gem-c-cards__list-item-wrapper">
         <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= link_to "Goods classifications", browse_sections_path, class: "govuk-link gem-c-cards__link" %>
+          <%= govuk_link_to "Goods classifications", browse_sections_path, class: 'gem-c-cards__link' %>
         </h3>
         <p class="govuk-body gem-c-cards__description">Browse the goods classification</p>
       </div>
@@ -52,7 +52,7 @@
     <li class="gem-c-cards__list-item">
       <div class="gem-c-cards__list-item-wrapper">
         <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= link_to "A-Z product index", a_z_index_path(letter: 'a'), class: "govuk-link gem-c-cards__link" %>
+          <%= govuk_link_to "A-Z product index", a_z_index_path(letter: 'a'), class: 'gem-c-cards__link' %>
         </h3>
         <p class="govuk-body gem-c-cards__description">Look for your product in the A-Z</p>
       </div>

--- a/app/views/search/_interactive_no_results_content.html.erb
+++ b/app/views/search/_interactive_no_results_content.html.erb
@@ -17,8 +17,8 @@
     <p class="govuk-body">Go back and search again, browse the tariff or look for your product in the A-Z.</p>
 
     <div class="govuk-button-group">
-      <%= link_to "Start search again", find_commodity_path, class: "govuk-button" %>
-      <%= link_to "Cancel", sections_path, class: "govuk-link" %>
+      <%= govuk_button_link_to 'Start search again', find_commodity_path %>
+      <%= govuk_link_to "Cancel", sections_path  %>
     </div>
   </div>
 
@@ -35,7 +35,7 @@
     <li class="gem-c-cards__list-item">
       <div class="gem-c-cards__list-item-wrapper">
         <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= link_to "Keyword or commodity code", find_commodity_path, class: "govuk-link gem-c-cards__link" %>
+          <%= govuk_link_to "Keyword or commodity code", find_commodity_path, class: 'gem-c-cards__link' %>
         </h3>
         <p class="govuk-body gem-c-cards__description">Search using keywords or use a known commodity code</p>
       </div>
@@ -43,7 +43,7 @@
     <li class="gem-c-cards__list-item">
       <div class="gem-c-cards__list-item-wrapper">
         <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= link_to "Goods classifications", browse_sections_path, class: "govuk-link gem-c-cards__link" %>
+          <%= govuk_link_to "Goods classifications", browse_sections_path, class: 'gem-c-cards__link' %>
         </h3>
         <p class="govuk-body gem-c-cards__description">Browse the goods classification</p>
       </div>
@@ -51,7 +51,7 @@
     <li class="gem-c-cards__list-item">
       <div class="gem-c-cards__list-item-wrapper">
         <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= link_to "A-Z product index", a_z_index_path(letter: 'a'), class: "govuk-link gem-c-cards__link" %>
+          <%= govuk_link_to "A-Z product index", a_z_index_path(letter: 'a'), class: 'gem-c-cards__link' %>
         </h3>
         <p class="govuk-body gem-c-cards__description">Look for your product in the A-Z</p>
       </div>

--- a/app/views/search/_interactive_results_content.html.erb
+++ b/app/views/search/_interactive_results_content.html.erb
@@ -50,11 +50,9 @@
             <p class="govuk-body-s govuk-!-margin-bottom-2 govuk-!-text-colour-secondary">
               <%= result.formatted_self_text %>
             </p>
-            <%= link_to "View this commodity code (opens in new tab)",
+            <%= govuk_link_to "View this commodity code",
                 commodity_path(result.goods_nomenclature_item_id, request_id: @search.request_id),
-                class: "govuk-link",
-                target: "_blank",
-                rel: "noopener noreferrer" %>
+                new_tab: true %>
           </div>
           <div class="interactive-result__confidence">
             <%= render_confidence_meter(result.try(:confidence)) %>

--- a/app/views/search/_interactive_results_sidebar.html.erb
+++ b/app/views/search/_interactive_results_sidebar.html.erb
@@ -7,19 +7,19 @@
     <nav role="navigation" class="gem-c-related-navigation__nav-section">
       <ul class="gem-c-related-navigation__link-list">
         <li class="gem-c-related-navigation__link">
-          <%= link_to "What are commodity codes?", "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods", class: "govuk-link gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other" %>
+          <%= govuk_link_to "What are commodity codes?", "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods", class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
         <li class="gem-c-related-navigation__link">
-          <%= link_to "Guidance on difficult to classify goods", "https://www.gov.uk/guidance/finding-commodity-codes-for-imports-or-exports", class: "govuk-link gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other" %>
+          <%= govuk_link_to "Guidance on difficult to classify goods", "https://www.gov.uk/guidance/finding-commodity-codes-for-imports-or-exports", class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
         <li class="gem-c-related-navigation__link">
-          <%= link_to "How to import goods", "https://www.gov.uk/import-goods-into-uk", class: "govuk-link gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other" %>
+          <%= govuk_link_to "How to import goods", "https://www.gov.uk/import-goods-into-uk", class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
         <li class="gem-c-related-navigation__link">
-          <%= link_to "How to export goods", "https://www.gov.uk/export-goods", class: "govuk-link gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other" %>
+          <%= govuk_link_to "How to export goods", "https://www.gov.uk/export-goods", class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
         <li class="gem-c-related-navigation__link">
-          <%= link_to "Ask for help on classifying your goods", "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods", class: "govuk-link gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other" %>
+          <%= govuk_link_to "Ask for help on classifying your goods", "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods", class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
       </ul>
     </nav>
@@ -39,7 +39,7 @@
         </p>
         <p class="govuk-body">
           <strong>Email</strong><br>
-          <a href="mailto:classification.enquiries@hmrc.gov.uk" class="govuk-link">classification.enquiries@hmrc.gov.uk</a>
+          <%= govuk_mail_to 'classification.enquiries@hmrc.gov.uk' %>
         </p>
       </div>
     </details>

--- a/app/views/search/_section.html.erb
+++ b/app/views/search/_section.html.erb
@@ -3,7 +3,7 @@
     <span class="govuk-visually-hidden">
       Section <%= section.numeral %>:
     </span>
-    <%= link_to section, section_path(section) %>
+    <%= govuk_link_to section, section_path(section) %>
   </td>
   <td class="govuk-table__cell">
     Section <%= section.numeral %>

--- a/app/views/search/certificate_search.html.erb
+++ b/app/views/search/certificate_search.html.erb
@@ -77,7 +77,7 @@
                   <% certificate.goods_nomenclatures.each do |goods_nomenclature| %>
                     <tr class="govuk-table__row">
                       <th scope="row" class="govuk-table__header">
-                        <%= link_to segmented_commodity_code(goods_nomenclature.goods_nomenclature_item_id),
+                        <%= govuk_link_to segmented_commodity_code(goods_nomenclature.goods_nomenclature_item_id),
                                     polymorphic_path(goods_nomenclature, day: nil, month: nil, year: nil) %>
                       </th>
 

--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -51,7 +51,7 @@
 
       <div class="govuk-button-group">
         <%= f.govuk_submit "Submit" %>
-        <%= link_to "Cancel", sections_path, class: "govuk-link" %>
+        <%= govuk_link_to "Cancel", sections_path  %>
       </div>
     <% end %>
 

--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -51,7 +51,7 @@
 
       <div class="govuk-button-group">
         <%= f.govuk_submit "Submit" %>
-        <%= govuk_link_to "Cancel", sections_path  %>
+        <%= govuk_link_to "Cancel", sections_path %>
       </div>
     <% end %>
 

--- a/app/views/search/quotas/_definition.html.erb
+++ b/app/views/search/quotas/_definition.html.erb
@@ -8,7 +8,7 @@
 
   <td class="govuk-table__cell" data-label="Commodity-code">
     <% definition.all_goods_nomenclatures.each do |goods_nomenclature| %>
-      <%= link_to goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature) %>
+      <%= govuk_link_to goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature) %>
       <br>
     <% end %>
   </td>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -69,7 +69,7 @@
         <li>Searching what the item is used for or made from</li>
         <li>Broadening your search criteria</li>
         <li>Checking your spelling</li>
-        <li>Browsing the <%= link_to 'A-Z of Classified Goods', a_z_index_path(letter: 'a') %></li>
+        <li>Browsing the <%= govuk_link_to 'A-Z of Classified Goods', a_z_index_path(letter: 'a') %></li>
       </ul>
     </div>
   <% end %>

--- a/app/views/search_references/show.html.erb
+++ b/app/views/search_references/show.html.erb
@@ -22,8 +22,8 @@
       <% @search_references.each do |search_reference| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <%= link_to search_reference.link do %>
-              <%= search_reference %><span class="govuk-visually-hidden"> (code: <%= search_reference.referenced_id %>)</span>
+            <%= govuk_link_to search_reference.link do %>
+              <%= search_reference %><%= govuk_visually_hidden " (code: #{search_reference.referenced_id})" %>
             <% end %>
           </td>
           <td class="govuk-table__cell">

--- a/app/views/sections/_section.html.erb
+++ b/app/views/sections/_section.html.erb
@@ -1,7 +1,7 @@
 <tr class="govuk-table__row">
   <td class="title govuk-table__cell">
-    <%= link_to section_path(section, request.query_parameters.symbolize_keys)  do %>
-      <span class="govuk-visually-hidden">Section <%= section.position %>: </span> <%=  section %>
+    <%= govuk_link_to section_path(section, request.query_parameters.symbolize_keys) do %>
+      <%= govuk_visually_hidden "Section #{section.position}: " %> <%= section %>
     <% end %>
   </td>
   <td class="numeral govuk-table__cell"><span class="govuk-visually-hidden">Section </span><%= section.numeral %></td>

--- a/app/views/sections/_stw_information.html.erb
+++ b/app/views/sections/_stw_information.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-m">Advance tariff rulings</h2>
   <p class="govuk-body">
     For more help in classifying your commodity, you can
-    <%= link_to('search for advance tariff rulings', 'https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search', target: '_blank', class: 'govuk-link') %>
+    <%= govuk_link_to('search for advance tariff rulings', 'https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search', new_tab: govuk_visually_hidden('(opens in new tab)')) %>
   </p>
   <p class="govuk-body">
     Advance tariff rulings allow you to get a legally binding decision on the
@@ -11,12 +11,11 @@
 
   <p class="govuk-body">
     Find out more about
-    <%= link_to('advance tariff rulings', 'https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling', target: '_blank', class: 'govuk-link') %>.
+    <%= govuk_link_to('advance tariff rulings', 'https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling', new_tab: govuk_visually_hidden('(opens in new tab)')) %>.
   </p>
 
   <p class="govuk-body">
-    <%= link_to('Contact HMRC if you need help finding the right commodity code for your
-      goods','https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', target: '_blank', class: 'govuk-link') %>.
+    <%= govuk_link_to('Contact HMRC if you need help finding the right commodity code for your goods', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', new_tab: govuk_visually_hidden('(opens in new tab)')) %>.
   </p>
 </div>
 
@@ -25,7 +24,7 @@
 
   <p class="govuk-body">
     Use the
-    '<%= link_to('Check how to import or export goods', 'https://www.gov.uk/check-how-to-import-export', target: '_blank', class: 'govuk-link') %>'
+    '<%= govuk_link_to('Check how to import or export goods', 'https://www.gov.uk/check-how-to-import-export', new_tab: govuk_visually_hidden('(opens in new tab)')) %>'
     service to get information about importing and exporting, including:
   </p>
 

--- a/app/views/sections/_stw_information.html.erb
+++ b/app/views/sections/_stw_information.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-m">Advance tariff rulings</h2>
   <p class="govuk-body">
     For more help in classifying your commodity, you can
-    <%= govuk_link_to('search for advance tariff rulings', 'https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search', new_tab: govuk_visually_hidden('(opens in new tab)')) %>
+    <%= govuk_link_to('search for advance tariff rulings', 'https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search', new_tab: govuk_visually_hidden('opens in new tab')) %>
   </p>
   <p class="govuk-body">
     Advance tariff rulings allow you to get a legally binding decision on the
@@ -11,11 +11,11 @@
 
   <p class="govuk-body">
     Find out more about
-    <%= govuk_link_to('advance tariff rulings', 'https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling', new_tab: govuk_visually_hidden('(opens in new tab)')) %>.
+    <%= govuk_link_to('advance tariff rulings', 'https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling', new_tab: govuk_visually_hidden('opens in new tab')) %>.
   </p>
 
   <p class="govuk-body">
-    <%= govuk_link_to('Contact HMRC if you need help finding the right commodity code for your goods', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', new_tab: govuk_visually_hidden('(opens in new tab)')) %>.
+    <%= govuk_link_to('Contact HMRC if you need help finding the right commodity code for your goods', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', new_tab: govuk_visually_hidden('opens in new tab')) %>.
   </p>
 </div>
 
@@ -24,7 +24,7 @@
 
   <p class="govuk-body">
     Use the
-    '<%= govuk_link_to('Check how to import or export goods', 'https://www.gov.uk/check-how-to-import-export', new_tab: govuk_visually_hidden('(opens in new tab)')) %>'
+    '<%= govuk_link_to('Check how to import or export goods', 'https://www.gov.uk/check-how-to-import-export', new_tab: govuk_visually_hidden('opens in new tab')) %>'
     service to get information about importing and exporting, including:
   </p>
 

--- a/app/views/shared/_callout.html.erb
+++ b/app/views/shared/_callout.html.erb
@@ -1,7 +1,7 @@
 <div class="panel panel-border-wide govuk-panel">
   <p>
     Chapter <%= @chapter.short_code %> contains <%= pluralize @headings.count, 'heading' %>. Choose the heading that best matches your goods.<br>
-    There are <%= link_to 'important notes for classifying your goods', "#notes" %> shown further down this page
+    There are <%= govuk_link_to 'important notes for classifying your goods', "#notes" %> shown further down this page
   </p>
 
   <%= render partial: 'chapters/chapter_guides', locals: {chapter: chapter} %>

--- a/app/views/shared/_country_picker.html.erb
+++ b/app/views/shared/_country_picker.html.erb
@@ -22,7 +22,7 @@
           </div>
 
           <div class="govuk-grid-column-one-third govuk-!-padding-top-2">
-            <%= link_to('Reset to all countries', goods_nomenclature_path(country: nil), class: 'govuk-link') %>
+            <%= govuk_link_to('Reset to all countries', goods_nomenclature_path(country: nil)) %>
           </div>
         </div>
       </div>

--- a/app/views/shared/_derived_goods_nomenclature.html.erb
+++ b/app/views/shared/_derived_goods_nomenclature.html.erb
@@ -11,7 +11,7 @@
     <tbody class="govuk-table__body">
       <% deriving_goods_nomenclatures.each do |goods_nomenclature| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= link_to(goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature)) %></th>
+        <td class="govuk-table__cell"><%= govuk_link_to(goods_nomenclature.goods_nomenclature_item_id, polymorphic_path(goods_nomenclature)) %></th>
         <td class="govuk-table__cell">
           <%= sanitize sanitize_quotes(goods_nomenclature.formatted_description) unless goods_nomenclature.formatted_description.nil? %>
         </td>

--- a/app/views/shared/_feedback_banner.html.erb
+++ b/app/views/shared/_feedback_banner.html.erb
@@ -6,7 +6,7 @@
         FEEDBACK
       </strong>
       <span class="govuk-phase-banner__text">
-        Help us improve this service and <%= govuk_link_to 'give your feedback', feedback_link_url,  **(subscriptions_page? ? {} : { new_tab: true }) %>.
+        Help us improve this service and <%= govuk_link_to 'give your feedback (opens in new tab)', feedback_link_url, **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %>.
       </span>
     </p>
   </div>

--- a/app/views/shared/_feedback_banner.html.erb
+++ b/app/views/shared/_feedback_banner.html.erb
@@ -6,7 +6,7 @@
         FEEDBACK
       </strong>
       <span class="govuk-phase-banner__text">
-        Help us improve this service and <%= link_to 'give your feedback (opens in new tab)', feedback_link_url, class: 'govuk-link', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %>.
+        Help us improve this service and <%= govuk_link_to 'give your feedback', feedback_link_url,  **(subscriptions_page? ? {} : { new_tab: true }) %>.
       </span>
     </p>
   </div>

--- a/app/views/shared/_feedback_banner_commodities.html.erb
+++ b/app/views/shared/_feedback_banner_commodities.html.erb
@@ -2,6 +2,6 @@
   <h2 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-2" id="feedback-banner-beta-heading">Give feedback about this service</h2>
   <p class="govuk-body govuk-!-margin-bottom-0">
     Help us improve this service by
-    <%= link_to 'giving your feedback (opens in a new tab)', 'https://surveys.transformuk.com/s3/40f03c68329d', class: 'govuk-link', target: '_blank', rel: 'noopener noreferrer' %>.
+    <%= govuk_link_to 'giving your feedback', 'https://surveys.transformuk.com/s3/40f03c68329d', new_tab: true %>.
   </p>
 </div>

--- a/app/views/shared/_feedback_useful_banner.html.erb
+++ b/app/views/shared/_feedback_useful_banner.html.erb
@@ -5,7 +5,7 @@
       <p class="govuk-body govuk-!-margin-bottom-0">Tell us about your experience using this service to help us improve it.</p>
     </div>
     <div class="govuk-footer__meta-item">
-      <%= link_to 'Share your feedback', feedback_link_url, class: 'govuk-button govuk-button--secondary', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %>
+      <%= govuk_button_link_to 'Share your feedback', feedback_link_url, secondary: true, **(subscriptions_page? ? {} : { new_tab: govuk_visually_hidden('(opens in new tab)') }) %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_feedback_useful_banner.html.erb
+++ b/app/views/shared/_feedback_useful_banner.html.erb
@@ -5,7 +5,7 @@
       <p class="govuk-body govuk-!-margin-bottom-0">Tell us about your experience using this service to help us improve it.</p>
     </div>
     <div class="govuk-footer__meta-item">
-      <%= govuk_button_link_to 'Share your feedback', feedback_link_url, secondary: true, **(subscriptions_page? ? {} : { new_tab: govuk_visually_hidden('(opens in new tab)') }) %>
+      <%= govuk_link_to 'Share your feedback', feedback_link_url, class: 'govuk-button--secondary', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_interactive_feedback_banner.html.erb
+++ b/app/views/shared/_interactive_feedback_banner.html.erb
@@ -6,7 +6,7 @@
         BETA
       </strong>
       <span class="govuk-phase-banner__text">
-        Help us improve this service and <%= link_to 'give your feedback', feedback_link_url, class: 'govuk-link', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %> (opens in a new tab).
+        Help us improve this service and <%= govuk_link_to 'give your feedback', feedback_link_url, **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %> (opens in a new tab).
       </span>
     </p>
   </div>

--- a/app/views/shared/_interactive_feedback_useful_banner.html.erb
+++ b/app/views/shared/_interactive_feedback_useful_banner.html.erb
@@ -6,7 +6,7 @@
         <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Give feedback about this service</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Tell us about your experience using this service to help us improve it.</p>
       </div>
-      <%= link_to 'Share your feedback', feedback_link_url, class: 'govuk-button app-feedback-useful-banner__button', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %>
+      <%= govuk_link_to 'Share your feedback', feedback_link_url, class: 'app-feedback-useful-banner__button', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_origin_reference_document.html.erb
+++ b/app/views/shared/_origin_reference_document.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-details__text">
     <div class="downloadable-document">
       <div class="downloadable-document__thumb">
-        <%= link_to asset_path(origin_reference_document.document_path) do %>
+        <%= govuk_link_to asset_path(origin_reference_document.document_path) do %>
           <svg class="rules-of-origin-ord-svg" version="1.1" viewBox="0 0 99 140" width="99" height="140" aria-hidden="false">
             <path d="M12 12h75v27H12zM12 59h9v9h-9zM12 77h9v9h-9zM12 95h9v9h-9zM12 113h9v9h-9zM30 59h57v9H30zM30 77h39v9H30zM30 95h57v9H30zM30 113h48v9H30z" stroke-width="0"></path>
           </svg>
@@ -19,7 +19,7 @@
 
         <br><br>
 
-        <%= link_to "Download rules of origin reference document.",
+        <%= govuk_link_to "Download rules of origin reference document.",
                     asset_path(origin_reference_document.document_path) %>
 
         <div class="subtext">

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -120,7 +120,7 @@
       <% id = "missing-definition-#{order_number.licenced? ? "licenced" : "non-licenced"}" %>
       <p id="<%= id %>" class="govuk-!-margin-top-4">
         <% if order_number.licenced? %>
-          Information on the availability of licenced quotas can be obtained from the <%= link_to("UK tariff rate quotas (opens in new browser window)", "https://www.gov.uk/government/collections/uk-tariff-rate-quotas-allocation-of-co-efficients", target: '_blank', class: 'govuk-link') %>.
+          Information on the availability of licenced quotas can be obtained from the <%= govuk_link_to("UK tariff rate quotas", "https://www.gov.uk/government/collections/uk-tariff-rate-quotas-allocation-of-co-efficients", new_tab: true) %>.
         <% else %>
           No further information for this quota can be found.
         <% end %>

--- a/app/views/shared/_quota_definition.html.erb
+++ b/app/views/shared/_quota_definition.html.erb
@@ -30,7 +30,7 @@
               <%= quota_definition.measurement_unit %>
               <% unless @search.date.today? %>
                 <br>
-                <%= link_to quota_search_today_params(order_number) do %>
+                <%= govuk_link_to quota_search_today_params(order_number) do %>
                   View balance for <%= Time.zone.today.to_formatted_s :short %>
                 <% end %>
               <% end %>

--- a/app/views/shared/callouts/_chapter.html.erb
+++ b/app/views/shared/callouts/_chapter.html.erb
@@ -5,7 +5,7 @@
 
   <% if @chapter.chapter_note.present? %>
   <p>
-    There are <%= link_to 'important notes for classifying your goods', "#notes" %> shown further down this page
+    There are <%= govuk_link_to 'important notes for classifying your goods', "#notes" %> shown further down this page
   </p>
   <% end %>
 

--- a/app/views/shared/callouts/_heading.html.erb
+++ b/app/views/shared/callouts/_heading.html.erb
@@ -6,7 +6,7 @@
 
   <% if section_note.present? || chapter_note.present? %>
     <p>
-      There are <%= link_to 'important notes for classifying your goods', "#notes" %> shown further down this page
+      There are <%= govuk_link_to 'important notes for classifying your goods', "#notes" %> shown further down this page
     </p>
   <% end %>
 </div>

--- a/app/views/shared/callouts/_subheading.html.erb
+++ b/app/views/shared/callouts/_subheading.html.erb
@@ -4,6 +4,6 @@
     Choose the commodity code that best matches your goods to see more information. If your item is not listed by name, it may be shown under what it's used for, what it's made from or 'Other'.
   </p>
   <p>
-    There are <%= link_to 'important notes for classifying your goods', "#notes" %> shown further down this page
+    There are <%= govuk_link_to 'important notes for classifying your goods', "#notes" %> shown further down this page
   </p>
 </div>

--- a/app/views/shared/context_tables/_chapter.html.erb
+++ b/app/views/shared/context_tables/_chapter.html.erb
@@ -25,7 +25,7 @@
       <%= @search.date.to_formatted_s(:long) %>
     </dd>
     <dd class="govuk-summary-list__actions">
-      <%= link_to('Change', import_export_dates_path(goods_nomenclature_code: current_goods_nomenclature_code), class: 'govuk-link') %>
+      <%= govuk_link_to('Change', import_export_dates_path(goods_nomenclature_code: current_goods_nomenclature_code)) %>
     </dd>
   </div>
 </dl>

--- a/app/views/shared/context_tables/_commodity.html.erb
+++ b/app/views/shared/context_tables/_commodity.html.erb
@@ -43,7 +43,7 @@
       <%= @search.date.to_formatted_s(:long) %>
     </dd>
     <dd class="govuk-summary-list__actions">
-      <%= link_to('Change', import_export_dates_path(goods_nomenclature_code: current_goods_nomenclature_code), class: 'govuk-link') %>
+      <%= govuk_link_to('Change', import_export_dates_path(goods_nomenclature_code: current_goods_nomenclature_code)) %>
     </dd>
   </div>
 </dl>

--- a/app/views/shared/context_tables/_heading.html.erb
+++ b/app/views/shared/context_tables/_heading.html.erb
@@ -28,7 +28,7 @@
       <%= @search.date.to_formatted_s(:long) %>
     </dd>
     <dd class="govuk-summary-list__actions">
-      <%= link_to('Change', import_export_dates_path(goods_nomenclature_code: current_goods_nomenclature_code), class: 'govuk-link') %>
+      <%= govuk_link_to('Change', import_export_dates_path(goods_nomenclature_code: current_goods_nomenclature_code)) %>
     </dd>
   </div>
 </dl>

--- a/app/views/shared/context_tables/_subheading.html.erb
+++ b/app/views/shared/context_tables/_subheading.html.erb
@@ -25,7 +25,7 @@
       <%= @search.date.to_formatted_s(:long) %>
     </dd>
     <dd class="govuk-summary-list__actions">
-      <%= link_to('Change', import_export_dates_path(goods_nomenclature_code: current_goods_nomenclature_code), class: 'govuk-link') %>
+      <%= govuk_link_to('Change', import_export_dates_path(goods_nomenclature_code: current_goods_nomenclature_code)) %>
     </dd>
   </div>
 </dl>

--- a/app/views/shared/search/_interactive_search_form.html.erb
+++ b/app/views/shared/search/_interactive_search_form.html.erb
@@ -99,7 +99,7 @@
             <p>Expect technical language. Commodity code descriptions can be quite formal. For example, a laptop might be described as a "Portable automatic data-processing machines, weighing not more than 10 kg, consisting of at least a central processing unit, a keyboard and a display."</p>
             <p>Use plain English and avoid using foreign words or special characters. The search is also unable to pick up on any spelling mistakes.</p>
             <p>Make sure you're using the correct country's classification. Commodity codes can vary between countries. Make sure you're using the right code for the country you're importing to or from.</p>
-            <p>If you are struggling to understand the duty you may need to pay then this guidance may help you: <%= link_to "Tax and customs for goods sent from abroad: Tax and duty - GOV.UK", "https://www.gov.uk/goods-sent-from-abroad/tax-and-duty" %></p>
+            <p>If you are struggling to understand the duty you may need to pay then this guidance may help you: <%= govuk_link_to "Tax and customs for goods sent from abroad: Tax and duty - GOV.UK", "https://www.gov.uk/goods-sent-from-abroad/tax-and-duty" %></p>
 
             <h3 class="govuk-heading-s">Steps for searching the tariff</h3>
             <ol class="special-numbered-list govuk-!-margin-bottom-0">

--- a/app/views/shared/webchat_message/_not_found.html.erb
+++ b/app/views/shared/webchat_message/_not_found.html.erb
@@ -4,7 +4,7 @@
 
         <p>
             If you
-            <%= link_to('cannot find the right commodity code for your goods', help_find_commodity_path, target: '_blank') %>
+            <%= govuk_link_to('cannot find the right commodity code for your goods', help_find_commodity_path, target: '_blank', rel: 'noopener') %>
             , you can contact HMRC for advice or for a decision on your goods.</p>
         </p>
 

--- a/app/views/simplified_procedural_values/_by_code.html.erb
+++ b/app/views/simplified_procedural_values/_by_code.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-column-two-thirds">
-  <%= link_to("Back", simplified_procedural_values_path, class: 'govuk-back-link') %>
+  <%= govuk_back_link(href: simplified_procedural_values_path) %>
   <%= page_header "Simplified procedure value rates for code #{@result.simplified_procedural_code} - #{@result.goods_nomenclature_label}" %>
 
   <% if @result.no_data %>

--- a/app/views/simplified_procedural_values/_by_date.html.erb
+++ b/app/views/simplified_procedural_values/_by_date.html.erb
@@ -36,7 +36,7 @@
       <% @result.measures.each do |measure| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <%= link_to  measure.resource_id, simplified_procedural_values_path(simplified_procedural_code: measure.resource_id) %>
+            <%= govuk_link_to measure.resource_id, simplified_procedural_values_path(simplified_procedural_code: measure.resource_id) %>
           </td>
           <td class="govuk-table__cell">
             <%= goods_nomenclature_item_id_links_for(measure.goods_nomenclature_item_ids) %>

--- a/app/views/subheadings/show_404.html.erb
+++ b/app/views/subheadings/show_404.html.erb
@@ -20,10 +20,10 @@
       <ul class="govuk-list govuk-list--bullet">
         <% @validity_periods.each do |validity_period| %>
           <li>
-            From <%= link_to validity_period.start_date.to_formatted_s(:long),
+            From <%= govuk_link_to validity_period.start_date.to_formatted_s(:long),
                              subheading_on_date_path(validity_period.to_param, validity_period.start_date) -%>
             <% if validity_period.end_date.present? -%>
-              to <%= link_to validity_period.end_date.to_formatted_s(:long),
+              to <%= govuk_link_to validity_period.end_date.to_formatted_s(:long),
                              subheading_on_date_path(validity_period.to_param, validity_period.end_date) -%>
             <% end -%>
           </li>
@@ -39,7 +39,7 @@
 
     <p>
       Alternatively, you can visit
-      <%= link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>
+      <%= govuk_link_to "chapter #{@chapter_code}", chapter_path(@chapter_code) %>
       <% unless @search.today? %>
         for <%= @search.date.to_formatted_s(:long) %>.
       <% end %>

--- a/app/views/trading_partners/show.html.erb
+++ b/app/views/trading_partners/show.html.erb
@@ -32,7 +32,7 @@
 
         <div class="govuk-button-group">
           <%= f.govuk_submit(t('trading_partner.form.submit')) %>
-          <%= link_to('Reset to all countries', goods_nomenclature_path(country: nil), class: 'govuk-link') %>
+          <%= govuk_link_to('Reset to all countries', goods_nomenclature_path(country: nil)) %>
         </div>
       <% end %>
       </fieldset>

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
     it 'opens commodity links in a new tab' do
       render partial: 'search/interactive_results_content'
 
-      expect(rendered).to have_css('a[target="_blank"][rel="noopener noreferrer"]', text: 'View this commodity code (opens in new tab)')
+      expect(rendered).to have_css('a[target="_blank"][rel="noreferrer noopener"]', text: 'View this commodity code (opens in new tab)')
     end
   end
 


### PR DESCRIPTION
## What?

Adds [govuk-components](https://github.com/x-govuk/govuk-components) gem and uses link helpers.

### Helpers
Links with "govuk-link" class have been converted to use [govuk_link_to](https://govuk-components.x-govuk.org/helpers/link/)
Links with "govuk-button" have been converted to use [govuk_button_link](https://govuk-components.x-govuk.org/helpers/button/)
Mailto links have been converted to use `govuk_mail_to`
Back links have been converted to use [govuk_back_link](https://govuk-components.x-govuk.org/components/back-link/)

### Options
Where a link opens in a new tab the [new_tab](https://govuk-components.x-govuk.org/helpers/link/#links-that-open-in-a-new-tab) option has been used. Where the link text specified that a new tab would be opened this has been standardised to show (opens in new tab), and otherwise this has been added as text for screen readers.

Where a link has the "govuk-button--secondary" class, [secondary](https://govuk-components.x-govuk.org/helpers/button/#other-button-styles) option has been used.
[Other link styles](https://govuk-components.x-govuk.org/helpers/link/#other-link-styles) have also been applied where appropriate.

Where there is hidden text for screen readers [govuk_visually_hidden](https://govuk-components.x-govuk.org/helpers/visually-hidden-text/) helper has been used.

