### PR TITLE
Remove inline styles

### DIFF
--- a/app/views/green_lanes/moving_requirements/new.html.erb
+++ b/app/views/green_lanes/moving_requirements/new.html.erb
@@ -24,7 +24,7 @@
                                             You can use the Online Tariff to " \
                                           "<a href='https://www.gov.uk/trade-tariff' target='_blank' rel='noopener noreferrer'>search for a commodity (opens in a new tab).</a>".html_safe
                                    },
-                             style: "width:330px" %>
+                             class: 'govuk-!-width-one-half' %>
 
       <%= f.govuk_collection_select :country_of_origin,
                               GreenLanes::CategoryAssessmentSearch.country_options,
@@ -36,7 +36,7 @@
                                             "If you are unsure, <a href='https://www.trade-tariff.service.gov.uk/howto/origin' target='_blank' rel='noopener noreferrer'>" \
                                             "find out how to determine the non-preferential origin of goods (opens in a new tab).</a>".html_safe
                                     },
-                              style: "width:330px" %>
+                              class: 'govuk-!-width-one-half' %>
 
       <%= f.label :commodity_code, "When is the internal movement of goods taking place?", class: 'govuk-heading-m',
                   for: 'green_lanes_moving_requirements_form_moving_date_3' %>

--- a/app/views/myott/stop_presses/check_your_answers.html.erb
+++ b/app/views/myott/stop_presses/check_your_answers.html.erb
@@ -18,7 +18,7 @@
       <div data-controller="chapter-selection">
         <%= form_with url: subscribe_myott_stop_press_path, method: :post, local: true do %>
           <%= render 'details_selected_sections_chapters', selected_sections_chapters: @selected_sections_chapters %>
-          <%= link_to "Edit your chapter preferences", edit_myott_stop_press_preferences_path, class: "link_button", style: "font-size: 19px;" %>
+          <%= govuk_link_to "Edit your chapter preferences", edit_myott_stop_press_preferences_path %>
           <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
           <h2 class="govuk-heading-m">Confirm your selection</h2>


### PR DESCRIPTION
## What:
Remove inline styles/font used in 3 places. 
The link had an unnecessary "link_button" style which made the text size smaller which had to be overridden so this had been removed and the govuk_link_to is now being used.
The 2 form elements have had width styling replaced with a class that sets width to half the gov uk standard width which is almost the same width that was previously being used.

## Why:
These were causing Content Security Policy violation reports

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Minor like for like change