### PR TITLE
HMRC:-2201: ActionView::Template::Error in frontend

### DIFF
--- a/app/controllers/duty_calculator/steps/import_date_controller.rb
+++ b/app/controllers/duty_calculator/steps/import_date_controller.rb
@@ -58,15 +58,27 @@ module DutyCalculator
       end
 
       def day
-        params[:day] || now.day
+        reference_date_components[0].to_s
       end
 
       def month
-        params[:month] || now.month
+        reference_date_components[1].to_s
       end
 
       def year
-        params[:year] || now.year
+        reference_date_components[2].to_s
+      end
+
+      def reference_date_components
+        @reference_date_components ||=
+          if params[:day].present? && params[:month].present? && params[:year].present?
+            [params[:day].to_i, params[:month].to_i, params[:year].to_i]
+          elsif user_session.import_date.present?
+            d = user_session.import_date
+            [d.day, d.month, d.year]
+          else
+            [now.day, now.month, now.year]
+          end
       end
 
       def now

--- a/app/decorators/duty_calculator/confirmation_decorator.rb
+++ b/app/decorators/duty_calculator/confirmation_decorator.rb
@@ -42,7 +42,13 @@ module DutyCalculator
   private
 
     def import_date_path
-      super(commodity_code: user_session.commodity_code)
+      params_hash = { commodity_code: user_session.commodity_code }
+      if user_session.import_date.present?
+        params_hash[:day] = user_session.import_date.day
+        params_hash[:month] = user_session.import_date.month
+        params_hash[:year] = user_session.import_date.year
+      end
+      super(**params_hash)
     end
 
     def additional_code_path

--- a/app/models/duty_calculator/steps/base.rb
+++ b/app/models/duty_calculator/steps/base.rb
@@ -37,7 +37,22 @@ module DutyCalculator
         UserSession.get
       end
 
+      def import_date_step_path
+        import_date_path(import_date_path_params_for_session)
+      end
+
       private
+
+      def import_date_path_params_for_session
+        params_hash = { commodity_code: user_session.commodity_code }
+        return params_hash if user_session.import_date.blank?
+
+        params_hash.merge(
+          day: user_session.import_date.day,
+          month: user_session.import_date.month,
+          year: user_session.import_date.year,
+        )
+      end
 
       def clean_user_session
         user_session.remove_step_ids(self.class::STEPS_TO_REMOVE_FROM_SESSION) unless user_session.nil?

--- a/app/models/duty_calculator/steps/import_destination.rb
+++ b/app/models/duty_calculator/steps/import_destination.rb
@@ -37,7 +37,7 @@ module DutyCalculator
       end
 
       def previous_step_path
-        import_date_path(commodity_code: user_session.commodity_code)
+        import_date_step_path
       end
 
       private

--- a/app/models/duty_calculator/steps/stopping.rb
+++ b/app/models/duty_calculator/steps/stopping.rb
@@ -4,7 +4,7 @@ module DutyCalculator
       def previous_step_path
         return document_codes_path(previous_measure_type_id) if stopping_document_codes?
 
-        import_date_path(commodity_code: user_session.commodity_code)
+        import_date_step_path
       end
 
       private

--- a/spec/controllers/duty_calculator/steps/import_date_controller_spec.rb
+++ b/spec/controllers/duty_calculator/steps/import_date_controller_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe DutyCalculator::Steps::ImportDateController, :user_session do
   describe 'GET #show' do
     subject(:response) { get :show, params: { commodity_code: } }
 
+    before do
+      stub_api_request("commodities/#{commodity_code}")
+        .with(query: { as_of: Time.zone.today })
+        .to_return(jsonapi_response(:commodity, commodity))
+    end
+
     it 'assigns the correct step' do
       response
       expect(assigns[:step]).to be_a(DutyCalculator::Steps::ImportDate)
