### PR TITLE
Fix use of visually hidden text in new tab links

### DIFF
--- a/app/views/duty_calculator/steps/customs_value/show.html.erb
+++ b/app/views/duty_calculator/steps/customs_value/show.html.erb
@@ -13,7 +13,7 @@
     <%= govuk_link_to(
       'How to calculate the customs value of your goods.',
       'https://www.gov.uk/government/publications/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics',
-      new_tab: govuk_visually_hidden('opens in new tab')
+      new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text
     ) %>
   </p>
   <%= f.govuk_text_field :monetary_value, width: 'one-quarter', label: { text: 'What is the value in GBP of the goods being imported?', class: 'govuk-label govuk-label--s' }, prefix_text: '£' %>

--- a/app/views/green_lanes/applicable_exemptions/_form.html.erb
+++ b/app/views/green_lanes/applicable_exemptions/_form.html.erb
@@ -26,7 +26,7 @@
           <% if category_assessment.regulation_url.present? %>
           <p>
             <%= govuk_link_to 'View Regulation document',
-                        category_assessment.regulation_url, new_tab: govuk_visually_hidden('opens in new tab')
+                        category_assessment.regulation_url, new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text
             %>
           </p>
           <% end %>

--- a/app/views/green_lanes/category_assessments/_category.html.erb
+++ b/app/views/green_lanes/category_assessments/_category.html.erb
@@ -34,7 +34,7 @@
     <p><%= category.regulation.description %></p>
     <% if category.regulation.regulation_url.present? %>
     <p>
-      <%= govuk_link_to 'Further information', category.regulation.regulation_url, new_tab: govuk_visually_hidden('opens in new tab') %>
+      <%= govuk_link_to 'Further information', category.regulation.regulation_url, new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %>
     </p>
     <% end %>
   </div>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -65,7 +65,7 @@
       <%= render "footnotes/critical_warning", footnote: footnote %>
     <% end %>
 
-    <p>The commodity code for exporting and <%= govuk_link_to 'Intrastat reporting', 'https://www.gov.uk/intrastat', new_tab: govuk_visually_hidden("opens in new tab") %> is <%= declarable.display_export_code %>.</p>
+    <p>The commodity code for exporting and <%= govuk_link_to 'Intrastat reporting', 'https://www.gov.uk/intrastat', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %> is <%= declarable.display_export_code %>.</p>
 
     <%= render 'declarables/consigned', declarable: declarable %>
 

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -61,7 +61,7 @@
     </ol>
 
     <h2 class="govuk-heading-s" id="leave-feedback">Leave feedback</h2>
-    <p><%= govuk_link_to 'Leave feedback or suggestions for improvements to this service.', feedback_link_url, new_tab: govuk_visually_hidden('opens in new tab') %></p>
+    <p><%= govuk_link_to 'Leave feedback or suggestions for improvements to this service.', feedback_link_url, new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %></p>
 
     <h2 class="govuk-heading-s" id="getting-help">Getting help from HMRC if you need to find a commodity code</h2>
     <p>If you <%= govuk_link_to 'cannot find the right commodity code for your goods', help_find_commodity_path %>, you can contact HMRC for advice or for a decision on your goods.</p>

--- a/app/views/pages/help_find_commodity.html.erb
+++ b/app/views/pages/help_find_commodity.html.erb
@@ -22,7 +22,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Informal advice</h2>
-    <p>You can <%= govuk_link_to "use HMRC's Tariff Classification Service", "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods", new_tab: govuk_visually_hidden("opens in new tab") %> to get non-legally binding classification advice.</p>
+    <p>You can <%= govuk_link_to "use HMRC's Tariff Classification Service", "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods", new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %> to get non-legally binding classification advice.</p>
     <p>HMRC will try to respond to your email within 5 working days.</p>
 
     <div class="govuk-inset-text">

--- a/app/views/pages/howtos/_commodity-codes.html.erb
+++ b/app/views/pages/howtos/_commodity-codes.html.erb
@@ -115,7 +115,7 @@
 
 <p>The classification process takes account of the characteristics using a series of six legally binding rules, known as the General Interpretative Rules (GIRs), which were set down by the World Customs Organisation (WCO) and are applied by its member countries.</p>
 
