### PR TITLE
AI-810: Show guided classification error page

### DIFF
--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -32,6 +32,8 @@ module InteractiveSearchable
       redirect_to url_for @results.to_param.merge(url_options).merge(request_id: @search.request_id, only_path: true)
     elsif @results.has_pending_question?
       render_interactive_question
+    elsif @results.all_unknown_confidence?
+      render_interactive_unknown_results
     elsif @results.none?
       render_interactive_no_results
     else
@@ -131,6 +133,13 @@ module InteractiveSearchable
     disable_search_form
     mark_interactive_search_page
     render :interactive_no_results
+  end
+
+  def render_interactive_unknown_results
+    disable_switch_service_banner
+    disable_search_form
+    mark_interactive_search_page
+    render :interactive_unknown_results
   end
 
   def render_interactive_results

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -91,11 +91,11 @@ class SearchController < ApplicationController
   end
 
   def missing_search_query_fallback_url
-    return sections_path(anchor:) if request.referer.blank?
+    return find_commodity_path(anchor:) if request.referer.blank?
 
     back_url = URI(request.referer)
     if back_url.host.present? && back_url.host != request.host
-      return sections_path(anchor:)
+      return find_commodity_path(anchor:)
     end
 
     query_values = Rack::Utils.parse_query(back_url.query || '')

--- a/app/javascript/controllers/copy_search_details_controller.js
+++ b/app/javascript/controllers/copy_search_details_controller.js
@@ -1,27 +1,31 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['button']
+  static targets = ['button', 'content']
 
   async copy() {
-    const detailsText = this.element.querySelector('.govuk-details__text')
+    const detailsText = this.hasContentTarget ? this.contentTarget : this.element.querySelector('.govuk-details__text')
     if (!detailsText) return
 
     const textContent = Array.from(detailsText.querySelectorAll('p'))
       .map((p) => p.textContent.trim())
       .join('\n')
 
-    try {
-      await navigator.clipboard.writeText(textContent)
-      this.#showCopied()
-    } catch {
-      // Fallback for older browsers or non-HTTPS contexts
-      this.#fallbackCopy(textContent)
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(textContent)
+        this.#showCopied()
+        return
+      } catch (_error) {
+        // Fall back for browsers that expose the API but deny access.
+      }
     }
+
+    if (this.#fallbackCopy(textContent)) this.#showCopied()
   }
 
   #showCopied() {
-    const original = this.buttonTarget.textContent
+    const original = this.buttonTarget.textContent.trim()
     this.buttonTarget.textContent = 'Copied'
     setTimeout(() => {
       this.buttonTarget.textContent = original
@@ -29,14 +33,23 @@ export default class extends Controller {
   }
 
   #fallbackCopy(text) {
+    if (!document.execCommand) return false
+
     const textarea = document.createElement('textarea')
     textarea.value = text
     textarea.style.position = 'fixed'
     textarea.style.opacity = '0'
     document.body.appendChild(textarea)
+    textarea.focus()
     textarea.select()
-    document.execCommand('copy')
-    document.body.removeChild(textarea)
-    this.#showCopied()
+    textarea.setSelectionRange(0, textarea.value.length)
+
+    try {
+      return document.execCommand('copy')
+    } catch (_error) {
+      return false
+    } finally {
+      document.body.removeChild(textarea)
+    }
   }
 }

--- a/app/models/search/internal_search_result.rb
+++ b/app/models/search/internal_search_result.rb
@@ -6,6 +6,7 @@ class Search
       'Commodity' => 'commodities',
       'Subheading' => 'subheadings',
     }.freeze
+    KNOWN_CONFIDENCE_LEVELS = %w[strong good possible unlikely].freeze
 
     attr_reader :type, :meta
 
@@ -49,6 +50,12 @@ class Search
 
     def confident_results
       @results.select { |r| r.try(:confidence).present? }
+    end
+
+    def all_unknown_confidence?
+      any? && @results.none? do |result|
+        KNOWN_CONFIDENCE_LEVELS.include?(result.try(:confidence).to_s.downcase)
+      end
     end
 
     def interactive_search?

--- a/app/views/find_commodities/show_interactive.html.erb
+++ b/app/views/find_commodities/show_interactive.html.erb
@@ -19,35 +19,7 @@
 
       <%= render 'shared/search/interactive_search_form' %>
 
