### PR TITLE
OTTIMP-533/OTTIMP-534 Use summary cards on mobile

### DIFF
--- a/app/views/myott/commodity_changes/classification.html.erb
+++ b/app/views/myott/commodity_changes/classification.html.erb
@@ -36,7 +36,8 @@
       <h2 class="govuk-heading-m">Total commodities affected: <%= @change.count %></h2>
 
       <% if @change.count.positive? %>
-        <table class="govuk-table">
+        <!-- Desktop table -->
+        <table class="govuk-table myott-mycommodities__responsive-table">
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th class="govuk-table__header">Commodity</th>
@@ -60,6 +61,41 @@
             <% end %>
           </tbody>
         </table>
+
+        <!-- Mobile cards -->
+        <div class="myott-mycommodities__responsive-mobile-cards">
+          <% @change.tariff_changes.each do |change| %>
+            <div class="govuk-summary-card">
+              <div class="govuk-summary-card__title-wrapper">
+                <h3 class="govuk-summary-card__title">
+                  Commodity: <%= change.goods_nomenclature_item_id %>
+                </h3>
+              </div>
+
+              <div class="govuk-summary-card__content">
+                <dl class="govuk-summary-list">
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      New classification
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      <%= sanitize change.classification_description %>
+                    </dd>
+                  </div>
+
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      Date of effect
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      <%= change.date_of_effect %>
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+          <% end %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/myott/commodity_changes/ending.html.erb
+++ b/app/views/myott/commodity_changes/ending.html.erb
@@ -38,7 +38,8 @@
       <h2 class="govuk-heading-m">Total commodities affected: <%= @change.count %></h2>
 
       <% if @change.count.positive? %>
-        <table class="govuk-table">
+        <!-- Desktop table -->
+        <table class="govuk-table myott-mycommodities__responsive-table">
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th class="govuk-table__header">Commodity</th>
@@ -62,6 +63,41 @@
             <% end %>
           </tbody>
         </table>
+
+        <!-- Mobile cards -->
+        <div class="myott-mycommodities__responsive-mobile-cards">
+          <% @change.tariff_changes.each do |change| %>
+            <div class="govuk-summary-card">
+              <div class="govuk-summary-card__title-wrapper">
+                <h3 class="govuk-summary-card__title">
+                  Commodity: <%= change.goods_nomenclature_item_id %>
+                </h3>
+              </div>
+
+              <div class="govuk-summary-card__content">
+                <dl class="govuk-summary-list">
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      Classification
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      <%= sanitize change.classification_description %>
+                    </dd>
+                  </div>
+
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      New end date
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      <%= change.date_of_effect %>
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+          <% end %>
+        </div>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
### Jira link

[OTTIMP-533](https://transformuk.atlassian.net/browse/OTTIMP-533)
[OTTIMP-534](https://transformuk.atlassian.net/browse/OTTIMP-534)

### What?
When a user has a my commodities subscription they can view the commodities that are changing in a table. This change uses summary cards instead when these pages are being viewed on mobile.

### Why?
Some descriptions are very long and therefore the table is required to be wide to show all the content.
On mobile, this required horizontal scrolling, which is a UX challenge.

### Screenshots
| Ending | Classification |
| ------- | ------------- |
| <img width="586" height="677" alt="Screenshot 2026-05-08 at 10 09 44" src="https://github.com/user-attachments/assets/e335b859-8233-4dbe-9415-9f10627e99b4" /> | <img width="583" height="730" alt="Screenshot 2026-05-08 at 10 15 03" src="https://github.com/user-attachments/assets/84427174-6b11-4ac9-a535-56c2f18178c9" /> |


