### PR TITLE
Guard total_amount against nil customs_value on routes that skip that step

### DIFF
--- a/app/models/duty_calculator/user_session.rb
+++ b/app/models/duty_calculator/user_session.rb
@@ -180,6 +180,8 @@ module DutyCalculator
     end
 
     def total_amount
+      return 0 if customs_value.blank?
+
       customs_value.values.map(&:to_f).reduce(:+)
     end
 

--- a/spec/models/duty_calculator/user_session_spec.rb
+++ b/spec/models/duty_calculator/user_session_spec.rb
@@ -91,6 +91,30 @@ RSpec.describe DutyCalculator::UserSession do
     end
   end
 
+  describe '#total_amount' do
+    context 'when customs_value has been set' do
+      subject(:user_session) do
+        build(:duty_calculator_user_session, customs_value: {
+          'monetary_value' => '12000',
+          'shipping_cost' => '1200',
+          'insurance_cost' => '340',
+        })
+      end
+
+      it 'returns the sum of all customs value components' do
+        expect(user_session.total_amount).to eq(13_540.0)
+      end
+    end
+
+    context 'when customs_value has not been set (routes that skip the customs value step)' do
+      subject(:user_session) { build(:duty_calculator_user_session) }
+
+      it 'returns 0' do
+        expect(user_session.total_amount).to eq(0)
+      end
+    end
+  end
+
   describe '#measure_amount' do
     subject(:user_session) { build(:duty_calculator_user_session, measure_amount: { foo: :bar }) }
 


### PR DESCRIPTION
## Problem

On XI routes where no duty is due (e.g. `ni_to_gb_route?`, `eu_to_ni_route?`), the duty calculator skips the customs value step entirely. This left `customs_value` as `nil` in the session, causing an `undefined method 'values' for nil` error when the duty results page called `total_amount`.

## Fix

Add a nil guard to `total_amount` — return `0` when `customs_value` is blank, consistent with the semantics of routes where no customs value is collected.

## Tests

Added two cases to the `UserSession#total_amount` spec:
- when `customs_value` is populated: returns the correct sum
- when `customs_value` is nil (routes that skip the step): returns `0`