@@ -37,7 +43,33 @@ RSpec.describe DutyCalculator::Steps::ImportDateController, :user_session do
 
       let(:expected) { Date.new(year.to_i, month.to_i, day.to_i) }
 
+      before do
+        stub_api_request("commodities/#{commodity_code}")
+          .with(query: { as_of: expected })
+          .to_return(jsonapi_response(:commodity, commodity))
+      end
+
       it { expect { response }.to change(user_session, :import_date).from(nil).to(expected) }
+    end
+
+    context 'when the session already has an import date' do
+      let(:user_session) do
+        build(
+          :duty_calculator_user_session,
+          :with_country_of_origin,
+          :with_import_date,
+          commodity_source: nil,
+        )
+      end
+      let(:stored_date) { Date.parse('2025-01-01') }
+
+      before do
+        stub_api_request("commodities/#{commodity_code}")
+          .with(query: { as_of: stored_date })
+          .to_return(jsonapi_response(:commodity, commodity))
+      end
+
+      it { expect { response }.not_to change(user_session, :import_date).from(stored_date) }
     end
   end
 

--- a/spec/decorators/duty_calculator/confirmation_decorator_spec.rb
+++ b/spec/decorators/duty_calculator/confirmation_decorator_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe DutyCalculator::ConfirmationDecorator, :user_session do
     it_behaves_like 'a valid path_for call', :document_code, '/duty-calculator/document-codes/103'
     it_behaves_like 'a valid path_for call', :excise, '/duty-calculator/excise/306'
     it_behaves_like 'a valid path_for call', :final_use, '/duty-calculator/final-use'
-    it_behaves_like 'a valid path_for call', :import_date, '/duty-calculator/0103921100/import-date'
+    it_behaves_like 'a valid path_for call', :import_date, '/duty-calculator/0103921100/import-date?day=1&month=1&year=2025'
     it_behaves_like 'a valid path_for call', :import_destination, '/duty-calculator/import-destination'
     it_behaves_like 'a valid path_for call', :measure_amount, '/duty-calculator/measure-amount'
     it_behaves_like 'a valid path_for call', :meursing_additional_code, '/duty-calculator/meursing-additional-codes'

--- a/spec/models/duty_calculator/steps/import_destination_spec.rb
+++ b/spec/models/duty_calculator/steps/import_destination_spec.rb
@@ -82,17 +82,37 @@ RSpec.describe DutyCalculator::Steps::ImportDestination, :step, :user_session do
   end
 
   describe '#previous_step_path' do
-    let(:user_session) do
-      build(
-        :duty_calculator_user_session,
-        commodity_code: '100000000',
-        commodity_source: nil,
-        referred_service: 'uk',
-      )
+    context 'when import date is not set on the session' do
+      let(:user_session) do
+        build(
+          :duty_calculator_user_session,
+          commodity_code: '100000000',
+          commodity_source: nil,
+          referred_service: 'uk',
+        )
+      end
+
+      it 'returns import_date_path with commodity code only' do
+        expect(step.previous_step_path).to eq(import_date_path(commodity_code: '100000000'))
+      end
     end
 
-    it 'returns import_date_path' do
-      expect(step.previous_step_path).to eq(import_date_path(commodity_code: '100000000'))
+    context 'when import date is set on the session' do
+      let(:user_session) do
+        build(
+          :duty_calculator_user_session,
+          :with_import_date,
+          commodity_code: '100000000',
+          commodity_source: nil,
+          referred_service: 'uk',
+        )
+      end
+
+      it 'returns import_date_path including the session import date' do
+        expect(step.previous_step_path).to eq(
+          import_date_path(commodity_code: '100000000', day: 1, month: 1, year: 2025),
+        )
+      end
     end
   end
 end

--- a/spec/models/duty_calculator/steps/stopping_spec.rb
+++ b/spec/models/duty_calculator/steps/stopping_spec.rb
@@ -15,9 +15,13 @@ RSpec.describe DutyCalculator::Steps::Stopping, :step, :user_session do
     end
 
     context 'when there are no document codes' do
