### PR TITLE
Use link helpers

### DIFF
--- a/app/views/duty_calculator/steps/customs_value/show.html.erb
+++ b/app/views/duty_calculator/steps/customs_value/show.html.erb
@@ -13,7 +13,7 @@
     <%= govuk_link_to(
       'How to calculate the customs value of your goods.',
       'https://www.gov.uk/government/publications/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics',
-      new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text
+      new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text
     ) %>
   </p>
   <%= f.govuk_text_field :monetary_value, width: 'one-quarter', label: { text: 'What is the value in GBP of the goods being imported?', class: 'govuk-label govuk-label--s' }, prefix_text: '£' %>

--- a/app/views/exchange_rates/_download_files.html.erb
+++ b/app/views/exchange_rates/_download_files.html.erb
@@ -1,6 +1,6 @@
 <dt class="gem-c-metadata__term">From:</dt>
 <dd class="gem-c-metadata__definition">
-  <strong><a href="https://www.gov.uk/government/organisations/hm-revenue-customs">HM Revenue &amp; Customs</a></strong>
+  <strong><%= govuk_link_to('HM Revenue &amp; Customs', 'https://www.gov.uk/government/organisations/hm-revenue-customs') %></strong>
 </dd>
 <dt class="gem-c-metadata__term">Published:</dt>
 <dd class="gem-c-metadata__definition"><%= @exchange_rate_collection.published_date %></dd>

--- a/app/views/exchange_rates/index.html.erb
+++ b/app/views/exchange_rates/index.html.erb
@@ -64,9 +64,7 @@
     <dt class="gem-c-metadata__term">From:</dt>
     <dd class="gem-c-metadata__definition">
       <strong>
-        <a href="https://www.gov.uk/government/organisations/hm-revenue-customs">
-          HM Revenue &amp; Customs
-        </a>
+        <%= govuk_link_to('HM Revenue &amp; Customs', 'https://www.gov.uk/government/organisations/hm-revenue-customs') %>
       </strong>
     </dd>
 

--- a/app/views/feedback/thanks.html.erb
+++ b/app/views/feedback/thanks.html.erb
@@ -22,6 +22,6 @@
 
 <% if @referrer.present? %>
   <p>
-    <a href=<%= @referrer %>>Return to page</a>
+    <%= govuk_link_to('Return to page', @referrer) %>
   </p>
 <% end %>

--- a/app/views/green_lanes/applicable_exemptions/_form.html.erb
+++ b/app/views/green_lanes/applicable_exemptions/_form.html.erb
@@ -26,7 +26,7 @@
           <% if category_assessment.regulation_url.present? %>
           <p>
             <%= govuk_link_to 'View Regulation document',
-                        category_assessment.regulation_url, new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text
+                        category_assessment.regulation_url, new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text
             %>
           </p>
           <% end %>

--- a/app/views/green_lanes/category_assessments/_category.html.erb
+++ b/app/views/green_lanes/category_assessments/_category.html.erb
@@ -34,7 +34,7 @@
     <p><%= category.regulation.description %></p>
     <% if category.regulation.regulation_url.present? %>
     <p>
-      <%= govuk_link_to 'Further information', category.regulation.regulation_url, new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %>
+      <%= govuk_link_to 'Further information', category.regulation.regulation_url, new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %>
     </p>
     <% end %>
   </div>

--- a/app/views/green_lanes/check_your_answers/_category_exemptions.html.erb
+++ b/app/views/green_lanes/check_your_answers/_category_exemptions.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-summary-card__title-wrapper">
       <h2 class="govuk-summary-card__title"><%= title %></h2>
       <div class="govuk-summary-card__actions">
-        <a class="govuk-link" href="<%= edit_path %>"></a>
+        <%= govuk_link_to('', edit_path) %>
       </div>
     </div>
     <div class="govuk-summary-card__content">

--- a/app/views/green_lanes/shared/_about_your_goods_card.html.erb
+++ b/app/views/green_lanes/shared/_about_your_goods_card.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title"><%= title %></h2>
     <div class="govuk-summary-card__actions">
-      <a class="govuk-link" href="<%= edit_path %>"></a>
+      <%= govuk_link_to('', edit_path) %>
     </div>
   </div>
   <div class="govuk-summary-card__content">

--- a/app/views/green_lanes/starts/new.html.erb
+++ b/app/views/green_lanes/starts/new.html.erb
@@ -16,7 +16,7 @@
     </p>
     <p>
       These simplified processes are introduced as part of the new arrangements for parcels and freight under the Windsor Framework.
-     <a href='http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland' target='_blank' rel='noopener noreferrer'> Find out more about Internal Market Movements (opens in new tab)</a>.
+     <%= govuk_link_to('Find out more about Internal Market Movements', 'http://www.gov.uk/guidance/internal-market-movements-from-great-britain-to-northern-ireland', new_tab: true) %>.
     <p>
 
     <p>