-<p>Read the <%= govuk_link_to 'full text of the General Interpretative Rules rules', 'https://www.wcoomd.org/-/media/wco/public/global/pdf/topics/nomenclature/instruments-and-tools/hs-interpretation-general-rules/0001_2012e_gir.pdf?la=en', new_tab: govuk_visually_hidden('opens in new tab') %>, with a simple description of what they do.</p>
+<p>Read the <%= govuk_link_to 'full text of the General Interpretative Rules rules', 'https://www.wcoomd.org/-/media/wco/public/global/pdf/topics/nomenclature/instruments-and-tools/hs-interpretation-general-rules/0001_2012e_gir.pdf?la=en', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %>, with a simple description of what they do.</p>
 
 <p>As most types of goods have been classified before and many are referred to within the text of the tariff and its notes, the right codes can often be identified using the search function on this service. Although you should always check associated notes and rules to ensure you are content that the proposed classification is correct, this aims to help you through this process by using knowledge and tips from HMRC's classification experts to direct you based on the search terms you have used.</p>
 

--- a/app/views/pages/howtos/_trade-remedies.html.erb
+++ b/app/views/pages/howtos/_trade-remedies.html.erb
@@ -40,7 +40,7 @@
 
 <h2 class="govuk-heading-m" id="usage">How does the UK apply trade remedies?</h2>
 
-<p>In the UK, trade remedies investigations are conducted by the Trade Remedies Authority. The <%= govuk_link_to 'Trade Remedies Service', 'https://www.trade-remedies.service.gov.uk', new_tab: govuk_visually_hidden('opens in new tab') %> allows UK companies to participate in ongoing trade remedies cases and request new reviews.</p>
+<p>In the UK, trade remedies investigations are conducted by the Trade Remedies Authority. The <%= govuk_link_to 'Trade Remedies Service', 'https://www.trade-remedies.service.gov.uk', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %> allows UK companies to participate in ongoing trade remedies cases and request new reviews.</p>
 
 <h2 class="govuk-heading-m" id="impact">How do trade remedies impact UK importers?</h2>
 

--- a/app/views/sections/_stw_information.html.erb
+++ b/app/views/sections/_stw_information.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-m">Advance tariff rulings</h2>
   <p class="govuk-body">
     For more help in classifying your commodity, you can
-    <%= govuk_link_to('search for advance tariff rulings', 'https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search', new_tab: govuk_visually_hidden('opens in new tab')) %>
+    <%= govuk_link_to('search for advance tariff rulings', 'https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>
   </p>
   <p class="govuk-body">
     Advance tariff rulings allow you to get a legally binding decision on the
@@ -11,11 +11,11 @@
 
   <p class="govuk-body">
     Find out more about
-    <%= govuk_link_to('advance tariff rulings', 'https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling', new_tab: govuk_visually_hidden('opens in new tab')) %>.
+    <%= govuk_link_to('advance tariff rulings', 'https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>.
   </p>
 
   <p class="govuk-body">
-    <%= govuk_link_to('Contact HMRC if you need help finding the right commodity code for your goods', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', new_tab: govuk_visually_hidden('opens in new tab')) %>.
+    <%= govuk_link_to('Contact HMRC if you need help finding the right commodity code for your goods', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>.
   </p>
 </div>
 
@@ -24,7 +24,7 @@
 
   <p class="govuk-body">
     Use the
-    '<%= govuk_link_to('Check how to import or export goods', 'https://www.gov.uk/check-how-to-import-export', new_tab: govuk_visually_hidden('opens in new tab')) %>'
+    '<%= govuk_link_to('Check how to import or export goods', 'https://www.gov.uk/check-how-to-import-export', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>'
     service to get information about importing and exporting, including:
   </p>
 


### PR DESCRIPTION
## What:
govuk_link_to helper has a new_tab argument. According to https://govuk-components.x-govuk.org/helpers/link/#links-that-open-in-a-new-tab you can pass a `govuk_visually_hidden` call to add visually hidden text, but in fact the resulting HTML is treated like a string.
The fix is to set the new_tab argument to "" so the link opens in a new tab and then the visually hidden (opens in new tab) text is added with the use of `visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text`

## Why:
Fixes a bug caused by https://github.com/trade-tariff/trade-tariff-frontend/pull/2955

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Just changes text of some links