-      <div class="gem-c-cards">
-        <h2 class="gem-c-cards__heading govuk-heading-m gem-c-cards__heading--underline">Other ways to search for a commodity</h2>
-        <ul class="gem-c-cards__list gem-c-cards__list--one-column">
-          <li class="gem-c-cards__list-item">
-            <div class="gem-c-cards__list-item-wrapper">
-              <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-                <%= govuk_link_to 'Keyword or commodity code', find_commodity_path, class: 'gem-c-cards__link' %>
-              </h3>
-              <p class="govuk-body gem-c-cards__description">Search using keywords or use a known commodity code</p>
-            </div>
-          </li>
-          <li class="gem-c-cards__list-item">
-            <div class="gem-c-cards__list-item-wrapper">
-              <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-                <%= govuk_link_to 'Goods classifications', browse_sections_path, class: 'gem-c-cards__link' %>
-              </h3>
-              <p class="govuk-body gem-c-cards__description">Browse the goods classification</p>
-            </div>
-          </li>
-          <li class="gem-c-cards__list-item">
-            <div class="gem-c-cards__list-item-wrapper">
-              <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-                <%= govuk_link_to 'A-Z product index', a_z_index_path('a'), class: 'gem-c-cards__link' %>
-              </h3>
-              <p class="govuk-body gem-c-cards__description">Look for your product in the A-Z</p>
-            </div>
-          </li>
-        </ul>
-      </div>
+      <%= render 'search/other_ways_to_search' %>
 
     </div>
   </div>

--- a/app/views/search/_interactive_dont_know.html.erb
+++ b/app/views/search/_interactive_dont_know.html.erb
@@ -25,37 +25,9 @@
     Go back and add more details
   </button>
   <%= govuk_button_link_to 'Start search again', find_commodity_path, secondary: true %>
-  <%= govuk_link_to "Cancel", sections_path  %>
+  <%= govuk_link_to "Cancel", find_commodity_path  %>
 </div>
 
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible app-section-break--thick">
+<%= govuk_section_break(size: 'l', visible: true, classes: 'app-section-break--thick') %>
 
-<div class="gem-c-cards">
-  <h2 class="gem-c-cards__heading govuk-heading-m gem-c-cards__heading--underline">Other ways to search for a commodity</h2>
-  <ul class="gem-c-cards__list gem-c-cards__list--one-column">
-    <li class="gem-c-cards__list-item">
-      <div class="gem-c-cards__list-item-wrapper">
-        <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= govuk_link_to "Keyword or commodity code", find_commodity_path, class: 'gem-c-cards__link' %>
-        </h3>
-        <p class="govuk-body gem-c-cards__description">Search using keywords or use a known commodity code</p>
-      </div>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <div class="gem-c-cards__list-item-wrapper">
-        <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= govuk_link_to "Goods classifications", browse_sections_path, class: 'gem-c-cards__link' %>
-        </h3>
-        <p class="govuk-body gem-c-cards__description">Browse the goods classification</p>
-      </div>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <div class="gem-c-cards__list-item-wrapper">
-        <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= govuk_link_to "A-Z product index", a_z_index_path(letter: 'a'), class: 'gem-c-cards__link' %>
-        </h3>
-        <p class="govuk-body gem-c-cards__description">Look for your product in the A-Z</p>
-      </div>
-    </li>
-  </ul>
-</div>
+<%= render 'search/other_ways_to_search' %>

