### PR TITLE
Use govuk-tag

### DIFF
--- a/app/assets/stylesheets/src/_commodity-codes.scss
+++ b/app/assets/stylesheets/src/_commodity-codes.scss
@@ -61,11 +61,6 @@
   }
 }
 
-.govuk-tag--green--wide {
-  @extend .govuk-tag--green;
-  max-width: 100%;
-}
-
 .search-results .commodity-code .code-text + .code-text {
   margin-left: 2px;
 }

--- a/app/assets/stylesheets/src/_govuk-frontend-extensions.scss
+++ b/app/assets/stylesheets/src/_govuk-frontend-extensions.scss
@@ -4,3 +4,9 @@
 .govuk-div--with-border {
   border: 1px solid  govuk-functional-colour(border)
 }
+
+.govuk-tag {
+  &--wide {
+    max-width: none;
+  }
+}

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -20,9 +20,7 @@
 
   <%= render 'shared/context_tables/commodity' %>
 
-  <strong class="govuk-tag govuk-tag--green--wide">
-    You are currently using the <%= service_name %>
-  </strong>
+  <%= govuk_tag(text: "You are currently using the #{service_name}", colour: 'green', classes: 'govuk-tag--wide') %>
 
   <p class="govuk-body govuk-!-margin-top-6">
     Use this page to find:


### PR DESCRIPTION
## What:
Use govuk-tag helper.
Moved `--wide` CSS class modifier to govuk-frontend_extensions.

## Why:
Standardising the use of gov uk helpers.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
Replacing like for like
