### PR TITLE
Handle Faraday::ResourceNotFound raised from within view partials in duty calculator

### DIFF
--- a/app/controllers/duty_calculator/steps/base_controller.rb
+++ b/app/controllers/duty_calculator/steps/base_controller.rb
@@ -6,11 +6,8 @@ module DutyCalculator
       include UkimsHelper
 
       rescue_from Errors::SessionIntegrityError, with: :handle_session_integrity_error
-      # Must be declared before rescue_from StandardError so it is matched first.
-      # Rails stores handlers in definition order and picks the first match. A missing
-      # commodity is an expected condition — the API returns 404 when a code doesn't
-      # exist or isn't declarable. We redirect silently rather than surfacing it in NewRelic.
       rescue_from Faraday::ResourceNotFound, with: :handle_commodity_not_found
+      rescue_from ActionView::Template::Error, with: :handle_template_error
       rescue_from StandardError, with: :handle_exception
 
       default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
@@ -65,6 +62,14 @@ module DutyCalculator
 
       def handle_commodity_not_found(_exception)
         redirect_to sections_url, allow_other_host: true
+      end
+
+      def handle_template_error(exception)
+        if exception.cause.is_a?(Faraday::ResourceNotFound)
+          handle_commodity_not_found(exception.cause)
+        else
+          handle_exception(exception)
+        end
       end
 
       def ensure_session_integrity

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -64,7 +64,7 @@ module Declarable
   end
 
   def critical_footnotes
-    @critical_footnotes = footnotes.select(&:critical_warning?)
+    @critical_footnotes ||= footnotes.select(&:critical_warning?)
   end
 
   def meursing_code?

--- a/app/presenters/measure_presenter.rb
+++ b/app/presenters/measure_presenter.rb
@@ -2,33 +2,41 @@ class MeasurePresenter < SimpleDelegator
   DOCUMENT_CODE_EXCLUSIONS = %w[999L].freeze
 
   def has_children_geographical_areas?
-    geographical_area.children_geographical_areas.any?
+    return @has_children_geographical_areas if instance_variable_defined?(:@has_children_geographical_areas)
+
+    @has_children_geographical_areas = geographical_area.children_geographical_areas.any?
   end
 
   def has_measure_conditions?
-    measure_conditions.any?
+    return @has_measure_conditions if instance_variable_defined?(:@has_measure_conditions)
+
+    @has_measure_conditions = measure_conditions.any?
   end
 
   def has_additional_code?
-    additional_code.present?
+    return @has_additional_code if instance_variable_defined?(:@has_additional_code)
+
+    @has_additional_code = additional_code.present?
   end
 
   def has_measure_footnotes?
-    footnotes.any?
+    return @has_measure_footnotes if instance_variable_defined?(:@has_measure_footnotes)
+
+    @has_measure_footnotes = footnotes.any?
   end
 
   def children_geographical_areas
-    geographical_area.children_geographical_areas.sort_by(&:id)
+    @children_geographical_areas ||= geographical_area.children_geographical_areas.sort_by(&:id)
   end
 
   def measure_conditions_without_exclusions
-    measure_conditions.reject do |condition|
+    @measure_conditions_without_exclusions ||= measure_conditions.reject do |condition|
       DOCUMENT_CODE_EXCLUSIONS.include?(condition.document_code)
     end
   end
 
   def grouped_measure_conditions