--- a/app/views/search/_interactive_error_sidebar.html.erb
+++ b/app/views/search/_interactive_error_sidebar.html.erb
@@ -1,0 +1,35 @@
+<div class="gem-c-contextual-sidebar govuk-!-margin-bottom-0">
+  <div class="gem-c-related-navigation">
+    <h2 class="gem-c-related-navigation__main-heading">
+      Help and guidance
+    </h2>
+
+    <nav role="navigation" class="gem-c-related-navigation__nav-section">
+      <ul class="gem-c-related-navigation__link-list">
+        <li class="gem-c-related-navigation__link">
+          <%= govuk_link_to 'Classifying your goods', '/howto/commodity-codes', class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
+        </li>
+        <li class="gem-c-related-navigation__link">
+          <%= govuk_link_to 'How to use quotas', '/howto/quotas', class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
+        </li>
+        <li class="gem-c-related-navigation__link">
+          <%= govuk_link_to 'How to value your goods for import or export', '/howto/valuation', class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
+        </li>
+        <li class="gem-c-related-navigation__link">
+          <%= govuk_link_to 'What are trade remedies, safeguards and retaliatory duties?', '/howto/trade-remedies', class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
+        </li>
+        <li class="gem-c-related-navigation__link">
+          <%= govuk_link_to 'What is origin and why is it important for international trade?', '/howto/origin', class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <% if TradeTariffFrontend.webchat_enabled? %>
+    <%= govuk_section_break(size: 'm', visible: true) %>
+
+    <%= govuk_details(summary_text: 'Get support') do %>
+      <%= render 'search/interactive_support_links' %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/search/_interactive_no_results_content.html.erb
+++ b/app/views/search/_interactive_no_results_content.html.erb
@@ -1,24 +1,26 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-inset-text">
-      <p class="govuk-body"><strong>You searched for</strong><br>
-      <%= @search.q %></p>
-    </div>
+    <%= govuk_inset_text do %>
+      <%= tag.p(class: 'govuk-body') do %>
+        <%= tag.strong('You searched for') %><br>
+        <%= @search.q %>
+      <% end %>
+    <% end %>
 
     <h2 class="govuk-heading-m">Tips for using guided search</h2>
     <p class="govuk-body">To get results from the guided search you should:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>search in English only</li>
-      <li>do not use any special characters</li>
-      <li>enter as much detail about the product as possible</li>
-    </ul>
+    <%= govuk_list [
+      'search in English only',
+      'do not use any special characters',
+      'enter as much detail about the product as possible',
+    ], type: :bullet %>
 
     <h2 class="govuk-heading-m">Next steps</h2>
     <p class="govuk-body">Go back and search again, browse the tariff or look for your product in the A-Z.</p>
 
     <div class="govuk-button-group">
       <%= govuk_button_link_to 'Start search again', find_commodity_path %>
-      <%= govuk_link_to "Cancel", sections_path  %>
+      <%= govuk_link_to "Cancel", find_commodity_path  %>
     </div>
   </div>
 
@@ -27,34 +29,6 @@
   </div>
 </div>
 
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible app-section-break--thick">
+<%= govuk_section_break(size: 'l', visible: true, classes: 'app-section-break--thick') %>
 
-<div class="gem-c-cards">
-  <h2 class="gem-c-cards__heading govuk-heading-m gem-c-cards__heading--underline">Other ways to search for a commodity</h2>
-  <ul class="gem-c-cards__list gem-c-cards__list--one-column">
-    <li class="gem-c-cards__list-item">
-      <div class="gem-c-cards__list-item-wrapper">
-        <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= govuk_link_to "Keyword or commodity code", find_commodity_path, class: 'gem-c-cards__link' %>
-        </h3>
-        <p class="govuk-body gem-c-cards__description">Search using keywords or use a known commodity code</p>
-      </div>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <div class="gem-c-cards__list-item-wrapper">
-        <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= govuk_link_to "Goods classifications", browse_sections_path, class: 'gem-c-cards__link' %>
-        </h3>
-        <p class="govuk-body gem-c-cards__description">Browse the goods classification</p>
-      </div>
-    </li>
-    <li class="gem-c-cards__list-item">
-      <div class="gem-c-cards__list-item-wrapper">
-        <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-          <%= govuk_link_to "A-Z product index", a_z_index_path(letter: 'a'), class: 'gem-c-cards__link' %>
-        </h3>
-        <p class="govuk-body gem-c-cards__description">Look for your product in the A-Z</p>
-      </div>
-    </li>
-  </ul>
-</div>
+<%= render 'search/other_ways_to_search' %>

--- a/app/views/search/_interactive_results_sidebar.html.erb
+++ b/app/views/search/_interactive_results_sidebar.html.erb
@@ -26,17 +26,10 @@
   </div>
 
   <% if TradeTariffFrontend.webchat_enabled? %>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <%= govuk_section_break(size: 'm', visible: true) %>
 
     <%= govuk_details(summary_text: 'Get support') do %>
