### PR TITLE
Fix repeated recomputation of per-request values on the commodity show page

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -64,7 +64,7 @@ module Declarable
   end
 
   def critical_footnotes
-    @critical_footnotes = footnotes.select(&:critical_warning?)
+    @critical_footnotes ||= footnotes.select(&:critical_warning?)
   end
 
   def meursing_code?

--- a/app/presenters/measure_presenter.rb
+++ b/app/presenters/measure_presenter.rb
@@ -1,34 +1,47 @@
 class MeasurePresenter < SimpleDelegator
   DOCUMENT_CODE_EXCLUSIONS = %w[999L].freeze
 
+  # Boolean memoization helper — ||= doesn't work for false values.
+  # Each predicate is called from both _measure.html.erb (the table row)
+  # and _measure_references.html.erb (the modal/footnote references panel),
+  # so we cache the result to avoid re-evaluating the same check twice per
+  # measure per request.
   def has_children_geographical_areas?
-    geographical_area.children_geographical_areas.any?
+    return @has_children_geographical_areas if instance_variable_defined?(:@has_children_geographical_areas)
+
+    @has_children_geographical_areas = geographical_area.children_geographical_areas.any?
   end
 
   def has_measure_conditions?
-    measure_conditions.any?
+    return @has_measure_conditions if instance_variable_defined?(:@has_measure_conditions)
+
+    @has_measure_conditions = measure_conditions.any?
   end
 
   def has_additional_code?
-    additional_code.present?
+    return @has_additional_code if instance_variable_defined?(:@has_additional_code)
+
+    @has_additional_code = additional_code.present?
   end
 
   def has_measure_footnotes?
-    footnotes.any?
+    return @has_measure_footnotes if instance_variable_defined?(:@has_measure_footnotes)
+
+    @has_measure_footnotes = footnotes.any?
   end
 
   def children_geographical_areas
-    geographical_area.children_geographical_areas.sort_by(&:id)
+    @children_geographical_areas ||= geographical_area.children_geographical_areas.sort_by(&:id)
   end
 
   def measure_conditions_without_exclusions
-    measure_conditions.reject do |condition|
+    @measure_conditions_without_exclusions ||= measure_conditions.reject do |condition|
       DOCUMENT_CODE_EXCLUSIONS.include?(condition.document_code)
     end
   end
 
   def grouped_measure_conditions
-    measure_conditions_without_exclusions.group_by do |condition|
+    @grouped_measure_conditions ||= measure_conditions_without_exclusions.group_by do |condition|
       {
         condition: condition.condition,
         partial_type: case condition.condition_code[0]

--- a/app/views/goods_nomenclatures/_ancestors.html.erb
+++ b/app/views/goods_nomenclatures/_ancestors.html.erb
@@ -64,7 +64,8 @@
       </li>
 
       <%# list each of commodities ancestors %>
-      <% goods_nomenclature.ancestors.each.with_index do |ancestor, index| %>
+      <% ancestors = goods_nomenclature.ancestors %>
+      <% ancestors.each.with_index do |ancestor, index| %>
       <li id="<%= commodity_ancestor_id(index + 1) %>"
           aria-owns="<%= commodity_ancestor_id(index + 2) %>">
         <%= link_to subheading_path("#{ancestor.code}-#{ancestor.producline_suffix}") do %>
@@ -80,7 +81,7 @@
       <% end %>
 
       <%# list current commodity %>
-      <li id="<%= commodity_ancestor_id(goods_nomenclature.ancestors.length + 1) %>">
+      <li id="<%= commodity_ancestor_id(ancestors.length + 1) %>">
         <span>
           <span class="commodity-ancestors__identifier">
             <%= segmented_commodity_code goods_nomenclature.code,


### PR DESCRIPTION
## Problem

A performance audit of `commodities#show` found three places where values were needlessly recomputed on every call within the same request, rather than being memoized after the first computation.

## Changes

### `declarable.rb` — `critical_footnotes` used `=` instead of `||=`

`critical_footnotes` filters footnotes by `:critical_warning?` and is called **three times per request**: once in the commodity show template and twice inside the measures partial (once each for the import and export tab). Every call re-ran the filter from scratch. Changed `=` to `||=`.

### `measure_presenter.rb` — seven methods recomputed on every call

Each measure is rendered **twice** per request:
1. As a table row in `_measure.html.erb`, which checks `has_measure_conditions?`, `has_measure_footnotes?`, `has_additional_code?`, and `has_children_geographical_areas?`
2. As a reference entry in `_measure_references.html.erb`, which re-checks the same predicates to decide whether to render the conditions modal, footnote panel, and additional code block

For a commodity with many measures (e.g. 6912002310) this adds up significantly.

- **Boolean predicates** (`has_measure_conditions?`, `has_measure_footnotes?`, `has_additional_code?`, `has_children_geographical_areas?`) use `instance_variable_defined?` memoization because `||=` cannot cache a `false` value.
- **`measure_conditions_without_exclusions`** and **`grouped_measure_conditions`** use `||=` since they always return an array/hash (truthy even when empty). `grouped_measure_conditions` calls `measure_conditions_without_exclusions` internally, so memoizing the inner result also removes a redundant `reject` pass.
- **`children_geographical_areas`** uses `||=` to cache the sorted result.

### `_ancestors.html.erb` — `ancestors` fetched twice

`goods_nomenclature.ancestors` was called twice in quick succession: once to iterate the ancestor list and immediately again to compute the id of the final `<li>` (`ancestors.length + 1`). Extracted to a local variable.
