### PR TITLE
Return early after redirect in HeadingsController#show for declarable headings

### DIFF
--- a/app/controllers/headings_controller.rb
+++ b/app/controllers/headings_controller.rb
@@ -4,7 +4,7 @@ class HeadingsController < GoodsNomenclaturesController
   def show
     fetch_heading
 
-    redirect_to commodity_path(id: heading.id) if heading.declarable?
+    return redirect_to commodity_path(id: heading.id) if heading.declarable?
 
     @commodities = HeadingCommodityPresenter.new(heading.commodities)
     @meursing_additional_code = session[:meursing_lookup].try(:[], 'result')

--- a/spec/controllers/headings_controller_spec.rb
+++ b/spec/controllers/headings_controller_spec.rb
@@ -84,11 +84,16 @@ RSpec.describe HeadingsController, type: :controller do
         expect(response.status).to redirect_to commodity_url(id: '0903000000')
       end
 
-      it 'redirects without double-rendering when a country param is present and the geographical area lookup raises a 404' do
-        allow_any_instance_of(Search).to receive(:geographical_area).and_raise(Faraday::ResourceNotFound)
+      context 'when a country param is also present' do
+        it 'does not raise a double-render error' do
+          expect { get :show, params: { id: '0903', country: 'XY' } }.not_to raise_error
+        end
 
-        expect { get :show, params: { id: '0903', country: 'XY' } }.not_to raise_error
-        expect(response.status).to redirect_to commodity_url(id: '0903000000', country: 'XY')
+        it 'redirects to the relevant commodity' do
+          get :show, params: { id: '0903', country: 'XY' }
+
+          expect(response.status).to redirect_to commodity_url(id: '0903000000', country: 'XY')
+        end
       end
     end
 

--- a/spec/controllers/headings_controller_spec.rb
+++ b/spec/controllers/headings_controller_spec.rb
@@ -83,6 +83,13 @@ RSpec.describe HeadingsController, type: :controller do
 
         expect(response.status).to redirect_to commodity_url(id: '0903000000')
       end
+
+      it 'redirects without double-rendering when a country param is present and the geographical area lookup raises a 404' do
+        allow_any_instance_of(Search).to receive(:geographical_area).and_raise(Faraday::ResourceNotFound)
+
+        expect { get :show, params: { id: '0903', country: 'XY' } }.not_to raise_error
+        expect(response.status).to redirect_to commodity_url(id: '0903000000', country: 'XY')
+      end
     end
 
     context 'with UK site' do


### PR DESCRIPTION
### Jira link

[HMRC-2226](https://transformuk.atlassian.net/browse/HMRC-2226)

### What?

I have a one-line fix — adding `return` before `redirect_to` in `HeadingsController#show` for declarable headings.

### Why?

Without `return`, execution continued past the redirect. When a `?country=` param was present, `@search.geographical_area` called `GeographicalArea.find(country)`. An invalid country code raised `Faraday::ResourceNotFound`, which the inline rescue caught and tried to handle with `render :show_404` — but the response body was already committed by the earlier `redirect_to`.

Rails raised `AbstractController::DoubleRenderError` from inside the rescue clause. Because that error was raised while rescuing `Faraday::ResourceNotFound`, its `.cause` was the original `Faraday::ResourceNotFound`. Rails' `rescue_with_handler` traverses the cause chain when no direct handler matches `DoubleRenderError`, found the `find_relevant_goods_code_or_fallback` handler, called it, and it attempted a second `redirect_to` — producing the "Render and/or redirect were called multiple times" error seen in production.

### Risk

**Risk level:** 🟢

**Reason for rating:** Single-character change (`return` added) on a path that was already broken in production. The only behaviour change is that execution no longer continues past the redirect for declarable headings — which was never the intended behaviour. Covered by an existing passing spec and a new regression spec for the specific failure scenario.