-      <p class="govuk-body">
-        <strong>Webchat</strong><br>
-        <%= webchat_link 'Ask HMRC online' %>
-      </p>
-      <p class="govuk-body">
-        <strong>Email</strong><br>
-        <%= govuk_mail_to 'classification.enquiries@hmrc.gov.uk' %>
-      </p>
+      <%= render 'search/interactive_support_links' %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/search/_interactive_support_links.html.erb
+++ b/app/views/search/_interactive_support_links.html.erb
@@ -1,0 +1,5 @@
+<% if TradeTariffFrontend.webchat_enabled? %>
+  <%= tag.p(class: 'govuk-body govuk-!-margin-bottom-1') do %><%= tag.strong('Webchat:') %> <%= webchat_link 'Ask HMRC online' %><% end %>
+<% end %>
+
+<%= tag.p(class: 'govuk-body') do %><%= tag.strong('Email:') %> <%= govuk_mail_to 'classification.enquiries@hmrc.gov.uk' %><% end %>

--- a/app/views/search/_interactive_unknown_results_content.html.erb
+++ b/app/views/search/_interactive_unknown_results_content.html.erb
@@ -1,0 +1,74 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_inset_text(html_attributes: { data: { controller: 'copy-search-details' } }) do %>
+      <div data-copy-search-details-target="content">
+        <%= tag.p('These are the details you supplied:', class: 'govuk-body') %>
+
+        <%= tag.p(class: 'govuk-body') do %>
+          <%= tag.strong('Initial search term') %><br>
+          <%= @search.q %>
+        <% end %>
+
+        <% @results.answered_questions.each do |qa| %>
+          <%= tag.p(class: 'govuk-body govuk-!-margin-bottom-3') do %>
+            <%= tag.strong(qa['question']) %><br>
+            <%= qa['answer'] %>
+          <% end %>
+        <% end %>
+      </div>
+
+      <%= tag.p(class: 'govuk-body') do %>
+        Copy details to clipboard if you want to save them or use them if you need to contact HMRC for more information.
+      <% end %>
+
+      <%= tag.button(class: "#{govuk_button_classes(secondary: true)} govuk-!-margin-bottom-0",
+                     type: 'button',
+                     data: { action: 'copy-search-details#copy',
+                             copy_search_details_target: 'button' }) do %>
+        Copy results to clipboard
+      <% end %>
+    <% end %>
+
+    <%= tag.p(class: 'govuk-body') do %>
+      Something about what you searched for has caused a problem and we're unable to suggest a commodity code.
+    <% end %>
+
+    <h2 class="govuk-heading-m">What information is needed?</h2>
+    <%= tag.p('The kind of details about the product you should include are:', class: 'govuk-body') %>
+    <%= govuk_list [
+      'the type of product',
+      'what the product is used for',
+      'the materials used to make it',
+      'how it is produced',
+      'how it is packaged',
+    ], type: :bullet %>
+
+    <h2 class="govuk-heading-m">Where can I find this information?</h2>
+    <%= tag.p('This information might be found on:', class: 'govuk-body') %>
+    <%= govuk_list [
+      'invoice or other billing documents',
+      'online listings',
+      'product information documents included in the packaging',
+    ], type: :bullet %>
+
+    <h2 class="govuk-heading-m">Next steps</h2>
+    <%= tag.p(class: 'govuk-body') do %>
+      Check your answers and start your search again. If you think your search is accurate, copy results to clipboard and contact HMRC.
+    <% end %>
+
+    <%= render 'search/interactive_support_links' %>
+
+    <div class="govuk-button-group">
+      <%= govuk_button_link_to 'Start search again', find_commodity_path %>
+      <%= govuk_link_to "Cancel", find_commodity_path  %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render 'search/interactive_error_sidebar' %>
+  </div>
+</div>
+
+<%= govuk_section_break(size: 'l', visible: true, classes: 'app-section-break--thick') %>
+
+<%= render 'search/other_ways_to_search' %>