@@ -65,14 +65,10 @@
     <p>You'll need to know:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        <a href='https://www.trade-tariff.service.gov.uk/find_commodity'>
-          the commodity code for your goods
-        </a>
+        <%= govuk_link_to('the commodity code for your goods', 'https://www.trade-tariff.service.gov.uk/find_commodity') %>
       </li>
       <li>
-        <a href='https://www.trade-tariff.service.gov.uk/howto/origin'>
-          the non-preferential origin of your goods
-        </a>
+        <%= govuk_link_to('the non-preferential origin of your goods', 'https://www.trade-tariff.service.gov.uk/howto/origin') %>
       </li>
       <li>when the internal movement of goods is likely to take place</li>
     </ul>

--- a/app/views/live_issues/_commodities.html.erb
+++ b/app/views/live_issues/_commodities.html.erb
@@ -6,16 +6,12 @@
 <%= govuk_details(summary_text: "#{live_issue.commodities.count} commodities affected") do %>
   <% live_issue.commodities.each do |commodity_code| %>
     <p class="govuk-body">
-      <a href="/commodities/<%= commodity_code %>" class="govuk-link">
-        <%= commodity_code %>
-      </a>
+      <%= govuk_link_to(commodity_code, "/commodities/#{commodity_code}") %>
     </p>
   <% end %>
 <% end %>
 <% else %>
 <p class="govuk-body">
-  <a href="/commodities/<%= live_issue.commodities.first %>" class="govuk-link">
-    <%= live_issue.commodities.first %>
-  </a>
+  <%= govuk_link_to(live_issue.commodities.first, "/commodities/#{live_issue.commodities.first}") %>
 </p>
 <% end %>

--- a/app/views/measure_types/preference_codes/show.html.erb
+++ b/app/views/measure_types/preference_codes/show.html.erb
@@ -70,7 +70,7 @@
           charges applicable to CAP goods.
         </p>
         <p class="govuk-body">
-          <a target="_blank" href="https://www.gov.uk/government/publications/preference-codes-for-data-element-417-of-the-customs-declaration-service">See all preference codes (opens in new tab)</a>
+          <%= govuk_link_to('See all preference codes', 'https://www.gov.uk/government/publications/preference-codes-for-data-element-417-of-the-customs-declaration-service', new_tab: true) %>
         </p>
       </div>
     </div>

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -42,7 +42,7 @@
       <%= render "footnotes/critical_warning", footnote: footnote %>
     <% end %>
 
-    <p>The commodity code for exporting and <%= govuk_link_to 'Intrastat reporting', 'https://www.gov.uk/intrastat', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %> is <%= declarable.display_export_code %>.</p>
+    <p>The commodity code for exporting and <%= govuk_link_to 'Intrastat reporting', 'https://www.gov.uk/intrastat', new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %> is <%= declarable.display_export_code %>.</p>
 
     <%= render 'declarables/consigned', declarable: declarable %>
 

--- a/app/views/myott/mycommodities/index.html.erb
+++ b/app/views/myott/mycommodities/index.html.erb
@@ -39,9 +39,7 @@
               You are subscribed to email notifications sent to <strong><%= current_user.email %></strong>
             </p>
             <p>
-              <a href="<%= myott_unsubscribe_path(current_subscription('my_commodities').resource_id) %>">
-                Unsubscribe from commodity watch list
-              </a>
+              <%= govuk_link_to('Unsubscribe from commodity watch list', myott_unsubscribe_path(current_subscription('my_commodities').resource_id)) %>
             </p>
           </div>
         </div>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -61,7 +61,7 @@
     </ol>
 
     <h2 class="govuk-heading-s" id="leave-feedback">Leave feedback</h2>
-    <p><%= govuk_link_to 'Leave feedback or suggestions for improvements to this service.', feedback_link_url, new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %></p>
+    <p><%= govuk_link_to 'Leave feedback or suggestions for improvements to this service.', feedback_link_url, new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %></p>
 
     <h2 class="govuk-heading-s" id="getting-help">Getting help from HMRC if you need to find a commodity code</h2>
     <p>If you <%= govuk_link_to 'cannot find the right commodity code for your goods', help_find_commodity_path %>, you can contact HMRC for advice or for a decision on your goods.</p>
@@ -138,13 +138,13 @@
           </li>
 
           <li class="gem-c-related-navigation__link">
-            <a href="https://www.gov.uk/government/collections/uk-trade-tariff-volume-3-for-cds--2#imports:-guidance-on-completing-an-import-declaration-for-the-customs-declaration-service">UK Trade Tariff: volume 3 for CDS</a>
+            <%= govuk_link_to('UK Trade Tariff: volume 3 for CDS', 'https://www.gov.uk/government/collections/uk-trade-tariff-volume-3-for-cds--2#imports:-guidance-on-completing-an-import-declaration-for-the-customs-declaration-service') %>
           </li>
           <li class="gem-c-related-navigation__link">
