### PR TITLE
Fix CSP violations for GTM script and blob connections

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
   <%= yield :head %>
 
   <script async src="/javascripts/es-module-shims.js?v=<%= CURRENT_REVISION %>"></script>
-  <script type="esms-options">
+  <script type="esms-options" nonce="<%= content_security_policy_nonce %>">
     {
       "noLoadEventRetriggers": true
     }

--- a/app/views/shared/_gtm.html.erb
+++ b/app/views/shared/_gtm.html.erb
@@ -1,10 +1,12 @@
 <% if part == 'head' %>
   <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','<%= TradeTariffFrontend.google_tag_manager_container_id %>');</script>
+  <%= javascript_tag(nonce: true) do %>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<%= TradeTariffFrontend.google_tag_manager_container_id %>');
+  <% end %>
   <!-- End Google Tag Manager -->
 <% else %>
   <!-- Google Tag Manager (noscript) -->

--- a/app/views/shared/search/_autocomplete.html.erb
+++ b/app/views/shared/search/_autocomplete.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-fieldset" id='autocomplete'>
-  <script>
+  <%= javascript_tag nonce: true do %>
     document.addEventListener('DOMContentLoaded', function() {
       try {
         let tempQuery = '';
@@ -43,7 +43,7 @@
         node.innerHTML = '<div class="autocomplete__wrapper"><input autocomplete="off" class="autocomplete__input autocomplete__input--default" id="q" name="q" placeholder="Enter the name of the goods or commodity code" type="text" role="combobox" required=""></div>'
       }
     })
-  </script>
+  <% end %>
 
   <noscript>
     <div class="autocomplete__wrapper">

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,6 +7,7 @@
 Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src :self, :https
+    policy.connect_src :self, :https, :blob
     policy.font_src    :self, :https, :data
     policy.img_src     :self, :https, :data
     policy.object_src  :none


### PR DESCRIPTION
### What?

Updates CSP-related frontend scripts so GTM and inline page scripts are nonce-compliant and compatible with es-module-shims.

- Added nonce support to the GTM head snippet by rendering it through a nonce-enabled Rails script helper.
- Added nonce support to the search autocomplete inline script.
- Added nonce to the es-module-shims options script tag while keeping it as raw JSON (not wrapped in Rails javascript helper output), so it remains valid for parsing.
- Added a connect-src directive to allow self, https, and blob connections.

### Why?

I am doing this because CSP report-only logs were showing violations for inline scripts and blob connections, and one attempted nonce fix caused es-module-shims JSON parsing to fail.

This change:
- Removes noisy CSP violations for known inline scripts by ensuring matching nonces are present.
- Preserves strict script policy without enabling unsafe-inline or unsafe-eval.
- Fixes the runtime error where es-module-shims rejected invalid JSON content.
- Keeps GTM functioning while aligning implementation with planned CSP enforcement.