-      let(:user_session) { build(:duty_calculator_user_session, :with_commodity_information) }
+      let(:user_session) { build(:duty_calculator_user_session, :with_commodity_information, :with_import_date) }
 
-      it { is_expected.to eq(import_date_path(commodity_code: user_session.commodity_code)) }
+      it {
+        expect(step).to eq(
+          import_date_path(commodity_code: user_session.commodity_code, day: 1, month: 1, year: 2025),
+        )
+      }
     end
   end
 end

--- a/spec/models/duty_calculator/steps/stopping_spec.rb
+++ b/spec/models/duty_calculator/steps/stopping_spec.rb
@@ -15,13 +15,21 @@ RSpec.describe DutyCalculator::Steps::Stopping, :step, :user_session do
     end
 
     context 'when there are no document codes' do
-      let(:user_session) { build(:duty_calculator_user_session, :with_commodity_information, :with_import_date) }
+      context 'when import date is not set on the session' do
+        let(:user_session) { build(:duty_calculator_user_session, :with_commodity_information) }
 
-      it {
-        expect(step).to eq(
-          import_date_path(commodity_code: user_session.commodity_code, day: 1, month: 1, year: 2025),
-        )
-      }
+        it { is_expected.to eq(import_date_path(commodity_code: user_session.commodity_code)) }
+      end
+
+      context 'when import date is set on the session' do
+        let(:user_session) { build(:duty_calculator_user_session, :with_commodity_information, :with_import_date) }
+
+        it {
+          expect(step).to eq(
+            import_date_path(commodity_code: user_session.commodity_code, day: 1, month: 1, year: 2025),
+          )
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
## What:
`DutyCalculator::Steps::Base: import_date_step_path` — builds `import_date_path` with day/month/year from user_session.import_date when present.
`ImportDestination` and `Stopping`: `previous_step_path` now uses import_date_step_path.
`ImportDateController`: day / month / year now come from query params if present, else user_session.import_date, else today — so returning from import-destination keeps the chosen date and does not overwrite the session with today.
`ConfirmationDecorator#import_date_path`: edit link includes the same date query params when the session has an import date.

## Why:
Duty Calculator back link omits the session import date, and ImportDateController#show defaults day/month/year to today when params are absent, overwriting the session and triggering commodity fetches with default date which is commodity would not be valid.

This scenario cause 404 response from backend

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2201

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
Fixing an existing bug
───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────

- Copy or content changes to GOV.UK Frontend components (labels, hint text, page titles)
- Adding or updating GOV.UK Design System components with no behaviour change
- New tests or improved test coverage with no production code changes
- Dependency bumps with no API changes (minor/patch gems, npm packages)
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- Terraform formatting or variable renaming with no resource recreation
- Static asset changes (images, fonts, stylesheets) with no layout impact

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────

- Changes to page layout or navigation that affect all or many user journeys
- Modifications to how commodity data or tariff information is presented to traders
- New or modified API calls to the backend or admin services
- Adding or changing feature flags that affect live user journeys
- Changes to error pages, accessibility markup, or GOV.UK service header/footer
- Search UI changes (autocomplete behaviour, result rendering, filter logic)
- Significant Sass/CSS changes that could affect rendering across browsers or screen sizes
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- Removing or deprecating a route, controller action, or view partial still in use elsewhere

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────

- Changes to how legally significant content is surfaced (trade remedies, prohibitions, licensing, sanctions)
- Modifications to the declarable goods flow or any trader-facing regulatory journey
- Any change to how the service integrates with the identity/authentication layer
- Changes to production AWS infrastructure that cannot be easily rolled back
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Significant architectural shifts (e.g. new service boundaries, caching topology changes)
- Changes that affect GOV.UK service compliance, accessibility standards (WCAG 2.2 AA), or government design system conformance
