### PR TITLE
HMRC:-2200: Handle expired commodities in duty calculator

### DIFF
--- a/app/controllers/duty_calculator/steps/import_date_controller.rb
+++ b/app/controllers/duty_calculator/steps/import_date_controller.rb
@@ -9,8 +9,12 @@ module DutyCalculator
 
       def create
         @step = Steps::ImportDate.new(permitted_params)
+        validate_commodity_validity! if @step.valid?
 
         validate(@step)
+      rescue Faraday::ResourceNotFound
+        add_commodity_unavailable_error
+        render 'show'
       end
 
       private
@@ -36,6 +40,21 @@ module DutyCalculator
         user_session.commodity_source = TradeTariffFrontend::ServiceChooser.service_name
         user_session.referred_service = TradeTariffFrontend::ServiceChooser.service_name
         user_session.import_date = @step.import_date.strftime('%Y-%m-%d')
+      end
+
+      def validate_commodity_validity!
+        Commodity.find(commodity_code, as_of: @step.import_date)
+      end
+
+      def add_commodity_unavailable_error
+        @commodity_validity_periods = fetch_validity_periods
+        @step.errors.add(:import_date, :commodity_not_available_on_date)
+      end
+
+      def fetch_validity_periods
+        ValidityPeriod.all(Commodity, commodity_code, as_of: @step.import_date)
+      rescue Faraday::ResourceNotFound
+        []
       end
 
       def day

--- a/app/views/duty_calculator/steps/import_date/show.html.erb
+++ b/app/views/duty_calculator/steps/import_date/show.html.erb
@@ -8,6 +8,22 @@
     hint: { text: 'As duties and quotas change over time, it may be important to enter the date you think your goods your goods will be imported.<br>
       Enter a date from 1 January 2021, or later.<br>
       Use the format day, month, year. For example, 27 3 2021.'.html_safe } %>
+  <% if @commodity_validity_periods.present? %>
+    <p class="govuk-body">
+      This commodity code is available for these periods:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <% @commodity_validity_periods.each do |period| %>
+        <li>
+          <% if period.end_date.present? %>
+            From <%= period.start_date.to_formatted_s(:long) %> to <%= period.end_date.to_formatted_s(:long) %>
+          <% else %>
+            From <%= period.start_date.to_formatted_s(:long) %> onwards
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
   <%= f.govuk_submit %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -359,6 +359,7 @@ en:
           attributes:
             import_date:
               invalid_date: Enter a valid date, no earlier than 1st January 2021
+              commodity_not_available_on_date: The commodity code could not be found for this date. Enter a different date.
         duty_calculator/steps/import_destination:
           attributes:
             import_destination:

--- a/spec/controllers/duty_calculator/steps/import_date_controller_spec.rb
+++ b/spec/controllers/duty_calculator/steps/import_date_controller_spec.rb
@@ -127,13 +127,23 @@ RSpec.describe DutyCalculator::Steps::ImportDateController, :user_session do
       it { expect(response).to render_template('import_date/show') }
       it { expect { response }.not_to change(user_session, :import_date).from(nil) }
 
-      it 'adds a date error with validity periods' do
+      it 'adds a date error' do
         response
 
         expect(assigns(:step).errors[:import_date]).to include(
           'The commodity code could not be found for this date. Enter a different date.',
         )
+      end
+
+      it 'assigns validity period start dates' do
+        response
+
         expect(assigns(:commodity_validity_periods).map(&:start_date)).to eq([first_start_date, second_start_date])
+      end
+
+      it 'assigns validity period end dates' do
+        response
+
         expect(assigns(:commodity_validity_periods).map(&:end_date)).to eq([first_end_date, nil])
       end
     end

--- a/spec/controllers/duty_calculator/steps/import_date_controller_spec.rb
+++ b/spec/controllers/duty_calculator/steps/import_date_controller_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe DutyCalculator::Steps::ImportDateController, :user_session do
   let(:user_session) { build(:duty_calculator_user_session, :with_country_of_origin, commodity_source: nil) }
   let(:commodity_code) { '01234567890' }
+  let(:commodity) { attributes_for(:commodity, goods_nomenclature_item_id: commodity_code) }
 
   include_context 'with UK service'
 
@@ -60,6 +61,12 @@ RSpec.describe DutyCalculator::Steps::ImportDateController, :user_session do
       let(:month) { now.month }
       let(:day) { now.day }
 
+      before do
+        stub_api_request("commodities/#{commodity_code}")
+          .with(query: { as_of: now })
+          .to_return(jsonapi_response(:commodity, commodity))
+      end
+
       it 'assigns the correct step' do
         response
         expect(assigns[:step]).to be_a(DutyCalculator::Steps::ImportDate)
@@ -81,6 +88,54 @@ RSpec.describe DutyCalculator::Steps::ImportDateController, :user_session do
 
       it { is_expected.to have_http_status(:ok) }
       it { expect { response }.not_to change(user_session, :import_date).from(nil) }
+    end
+
+    context 'when the selected date is invalid for the commodity and validity periods are available' do
+      let(:year) { now.year }
+      let(:month) { now.month }
+      let(:day) { now.day }
+      let(:first_start_date) { Date.new(2024, 1, 1) }
+      let(:first_end_date) { Date.new(2024, 12, 31) }
+      let(:second_start_date) { Date.new(2025, 1, 1) }
+      let(:validity_periods) do
+        [
+          attributes_for(
+            :validity_period,
+            goods_nomenclature_item_id: commodity_code,
+            validity_start_date: first_start_date,
+            validity_end_date: first_end_date,
+          ),
+          attributes_for(
+            :validity_period,
+            goods_nomenclature_item_id: commodity_code,
+            validity_start_date: second_start_date,
+            validity_end_date: nil,
+          ),
+        ]
+      end
+
+      before do
+        stub_api_request("commodities/#{commodity_code}")
+          .with(query: { as_of: now })
+          .to_return(jsonapi_error_response(404))
+        stub_api_request("commodities/#{commodity_code}/validity_periods")
+          .with(query: { as_of: now })
+          .to_return(jsonapi_response(:validity_periods, validity_periods))
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response).to render_template('import_date/show') }
+      it { expect { response }.not_to change(user_session, :import_date).from(nil) }
+
+      it 'adds a date error with validity periods' do
+        response
+
+        expect(assigns(:step).errors[:import_date]).to include(
+          'The commodity code could not be found for this date. Enter a different date.',
+        )
+        expect(assigns(:commodity_validity_periods).map(&:start_date)).to eq([first_start_date, second_start_date])
+        expect(assigns(:commodity_validity_periods).map(&:end_date)).to eq([first_end_date, nil])
+      end
     end
   end
 end


