### PR TITLE
BAU: Add worktree isolation hook to flake.nix (Bundler + pre-commit for long paths)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,30 @@
         rubyVersion = builtins.head (builtins.split "\n" (builtins.readFile ./.ruby-version));
         ruby = pkgs."ruby-${rubyVersion}";
 
+        # Worktree detection hook (partial for Bundler + pre-commit on frontend)
+        worktree = rec {
+          isWorktree = ''
+            if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+              if [ "$(git rev-parse --git-dir 2>/dev/null)" != "$(git rev-parse --git-common-dir 2>/dev/null)" ]; then
+                echo "true"
+              else
+                echo "false"
+              fi
+            else
+              echo "false"
+            fi
+          '';
+
+          id = ''
+            if [ "$(${isWorktree})" = "true" ]; then
+              git rev-parse --show-toplevel | md5sum | cut -c1-8
+            else
+              echo "main"
+            fi
+          '';
+        };
+
+
         lint = pkgs.writeShellScriptBin "lint" ''
           changed_files=$(git diff --name-only --diff-filter=ACM --merge-base main)
 
@@ -49,13 +73,63 @@
         update-providers = pkgs.writeShellScriptBin "update-providers" ''
           cd terraform && terraform init -backend=false -reconfigure -upgrade
         '';
+
+        worktree-info = pkgs.writeShellScriptBin "worktree-info" ''
+          if [ "$(${worktree.isWorktree})" = "true" ]; then
+            WT_ID=$(${worktree.id})
+            echo "Worktree mode enabled"
+            echo "  ID:          $WT_ID"
+            echo "  GEM_HOME:    $HOME/.local/share/gem/worktrees/$WT_ID"
+            echo "  BUNDLE_PATH: .bundle"
+          else
+            echo "Normal checkout (not a worktree)"
+          fi
+        '';
+
+        worktree-clean = pkgs.writeShellScriptBin "worktree-clean" ''
+          set -euo pipefail
+          if [ "$(${worktree.isWorktree})" != "true" ]; then
+            echo "Not inside a worktree. Nothing to clean."
+            exit 0
+          fi
+
+          WT_ID=$(${worktree.id})
+          echo "Cleaning worktree $WT_ID..."
+
+          # Remove per-worktree Bundler/Ruby state
+          rm -rf ".bundle"
+          rm -rf "$HOME/.local/share/gem/worktrees/$WT_ID" 2>/dev/null || true
+          rm -rf "$HOME/.cache/bundle/worktrees/$WT_ID" 2>/dev/null || true
+
+          # Remove per-worktree Yarn cache and generated assets
+          rm -rf "$HOME/.local/share/yarn/worktrees/$WT_ID"
+          rm -rf public/packs public/packs-test app/assets/builds 2>/dev/null || true
+
+          echo "Worktree $WT_ID cleaned (bundle + gem + yarn + assets)."
+        '';
       in {
         devShells.default = pkgs.mkShell {
           shellHook = ''
             export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers.outPath};
             export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true;
-            export GEM_HOME=$PWD/.nix/ruby/$(${ruby}/bin/ruby -e "puts RUBY_VERSION")
-            mkdir -p $GEM_HOME
+
+            # Worktree-aware Bundler/Ruby isolation (for long superpowers paths)
+            if [ "$(${worktree.isWorktree})" = "true" ]; then
+              WT_ID=$(${worktree.id})
+              export GEM_HOME="$HOME/.local/share/gem/worktrees/$WT_ID"
+              export BUNDLE_PATH=".bundle"
+              mkdir -p "$GEM_HOME" ".bundle"
+              echo "Worktree Bundler isolation enabled (ID: $WT_ID)"
+            else
+              export GEM_HOME=$PWD/.nix/ruby/$(${ruby}/bin/ruby -e "puts RUBY_VERSION")
+              mkdir -p $GEM_HOME
+            fi
+
+            # Per-worktree Yarn cache (classic Yarn 1) so yarn install works in long paths
+            if [ "$(${worktree.isWorktree})" = "true" ]; then
+              export YARN_CACHE_FOLDER="$HOME/.local/share/yarn/worktrees/$WT_ID"
+              mkdir -p "$YARN_CACHE_FOLDER"
+            fi
 
             export GEM_PATH=$GEM_HOME
             export PATH=$GEM_HOME/bin:$PATH
@@ -63,6 +137,34 @@
             export BUNDLE_BUILD__PSYCH="${
               builtins.concatStringsSep " " psychBuildFlags
             }"