-    measure_conditions_without_exclusions.group_by do |condition|
+    @grouped_measure_conditions ||= measure_conditions_without_exclusions.group_by do |condition|
       {
         condition: condition.condition,
         partial_type: case condition.condition_code[0]

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -1,6 +1,5 @@
 <% cacheable = params.values.compact.none? { |v| v.is_a?(ActionController::Parameters) } %>
 
-<%# These are always needed regardless of cache state — set them before the cache block. %>
 <% content_for :title, strip_tags(commodity_title(declarable)) %>
 <% content_for :head do %>
   <meta name="description" content="<%= declarable.description_plain %>">

--- a/app/views/goods_nomenclatures/_ancestors.html.erb
+++ b/app/views/goods_nomenclatures/_ancestors.html.erb
@@ -64,7 +64,8 @@
       </li>
 
       <%# list each of commodities ancestors %>
-      <% goods_nomenclature.ancestors.each.with_index do |ancestor, index| %>
+      <% ancestors = goods_nomenclature.ancestors %>
+      <% ancestors.each.with_index do |ancestor, index| %>
       <li id="<%= commodity_ancestor_id(index + 1) %>"
           aria-owns="<%= commodity_ancestor_id(index + 2) %>">
         <%= link_to subheading_path("#{ancestor.code}-#{ancestor.producline_suffix}") do %>
@@ -80,7 +81,7 @@
       <% end %>
 
       <%# list current commodity %>
-      <li id="<%= commodity_ancestor_id(goods_nomenclature.ancestors.length + 1) %>">
+      <li id="<%= commodity_ancestor_id(ancestors.length + 1) %>">
         <span>
           <span class="commodity-ancestors__identifier">
             <%= segmented_commodity_code goods_nomenclature.code,

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -1,6 +1,5 @@
 <% cacheable = params.values.compact.none? { |v| v.is_a?(ActionController::Parameters) } %>
 
-<%# Always set content_for outside the cache block so it is populated on cache hits too. %>
 <% content_for :title, goods_nomenclature_title(@heading) %>
 <% content_for :head do %>
   <meta name="description" content="<%= @heading %>">

--- a/spec/controllers/duty_calculator/steps/base_controller_spec.rb
+++ b/spec/controllers/duty_calculator/steps/base_controller_spec.rb
@@ -60,6 +60,51 @@ RSpec.describe DutyCalculator::Steps::BaseController, :user_session do
     end
   end
 
+  describe 'ActionView::Template::Error rescue_from registration' do
+    it 'is registered as the rescue handler for ActionView::Template::Error' do
+      registered = described_class.rescue_handlers.detect { |klass, _| klass == 'ActionView::Template::Error' }
+
+      expect(registered).not_to be_nil
+    end
+
+    it 'delegates to handle_template_error' do
+      registered = described_class.rescue_handlers.detect { |klass, _| klass == 'ActionView::Template::Error' }
+
+      expect(registered[1]).to eq(:handle_template_error)
+    end
+
+    it 'is positioned before the StandardError handler so it takes priority' do
+      handlers = described_class.rescue_handlers
+      template_error_index = handlers.index { |klass, _| klass == 'ActionView::Template::Error' }
+      standard_error_index = handlers.index { |klass, _| klass == 'StandardError' }
+
+      expect(template_error_index).to be < standard_error_index
+    end
+
+    it 'redirects to sections and does not notify NewRelic when the cause is Faraday::ResourceNotFound' do
+      cause = Faraday::ResourceNotFound.new('commodity not found')
+      exception = double('ActionView::Template::Error', cause: cause)
+      allow(NewRelic::Agent).to receive(:notice_error)
+      allow(controller).to receive(:sections_url).and_return('/sections')
+      allow(controller).to receive(:redirect_to)
+
+      controller.send(:handle_template_error, exception)
+
+      expect(controller).to have_received(:redirect_to).with('/sections', allow_other_host: true)
+      expect(NewRelic::Agent).not_to have_received(:notice_error)
+    end
+
+    it 'delegates to handle_exception when the cause is not Faraday::ResourceNotFound' do
+      cause = RuntimeError.new('something else broke')
+      exception = double('ActionView::Template::Error', cause: cause)
+      allow(controller).to receive(:handle_exception)
+
+      controller.send(:handle_template_error, exception)
+
+      expect(controller).to have_received(:handle_exception).with(exception)
+    end
+  end
+
   describe 'GET #index' do
     subject(:response) { get :index }
 


### PR DESCRIPTION
## Problem

`ActionView::Template::Error` is still surfacing in NewRelic for requests like `/duty-calculator/0702009907/import-date` even though a `rescue_from Faraday::ResourceNotFound` handler was added in #2946.

### Why the previous fix didn't catch it

The previous fix only covered 404s raised **directly** in a controller action or `before_action` callback. On the import-date page the exception is actually raised **inside a view partial**: `_commodity_details.html.erb` calls the `commodity` helper, which calls `CommodityContextService#call` → `Api::Commodity.build` → 404 → `Faraday::ResourceNotFound`.

ActionView wraps that exception in `ActionView::Template::Error` before it reaches the controller's rescue machinery. `ActionView::Template::Error` inherits from `StandardError`, so the existing `rescue_from StandardError` handler matched **first** (Rails checks in definition order, first match wins). That handler (`handle_exception`) re-raises — which exits `rescue_with_handler` before Rails ever gets a chance to inspect the cause chain. `Faraday::ResourceNotFound` was never seen, and the original error continued to surface in NewRelic.

## Fix

Add an explicit `rescue_from ActionView::Template::Error` handler, positioned before the `StandardError` catch-all:

```ruby
rescue_from Faraday::ResourceNotFound, with: :handle_commodity_not_found
rescue_from ActionView::Template::Error, with: :handle_template_error  # new
rescue_from StandardError, with: :handle_exception
```

`handle_template_error` inspects `exception.cause`:
- **`Faraday::ResourceNotFound`** → delegates to `handle_commodity_not_found` (silent redirect to `/sections`, no NewRelic noise)
- **anything else** → delegates to `handle_exception` (existing behaviour, exception is re-raised)