--- a/app/views/search/_other_ways_to_search.html.erb
+++ b/app/views/search/_other_ways_to_search.html.erb
@@ -1,0 +1,29 @@
+<div class="gem-c-cards">
+  <h2 class="gem-c-cards__heading govuk-heading-m gem-c-cards__heading--underline">Other ways to search for a commodity</h2>
+  <ul class="gem-c-cards__list gem-c-cards__list--one-column">
+    <li class="gem-c-cards__list-item">
+      <div class="gem-c-cards__list-item-wrapper">
+        <h3 class="gem-c-cards__sub-heading govuk-heading-s">
+          <%= govuk_link_to 'Keyword or commodity code', find_commodity_path, class: 'gem-c-cards__link' %>
+        </h3>
+        <p class="govuk-body gem-c-cards__description">Search using keywords or use a known commodity code</p>
+      </div>
+    </li>
+    <li class="gem-c-cards__list-item">
+      <div class="gem-c-cards__list-item-wrapper">
+        <h3 class="gem-c-cards__sub-heading govuk-heading-s">
+          <%= govuk_link_to 'Goods classifications', browse_sections_path, class: 'gem-c-cards__link' %>
+        </h3>
+        <p class="govuk-body gem-c-cards__description">Browse the goods classification</p>
+      </div>
+    </li>
+    <li class="gem-c-cards__list-item">
+      <div class="gem-c-cards__list-item-wrapper">
+        <h3 class="gem-c-cards__sub-heading govuk-heading-s">
+          <%= govuk_link_to 'A-Z product index', a_z_index_path(letter: 'a'), class: 'gem-c-cards__link' %>
+        </h3>
+        <p class="govuk-body gem-c-cards__description">Look for your product in the A-Z</p>
+      </div>
+    </li>
+  </ul>
+</div>

--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -51,7 +51,7 @@
 
       <div class="govuk-button-group">
         <%= f.govuk_submit "Submit" %>
-        <%= govuk_link_to "Cancel", sections_path %>
+        <%= govuk_link_to "Cancel", find_commodity_path %>
       </div>
     <% end %>
 

--- a/app/views/search/interactive_unknown_results.html.erb
+++ b/app/views/search/interactive_unknown_results.html.erb
@@ -1,0 +1,7 @@
+<% content_for :top_breadcrumbs do %>
+  <%= generate_breadcrumbs "Search", [["Home", home_path]] %>
+<% end %>
+
+<%= page_header "Search cannot suggest a code" %>
+
+<%= render 'search/interactive_unknown_results_content' %>

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe SearchController, type: :controller do
 
         it { is_expected.to have_http_status(:redirect) }
         it { expect(assigns(:search)).to be_a(Search) }
-        it { is_expected.to redirect_to(sections_path) }
+        it { is_expected.to redirect_to(find_commodity_path) }
       end
 
       context 'when date param does not have all components present' do
@@ -163,7 +163,7 @@ RSpec.describe SearchController, type: :controller do
 
         it { is_expected.to have_http_status(:redirect) }
         it { expect(assigns(:search)).to be_a(Search) }
-        it { is_expected.to redirect_to(sections_path) }
+        it { is_expected.to redirect_to(find_commodity_path) }
       end
     end
 
@@ -285,6 +285,7 @@ RSpec.describe SearchController, type: :controller do
             'formatted_description' => 'Pure-bred breeding animals',
             'declarable' => true,
             'score' => 12.5,
+            'confidence' => 'strong',
           },
         }
       end
@@ -397,6 +398,83 @@ RSpec.describe SearchController, type: :controller do
 
         it { is_expected.to have_http_status(:ok) }
         it { is_expected.to render_template(:interactive_results) }
+      end
+
+      context 'when backend returns only unknown confidence results' do
+        render_views
+
+        let(:params) do
+          {
+            q: 'citrus jam',
+            interactive_search: 'true',
+            request_id: 'abc-123',
+            answers: [
+              { question: 'What type of fruit?', options: %w[Citrus Berry], answer: 'Citrus' },
+            ],
+          }
+        end
+
+        let(:unknown_commodity_data) do
+          commodity_data.deep_merge(
+            'attributes' => {
+              'confidence' => 'unknown',
+              'score' => 12.5,
+            },
+          )
+        end
+
+        before do
+          stub_api_request('search', :post, internal: true).to_return(
+            status: 200,
+            body: {
+              'data' => [unknown_commodity_data],
+              'meta' => {
+                'interactive_search' => {
+                  'query' => 'citrus jam',
+                  'request_id' => 'abc-123',
+                  'result_limit' => 5,
+                  'answers' => [
+                    { 'question' => 'What type of fruit?', 'options' => %w[Citrus Berry], 'answer' => 'Citrus' },
+                  ],
+                },
+              },
+            }.to_json,
+            headers: { 'content-type' => 'application/json; charset=utf-8' },
+          )
+          do_response
+        end
+
+        it { is_expected.to have_http_status(:ok) }
+        it { is_expected.to render_template(:interactive_unknown_results) }
+        it { expect(response.body).to include('Search cannot suggest a code') }
+      end
+
+      context 'when backend returns no results' do
+        render_views
+
+        let(:params) { { q: 'flimflammagoo', interactive_search: 'true' } }
+
+        before do
+          stub_api_request('search', :post, internal: true).to_return(
+            status: 200,
+            body: {
+              'data' => [],
+              'meta' => {
+                'interactive_search' => {
+                  'query' => 'flimflammagoo',
+                  'request_id' => 'abc-123',
+                  'answers' => [],
+                },
+              },
+            }.to_json,
+            headers: { 'content-type' => 'application/json; charset=utf-8' },
+          )
+          do_response
+        end
+
+        it { is_expected.to have_http_status(:ok) }
+        it { is_expected.to render_template(:interactive_no_results) }
+        it { expect(response.body).to include('No search results could be found') }
       end
     end
 