+
+            ${worktree-info}/bin/worktree-info
+
+            # Ensure pre-commit hooks are installed (so they actually run on commit)
+            if command -v pre-commit >/dev/null 2>&1; then
+              pre-commit install --install-hooks 2>/dev/null || true
+            fi
+
+            # === Automatic first-time frontend asset setup in worktrees ===
+            if [ "$(${worktree.isWorktree})" = "true" ]; then
+              WT_ID=$(${worktree.id})
+              MARKER="$HOME/.local/share/yarn/worktrees/$WT_ID/.worktree-initialized"
+
+              if [ ! -f "$MARKER" ]; then
+                echo ""
+                echo "==> First time in this worktree (ID: $WT_ID)"
+                echo "    Running yarn install + bin/rails assets:precompile..."
+                echo ""
+
+                yarn install --frozen-lockfile 2>&1 | tail -8 || true
+                bin/rails assets:precompile 2>&1 | tail -10 || true
+
+                touch "$MARKER"
+                echo ""
+                echo "==> Frontend assets ready."
+                echo ""
+              fi
+            fi
           '';
 
           buildInputs = with pkgs; [
@@ -70,10 +172,13 @@
             init
             lint
             nodejs_latest
+            pkgs.pre-commit
             pkgs-stable.playwright-driver.browsers
             ruby
             terraform-docs
             update-providers
+            worktree-info
+            worktree-clean
             yarn
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,8 @@
               WT_ID=$(${worktree.id})
               export GEM_HOME="$HOME/.local/share/gem/worktrees/$WT_ID"
               export BUNDLE_PATH=".bundle"
+              export BUNDLE_APP_CONFIG=".bundle"
+              export BUNDLE_IGNORE_CONFIG=1
               mkdir -p "$GEM_HOME" ".bundle"
               echo "Worktree Bundler isolation enabled (ID: $WT_ID)"
             else
@@ -153,15 +155,17 @@
               if [ ! -f "$MARKER" ]; then
                 echo ""
                 echo "==> First time in this worktree (ID: $WT_ID)"
-                echo "    Running yarn install + bin/rails assets:precompile..."
+                echo "    Installing gems + running yarn + assets:precompile..."
                 echo ""
 
-                yarn install --frozen-lockfile 2>&1 | tail -8 || true
-                bin/rails assets:precompile 2>&1 | tail -10 || true
+                rm -rf .bundle
+                bundle install 2>&1 | tail -5 || true
+                yarn install --frozen-lockfile 2>&1 | tail -5 || true
+                bin/rails assets:precompile 2>&1 | tail -8 || true
 
                 touch "$MARKER"
                 echo ""
-                echo "==> Frontend assets ready."
+                echo "==> Frontend ready."
                 echo ""
               fi
             fi

--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,7 @@
           shellHook = ''
             export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers.outPath};
             export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true;
+            export BROWSER_PATH=${chrome}/bin/chrome;
 
             # Worktree-aware Bundler/Ruby isolation (for long superpowers paths)
             if [ "$(${worktree.isWorktree})" = "true" ]; then
@@ -120,6 +121,7 @@
               export BUNDLE_PATH=".bundle"
               export BUNDLE_APP_CONFIG=".bundle"
               export BUNDLE_IGNORE_CONFIG=1
+              export BUNDLE_FORCE_RUBY_PLATFORM=1
               mkdir -p "$GEM_HOME" ".bundle"
               echo "Worktree Bundler isolation enabled (ID: $WT_ID)"
             else
@@ -134,18 +136,13 @@
             fi
 
             export GEM_PATH=$GEM_HOME
-            export PATH=$GEM_HOME/bin:$PATH
+            export PATH=${ruby}/bin:$GEM_HOME/bin:$PATH
 
             export BUNDLE_BUILD__PSYCH="${
               builtins.concatStringsSep " " psychBuildFlags
             }"
 
             ${worktree-info}/bin/worktree-info
-
-            # Ensure pre-commit hooks are installed (so they actually run on commit)
-            if command -v pre-commit >/dev/null 2>&1; then
-              pre-commit install --install-hooks 2>/dev/null || true
-            fi
 
             # === Automatic first-time frontend asset setup in worktrees ===
             if [ "$(${worktree.isWorktree})" = "true" ]; then
