### PR TITLE
Use govuk_start_button

### DIFF
--- a/app/views/green_lanes/starts/new.html.erb
+++ b/app/views/green_lanes/starts/new.html.erb
@@ -77,12 +77,10 @@
       <li>when the internal movement of goods is likely to take place</li>
     </ul>
 
-    <%= button_to green_lanes_your_movement_path,
-                  params: (@commodity_code ? {commodity_code: @commodity_code} : {}),
-                  class: "govuk-button govuk-button--start govuk-!-margin-top-2", method: :get do %>
-
-      <span>Start now</span>
-      <%= render 'shared/start_arrow' %>
-    <% end %>
+    <%= govuk_start_button(
+          text: 'Start now',
+          href: green_lanes_your_movement_path(@commodity_code ? { commodity_code: @commodity_code } : {}),
+          classes: 'govuk-!-margin-top-2'
+        ) %>
   </div>
 </div>

--- a/app/views/meursing_lookup/steps/_start.html.erb
+++ b/app/views/meursing_lookup/steps/_start.html.erb
@@ -34,10 +34,11 @@
       <li>sucrose, invert sugar, isoglucose</li>
     </ul>
 
-    <a href=<%= meursing_lookup_step_path('starch', goods_nomenclature_code: current_goods_nomenclature_code) %> role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button">
-      Start now
-      <%= render 'shared/start_arrow' %>
-    </a>
+    <%= govuk_start_button(
+          text: 'Start now',
+          href: meursing_lookup_step_path('starch', goods_nomenclature_code: current_goods_nomenclature_code),
+          classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-8'
+        ) %>
 
     <h2 class="govuk-heading-m">Documents to download</h2>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/myott/subscriptions/start.html.erb
+++ b/app/views/myott/subscriptions/start.html.erb
@@ -30,10 +30,7 @@
     </p>
 
 
-    <a href="<%= @continue_url %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
-      Start now
-      <%= render 'shared/start_arrow' %>
-    </a>
+    <%= govuk_start_button(text: 'Start now', href: @continue_url) %>
 
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 

--- a/app/views/product_experience/enquiry_form/show.html.erb
+++ b/app/views/product_experience/enquiry_form/show.html.erb
@@ -15,16 +15,9 @@
       <p class="govuk-body">Along with the details of your enquiry, you will be asked for your email address
       so we can reply to you.</p>
 
-    <%= link_to product_experience_enquiry_form_field_path(EnquiryFormHelper.fields.first, submission_token: session[:submission_token]),
-            role: "button",
-            draggable: "false",
-            class: "govuk-button govuk-button--start",
-            data: { module: "govuk-button" },
-            method: :post do %>
-        Start
-        <%= render 'shared/start_arrow' %>
-    <% end %>
-
-
+    <%= govuk_start_button(
+        text: 'Start',
+        href: product_experience_enquiry_form_field_path(EnquiryFormHelper.fields.first, submission_token: session[:submission_token])
+      ) %>
   </div>
 </div>

--- a/app/views/shared/_start_arrow.html.erb
+++ b/app/views/shared/_start_arrow.html.erb
@@ -1,3 +1,0 @@
-<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-  <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-</svg>


### PR DESCRIPTION
### What?

Uses govuk_start_button to render start buttons.

The start button for enquiry form specifies that the method should be post, but in reality it was using a GET. Replacing with a POST causes a validation error on the next page so GET seems correct.
