### PR TITLE
BAU: Label deployment PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,3 +4,4 @@ needs-deployment:
     - any-glob-to-any-file:
       - "db/**"
       - "Dockerfile"
+      - "terraform/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+# Add "needs-deployment" label to pull requests that should be deployed
+needs-deployment:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "db/**"
+      - "Dockerfile"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "Label PRs"
+
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v6


### PR DESCRIPTION
## What:

- Add `needs-deployment` PR labelling for root `Dockerfile` changes.
- Add `needs-deployment` PR labelling for recursive `db/` changes.
- Add `needs-deployment` PR labelling for recursive `terraform/` changes.

## Why:

PRs that change the deployed image, database files, or app Terraform should request a development deployment automatically.

## Ticket:

BAU

## Risk:

**Risk level:** Green

**Reason for rating:**

CI label configuration only. This changes when a deployment label is applied to PRs, not application runtime behaviour.
