### PR TITLE
HMRC-2209: Bump ECS service tf module 

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -49,8 +49,8 @@ Terraform to deploy the service into AWS.
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Smallest number of tasks the service can scale-in to. | `number` | `1` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
-| <a name="input_scale_in_cooldown"></a> [scale\_in\_cooldown](#input\_scale\_in\_cooldown) | Prevents aggressive scale-in by enforcing a waiting period after tasks are removed. | `number` | n/a | yes |
-| <a name="input_scale_out_cooldown"></a> [scale\_out\_cooldown](#input\_scale\_out\_cooldown) | Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity. | `number` | n/a | yes |
+| <a name="input_scale_in_cooldown"></a> [scale\_in\_cooldown](#input\_scale\_in\_cooldown) | Prevents aggressive scale-in by enforcing a waiting period after tasks are removed. | `number` | `300` | no |
+| <a name="input_scale_out_cooldown"></a> [scale\_out\_cooldown](#input\_scale\_out\_cooldown) | Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity. | `number` | `60` | no |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | `2` | no |
 
 ## Outputs

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,7 +19,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v2.0.1 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
 
 ## Resources
 
@@ -49,6 +49,8 @@ Terraform to deploy the service into AWS.
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Smallest number of tasks the service can scale-in to. | `number` | `1` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
+| <a name="input_scale_in_cooldown"></a> [scale\_in\_cooldown](#input\_scale\_in\_cooldown) | Prevents aggressive scale-in by enforcing a waiting period after tasks are removed. | `number` | n/a | yes |
+| <a name="input_scale_out_cooldown"></a> [scale\_out\_cooldown](#input\_scale\_out\_cooldown) | Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity. | `number` | n/a | yes |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | `2` | no |
 
 ## Outputs

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -5,3 +5,7 @@ memory        = 4096
 service_count = 4
 min_capacity  = 3
 max_capacity  = 16
+
+# Temporarily pinned autoscaling cooldown values in Production to preserve existing behaviour while testing changes in dev and staging
+scale_in_cooldown  = 0
+scale_out_cooldown = 0

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v2.0.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.0.1"
 
   region = var.region
 
@@ -27,9 +27,11 @@ module "service" {
 
   service_environment_config = local.frontend_service_env_vars
 
-  has_autoscaler = local.has_autoscaler
-  min_capacity   = var.min_capacity
-  max_capacity   = var.max_capacity
+  has_autoscaler     = local.has_autoscaler
+  min_capacity       = var.min_capacity
+  max_capacity       = var.max_capacity
+  scale_in_cooldown  = var.scale_in_cooldown
+  scale_out_cooldown = var.scale_out_cooldown
 
   autoscaling_metrics = {
     cpu = {
@@ -43,7 +45,7 @@ module "service" {
   }
 
   enable_alarms       = var.enable_alarms
-  cpu_alarm_threshold = 70
+  cpu_alarm_threshold = 85
 
   sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -46,3 +46,13 @@ variable "enable_alarms" {
   type        = bool
   default     = true
 }
+
+variable "scale_in_cooldown" {
+  description = "Prevents aggressive scale-in by enforcing a waiting period after tasks are removed."
+  type        = number
+}
+
+variable "scale_out_cooldown" {
+  description = "Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity."
+  type        = number
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -50,9 +50,11 @@ variable "enable_alarms" {
 variable "scale_in_cooldown" {
   description = "Prevents aggressive scale-in by enforcing a waiting period after tasks are removed."
   type        = number
+  default     = 300
 }
 
 variable "scale_out_cooldown" {
   description = "Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity."
   type        = number
+  default     = 60
 }


### PR DESCRIPTION
### Jira link

[HMRC-2209](https://transformuk.atlassian.net/browse/HMRC-2209)

### What?

I have
- Updated ECS service terraform module version from 2.0.1 to 3.0.1
- Explicitly pin ECS autoscaling settings in prod to current values

- Temporarily increase cpu_alarm_threshold from 70 to 85.


### Why?

I am doing this because...

- This ensures there is no behaviour change in production following the ECS module upgrade.
- Current prod autoscaling uses a CPU target of 50% with zero scale-in and scale-out cooldowns; Configurable cooldowns are introduced to stabilise scaling behaviour and avoid unnecessary churn.

- This temporary adjustment reduces alert noise while we evaluate and determine the appropriate long-term threshold values.

Ref
[HMRC-1766: Configure scaling policies](https://github.com/trade-tariff/trade-tariff-platform-terraform-modules/pull/84)


Deployment risk
🟠 Medium – infrastructure configuration changes affecting autoscaling logic.

Reason for rating:
This change modifies Terraform autoscaling logic and resource creation conditions. While production behaviour is explicitly preserved and changes are first applied to non-production environments, the work alters infrastructure behaviour and requires team awareness 

