### PR TITLE
Use govuk_service_navigation helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,37 +50,18 @@ module ApplicationHelper
            extra_content:
   end
 
-  def govuk_service_navigation_item(active_class: '', &block)
-    base_class_name = 'govuk-service-navigation__item'
-    active_class_name = active_class.present? ? "#{base_class_name}--active" : ''
+  def service_navigation_active_when(*prefixes)
+    normalized_prefixes = prefixes.flatten.compact.filter_map do |prefix|
+      cleaned_prefix = prefix.to_s.sub(%r{\A/}, '')
+      Regexp.escape(cleaned_prefix) if cleaned_prefix.present?
+    end
 
-    tag.li(class: "#{base_class_name} #{active_class_name}", &block)
-  end
-
-  def search_active_class
-    'active' if action_name == 'search' ||
-      (controller_name == 'sections' && action_name == 'index') ||
-      controller_name == 'find_commodities'
-  end
-
-  def browse_active_class
-    'active' if controller_name == 'browse_sections'
-  end
-
-  def a_z_active_class
-    'active' if controller_name == 'search_references'
-  end
-
-  def tools_active_class
-    'active' if action_name == 'tools'
-  end
-
-  def help_active_class
-    'active' if %w[help howto].include?(action_name)
-  end
-
-  def updates_active_class
-    'active' if controller_name == 'news_items'
+    # if prefix is news this regex will match:
+    # /news
+    # /xi/news
+    # /uk/news
+    # /news/anything-else
+    %r{\A/(?:(?:xi|uk)/)?(?:#{normalized_prefixes.join('|')})}
   end
 
   def currency_options

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -13,42 +13,21 @@
 <% end %>
 
 <% content_for :service_navigation do %>
-  <section class="govuk-service-navigation" data-module="govuk-service-navigation" aria-label="Service">
-    <div class="govuk-width-container">
-      <div class="govuk-service-navigation__container">
-        <span class="govuk-service-navigation__service-name">
-          <a href="<%= home_path %>" class="govuk-service-navigation__link" id="proposition-name">
-            <%= trade_tariff_heading %>
-          </a>
-        </span>
-        <nav aria-label="Top Level Navigation" class="govuk-service-navigation__wrapper">
-          <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="proposition-links" hidden>
-            Menu
-          </button>
-          <ul id="proposition-links" class="govuk-service-navigation__list">
-            <%= govuk_service_navigation_item(active_class: search_active_class) do %>
-              <%= govuk_link_to 'Search', home_path, class: "govuk-service-navigation__link" %>
-            <% end %>
-            <%= govuk_service_navigation_item(active_class: browse_active_class) do %>
-              <%= govuk_link_to 'Browse', browse_sections_path, class: "govuk-service-navigation__link" %>
-            <% end %>
-            <%= govuk_service_navigation_item(active_class: a_z_active_class) do %>
-              <%= govuk_link_to "A-Z", a_z_index_path(letter: "a"), class: "govuk-service-navigation__link" %>
-            <% end %>
-            <%= govuk_service_navigation_item(active_class: tools_active_class) do %>
-              <%= govuk_link_to "Tools", tools_path, class: "govuk-service-navigation__link" %>
-            <% end %>
-            <%= govuk_service_navigation_item(active_class: updates_active_class) do %>
-              <%= govuk_link_to "News", news_items_path, class: "govuk-service-navigation__link" %>
-            <% end %>
-            <%= govuk_service_navigation_item(active_class: help_active_class) do %>
-              <%= govuk_link_to "Help", help_path, class: "govuk-service-navigation__link" %>
-            <% end %>
-          </ul>
-        </nav>
-      </div>
-    </div>
-  </section>
+  <%= govuk_service_navigation(
+    service_name: trade_tariff_heading,
+    service_url: home_path,
+    current_path: request.path,
+    aria_label: 'Service',
+    navigation_id: 'proposition-links',
+    navigation_items: [
+      { text: 'Search', href: home_path, active_when: service_navigation_active_when('search', 'find_commodity') },
+      { text: 'Browse', href: browse_sections_path, active_when: service_navigation_active_when('browse') },
+      { text: 'A-Z', href: a_z_index_path(letter: 'a'), active_when: service_navigation_active_when('a-z-index') },
+      { text: 'Tools', href: tools_path, active_when: service_navigation_active_when('tools') },
+      { text: 'News', href: news_items_path, active_when: service_navigation_active_when('news') },
+      { text: 'Help', href: help_path, active_when: service_navigation_active_when('help', 'howto') },
+    ]
+  ) %>
 <% end %>
 
 <% content_for :footer_top do %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -105,126 +105,17 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#search_active_class' do
-    subject { helper.search_active_class }
+  describe '#service_navigation_active_when' do
+    subject(:active_when_pattern) { helper.service_navigation_active_when(*prefixes) }
 
-    before do
-      allow(helper).to receive_messages(controller_name: controller_name, action_name: action)
-    end
+    let(:prefixes) { %w[search find_commodity] }
 
-    context 'with sections page' do
-      let(:controller_name) { 'sections' }
-      let(:action) { 'index' }
-
-      it { is_expected.to eq 'active' }
-    end
-
-    context 'with find_commodity page' do
-      let(:controller_name) { 'find_commodities' }
-      let(:action) { 'show' }
-
-      it { is_expected.to eq 'active' }
-    end
-
-    context 'with search results page' do
-      let(:controller_name) { 'search' }
-      let(:action) { 'search' }
-
-      it { is_expected.to eq 'active' }
-    end
-
-    context 'with another page' do
-      let(:controller_name) { 'browse' }
-      let(:action) { 'index' }
-
-      it { is_expected.to be_nil }
-    end
-  end
-
-  describe '#a_z_active_class' do
-    subject { helper.a_z_active_class }
-
-    context 'when controller is search_references' do
-      before { allow(helper).to receive(:controller_name).and_return('search_references') }
-
-      it { is_expected.to eql 'active' }
-    end
-
-    context 'when controller is not tools' do
-      before { allow(helper).to receive(:controller_name).and_return('something') }
-
-      it { is_expected.to be_nil }
-    end
-  end
-
-  describe '#tools_active_class' do
-    subject { helper.tools_active_class }
-
-    context 'when action is tools' do
-      before { allow(helper).to receive(:action_name).and_return('tools') }
-
-      it { is_expected.to eql 'active' }
-    end
-
-    context 'when action is not tools' do
-      before { allow(helper).to receive(:action_name).and_return('something') }
-
-      it { is_expected.to be_nil }
-    end
-  end
-
-  describe '#help_active_class' do
-    subject { helper.help_active_class }
-
-    context 'when action is help' do
-      before { allow(helper).to receive(:action_name).and_return('help') }
-
-      it { is_expected.to eql 'active' }
-    end
-
-    context 'when action is howto' do
-      before { allow(helper).to receive(:action_name).and_return('howto') }
-
-      it { is_expected.to eql 'active' }
-    end
-
-    context 'when action is not help' do
-      before { allow(helper).to receive(:action_name).and_return('something') }
-
-      it { is_expected.to be_nil }
-    end
-  end
-
-  describe '#browse_active_class' do
-    subject { helper.browse_active_class }
-
-    context 'with browse controller' do
-      before { allow(helper).to receive(:controller_name).and_return 'browse_sections' }
-
-      it { is_expected.to eql 'active' }
-    end
-
-    context 'with other controller' do
-      before { allow(helper).to receive(:controller_name).and_return 'search' }
-
-      it { is_expected.to be_nil }
-    end
-  end
-
-  describe '#updates_active_class' do
-    subject { helper.updates_active_class }
-
-    context 'with news_items controller' do
-      before { allow(helper).to receive(:controller_name).and_return 'news_items' }
-
-      it { is_expected.to eql 'active' }
-    end
-
-    context 'with other controller' do
-      before { allow(helper).to receive(:controller_name).and_return 'search' }
-
-      it { is_expected.to be_nil }
-    end
+    it { expect(active_when_pattern).to be_a(Regexp) }
+    it { expect(active_when_pattern).to match('/search') }
+    it { expect(active_when_pattern).to match('/find_commodity') }
+    it { expect(active_when_pattern).to match('/xi/search') }
+    it { expect(active_when_pattern).to match('/uk/find_commodity') }
+    it { expect(active_when_pattern).not_to match('/browse') }
   end
 
   describe '#page_header' do


### PR DESCRIPTION
### What?

Updated service navigation to use [govuk_service_navigation](https://govuk-components.x-govuk.org/components/service-navigation/) helper.
The matching for when to apply the active class has been updated to use a new service_navigation_active_when method.