-            <a href="https://www.gov.uk/government/publications/customs-declaration-completion-requirements-for-great-britain">Customs Declaration Completion Requirements for Great Britain</a>
+            <%= govuk_link_to('Customs Declaration Completion Requirements for Great Britain', 'https://www.gov.uk/government/publications/customs-declaration-completion-requirements-for-great-britain') %>
           </li>
           <li class="gem-c-related-navigation__link">
-            <a href="https://www.gov.uk/government/publications/customs-declaration-completion-requirements-for-the-northern-ireland-protocol">Customs Declaration Completion Requirements for The Northern Ireland Protocol</a>
+            <%= govuk_link_to('Customs Declaration Completion Requirements for The Northern Ireland Protocol', 'https://www.gov.uk/government/publications/customs-declaration-completion-requirements-for-the-northern-ireland-protocol') %>
           </li>
         </ul>
       </nav>
@@ -154,10 +154,10 @@
       <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-related_items-40a88cdf" data-module="gem-toggle" data-gem-toggle-module-started="true">
         <ul class="gem-c-related-navigation__link-list" data-module="gem-track-click" data-gem-track-click-module-started="true">
           <li class="gem-c-related-navigation__link">
-            <a href="https://www.gov.uk/government/collections/uk-trade-tariff-volume-3-for-chief">UK Trade Tariff: volume 3 for CHIEF</a>
+            <%= govuk_link_to('UK Trade Tariff: volume 3 for CHIEF', 'https://www.gov.uk/government/collections/uk-trade-tariff-volume-3-for-chief') %>
           </li>
           <li class="gem-c-related-navigation__link">
-            <a href="https://www.gov.uk/government/publications/customs-declaration-completion-requirements-for-great-britain">Customs Declaration Completion Requirements for Great Britain</a>
+            <%= govuk_link_to('Customs Declaration Completion Requirements for Great Britain', 'https://www.gov.uk/government/publications/customs-declaration-completion-requirements-for-great-britain') %>
           </li>
         </ul>
       </nav>

--- a/app/views/pages/help_find_commodity.html.erb
+++ b/app/views/pages/help_find_commodity.html.erb
@@ -22,7 +22,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Informal advice</h2>
-    <p>You can <%= govuk_link_to "use HMRC's Tariff Classification Service", "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods", new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %> to get non-legally binding classification advice.</p>
+    <p>You can <%= govuk_link_to "use HMRC's Tariff Classification Service", "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods", new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %> to get non-legally binding classification advice.</p>
     <p>HMRC will try to respond to your email within 5 working days.</p>
 
     <div class="govuk-inset-text">
@@ -47,8 +47,8 @@
     <p>If you want to check if a decision has already been made on goods that are similar to yours you can search for previous:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li><a href="https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search?enableTrackingConsent=true">Advance Tariff Rulings for Great Britain (England, Wales and Scotland)</a></li>
-      <li><a href="https://ec.europa.eu/taxation_customs/dds2/ebti/ebti_home.jsp?Lang=en">European Binding Tariff Information decisions for Northern Ireland</a></li>
+      <li><%= govuk_link_to('Advance Tariff Rulings for Great Britain (England, Wales and Scotland)', 'https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search?enableTrackingConsent=true') %></li>
+      <li><%= govuk_link_to('European Binding Tariff Information decisions for Northern Ireland', 'https://ec.europa.eu/taxation_customs/dds2/ebti/ebti_home.jsp?Lang=en') %></li>
     </ul>
   </div>
 </div>

--- a/app/views/pages/howtos/_commodity-codes.html.erb
+++ b/app/views/pages/howtos/_commodity-codes.html.erb
@@ -115,7 +115,7 @@
 
 <p>The classification process takes account of the characteristics using a series of six legally binding rules, known as the General Interpretative Rules (GIRs), which were set down by the World Customs Organisation (WCO) and are applied by its member countries.</p>
 
-<p>Read the <%= govuk_link_to 'full text of the General Interpretative Rules rules', 'https://www.wcoomd.org/-/media/wco/public/global/pdf/topics/nomenclature/instruments-and-tools/hs-interpretation-general-rules/0001_2012e_gir.pdf?la=en', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %>, with a simple description of what they do.</p>
+<p>Read the <%= govuk_link_to 'full text of the General Interpretative Rules rules', 'https://www.wcoomd.org/-/media/wco/public/global/pdf/topics/nomenclature/instruments-and-tools/hs-interpretation-general-rules/0001_2012e_gir.pdf?la=en', new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %>, with a simple description of what they do.</p>
 
 <p>As most types of goods have been classified before and many are referred to within the text of the tariff and its notes, the right codes can often be identified using the search function on this service. Although you should always check associated notes and rules to ensure you are content that the proposed classification is correct, this aims to help you through this process by using knowledge and tips from HMRC's classification experts to direct you based on the search terms you have used.</p>
 