### PR DESCRIPTION
## What:
Added the same commodity validity-period fallback pattern to `DutyCalculator::Steps::ImportDateController`, aligned with `CommoditiesController`

## Why:
Traders should see a clear validation message when their selected import date is outside the commodity's valid date range, rather than the duty calculator failing

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2200

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Fixing an existing bug

<img width="1512" height="762" alt="Screenshot 2026-05-11 at 11 37 25" src="https://github.com/user-attachments/assets/9a7dc789-4519-4ce6-ac1e-ed1b275bdbbd" />


───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────

- Copy or content changes to GOV.UK Frontend components (labels, hint text, page titles)
- Adding or updating GOV.UK Design System components with no behaviour change
- New tests or improved test coverage with no production code changes
- Dependency bumps with no API changes (minor/patch gems, npm packages)
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- Terraform formatting or variable renaming with no resource recreation
- Static asset changes (images, fonts, stylesheets) with no layout impact

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────

- Changes to page layout or navigation that affect all or many user journeys
- Modifications to how commodity data or tariff information is presented to traders
- New or modified API calls to the backend or admin services
- Adding or changing feature flags that affect live user journeys
- Changes to error pages, accessibility markup, or GOV.UK service header/footer
- Search UI changes (autocomplete behaviour, result rendering, filter logic)
- Significant Sass/CSS changes that could affect rendering across browsers or screen sizes
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- Removing or deprecating a route, controller action, or view partial still in use elsewhere

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────

- Changes to how legally significant content is surfaced (trade remedies, prohibitions, licensing, sanctions)
- Modifications to the declarable goods flow or any trader-facing regulatory journey
- Any change to how the service integrates with the identity/authentication layer
- Changes to production AWS infrastructure that cannot be easily rolled back
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Significant architectural shifts (e.g. new service boundaries, caching topology changes)
- Changes that affect GOV.UK service compliance, accessibility standards (WCAG 2.2 AA), or government design system conformance