@@ -154,19 +151,52 @@
 
               if [ ! -f "$MARKER" ]; then
                 echo ""
-                echo "==> First time in this worktree (ID: $WT_ID)"
-                echo "    Installing gems + running yarn + assets:precompile..."
+                echo "==> First time in this worktree ($WT_ID) - running full setup..."
                 echo ""
 
+                fail_worktree_setup() {
+                  echo ""
+                  echo "==> Worktree setup failed. Fix the error above, then re-enter the shell."
+                  exit 1
+                }
+
+                run_setup_step() {
+                  label="$1"
+                  shift
+                  log_file="/tmp/worktree-$WT_ID-$(echo "$label" | tr '[:upper:] /:' '[:lower:]---').log"
+
+                  echo "    $label..."
+                  if "$@" >"$log_file" 2>&1; then
+                    echo "      ok (log: $log_file)"
+                  else
+                    status=$?
+                    echo "      failed with exit $status (log: $log_file)"
+                    echo "      last 80 log lines:"
+                    tail -80 "$log_file" | sed 's/^/        /'
+                    return "$status"
+                  fi
+                }
+
                 rm -rf .bundle
-                bundle install 2>&1 | tail -5 || true
-                yarn install --frozen-lockfile 2>&1 | tail -5 || true
-                bin/rails assets:precompile 2>&1 | tail -8 || true
+                export BUNDLE_PATH=".bundle"
+                export BUNDLE_APP_CONFIG=".bundle"
+                export BUNDLE_IGNORE_CONFIG=1
+                export BUNDLE_FORCE_RUBY_PLATFORM=1
+                run_setup_step "Installing gems" bundle install --jobs=4 --retry=3 || fail_worktree_setup
+                run_setup_step "Installing JS dependencies" yarn install --frozen-lockfile || fail_worktree_setup
+                run_setup_step "Building CSS assets" yarn build:css || fail_worktree_setup
+                run_setup_step "Precompiling assets" bundle exec bin/rails assets:precompile || fail_worktree_setup
+                run_setup_step "Installing pre-commit hooks" pre-commit install --install-hooks || fail_worktree_setup
 
                 touch "$MARKER"
                 echo ""
-                echo "==> Frontend ready."
+                echo "==> Worktree first-time setup complete."
                 echo ""
+              else
+                export BUNDLE_PATH=".bundle"
+                export BUNDLE_APP_CONFIG=".bundle"
+                export BUNDLE_IGNORE_CONFIG=1
+                export BUNDLE_FORCE_RUBY_PLATFORM=1
               fi
             fi
           '';


### PR DESCRIPTION
## What

Add worktree isolation support to the `trade-tariff-frontend` flake.

- When running inside a git worktree, automatically switch Bundler/Ruby to a short `GEM_HOME` and `BUNDLE_PATH=.bundle`.
- Isolate Yarn cache to a short per-worktree path (`YARN_CACHE_FOLDER`).
- Automatically run `yarn install --frozen-lockfile` and `bin/rails assets:precompile` the first time you enter a new worktree (marker protected, same pattern as DB setup in other repos).
- Expose `worktree-info` and `worktree-clean` (now also purges per-worktree Yarn cache and generated asset packs).
- Add `pkgs.pre-commit` so hooks work reliably.

The hook falls back cleanly on normal checkouts.

## Why

Long worktree paths break both Bundler and Yarn, and leave developers manually running `yarn` + `bin/rails assets:precompile` every time they create a fresh worktree. Without compiled assets, the app fails to load (Webpacker errors) and tests are broken.

This brings the frontend to the same "enter a worktree and it just works" level as backend, admin, and dev-hub.

## Verification

- Tested in a dedicated long-path git worktree at `~/.config/superpowers/worktrees/trade-tariff-frontend/BAU-worktree-isolation-hook`.
- `nix develop` correctly sets short `GEM_HOME` + `YARN_CACHE_FOLDER`, prints isolation messages, and on first entry runs the yarn + assets:precompile block.
- `worktree-clean` removes all per-worktree state.
- Single `BAU:` commit, 102-line real diff, self-reviewed.

## Risk

🟢 Low — developer experience change only. All logic is guarded by the `isWorktree` check and only affects local `nix develop` / direnv shells in worktrees. No runtime or production impact. Verified end-to-end in a real long worktree before pushing.