--- a/app/views/pages/howtos/_origin.html.erb
+++ b/app/views/pages/howtos/_origin.html.erb
@@ -58,7 +58,7 @@
   <li>What was the last substantial transformation: in a case where more than one country was involved in the production of the good, the country where the last substantial transformation took place determines the origin of the good. </li>
 </ul>
 
-<p>Find <a href="https://www.gov.uk/government/publications/reference-document-for-the-customs-origin-of-chargeable-goods-eu-exit-regulations-2020">more information about non-preferential rules of origin</a>.</p>
+<p>Find <%= govuk_link_to('more information about non-preferential rules of origin', 'https://www.gov.uk/government/publications/reference-document-for-the-customs-origin-of-chargeable-goods-eu-exit-regulations-2020') %>.</p>
 
 <h2 class="govuk-heading-m" id="preferential">How to determine preferential rules of origin?</h2>
 
@@ -74,7 +74,7 @@
 
 <p>Different ways to certify preferential origin are available. The specific method that should be used will depend on the text of the relevant agreement, e.g. Statement on origin.</p>
 
-<p>View <a href="https://www.trade-tariff.service.gov.uk/rules_of_origin/proofs">proofs of origin for all UK trade agreements</a>.</p>
+<p>View <%= govuk_link_to('proofs of origin for all UK trade agreements', 'https://www.trade-tariff.service.gov.uk/rules_of_origin/proofs') %>.</p>
 
 <h2 class="govuk-heading-m" id="responsible">Who is responsible for determining the origin of products?</h2>
 
@@ -85,7 +85,7 @@
 <p>If HMRC has reasons to doubt the validity of a proof of origin, it can request further documents from the importer or verification from the customs authority in the country of export.</p>
 
 <h2 class="govuk-heading-m" id="ott">Using the Online Trade Tariff to work out origin</h2>
-<p>Once you have found the commodity code that you want to trade, you can click on the origin tab to work out if your goods can be classed as originating. For all countries, the <a href="#non-preferential">non-preferential rules of origin</a> are shown. You can download the non-preferential
+<p>Once you have found the commodity code that you want to trade, you can click on the origin tab to work out if your goods can be classed as originating. For all countries, the <%= govuk_link_to('non-preferential rules of origin', '#non-preferential') %> are shown. You can download the non-preferential
   rules of origin to see how the rules apply to your trade.</p>
 
 <p>To see the preferential rules of origin associated with a trading partner with which the UK has a trade agreement, select the country with which you are trading the goods. Once you have selected the country, you will see:</p>

--- a/app/views/pages/howtos/_quotas.html.erb
+++ b/app/views/pages/howtos/_quotas.html.erb
@@ -43,7 +43,7 @@
 
 <p>As a result, goods from certain countries could be eligible for imports under a lower, in-quota rate whilst the same goods originating in other countries can be subject to a higher, out-of-quota rate, because their quota has run out.</p>
 
-<p>Find out more about <a href="/howto/origin">determining the origin of your goods</a>.</p>
+<p>Find out more about <%= govuk_link_to('determining the origin of your goods', '/howto/origin') %>.</p>
 
 <h2 class="govuk-heading-m" id="application">When are quotas applied and can they be agreed in advance? </h2>
 
@@ -98,7 +98,7 @@
 <ul class="govuk-list govuk-list--bullet">
   <li>the country or countries to which the quota applies.</li>
   <li>the type of quota. There are two main types of quota: non-preferential (open to many countries) or preferential (restricted to a particular trading partner).
-    Each of these may also be available on goods that are for <a href="https://www.gov.uk/guidance/apply-to-pay-less-duty-on-goods-you-import-for-specific-uses">authorised use only</a>.</li>
+    Each of these may also be available on goods that are for <%= govuk_link_to('authorised use only', 'https://www.gov.uk/guidance/apply-to-pay-less-duty-on-goods-you-import-for-specific-uses') %>.</li>
   <li>the 6-digit quota order number. Most tariff quotas operate on a first come first serve basis, but some are licence based. You can tell if a
     quota requires a licence, because it has starts with the characters '054'. All other quotas are first-come, first-serve.</li>
   <li>the in-quota duty rate, i.e. the duty rate that applies when you request usage of the quota on your import declaration and the quota is not exhausted.</li>

--- a/app/views/pages/howtos/_trade-remedies.html.erb
+++ b/app/views/pages/howtos/_trade-remedies.html.erb
@@ -40,7 +40,7 @@
 
 <h2 class="govuk-heading-m" id="usage">How does the UK apply trade remedies?</h2>
 