--- a/spec/javascript/controllers/copy_search_details_controller_spec.js
+++ b/spec/javascript/controllers/copy_search_details_controller_spec.js
@@ -3,8 +3,12 @@ import CopySearchDetailsController from '../../../app/javascript/controllers/cop
 
 describe('CopySearchDetailsController', () => {
   let application;
+  let originalExecCommand;
 
   beforeEach(() => {
+    originalExecCommand = document.execCommand;
+    document.execCommand = undefined;
+
     document.body.innerHTML = `
       <details class="govuk-details" data-controller="copy-search-details">
         <summary class="govuk-details__summary">
@@ -27,6 +31,7 @@ describe('CopySearchDetailsController', () => {
 
   afterEach(() => {
     application.stop();
+    document.execCommand = originalExecCommand;
   });
 
   describe('#copy', () => {
@@ -50,6 +55,65 @@ describe('CopySearchDetailsController', () => {
       expect(button.textContent).toBe('Copy search details');
 
       jest.useRealTimers();
+    });
+
+    it('copies text from an explicit content target', async () => {
+      document.body.innerHTML = `
+        <div data-controller="copy-search-details">
+          <div data-copy-search-details-target="content">
+            <p>Initial search term: citrus jam</p>
+            <p>What type of fruit? Citrus</p>
+          </div>
+          <button data-action="copy-search-details#copy"
+                  data-copy-search-details-target="button">
+            Copy results to clipboard
+          </button>
+        </div>
+      `;
+
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, {clipboard: {writeText}});
+
+      const button = document.querySelector('button');
+      await Promise.resolve();
+      button.click();
+
+      await Promise.resolve();
+
+      expect(writeText).toHaveBeenCalledWith(
+        'Initial search term: citrus jam\nWhat type of fruit? Citrus',
+      );
+      expect(button.textContent).toBe('Copied');
+    });
+
+    it('uses the synchronous clipboard fallback when available', async () => {
+      Object.assign(navigator, {clipboard: undefined});
+      document.execCommand = jest.fn().mockReturnValue(true);
+
+      const button = document.querySelector('button');
+      button.click();
+
+      await Promise.resolve();
+
+      expect(document.execCommand).toHaveBeenCalledWith('copy');
+      expect(button.textContent).toBe('Copied');
+    });
+
+    it('prefers the Clipboard API over the legacy fallback', async () => {
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, {clipboard: {writeText}});
+      document.execCommand = jest.fn().mockReturnValue(true);
+
+      const button = document.querySelector('button');
+      button.click();
+
+      await Promise.resolve();
+
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringContaining('citrus jam'),
+      );
+      expect(document.execCommand).not.toHaveBeenCalled();
+      expect(button.textContent).toBe('Copied');
     });
   });
 });

--- a/spec/models/search/internal_search_result_spec.rb
+++ b/spec/models/search/internal_search_result_spec.rb
@@ -406,6 +406,26 @@ RSpec.describe Search::InternalSearchResult do
     end
   end
 
+  describe '#all_unknown_confidence?' do
+    context 'when every result has unknown confidence' do
+      subject { described_class.new([commodity_attrs('confidence' => 'unknown'), heading_attrs('confidence' => nil)]) }
+
+      it { is_expected.to be_all_unknown_confidence }
+    end
+
+    context 'when any result has recognised confidence' do
+      subject { described_class.new([commodity_attrs('confidence' => 'possible'), heading_attrs('confidence' => 'unknown')]) }
+
+      it { is_expected.not_to be_all_unknown_confidence }
+    end
+
+    context 'when there are no results' do
+      subject { described_class.new([]) }
+
+      it { is_expected.not_to be_all_unknown_confidence }
+    end
+  end
+
   describe '#query' do
     subject { described_class.new([commodity_attrs], meta).query }
 

--- a/spec/views/search/_interactive_dont_know.html.erb_spec.rb
+++ b/spec/views/search/_interactive_dont_know.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'search/_interactive_dont_know', type: :view do
   it { is_expected.to have_text('Go back and add more details so we can find the relevant commodity code with the highest accuracy.') }
   it { is_expected.to have_css('button', text: 'Go back and add more details') }
   it { is_expected.to have_link('Start search again') }
-  it { is_expected.to have_link('Cancel') }
+  it { is_expected.to have_link('Cancel', href: find_commodity_path) }
 
   describe 'alternative search cards' do
     it { is_expected.to have_css('h2', text: 'Other ways to search for a commodity') }

--- a/spec/views/search/_interactive_no_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_no_results_content.html.erb_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'search/_interactive_no_results_content', type: :view do
     it { is_expected.to have_css('h2', text: 'Next steps') }
     it { is_expected.to have_text('Go back and search again, browse the tariff or look for your product in the A-Z.') }
     it { is_expected.to have_link('Start search again', href: find_commodity_path) }
-    it { is_expected.to have_link('Cancel', href: sections_path) }
+    it { is_expected.to have_link('Cancel', href: find_commodity_path) }
   end
 
   describe 'sidebar' do

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -142,6 +142,10 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
       before { allow(TradeTariffFrontend).to receive(:webchat_enabled?).and_return(true) }
 
       it { is_expected.to have_css('.govuk-details__summary-text', text: 'Get support') }
+      it { is_expected.to have_css('p.govuk-body', text: 'Webchat: Ask HMRC online') }
+      it { is_expected.to have_css('p.govuk-body', text: 'Email: classification.enquiries@hmrc.gov.uk') }
+      it { is_expected.to have_link('Ask HMRC online') }
+      it { is_expected.to have_link('classification.enquiries@hmrc.gov.uk', href: 'mailto:classification.enquiries@hmrc.gov.uk') }
     end
 
     context 'when webchat is disabled' do

--- a/spec/views/search/_interactive_unknown_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_unknown_results_content.html.erb_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe 'search/_interactive_unknown_results_content', type: :view do
+  subject { render partial: 'search/interactive_unknown_results_content' }
+
+  before do
+    assign(:results, results)
+    assign(:search, search)
+  end
+
+  let(:search) { Search.new(q: 'flimflammagoo', request_id: 'test-uuid-123', interactive_search: true) }
+  let(:results) { Search::InternalSearchResult.new([], meta) }
+  let(:meta) do
+    {
+      'interactive_search' => {
+        'query' => 'flimflammagoo',
+        'answers' => [
+          { 'question' => 'Which of these best describes the product?', 'answer' => 'Standard jam / jelly / marmalade / fruit spread for general consumption' },
+          { 'question' => 'What type of fruit is the spread primarily made from?', 'answer' => 'Citrus fruit' },
+        ],
+      },
+    }
+  end
+
+  describe 'inset text' do
+    it { is_expected.to have_css('.govuk-inset-text', text: 'These are the details you supplied:') }
+    it { is_expected.to have_css('.govuk-inset-text', text: 'Initial search term') }
+    it { is_expected.to have_css('.govuk-inset-text', text: 'flimflammagoo') }
+    it { is_expected.to have_css('.govuk-inset-text', text: 'Which of these best describes the product?') }
+    it { is_expected.to have_css('.govuk-inset-text', text: 'Standard jam / jelly / marmalade / fruit spread for general consumption') }
+    it { is_expected.to have_css('button', text: 'Copy results to clipboard') }
+    it { is_expected.to have_css('button[type="button"][data-action="copy-search-details#copy"][data-copy-search-details-target="button"]') }
+    it { is_expected.to have_css('[data-copy-search-details-target="content"]') }
+  end
+
+  describe 'error guidance' do
+    it { is_expected.to have_text('Something about what you searched for has caused a problem') }
+    it { is_expected.to have_css('h2', text: 'What information is needed?') }
+    it { is_expected.to have_text('the type of product') }
+    it { is_expected.to have_text('what the product is used for') }
+    it { is_expected.to have_css('h2', text: 'Where can I find this information?') }
+    it { is_expected.to have_text('invoice or other billing documents') }
+  end
+
+  describe 'next steps' do
+    it { is_expected.to have_css('h2', text: 'Next steps') }
+    it { is_expected.to have_text('Check your answers and start your search again.') }
+    it { is_expected.to have_link('Start search again', href: find_commodity_path) }
+    it { is_expected.to have_link('Cancel', href: find_commodity_path) }
+
+    context 'when webchat is enabled' do
+      before { allow(TradeTariffFrontend).to receive(:webchat_enabled?).and_return(true) }
+
+      it { is_expected.to have_css('p.govuk-body', text: 'Webchat: Ask HMRC online') }
+      it { is_expected.to have_css('p.govuk-body', text: 'Email: classification.enquiries@hmrc.gov.uk') }
+      it { is_expected.to have_link('Ask HMRC online') }
+      it { is_expected.to have_link('classification.enquiries@hmrc.gov.uk', href: 'mailto:classification.enquiries@hmrc.gov.uk') }
+    end
+
+    context 'when webchat is disabled' do
+      before { allow(TradeTariffFrontend).to receive(:webchat_enabled?).and_return(false) }
+
+      it { is_expected.not_to have_link('Ask HMRC online') }
+      it { is_expected.to have_css('p.govuk-body', text: 'Email: classification.enquiries@hmrc.gov.uk') }
+      it { is_expected.to have_link('classification.enquiries@hmrc.gov.uk', href: 'mailto:classification.enquiries@hmrc.gov.uk') }
+    end
+  end
+
+  describe 'sidebar' do
+    it { is_expected.to have_text('Help and guidance') }
+    it { is_expected.to have_link('Classifying your goods') }
+    it { is_expected.to have_link('How to use quotas') }
+    it { is_expected.to have_link('How to value your goods for import or export') }
+  end
+
+  describe 'alternative search cards' do
+    it { is_expected.to have_css('h2', text: 'Other ways to search for a commodity') }
+    it { is_expected.to have_link('Keyword or commodity code') }
+    it { is_expected.to have_link('Goods classifications') }
+    it { is_expected.to have_link('A-Z product index') }
+  end
+end

--- a/spec/views/search/interactive_question.html.erb_spec.rb
+++ b/spec/views/search/interactive_question.html.erb_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe 'search/interactive_question', type: :view do
+  subject { render }
+
+  before do
+    assign(:search, Search.new(q: 'citrus jam', request_id: 'test-uuid-123', interactive_search: true))
+    assign(:results, Search::InternalSearchResult.new([], meta))
+  end
+
+  let(:meta) do
+    {
+      'interactive_search' => {
+        'query' => 'citrus jam',
+        'request_id' => 'test-uuid-123',
+        'answers' => [
+          { 'question' => 'What type of fruit?', 'options' => %w[Citrus Berry], 'answer' => nil },
+        ],
+      },
+    }
+  end
+
+  it { is_expected.to have_css('h1', text: 'Search for a commodity') }
+  it { is_expected.to have_link('Cancel', href: find_commodity_path) }
+end


### PR DESCRIPTION
## What

<img width="886" height="1257" alt="image" src="https://github.com/user-attachments/assets/87527b31-4eb2-4fb0-a65e-83e04cc56e3f" />

- [x] Route guided classification results with only unknown confidence to the error page instead of the results list
- [x] Replace the guided no-results content with the PUFD error-page copy and search detail playback
- [x] Add clipboard copying for the replayed search details in the inset text component
- [x] Add focused model, controller, view, and JavaScript coverage

## Why

The PUFD asks for failed guided classification searches to explain that the service cannot suggest a commodity code, preserve the details the trader supplied, and give clear next steps rather than showing a list of Unknown results.

## Ticket

[AI-810](https://transformuk.atlassian.net/browse/AI-810)

## Risk:

**Risk level:** 🟠

**Reason for rating:**
This changes the guided search error path and trader-facing recovery content. The change is contained to interactive search routing and the existing no-results/error page, with focused tests and full RSpec/Jest passing locally.
