### PR TITLE
OTTIMP-540 Add Developer Portal to Tools page

### DIFF
--- a/app/assets/stylesheets/src/_cards.scss
+++ b/app/assets/stylesheets/src/_cards.scss
@@ -29,6 +29,10 @@
   margin: 0 govuk-spacing(6) govuk-spacing(2) 0;
 }
 
+.gem-c-cards__status {
+  margin-bottom: govuk-spacing(2);
+}
+
 .gem-c-cards__link {
   &::after {
     bottom: 0;

--- a/app/assets/stylesheets/src/_colors.scss
+++ b/app/assets/stylesheets/src/_colors.scss
@@ -3,7 +3,7 @@ $chapter-code-bg: #d1d2e6;
 $heading-code-bg: #b3d9ee;
 $commodity-code-bg: #abeae5;
 $table-header-bg: #e1e8e8;
-$table-sub-border: govuk-colour("black", $variant: "tint-95");
+$table-sub-border: govuk-tint(govuk-colour("black"), 95%);
 
 $tariff-inset-background-color-meursing: #e9f4f9;
 $tariff-inset-border-left-color-meursing: #098dc1;

--- a/app/assets/stylesheets/src/_downloadable-document.scss
+++ b/app/assets/stylesheets/src/_downloadable-document.scss
@@ -18,7 +18,7 @@
       stroke      : govuk-functional-colour(border);
       margin-right: 0.5em;
       border      : 1px solid govuk-functional-colour(border);
-      box-shadow  : 4px 4px govuk-colour("black", $variant: "tint-25");
+      box-shadow  : 4px 4px govuk-tint(govuk-colour("black"), 25%);
       max-width   : 64px;
       max-height  : 80px;
     }

--- a/app/assets/stylesheets/src/_feedback_banner_beta.scss
+++ b/app/assets/stylesheets/src/_feedback_banner_beta.scss
@@ -1,5 +1,5 @@
 // Modifier for panel: blue left border and light blue background (GOV.UK notice style)
 .panel--feedback {
   border-left-color: govuk-functional-colour(brand);
-  background-color: govuk-colour("blue", $variant: "tint-95");
+  background-color: govuk-tint(govuk-colour("blue"), 95%);
 }

--- a/app/assets/stylesheets/src/_feedback_useful_banner.scss
+++ b/app/assets/stylesheets/src/_feedback_useful_banner.scss
@@ -3,7 +3,7 @@
   border-top: 1px solid govuk-functional-colour(border);
 
   &__inner {
-    background-color: govuk-colour("black", $variant: "tint-95");
+    background-color: govuk-colour("light-grey");
     border-bottom: 1px solid govuk-functional-colour(border);
     padding: govuk-spacing(4);
     // Reapply footer meta flex layout (normally scoped under .govuk-footer)

--- a/app/assets/stylesheets/src/_interactive-search.scss
+++ b/app/assets/stylesheets/src/_interactive-search.scss
@@ -1,5 +1,3 @@
-@use "sass:color";
-
 // Interactive search Q&A styles
 
 .interactive-results .interactive-result {
@@ -49,7 +47,7 @@
 
 // Interactive feedback useful banner - full-width grey banner with blue bottom border
 .app-feedback-useful-banner {
-  background: govuk-colour("black", $variant: "tint-95");
+  background: govuk-tint(govuk-colour("black"), 95%);
   border-bottom: 4px solid govuk-functional-colour(brand);
 
   .app-feedback-useful-banner__content {
@@ -81,7 +79,7 @@
 
     &:hover {
       color: govuk-functional-colour(text);
-      background-color: color.adjust(govuk-colour("black", $variant: "tint-95"), $lightness: -3%);
+      background-color: govuk-tint(govuk-colour("black"), 92%);
     }
   }
 }
@@ -93,7 +91,7 @@
 
 // Devolved nations panel - grey background matching gem-c-devolved-nations
 .app-devolved-nations {
-  background: govuk-colour("black", $variant: "tint-95");
+  background: govuk-tint(govuk-colour("black"), 95%);
   margin-bottom: govuk-spacing(3);
   padding: govuk-spacing(3);
 

--- a/app/assets/stylesheets/src/_panel.scss
+++ b/app/assets/stylesheets/src/_panel.scss
@@ -10,7 +10,7 @@
   }
 
   &--grey {
-    background-color: govuk-colour("black", $variant: "tint-95");
+    background-color: govuk-tint(govuk-colour("black"), 95%);
   }
 
   .govuk-warning-text {

--- a/app/assets/stylesheets/src/_rules_of_origin.scss
+++ b/app/assets/stylesheets/src/_rules_of_origin.scss
@@ -40,7 +40,7 @@
 
 .rules-of-origin-met-message {
   padding: govuk-spacing(3);
-  background-color: govuk-colour("black", $variant: "tint-95");
+  background-color: govuk-tint(govuk-colour("black"), 95%);
   margin-bottom: 2em;
 
   p {

--- a/app/assets/stylesheets/src/_simplified_procedural_values.scss
+++ b/app/assets/stylesheets/src/_simplified_procedural_values.scss
@@ -1,4 +1,4 @@
 .simplified-procedural-values-form {
-  background-color: govuk-colour("black", $variant: "tint-95");
+  background-color: govuk-tint(govuk-colour("black"), 95%);
   padding: govuk-spacing(2);
 }

--- a/app/assets/stylesheets/src/_tariff-breadcrumbs.scss
+++ b/app/assets/stylesheets/src/_tariff-breadcrumbs.scss
@@ -4,7 +4,7 @@
   margin: govuk-spacing(4) 0 govuk-spacing(7) 0;
   @include govuk-clearfix;
 
-  background-color: govuk-colour("black", $variant: "tint-95");
+  background-color: govuk-colour("light-grey");
 
   .full-code {
     width: 171px;

--- a/app/assets/stylesheets/src/_typography.scss
+++ b/app/assets/stylesheets/src/_typography.scss
@@ -23,7 +23,7 @@ blockquote {
   padding: govuk-spacing(2);
   margin-left: 0;
   margin-right: 0;
-  background-color: govuk-colour("black", $variant: "tint-95");
+  background-color: govuk-tint(govuk-colour("black"), 95%);
 }
 
 .tariff-body-subtext {

--- a/app/assets/stylesheets/src/vendor/govuk_publishing_components/print-link.scss
+++ b/app/assets/stylesheets/src/vendor/govuk_publishing_components/print-link.scss
@@ -27,7 +27,7 @@ $gem-c-print-link-background-height: 18px;
   }
 
   &:hover {
-    background-color: govuk-colour("black", $variant: "tint-95");
+    background-color: govuk-tint(govuk-colour("black"), 95%);
   }
 }
 

--- a/app/assets/stylesheets/src/vendor/step-by-step-nav.scss
+++ b/app/assets/stylesheets/src/vendor/step-by-step-nav.scss
@@ -7,7 +7,7 @@ $stroke-width: 2px;
 $stroke-width-large: 3px;
 $number-circle-size: 26px;
 $number-circle-size-large: 35px;
-$top-border: solid 2px govuk-colour("black", $variant: "tint-80");
+$top-border: solid 2px govuk-tint(govuk-colour("black"), 80%);
 
 @mixin step-nav-vertical-line ($line-style: solid) {
   content: "";
@@ -15,7 +15,7 @@ $top-border: solid 2px govuk-colour("black", $variant: "tint-80");
   z-index: 2;
   width: 0;
   height: 100%;
-  border-left: $line-style $stroke-width govuk-colour("black", $variant: "tint-80");
+  border-left: $line-style $stroke-width govuk-tint(govuk-colour("black"), 80%);
   background: govuk-colour("white");
 }
 
@@ -146,7 +146,7 @@ $top-border: solid 2px govuk-colour("black", $variant: "tint-80");
     margin-left: math.div($number-circle-size, 4);
     width: math.div($number-circle-size, 2);
     height: 0;
-    border-bottom: solid $stroke-width govuk-colour("black", $variant: "tint-80");
+    border-bottom: solid $stroke-width govuk-tint(govuk-colour("black"), 80%);
   }
 
   &:after {
@@ -210,7 +210,7 @@ $top-border: solid 2px govuk-colour("black", $variant: "tint-80");
 
 .app-step-nav__circle--number {
   @include step-nav-font(16, $weight: bold, $line-height: 23px);
-  border: solid $stroke-width govuk-colour("black", $variant: "tint-80");
+  border: solid $stroke-width govuk-tint(govuk-colour("black"), 80%);
 
   .app-step-nav--large & {
     @include step-nav-font(16, $tablet-size: 19, $weight: bold, $line-height: 23px, $tablet-line-height: 30px);
@@ -422,7 +422,7 @@ $top-border: solid 2px govuk-colour("black", $variant: "tint-80");
 .app-step-nav__context {
   display: inline-block;
   font-weight: normal;
-  color: govuk-colour("black", $variant: "tint-25");
+  color: govuk-tint(govuk-colour("black"), 25%);
 
   &:before {
     content: " \2013\00a0"; // dash followed by &nbsp;

--- a/app/javascript/controllers/analytics_controller.js
+++ b/app/javascript/controllers/analytics_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  track(event) {
+    if (!window.dataLayer) return
+
+    const link = event.currentTarget
+
+    window.dataLayer.push({
+      event: link.dataset.analyticsEvent,
+      link_id: link.id,
+      link_text: link.textContent.trim(),
+      link_url: link.href,
+    })
+  }
+}

--- a/app/views/pages/_tool_card.html.erb
+++ b/app/views/pages/_tool_card.html.erb
@@ -1,0 +1,11 @@
+<li class="gem-c-cards__list-item">
+  <div class="gem-c-cards__list-item-wrapper">
+    <% if local_assigns[:status].present? %>
+      <%= govuk_tag(text: local_assigns[:status], colour: local_assigns.fetch(:status_colour, 'magenta'), classes: 'gem-c-cards__status') %>
+    <% end %>
+    <h2 class="gem-c-cards__sub-heading govuk-heading-s">
+      <%= link_to title, url, { class: 'govuk-link gem-c-cards__link' }.merge(local_assigns.fetch(:link_options, {})) %>
+    </h2>
+    <p class="govuk-body gem-c-cards__description"><%= description %></p>
+  </div>
+</li>

--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -11,66 +11,61 @@
   <div class="govuk-grid-column-full">
     <%= page_header 'Tariff tools' %>
 
-    <ul class="govuk-list">
+    <ul class="gem-c-cards__list gem-c-cards__list--one-column">
       <% if TradeTariffFrontend::ServiceChooser.uk? %>
-        <li>
-          <p>
-            <%= govuk_link_to t('breadcrumb.exchange_rates'), exchange_rates_path %>
-            <br>
-            View official monthly, average and spot exchange rates online, or download in CSV or XML. You can also request accessible formats.
-          </p>
-        </li>
+        <%= render 'tool_card',
+                   title: 'Exchange rates',
+                   url: exchange_rates_path,
+                   description: 'Use official exchange rates for customs values. View average monthly exchange rates, or download in CSV or XML' %>
       <% end %>
-      <li>
-        <p>
-          <%= govuk_link_to t('breadcrumb.simplified_procedural_values'), simplified_procedural_values_path %>
-          <br>
-          Use simplified procedure value rates for fresh fruit and vegetable goods that you import.
-        </p>
-      </li>
+      <%= render 'tool_card',
+                 title: 'Simplified procedure value rates',
+                 url: simplified_procedural_values_path,
+                 description: 'Check simplified procedure value rates for fresh fruit and vegetables' %>
       <% if TradeTariffFrontend::ServiceChooser.uk? %>
-        <li>
-          <p>
-            <%= govuk_link_to t('breadcrumb.quotas'), quota_search_path %>
-            <br>
-            Search for tariff quotas, including daily updated balances.
-          </p>
-        </li>
+        <%= render 'tool_card',
+                   title: t('breadcrumb.quotas'),
+                   url: quota_search_path,
+                   description: 'Search tariff quotas. Balances are updated daily' %>
       <% end %>
-      <li>
-        <p>
-          <%= govuk_link_to "Certificates, licences and documents", certificate_search_path %>
-          <br>
-          Search for certificates, licences and other document codes.
-        </p>
-      </li>
-      <li>
-        <p>
-          <%= govuk_link_to t('breadcrumb.additional_codes'), additional_code_search_path %>
-          <br>
-          Search for additional codes. Additional codes are used on the tariff for a number of purposes to help you to classify goods accurately on your customs declaration.
-        </p>
-      </li>
-      <li>
-        <p>
-          <%= govuk_link_to 'Footnotes', footnote_search_path %>
-          <br>Search the tariff for footnotes.
-        </p>
-      </li>
-      <li>
-        <p>
-          <%= govuk_link_to t('breadcrumb.chemicals'), chemical_search_path %>
-          <br>Search the tariff for chemicals by <abbr title="Chemical Abstracts Service">CAS</abbr> Registry Number (RN).
-        </p>
-      </li>
+      <%= render 'tool_card',
+                 title: 'Certificates, licences and documents',
+                 url: certificate_search_path,
+                 description: 'Find document codes and guidance for importing and exporting goods' %>
+      <% if TradeTariffFrontend::ServiceChooser.uk? %>
+        <%= render 'tool_card',
+                   title: 'Developer Portal (opens in new tab)',
+                   url: TradeTariffFrontend.developer_portal_url,
+                   description: 'Access official trade tariff data from HMRC and create and manage API keys',
+                   status: 'New',
+                   link_options: {
+                     id: 'developer-portal-tools-link',
+                     target: '_blank',
+                     rel: 'noopener noreferrer',
+                     data: {
+                       controller: 'analytics',
+                       action: 'click->analytics#track',
+                       analytics_event: 'developer_portal_tools_link_click',
+                     },
+                   } %>
+      <% end %>
+      <%= render 'tool_card',
+                 title: t('breadcrumb.additional_codes'),
+                 url: additional_code_search_path,
+                 description: 'Find additional codes for use on customs declarations' %>
+      <%= render 'tool_card',
+                 title: 'Footnotes',
+                 url: footnote_search_path,
+                 description: 'Search footnotes applying to a commodity code' %>
+      <%= render 'tool_card',
+                 title: t('breadcrumb.chemicals'),
+                 url: chemical_search_path,
+                 description: safe_join(['Look up chemicals by ', tag.abbr('CAS', title: 'Chemical Abstracts Service'), ' Registry Number (RN)']) %>
       <% if TradeTariffFrontend::ServiceChooser.xi? %>
-        <li>
-          <p>
-            <%= govuk_link_to t('breadcrumb.meursing_lookup'), meursing_lookup_step_path('start') %>
-            <br>
-            Find the Meursing code for your composite agrifood.
-          </p>
-        </li>
+        <%= render 'tool_card',
+                   title: t('breadcrumb.meursing_lookup'),
+                   url: meursing_lookup_step_path('start'),
+                   description: 'Find the Meursing code for your composite agrifood' %>
       <% end %>
     </ul>
   </div>

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -55,6 +55,10 @@ module TradeTariffFrontend
     ENV.fetch('FRONTEND_HOST', 'http://localhost')
   end
 
+  def developer_portal_url
+    ENV.fetch('DEVELOPER_PORTAL_URL') { "https://hub.#{base_domain}/" }
+  end
+
   def identity_base_url
     ENV.fetch('IDENTITY_BASE_URL', 'http://localhost:3005')
   end

--- a/spec/javascript/controllers/analytics_controller_spec.js
+++ b/spec/javascript/controllers/analytics_controller_spec.js
@@ -1,0 +1,56 @@
+import { Application } from '@hotwired/stimulus'
+import AnalyticsController from '../../../app/javascript/controllers/analytics_controller'
+
+describe('AnalyticsController', () => {
+  let application
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <a
+        id="developer-portal-tools-link"
+        href="https://hub.dev.trade-tariff.service.gov.uk/"
+        data-controller="analytics"
+        data-action="click->analytics#track"
+        data-analytics-event="developer_portal_tools_link_click">
+        Developer Portal (opens in new tab)
+      </a>
+    `
+
+    application = Application.start()
+    application.register('analytics', AnalyticsController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+
+  afterEach(() => {
+    application.stop()
+    delete window.dataLayer
+  })
+
+  it('pushes the configured event to the data layer on click', () => {
+    window.dataLayer = []
+
+    const link = document.querySelector('#developer-portal-tools-link')
+    link.addEventListener('click', (event) => event.preventDefault())
+
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+
+    expect(window.dataLayer).toEqual([
+      {
+        event: 'developer_portal_tools_link_click',
+        link_id: 'developer-portal-tools-link',
+        link_text: 'Developer Portal (opens in new tab)',
+        link_url: 'https://hub.dev.trade-tariff.service.gov.uk/',
+      },
+    ])
+  })
+
+  it('does nothing when the data layer is absent', () => {
+    const link = document.querySelector('#developer-portal-tools-link')
+    link.addEventListener('click', (event) => event.preventDefault())
+
+    expect(() => {
+      link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    }).not.toThrow()
+    expect(window.dataLayer).toBeUndefined()
+  })
+})

--- a/spec/lib/trade_tariff_frontend_spec.rb
+++ b/spec/lib/trade_tariff_frontend_spec.rb
@@ -1,6 +1,37 @@
 require 'spec_helper'
 
 RSpec.describe TradeTariffFrontend do
+  describe '.developer_portal_url' do
+    around do |example|
+      described_class.instance_variable_set(:@base_domain, nil)
+      example.run
+      described_class.instance_variable_set(:@base_domain, nil)
+    end
+
+    context 'without DEVELOPER_PORTAL_URL configured' do
+      before do
+        stub_const(
+          'ENV',
+          ENV.to_hash.except('DEVELOPER_PORTAL_URL').merge('GOVUK_APP_DOMAIN' => 'dev.trade-tariff.service.gov.uk'),
+        )
+      end
+
+      it 'returns the Developer Portal URL for the current app domain' do
+        expect(described_class.developer_portal_url).to eq('https://hub.dev.trade-tariff.service.gov.uk/')
+      end
+    end
+
+    context 'with DEVELOPER_PORTAL_URL configured' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('DEVELOPER_PORTAL_URL' => 'http://dev.localhost:9080/'))
+      end
+
+      it 'returns the configured Developer Portal URL' do
+        expect(described_class.developer_portal_url).to eq('http://dev.localhost:9080/')
+      end
+    end
+  end
+
   describe '.identity_cookie_domain' do
     around do |example|
       # Clear cached values before and after each test to prevent contamination

--- a/spec/views/pages/tools.html.erb_spec.rb
+++ b/spec/views/pages/tools.html.erb_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+RSpec.describe 'pages/tools', type: :view do
+  subject(:rendered_page) { render && rendered }
+
+  context 'with UK service' do
+    include_context 'with UK service'
+
+    before do
+      allow(TradeTariffFrontend).to receive(:developer_portal_url).and_return('https://hub.dev.trade-tariff.service.gov.uk/')
+    end
+
+    it 'renders tools as GOV.UK card links', :aggregate_failures do
+      expect(rendered_page).to have_css('.gem-c-cards__list.gem-c-cards__list--one-column')
+      expect(rendered_page).to have_css('.gem-c-cards__list-item', count: 8)
+      expect(rendered_page).to have_css('.gem-c-cards__link', text: 'Exchange rates')
+    end
+
+    it 'renders the reviewed tools content without trailing full stops', :aggregate_failures do
+      expect(rendered_page).to have_css('.gem-c-cards__link', text: 'Exchange rates')
+      expect(rendered_page).to have_css('.gem-c-cards__description', text: 'Use official exchange rates for customs values. View average monthly exchange rates, or download in CSV or XML')
+      expect(rendered_page).to have_css('.gem-c-cards__link', text: 'Simplified procedure value rates')
+      expect(rendered_page).to have_css('.gem-c-cards__description', text: 'Check simplified procedure value rates for fresh fruit and vegetables')
+      expect(rendered_page).to have_css('.gem-c-cards__description', text: 'Search tariff quotas. Balances are updated daily')
+      expect(rendered_page).to have_css('.gem-c-cards__description', text: 'Find document codes and guidance for importing and exporting goods')
+      expect(rendered_page).to have_css('.gem-c-cards__description', text: 'Find additional codes for use on customs declarations')
+      expect(rendered_page).to have_css('.gem-c-cards__description', text: 'Search footnotes applying to a commodity code')
+      expect(rendered_page).to have_css('.gem-c-cards__description', text: 'Look up chemicals by CAS Registry Number (RN)')
+
+      descriptions = Capybara.string(rendered_page).all('.gem-c-cards__description').map { |description| description.text.strip }
+      expect(descriptions).not_to include(a_string_matching(/\.\z/))
+    end
+
+    it 'links to the Developer Portal in a new tab', :aggregate_failures do
+      expect(rendered_page).to have_link(
+        'Developer Portal (opens in new tab)',
+        href: 'https://hub.dev.trade-tariff.service.gov.uk/',
+      )
+      expect(rendered_page).to have_css(
+        'a#developer-portal-tools-link[target="_blank"][rel="noopener noreferrer"]',
+        text: 'Developer Portal (opens in new tab)',
+      )
+      expect(rendered_page).to have_css(
+        'a#developer-portal-tools-link[data-controller="analytics"][data-action="click->analytics#track"][data-analytics-event="developer_portal_tools_link_click"]',
+      )
+      expect(rendered_page).to have_css(
+        '.gem-c-cards__description',
+        text: 'Access official trade tariff data from HMRC and create and manage API keys',
+      )
+    end
+
+    it 'renders the Developer Portal New status tag' do
+      developer_portal_card = Capybara.string(rendered_page).find('.gem-c-cards__list-item', text: 'Developer Portal')
+
+      expect(developer_portal_card).to have_css('.govuk-tag.govuk-tag--magenta', text: 'New')
+    end
+  end
+
+  context 'with XI service' do
+    include_context 'with XI service'
+
+    it 'renders existing XI tools as cards without the Developer Portal link', :aggregate_failures do
+      expect(rendered_page).to have_css('.gem-c-cards__list-item', count: 6)
+      expect(rendered_page).to have_link('Meursing code finder')
+      expect(rendered_page).not_to have_link('Developer Portal (opens in new tab)')
+
+      descriptions = Capybara.string(rendered_page).all('.gem-c-cards__description').map { |description| description.text.strip }
+      expect(descriptions).not_to include(a_string_matching(/\.\z/))
+    end
+  end
+end


### PR DESCRIPTION
## What:

- Adds a Developer Portal entry to the UK `/tools` page.
- Converts the Tools list to the GOV.UK browse-style card pattern.
- Applies reviewed Tools card content and adds the `New` status tag to the Developer Portal card.
- Removes trailing full stops from Tools card descriptions.
- Adds a named `dataLayer` click event for the Developer Portal Tools link.
- Makes the Developer Portal URL configurable, defaulting to `https://hub.<GOVUK_APP_DOMAIN>/`.
- Updates Sass colour calls so the local/current GOV.UK frontend build compiles and the switch/feedback grey panels render as GOV.UK light grey.

## Screenshots

<img width="896" height="1193" alt="Screenshot 2026-05-13 at 09 55 11" src="https://github.com/user-attachments/assets/22820d5a-e344-43ff-b67f-f083664a0e21" />
<img width="831" height="1184" alt="Screenshot 2026-05-13 at 09 55 18" src="https://github.com/user-attachments/assets/d09a8fd4-2e62-4ab4-a6de-ceb413b1206b" />


## Why:

Users need an always-on route from OTT to the Developer Portal from the Tools page, with click tracking for adoption measurement.

## Ticket:

https://transformuk.atlassian.net/browse/OTTIMP-540

## Risk:

**Risk level:** Amber

**Reason for rating:**
This changes the layout of the Tools page and introduces a card-style link pattern. The change is covered by focused view specs, JS analytics specs, Sass build verification, and local stack checks.

## Verification:

- `bundle exec rspec spec/views/pages/tools.html.erb_spec.rb spec/lib/trade_tariff_frontend_spec.rb spec/features/search_spec.rb`
- `yarn jest spec/javascript/controllers/analytics_controller_spec.js --runInBand`
- `npm run build:css`
- `bundle exec rubocop lib/trade_tariff_frontend.rb spec/lib/trade_tariff_frontend_spec.rb spec/views/pages/tools.html.erb_spec.rb`
- `GOVUK_APP_DOMAIN=dev.trade-tariff.service.gov.uk bundle exec rails runner 'puts TradeTariffFrontend.developer_portal_url'`
- `GOVUK_APP_DOMAIN=dev.trade-tariff.service.gov.uk DEVELOPER_PORTAL_URL=https://override.example.test/ bundle exec rails runner 'puts TradeTariffFrontend.developer_portal_url'`
- `pre-commit run trailing-whitespace --files <changed files>`
- `pre-commit run end-of-file-fixer --files <changed files>`
- `pre-commit run rubocop --files lib/trade_tariff_frontend.rb spec/lib/trade_tariff_frontend_spec.rb spec/views/pages/tools.html.erb_spec.rb`
- Local stack: `http://localhost:9080/tools` and `http://localhost:9080/xi/tools` return 200.
- Headless Chrome/Playwright verified 8 UK cards, visible Developer Portal link, `New` status tag, new-tab attributes, no trailing description full stops, and GOV.UK light-grey switch/feedback backgrounds.