-<p>In the UK, trade remedies investigations are conducted by the Trade Remedies Authority. The <%= govuk_link_to 'Trade Remedies Service', 'https://www.trade-remedies.service.gov.uk', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %> allows UK companies to participate in ongoing trade remedies cases and request new reviews.</p>
+<p>In the UK, trade remedies investigations are conducted by the Trade Remedies Authority. The <%= govuk_link_to 'Trade Remedies Service', 'https://www.trade-remedies.service.gov.uk', new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text %> allows UK companies to participate in ongoing trade remedies cases and request new reviews.</p>
 
 <h2 class="govuk-heading-m" id="impact">How do trade remedies impact UK importers?</h2>
 

--- a/app/views/pages/howtos/_valuation.html.erb
+++ b/app/views/pages/howtos/_valuation.html.erb
@@ -33,14 +33,14 @@
 
 <h2 class="govuk-heading-m" id="determination">How is customs value determined?</h2>
 
-<p>The main method for determining the customs value is the transaction value defined as the price paid or payable, for the goods, when sold for export to the UK. This is known as <a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-1-transaction-value">Method 1</a> in the UK.</p>
+<p>The main method for determining the customs value is the transaction value defined as the price paid or payable, for the goods, when sold for export to the UK. This is known as <%= govuk_link_to('Method 1', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-1-transaction-value') %> in the UK.</p>
 
 <p>You will need to add certain additional costs and will be allowed to deduct others, if they are not already accounted for in the transaction value. For example, the cost of transport up to the first point of arrival in the UK needs to be added but the cost of transport beyond that point can be excluded. Royalties, license fees and some types of commissions will also need to be added. Additional rules apply to related companies to ensure that the relationship between entities does not affect valuation and as a result, the amount of duty and import VAT due.</p>
 
 <p>In cases where there is no sale or no suitable transaction value to determine the customs value under Method 1 rules,  alternative valuation methods must be used. There are five other valuation methods that need to be applied in the order and manner set out in the Customs Valuation Agreement.</p>
 
 <p>
-  <a href="https://www.gov.uk/government/collections/working-out-the-customs-value-of-your-imported-goods">Learn more about the different valuation methods</a> as well as the costs that need to be added or subtracted from the value.</p>
+  <%= govuk_link_to('Learn more about the different valuation methods', 'https://www.gov.uk/government/collections/working-out-the-customs-value-of-your-imported-goods') %> as well as the costs that need to be added or subtracted from the value.</p>
 
 <h2 class="govuk-heading-m" id="responsibility">Who is responsible for determining the customs value of products?</h2>
 
@@ -52,12 +52,12 @@
 
 <p>Check detailed information on the different valuation methods to work out the customs value of your imports.</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li><a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-1-transaction-value">Valuing imported goods using Method 1 (transaction value)</a></li>
-  <li><a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-2-transaction-value-of-identical-goods">Valuing imported goods using Method 2 (transaction value of identical goods)</a></li>
-  <li><a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-3-transaction-value-of-similar-goods">Valuing imported goods using Method 3 (transaction value of similar goods)</a></li>
-  <li><a href="https://www.gov.uk/guidance/adjusting-for-level-and-quantity-when-using-methods-2-or-3">Adjusting for level and quantity when using Methods 2 or 3</a></li>
-  <li><a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-4-deductive-method">Valuing imported goods using Method 4 (deductive method)</a></li><a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-4-deductive-method">
-  </a><li><a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-4-deductive-method"></a><a href="https://www.gov.uk/guidance/valuing-imported-fruit-and-vegetables-using-simplified-procedure-values-with-method-4">Valuing imported fruit and vegetables using simplified procedure values with Method 4</a></li>
-  <li><a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-5-computed-value">Valuing imported goods using Method 5 (computed value)</a></li>
-  <li><a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-6-fall-back-method">Valuing imported goods using Method 6 (fall-back method)</a></li>
+  <li><%= govuk_link_to('Valuing imported goods using Method 1 (transaction value)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-1-transaction-value') %></li>
+  <li><%= govuk_link_to('Valuing imported goods using Method 2 (transaction value of identical goods)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-2-transaction-value-of-identical-goods') %></li>
+  <li><%= govuk_link_to('Valuing imported goods using Method 3 (transaction value of similar goods)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-3-transaction-value-of-similar-goods') %></li>
+  <li><%= govuk_link_to('Adjusting for level and quantity when using Methods 2 or 3', 'https://www.gov.uk/guidance/adjusting-for-level-and-quantity-when-using-methods-2-or-3') %></li>
+  <li><%= govuk_link_to('Valuing imported goods using Method 4 (deductive method)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-4-deductive-method') %></li>
+  <li><%= govuk_link_to('Valuing imported fruit and vegetables using simplified procedure values with Method 4', 'https://www.gov.uk/guidance/valuing-imported-fruit-and-vegetables-using-simplified-procedure-values-with-method-4') %></li>
+  <li><%= govuk_link_to('Valuing imported goods using Method 5 (computed value)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-5-computed-value') %></li>
+  <li><%= govuk_link_to('Valuing imported goods using Method 6 (fall-back method)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-6-fall-back-method') %></li>
 </ul>

--- a/app/views/pages/rules_of_origin_duty_drawback.html.erb
+++ b/app/views/pages/rules_of_origin_duty_drawback.html.erb
@@ -62,11 +62,11 @@
               <td class="govuk-table__cell">
                 <ul class="govuk-list">
                   <li>
-                    <a href=<%= scheme.agreement_link %> target="_blank" rel="noopener noreferrer">View agreement details</a>
+                    <%= govuk_link_to('View agreement details', scheme.agreement_link, new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>
                   </li>
                   <% if scheme.origin_reference_document&.ord_original&.present? %>
                     <li>
-                      <a href=<%= scheme.origin_reference_document.document_path %> target="_blank" rel="noopener noreferrer">View origin reference document</a>
+                      <%= govuk_link_to('View origin reference document', scheme.origin_reference_document.document_path, new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>
                     </li>
                   <% end %>
                 </ul>

--- a/app/views/product_experience/enquiry_form/show.html.erb
+++ b/app/views/product_experience/enquiry_form/show.html.erb
@@ -6,10 +6,10 @@
       about trade tariffs. We aim to reply to all questions within 10 working days.</p>
 
     <h2 class="govuk-heading-m">Before you start</h1>
-      <p class="govuk-body">The answer to your question might be in the <a href=<%= help_path %>>help section</a>. If the answer you
+      <p class="govuk-body">The answer to your question might be in the <%= govuk_link_to('help section', help_path) %>. If the answer you
       want is not there, submit the question using the enquiry form.</p>
 
-      <p class="govuk-body">Please also check the <a href=<%= live_issues_path %>>live issues log</a> as your query may be related to a known issue.</p>
+      <p class="govuk-body">Please also check the <%= govuk_link_to('live issues log', live_issues_path) %> as your query may be related to a known issue.</p>
 
     <h2 class="govuk-heading-m">What you’ll need</h1>
       <p class="govuk-body">Along with the details of your enquiry, you will be asked for your email address

--- a/app/views/search/_commodity.html.erb
+++ b/app/views/search/_commodity.html.erb
@@ -1,16 +1,12 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell commodity-result">
-    <a href="<%= commodity_path(commodity, request_id: @search.request_id) %>" aria-describedby="code-for-commodity-<%= commodity.id %>">
+    <%= govuk_link_to('', commodity_path(commodity, request_id: @search.request_id), aria_describedby: "code-for-commodity-#{commodity.id}", visually_hidden_suffix: "(code #{commodity.code})") do %>
       <% if commodity.ancestor_descriptions.present? %>
         <%= descriptions_with_other_handling(commodity) %>
       <% else %>
         <%= sanitize commodity.description %>
       <% end %>
-
-      <span class="govuk-visually-hidden">
-        (code <%= commodity.code %>)
-      </span>
-    </a>
+    <% end %>
   </td>
 
   <td class="govuk-table__cell text-right" id="code-for-commodity-<%= commodity.id %>">

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="line-text">
       <h4 class="govuk-heading-s govuk-!-margin-bottom-2">
-        <a href="<%= chapter_path(chapter, request_id: @search.request_id) %>"><%= sanitize chapter.description %></a>
+        <%= govuk_link_to(sanitize(chapter.description), chapter_path(chapter, request_id: @search.request_id)) %>
       </h4>
     </div>
   </div>
@@ -25,7 +25,7 @@
         <li>
           <div class="heading">
             <div class="line-text">
-              <a href="<%= heading_path(heading, request_id: @search.request_id) %>"><%= sanitize heading.description %></a>
+              <%= govuk_link_to(sanitize(heading.description), heading_path(heading, request_id: @search.request_id)) %>
             </div>
             <div class="full-code">
               <div class="chapter-code">

--- a/app/views/search/additional_code_search.html.erb
+++ b/app/views/search/additional_code_search.html.erb
@@ -43,7 +43,7 @@
             <% else %>
               <tr class="govuk-table__row">
                 <td colspan="2" class="govuk-table__cell">
-                  No valid commodities are associated with additional code <a class="inline" href="<%= additional_code_search_path(type: additional_code.additional_code_type_id, code: additional_code.additional_code) %>"><%= additional_code.code %></a>.
+                  No valid commodities are associated with additional code <%= govuk_link_to(additional_code.code, additional_code_search_path(type: additional_code.additional_code_type_id, code: additional_code.additional_code)) %>.
                 </td>
               </tr>
             <% end %>

--- a/app/views/search/common/_goods_nomenclature.html.erb
+++ b/app/views/search/common/_goods_nomenclature.html.erb
@@ -1,17 +1,10 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
     <% if goods_nomenclature.instance_of?(GoodsNomenclature) %>
-      <a href="<%= commodity_path(goods_nomenclature, day: nil, month: nil, year: nil) %>" aria-describedby="code-for-commodity-<%= goods_nomenclature.id %>">
+      <%= govuk_link_to(goods_nomenclature.description.html_safe, commodity_path(goods_nomenclature, day: nil, month: nil, year: nil), aria_describedby: "code-for-commodity-#{goods_nomenclature.id}", visually_hidden_suffix: "(code #{goods_nomenclature.code})") %>
     <% else %>
-      <a href="<%= polymorphic_path(goods_nomenclature, day: nil, month: nil, year: nil) %>" aria-describedby="code-for-commodity-<%= goods_nomenclature.id %>">
+      <%= govuk_link_to(goods_nomenclature.description.html_safe, polymorphic_path(goods_nomenclature, day: nil, month: nil, year: nil), aria_describedby: "code-for-commodity-#{goods_nomenclature.id}", visually_hidden_suffix: "(code #{goods_nomenclature.code})") %>
     <% end  %>
-
-    <%= goods_nomenclature.description.html_safe %>
-
-    <span class="govuk-visually-hidden">
-      (code <%= goods_nomenclature.code %>)
-    </span>
-    </a>
   </td>
 
   <td class="govuk-table__cell text-right" id="code-for-commodity-<%= goods_nomenclature.id %>">

--- a/app/views/search/search_by_footnote.html.erb
+++ b/app/views/search/search_by_footnote.html.erb
@@ -30,7 +30,7 @@
           <% if goods_nomenclatures.empty? %>
             <tr class="govuk-table__row">
               <td colspan="2" class="govuk-table__cell">
-                No valid commodities are associated with footnote <a class="inline" href="<%= footnote_search_path(code: footnote.code) %>"><%= footnote.code %></a>.
+                No valid commodities are associated with footnote <%= govuk_link_to(footnote.code, footnote_search_path(code: footnote.code)) %>.
               </td>
             </tr>
           <% else %>

--- a/app/views/sections/_stw_information.html.erb
+++ b/app/views/sections/_stw_information.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-m">Advance tariff rulings</h2>
   <p class="govuk-body">
     For more help in classifying your commodity, you can
-    <%= govuk_link_to('search for advance tariff rulings', 'https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>
+    <%= govuk_link_to('search for advance tariff rulings', 'https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/search', new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>
   </p>
   <p class="govuk-body">
     Advance tariff rulings allow you to get a legally binding decision on the
@@ -11,11 +11,11 @@
 
   <p class="govuk-body">
     Find out more about
-    <%= govuk_link_to('advance tariff rulings', 'https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>.
+    <%= govuk_link_to('advance tariff rulings', 'https://www.gov.uk/guidance/apply-for-an-advance-tariff-ruling', new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>.
   </p>
 
   <p class="govuk-body">
-    <%= govuk_link_to('Contact HMRC if you need help finding the right commodity code for your goods', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>.
+    <%= govuk_link_to('Contact HMRC if you need help finding the right commodity code for your goods', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods', new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>.
   </p>
 </div>
 
@@ -24,7 +24,7 @@
 
   <p class="govuk-body">
     Use the
-    '<%= govuk_link_to('Check how to import or export goods', 'https://www.gov.uk/check-how-to-import-export', new_tab: "", visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>'
+    '<%= govuk_link_to('Check how to import or export goods', 'https://www.gov.uk/check-how-to-import-export', new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text) %>'
     service to get information about importing and exporting, including:
   </p>
 

--- a/app/views/shared/search/_interactive_search_form.html.erb
+++ b/app/views/shared/search/_interactive_search_form.html.erb
@@ -11,7 +11,7 @@
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
         <% @search.errors.each do |error| %>
-          <li><a href="#guided_q"><%= error.message %></a></li>
+          <li><%= govuk_link_to(error.message, '#guided_q') %></li>
         <% end %>
       </ul>
     </div>

--- a/app/views/shared/search/_search_form.html.erb
+++ b/app/views/shared/search/_search_form.html.erb
@@ -7,7 +7,7 @@
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
         <% @search.errors.each do |error| %>
-          <li><a href="#q"><%= error.message %></a></li>
+          <li><%= govuk_link_to(error.message, '#q') %></li>
         <% end %>
       </ul>
     </div>

--- a/app/views/simplified_procedural_values/_by_date.html.erb
+++ b/app/views/simplified_procedural_values/_by_date.html.erb
@@ -2,11 +2,11 @@
   <%= page_header "Check simplified procedure value rates for fresh fruit and vegetables" %>
 
   <h2 class="govuk-heading-s">When to use a simplified procedure value</h2>
-  <p>If you import whole fruit or vegetables into the UK on a consignment basis you may be able to <a href="https://www.gov.uk/guidance/how-to-value-your-imports-for-customs-duty-and-trade-statistics#simp-val">use a simplified procedure value</a> using the <a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-4-deductive-method">method 4 valuation</a> to declare the produce.</p>
+  <p>If you import whole fruit or vegetables into the UK on a consignment basis you may be able to <%= govuk_link_to('use a simplified procedure value', 'https://www.gov.uk/guidance/how-to-value-your-imports-for-customs-duty-and-trade-statistics#simp-val') %> using the <%= govuk_link_to('method 4 valuation', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-4-deductive-method') %> to declare the produce.</p>
 
   <h2 class="govuk-heading-s">Goods that are excluded</h2>
   <p>Fruit or vegetable products that are cut and diced before they’re imported are excluded from the scheme.</p>
-  <p>You cannot use the simplified procedure value if there is a sale for export and the transaction value is known. Those goods must be valued using <a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-1-transaction-value">valuation method 1</a>.</p>
+  <p>You cannot use the simplified procedure value if there is a sale for export and the transaction value is known. Those goods must be valued using <%= govuk_link_to('valuation method 1', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-1-transaction-value') %>.</p>
 
   <h2 class="govuk-heading-s">Rates for period <%= date_range_message(@result.validity_start_date, @result.validity_end_date) %></h2>
   <p>Simplified procedure value rates change every 14 days. You may only use the rate that applies to the produce you are importing within the correct 14-day period.</p>

--- a/app/views/simplified_procedural_values/_sidebar.html.erb
+++ b/app/views/simplified_procedural_values/_sidebar.html.erb
@@ -5,25 +5,25 @@
     <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-related_items-40a88cdf" data-module="gem-toggle" data-gem-toggle-module-started="true">
       <ul class="gem-c-related-navigation__link-list" data-module="gem-track-click" data-gem-track-click-module-started="true">
         <li class="gem-c-related-navigation__link">
-          <a href="https://www.gov.uk/government/collections/working-out-the-customs-value-of-your-imported-goods">Working out the customs value of your imported goods</a>
+          <%= govuk_link_to('Working out the customs value of your imported goods', 'https://www.gov.uk/government/collections/working-out-the-customs-value-of-your-imported-goods') %>
         </li>
         <li class="gem-c-related-navigation__link">
-          <a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-1-transaction-value">Valuing imported goods using Method 1 (transaction value)</a>
+          <%= govuk_link_to('Valuing imported goods using Method 1 (transaction value)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-1-transaction-value') %>
         </li>
         <li class="gem-c-related-navigation__link">
-          <a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-2-transaction-value-of-identical-goods">Valuing imported goods using Method 2 (transaction value of identical goods)</a>
+          <%= govuk_link_to('Valuing imported goods using Method 2 (transaction value of identical goods)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-2-transaction-value-of-identical-goods') %>
         </li>
         <li class="gem-c-related-navigation__link">
-          <a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-3-transaction-value-of-similar-goods">Valuing imported goods using Method 3 (transaction value of similar goods)</a>
+          <%= govuk_link_to('Valuing imported goods using Method 3 (transaction value of similar goods)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-3-transaction-value-of-similar-goods') %>
         </li>
         <li class="gem-c-related-navigation__link">
-          <a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-4-deductive-method">Valuing imported goods using Method 4 (deductive method)</a>
+          <%= govuk_link_to('Valuing imported goods using Method 4 (deductive method)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-4-deductive-method') %>
         </li>
         <li class="gem-c-related-navigation__link">
-          <a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-5-computed-value">Valuing imported goods using Method 5 (computed value)</a>
+          <%= govuk_link_to('Valuing imported goods using Method 5 (computed value)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-5-computed-value') %>
         </li>
         <li class="gem-c-related-navigation__link">
-          <a href="https://www.gov.uk/guidance/valuing-imported-goods-using-method-6-fall-back-method">Valuing imported goods using Method 6 (fall-back method)</a>
+          <%= govuk_link_to('Valuing imported goods using Method 6 (fall-back method)', 'https://www.gov.uk/guidance/valuing-imported-goods-using-method-6-fall-back-method') %>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
## What:
Converts plain a tags to use `govuk_link_to`. The the visually_hidden_suffix param has been used where appropriate.

## Why:
This helper is being used across the codebase and in addition using this helper adds the 'govuk_link' class which is used by Amplitude to classify links. This addresses the issue with start page click tracking on the enquiry form.

## Ticket:
https://transformuk.atlassian.net/browse/OTTIMP-513

## Risk:

**Risk level:** 🟢

**Reason for rating:**
The changes should result in the same HTML being rendered with the addition of a 'govuk-link' class which has no visual impact.
