### PR TITLE
Fix feedback button

### DIFF
--- a/app/assets/stylesheets/src/_feedback_useful_banner.scss
+++ b/app/assets/stylesheets/src/_feedback_useful_banner.scss
@@ -6,6 +6,7 @@
     background-color: govuk-colour("black", $variant: "tint-95");
     border-bottom: 1px solid govuk-functional-colour(border);
     padding: govuk-spacing(4);
+    margin: 0;
     // Reapply footer meta flex layout (normally scoped under .govuk-footer)
     display: flex;
     flex-wrap: wrap;
@@ -30,16 +31,16 @@
       min-width: 6em;
     }
   }
-}
 
-@include govuk-media-query($until: tablet) {
-  .feedback-useful-banner__inner {
-    flex-direction: column;
-    align-items: stretch;
+  @include govuk-media-query($until: tablet) {
+    &__inner {
+      flex-direction: column;
+      align-items: stretch;
 
-    .govuk-footer__meta-item .govuk-button {
-      width: 100%;
-      min-width: 0;
+      .govuk-footer__meta-item .govuk-button {
+        width: 100%;
+        min-width: 0;
+      }
     }
   }
 }

--- a/app/views/myott/subscriptions/index.html.erb
+++ b/app/views/myott/subscriptions/index.html.erb
@@ -1,11 +1,9 @@
 <% myott_page_title "Your tariff watch lists" %>
 
-<div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Your tariff watch lists</h1>
     <p class="govuk-body"><strong>Email address:</strong> <%= @current_user.email %></p>
   </div>
-
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
@@ -38,4 +36,3 @@
       </div>
     </div>
   </div>
-</div>

--- a/app/views/myott/subscriptions/start.html.erb
+++ b/app/views/myott/subscriptions/start.html.erb
@@ -41,8 +41,6 @@
       change your preferences or unsubscribe from all emails.
     </p>
 
-    <a href="<%= @continue_url %>" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-      Continue
-    </a>
+    <%= govuk_button_link_to 'Continue', @continue_url, secondary: true %>
   </div>
 </div>

--- a/app/views/shared/_feedback_useful_banner.html.erb
+++ b/app/views/shared/_feedback_useful_banner.html.erb
@@ -5,7 +5,7 @@
       <p class="govuk-body govuk-!-margin-bottom-0">Tell us about your experience using this service to help us improve it.</p>
     </div>
     <div class="govuk-footer__meta-item">
-      <%= govuk_link_to 'Share your feedback', feedback_link_url, class: 'govuk-button--secondary', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %>
+      <%= govuk_button_link_to 'Share your feedback', feedback_link_url, secondary: true, **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_interactive_feedback_useful_banner.html.erb
+++ b/app/views/shared/_interactive_feedback_useful_banner.html.erb
@@ -6,7 +6,7 @@
         <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Give feedback about this service</h2>
         <p class="govuk-body govuk-!-margin-bottom-0">Tell us about your experience using this service to help us improve it.</p>
       </div>
-      <%= govuk_link_to 'Share your feedback', feedback_link_url, class: 'app-feedback-useful-banner__button', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %>
+      <%= govuk_button_link_to 'Share your feedback', feedback_link_url, class: 'app-feedback-useful-banner__button', **(subscriptions_page? ? {} : { target: '_blank', rel: 'noopener' }) %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## What:
- Fix share feedback link to render as a button again
- Remove margin so the background does not extend beyond the top border
- Narrow watch list cards on MyOTT page so they fit with other components
- Use govuk_button_to on MyOTT start page

| Before | After |
| ------ | ----- |
| <img width="1069" height="717" alt="Screenshot 2026-05-12 at 11 08 55" src="https://github.com/user-attachments/assets/e10d3e22-6b00-489d-b67c-d5215a3e7d24" /> | <img width="1055" height="727" alt="Screenshot 2026-05-12 at 11 09 02" src="https://github.com/user-attachments/assets/f60abc60-ba5b-4ff2-9a8f-5b24d3d38d23" /> |

## Why:
Changes to make use of gov uk link helpers caused a regression in how the share feedback button is rendered. The other changes are for consistency

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Fixes display regression and other minor display changes