### PR TITLE
AI-721: Show blocking description intercept guidance

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -29,5 +29,5 @@ TARIFF_FROM_EMAIL=no-reply@example.com
 TARIFF_SUPPORT_EMAIL=support@example.com
 TARIFF_TO_EMAIL=support@example.com
 UPDATED_NAVIGATION=true
-WEBCHAT_URL='test-online-services-helpdesk'
+WEBCHAT_URL='https://www.tax.service.gov.uk/ask-hmrc/chat/online-services-helpdesk'
 WELSH=true

--- a/.env.test
+++ b/.env.test
@@ -24,5 +24,5 @@ TARIFF_FROM_EMAIL=no-reply@example.com
 TARIFF_SUPPORT_EMAIL=support@example.com
 TARIFF_TO_EMAIL=support@example.com
 UPDATED_NAVIGATION=true
-WEBCHAT_URL='test-online-services-helpdesk'
+WEBCHAT_URL='https://www.tax.service.gov.uk/ask-hmrc/chat/online-services-helpdesk'
 WELSH=true

--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -14,6 +14,7 @@ module InteractiveSearchable
     merge_current_answer
 
     @results = @search.perform
+    sync_interactive_request_id
 
     if @search.errors.any?
       render_interactive_search_page
@@ -32,6 +33,10 @@ module InteractiveSearchable
       redirect_to url_for @results.to_param.merge(url_options).merge(request_id: @search.request_id, only_path: true)
     elsif @results.has_pending_question?
       render_interactive_question
+    elsif @results.blocking_guidance?
+      return redirect_to_interactive_blocking if redirectable_interactive_blocking?
+
+      render_interactive_blocking
     elsif @results.all_unknown_confidence?
       render_interactive_unknown_results
     elsif @results.none?
@@ -71,6 +76,22 @@ module InteractiveSearchable
 
   def interactive_search?
     @search.interactive_search && TradeTariffFrontend.interactive_search_enabled?
+  end
+
+  def sync_interactive_request_id
+    return unless @results.respond_to?(:request_id) && @results.request_id.present?
+
+    @search.request_id = @results.request_id
+  end
+
+  def redirectable_interactive_blocking?
+    request.post? && params[:request_id].blank?
+  end
+
+  def redirect_to_interactive_blocking
+    redirect_to perform_search_path(
+      search_params.to_h.merge(interactive_search: 'true', request_id: @search.request_id),
+    )
   end
 
   def merge_current_answer
@@ -140,6 +161,13 @@ module InteractiveSearchable
     disable_search_form
     mark_interactive_search_page
     render :interactive_unknown_results
+  end
+
+  def render_interactive_blocking
+    disable_switch_service_banner
+    disable_search_form
+    mark_interactive_search_page
+    render :interactive_blocking
   end
 
   def render_interactive_results

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include InterceptGuidanceHelper
+
   def home_path(*args, &block)
     find_commodity_path(*args, &block)
   end

--- a/app/helpers/intercept_guidance_helper.rb
+++ b/app/helpers/intercept_guidance_helper.rb
@@ -1,0 +1,54 @@
+module InterceptGuidanceHelper
+  SUPPORTED_PLACEHOLDERS = {
+    'request_id' => ->(search) { "**#{search.request_id}**" },
+    'search_term' => ->(search) { search.q },
+    'enquiries_email' => ->(_) { TradeTariffFrontend.enquiries_email },
+    'webchat_url' => ->(_) { TradeTariffFrontend.webchat_url },
+  }.freeze
+
+  GOVUK_MARKDOWN_CLASSES = {
+    'p' => %w[govuk-body],
+    'a' => %w[govuk-link],
+    'ul' => %w[govuk-list govuk-list--bullet],
+    'ol' => %w[govuk-list govuk-list--number],
+    'h2' => %w[govuk-heading-m],
+    'h3' => %w[govuk-heading-s],
+    'h4, h5, h6' => %w[govuk-heading-s],
+  }.freeze
+
+  def resolve_intercept_placeholders(message, search:)
+    return message if message.blank? || search.blank?
+
+    message.to_s.gsub(/\{\{(\w+)\}\}/) do |match|
+      key = ::Regexp.last_match(1)
+      resolver = SUPPORTED_PLACEHOLDERS[key]
+      resolver ? resolver.call(search) : match
+    end
+  end
+
+  def render_intercept_message(message, search:)
+    resolved = resolve_intercept_placeholders(message, search:)
+    govuk_markdown(linkified_code_references(govspeak(resolved)))
+  end
+
+private
+
+  def linkified_code_references(html)
+    GoodsNomenclatureCodeLinkifier.new(html).render
+  end
+
+  def govuk_markdown(html)
+    fragment = Nokogiri::HTML::DocumentFragment.parse(html.to_s)
+    fragment.css('[style]').each { |node| node.remove_attribute('style') }
+
+    GOVUK_MARKDOWN_CLASSES.each do |selector, classes|
+      fragment.css(selector).each { |node| append_classes(node, classes) }
+    end
+
+    fragment.to_html.html_safe
+  end
+
+  def append_classes(node, classes)
+    node['class'] = (node['class'].to_s.split + classes).uniq.join(' ')
+  end
+end

--- a/app/models/goods_nomenclature_code_linkifier.rb
+++ b/app/models/goods_nomenclature_code_linkifier.rb
@@ -1,0 +1,87 @@
+class GoodsNomenclatureCodeLinkifier
+  Pattern = Data.define(:regexp, :code_from_match)
+
+  SPACED_TERMINATORS = /(?=\s|;|,|$|\.|\)|\z)/
+  PUNCTUATION_TERMINATORS = /(?=;|,|$|\)|\z|<br>|<\/br>)/
+  COMBINED_TERMINATORS = /(?=\s|;|,|$|\.|\)|\z|<br>|<\/br>)/
+  CODE_BOUNDARY_START = /(?<![A-Za-z0-9.\/-])/
+  CODE_BOUNDARY_END = /(?![A-Za-z0-9.\/-])/
+  HEADING_CODE = /(?:0[1-9]|[1-9]\d)(?:0[1-9]|[1-9]\d)/
+
+  PATTERNS = [
+    Pattern.new(/chapter\s+(\d{2})#{SPACED_TERMINATORS}/i, ->(match) { match[1] }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})\.(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}" }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})\s(\d{2})\s(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}#{match[3]}" }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})\s(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}" }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{10}|\d{8}|\d{6})#{COMBINED_TERMINATORS}/, ->(match) { match[1] }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{10}|\d{8}|\d{6}|\d{2})#{CODE_BOUNDARY_END}/, ->(match) { match[1] }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{2})(?=\.\s|\.\z)/, ->(match) { match[1] }),
+    Pattern.new(/\A(#{HEADING_CODE})#{SPACED_TERMINATORS}/, ->(match) { match[1] }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(#{HEADING_CODE})#{COMBINED_TERMINATORS}/, ->(match) { match[1] }),
+  ].freeze
+
+  def initialize(html, service_path: nil)
+    @html = html.to_s
+    @service_path = service_path || current_service_path
+  end
+
+  def render
+    fragment = Nokogiri::HTML::DocumentFragment.parse(@html)
+
+    fragment.xpath('.//text()[normalize-space()] | ./text()[normalize-space()]').each do |node|
+      next if node.ancestors.any? { |ancestor| ancestor.name == 'a' }
+
+      replacement = linkify_text(node.text)
+      next if replacement == CGI.escapeHTML(node.text)
+
+      node.replace(Nokogiri::HTML::DocumentFragment.parse(replacement))
+    end
+
+    fragment.to_html
+  end
+
+private
+
+  def linkify_text(text)
+    html = +''
+    position = 0
+
+    while position < text.length
+      pattern, match = next_match(text, position)
+
+      unless match
+        html << CGI.escapeHTML(text[position..])
+        break
+      end
+
+      html << CGI.escapeHTML(text[position...match.begin(0)])
+      html << link_for(match[0], pattern.code_from_match.call(match))
+      position = match.end(0)
+    end
+
+    html
+  end
+
+  def next_match(text, position)
+    PATTERNS.each_with_object([nil, nil]) do |pattern, best|
+      match = pattern.regexp.match(text, position)
+      next unless match
+
+      if best[1].nil? || match.begin(0) < best[1].begin(0)
+        best[0] = pattern
+        best[1] = match
+      end
+    end
+  end
+
+  def link_for(text, code)
+    href = "#{@service_path}/search?#{Rack::Utils.build_query(q: code)}"
+    link_text = %(#{CGI.escapeHTML(text)}<span class="govuk-visually-hidden"> (opens in new tab)</span>)
+
+    %(<a class="govuk-link" href="#{CGI.escapeHTML(href)}" rel="noopener noreferrer" target="_blank">#{link_text}</a>)
+  end
+
+  def current_service_path
+    TradeTariffFrontend::ServiceChooser.xi? ? '/xi' : ''
+  end
+end

--- a/app/models/search/internal_search_result.rb
+++ b/app/models/search/internal_search_result.rb
@@ -93,6 +93,31 @@ class Search
       meta&.dig('interactive_search', 'query')
     end
 
+    def description_intercept
+      meta&.dig('description_intercept')
+    end
+
+    def blocking_guidance?
+      di = description_intercept
+      return false unless di
+
+      ActiveModel::Type::Boolean.new.cast(di['excluded']) &&
+        di['message_header'].present? &&
+        di['message'].present?
+    end
+
+    def description_intercept_message_header
+      description_intercept&.dig('message_header')
+    end
+
+    def description_intercept_message
+      description_intercept&.dig('message')
+    end
+
+    def description_intercept_term
+      description_intercept&.dig('term')
+    end
+
     private
 
     def build_model(entry)

--- a/app/views/search/_interactive_blocking_content.html.erb
+++ b/app/views/search/_interactive_blocking_content.html.erb
@@ -1,0 +1,25 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_inset_text do %>
+      <%= tag.p(class: 'govuk-body') do %>
+        <%= tag.strong('You searched for') %><br>
+        <%= @results.description_intercept_term.presence || @search.q %>
+      <% end %>
+    <% end %>
+
+    <%= render_intercept_message(@results.description_intercept_message, search: @search) %>
+
+    <div class="govuk-button-group">
+      <%= govuk_button_link_to 'Start search again', find_commodity_path %>
+      <%= govuk_link_to 'Cancel', find_commodity_path %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render 'search/interactive_error_sidebar' %>
+  </div>
+</div>
+
+<%= govuk_section_break(size: 'l', visible: true) %>
+
+<%= render 'search/other_ways_to_search' %>

--- a/app/views/search/interactive_blocking.html.erb
+++ b/app/views/search/interactive_blocking.html.erb
@@ -1,0 +1,7 @@
+<% content_for :top_breadcrumbs do %>
+  <%= generate_breadcrumbs "Search", [["Home", home_path]] %>
+<% end %>
+
+<%= page_header @results.description_intercept_message_header.presence || "Search blocked" %>
+
+<%= render 'search/interactive_blocking_content' %>

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -1,4 +1,8 @@
 module TradeTariffFrontend
+  DEFAULT_ENQUIRIES_EMAIL = 'classification.enquiries@hmrc.gov.uk'.freeze
+  DEFAULT_SUPPORT_EMAIL = DEFAULT_ENQUIRIES_EMAIL
+  WEBCHAT_BASE_URL = 'https://www.tax.service.gov.uk/ask-hmrc/chat/'.freeze
+
   autoload :Presenter,      'trade_tariff_frontend/presenter'
   autoload :ServiceChooser, 'trade_tariff_frontend/service_chooser'
   autoload :ViewContext,    'trade_tariff_frontend/view_context'
@@ -44,7 +48,11 @@ module TradeTariffFrontend
   end
 
   def support_email
-    ENV['TARIFF_SUPPORT_EMAIL']
+    ENV['TARIFF_SUPPORT_EMAIL'].presence || DEFAULT_SUPPORT_EMAIL
+  end
+
+  def enquiries_email
+    DEFAULT_ENQUIRIES_EMAIL
   end
 
   def currency_default
@@ -119,7 +127,11 @@ module TradeTariffFrontend
   end
 
   def webchat_url
-    ENV['WEBCHAT_URL']
+    configured_url = ENV['WEBCHAT_URL']
+    return if configured_url.blank?
+    return configured_url if configured_url.match?(%r{\Ahttps?://})
+
+    URI.join(WEBCHAT_BASE_URL, configured_url).to_s
   end
 
   def legacy_results_to_show

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -449,6 +449,90 @@ RSpec.describe SearchController, type: :controller do
         it { expect(response.body).to include('Search cannot suggest a code') }
       end
 
+      context 'when backend returns a blocking description intercept' do
+        render_views
+
+        let(:params) { { q: 'exampleterm', interactive_search: 'true' } }
+        let(:backend_meta) do
+          {
+            'interactive_search' => {
+              'query' => 'exampleterm',
+              'request_id' => 'stable-request-id',
+              'answers' => [],
+            },
+            'description_intercept' => {
+              'excluded' => true,
+              'message_header' => 'Example guidance header',
+              'message' => 'Example guidance message body {{request_id}} {{enquiries_email}} [Ask HMRC online]({{webchat_url}}).',
+            },
+          }
+        end
+
+        before do
+          allow(SecureRandom).to receive(:uuid).and_return('generated-request-id')
+          allow(TradeTariffFrontend).to receive_messages(
+            enquiries_email: 'classification.enquiries@hmrc.gov.uk',
+            webchat_url: 'https://example.com/webchat',
+          )
+
+          stub_api_request('search', :post, internal: true).to_return(
+            status: 200,
+            body: {
+              'data' => [],
+              'meta' => backend_meta,
+            }.to_json,
+            headers: { 'content-type' => 'application/json; charset=utf-8' },
+          )
+          do_response
+        end
+
+        it { is_expected.to redirect_to(perform_search_path(q: 'exampleterm', interactive_search: 'true', request_id: 'stable-request-id')) }
+      end
+
+      context 'when rendering a blocking description intercept with request_id in the URL' do
+        render_views
+
+        subject(:do_response) { get :search, params: }
+
+        let(:params) { { q: 'exampleterm', interactive_search: 'true', request_id: 'stable-request-id' } }
+
+        before do
+          allow(SecureRandom).to receive(:uuid).and_return('generated-request-id')
+          allow(TradeTariffFrontend).to receive_messages(
+            enquiries_email: 'classification.enquiries@hmrc.gov.uk',
+            webchat_url: 'https://example.com/webchat',
+          )
+
+          stub_api_request('search', :post, internal: true).to_return(
+            status: 200,
+            body: {
+              'data' => [],
+              'meta' => {
+                'description_intercept' => {
+                  'excluded' => true,
+                  'message_header' => 'Example guidance header',
+                  'message' => 'Example guidance message body {{request_id}} {{enquiries_email}} [Ask HMRC online]({{webchat_url}}).',
+                },
+              },
+            }.to_json,
+            headers: { 'content-type' => 'application/json; charset=utf-8' },
+          )
+          do_response
+        end
+
+        it { is_expected.to have_http_status(:ok) }
+        it { is_expected.to render_template(:interactive_blocking) }
+        it { expect(response.body).to include('Example guidance header') }
+        it { expect(response.body).to include('Example guidance message body') }
+        it { expect(response.body).to include('<strong>stable-request-id</strong>') }
+        it { expect(response.body).not_to include('generated-request-id') }
+        it { expect(response.body).to include('classification.enquiries@hmrc.gov.uk') }
+        it { expect(response.body).to include('href="https://example.com/webchat"') }
+        it { expect(response.body).to include('exampleterm') }
+        it { expect(response.body).not_to include('style=') }
+        it { expect(response.body).not_to include('app-section-break--thick') }
+      end
+
       context 'when backend returns no results' do
         render_views
 

--- a/spec/helpers/intercept_guidance_helper_spec.rb
+++ b/spec/helpers/intercept_guidance_helper_spec.rb
@@ -1,0 +1,88 @@
+# spec/helpers/intercept_guidance_helper_spec.rb
+require 'spec_helper'
+
+RSpec.describe InterceptGuidanceHelper do
+  include ApplicationHelper
+  include described_class
+
+  let(:search) { Search.new(q: 'toiletries set', request_id: 'req-abc-123') }
+
+  describe '#resolve_intercept_placeholders' do
+    it 'replaces {{request_id}} with the bold search request_id' do
+      msg = 'Your reference is {{request_id}}. Please quote it.'
+      expect(resolve_intercept_placeholders(msg, search:)).to eq('Your reference is **req-abc-123**. Please quote it.')
+    end
+
+    it 'replaces {{search_term}} with the original query' do
+      msg = 'You searched for {{search_term}}'
+      expect(resolve_intercept_placeholders(msg, search:)).to eq('You searched for toiletries set')
+    end
+
+    it 'replaces {{enquiries_email}} with the default enquiries email' do
+      msg = 'Contact {{enquiries_email}} for help.'
+      allow(TradeTariffFrontend).to receive(:enquiries_email).and_return('classification.enquiries@hmrc.gov.uk')
+
+      expect(resolve_intercept_placeholders(msg, search:)).to eq('Contact classification.enquiries@hmrc.gov.uk for help.')
+    end
+
+    it 'replaces {{webchat_url}} with the configured webchat URL' do
+      msg = '[Ask HMRC online]({{webchat_url}})'
+      allow(TradeTariffFrontend).to receive(:webchat_url).and_return('https://example.com/webchat')
+
+      expect(resolve_intercept_placeholders(msg, search:)).to eq('[Ask HMRC online](https://example.com/webchat)')
+    end
+
+    it 'leaves unknown placeholders untouched' do
+      msg = 'Contact {{unknown_email}} for help.'
+      expect(resolve_intercept_placeholders(msg, search:)).to eq('Contact {{unknown_email}} for help.')
+    end
+
+    it 'handles multiple replacements in one message' do
+      msg = 'Ref: {{request_id}} | Term: {{search_term}}'
+      result = resolve_intercept_placeholders(msg, search:)
+      expect(result).to eq('Ref: **req-abc-123** | Term: toiletries set')
+    end
+  end
+
+  describe '#render_intercept_message' do
+    it 'resolves placeholders then renders via govspeak', :aggregate_failures do
+      msg = "Hello {{search_term}}\n\nReference: {{request_id}}"
+      html = render_intercept_message(msg, search:)
+      expect(html).to include('Hello toiletries set')
+      expect(html).to include('Reference: <strong>req-abc-123</strong>')
+    end
+
+    it 'uses GOV.UK Frontend typography classes for rendered markdown', :aggregate_failures do
+      html = render_intercept_message(
+        "## Next steps\n\nDo this:\n\n- Contact HMRC\n\n[Ask HMRC online](https://example.com/webchat)",
+        search:,
+      )
+
+      expect(html).to have_css('h2.govuk-heading-m', text: 'Next steps')
+      expect(html).to have_css('p.govuk-body', text: 'Do this:')
+      expect(html).to have_css('ul.govuk-list.govuk-list--bullet li', text: 'Contact HMRC')
+      expect(html).to have_css('a.govuk-link[href="https://example.com/webchat"]', text: 'Ask HMRC online')
+      expect(html).not_to include('style=')
+    end
+
+    it 'linkifies goods nomenclature code references like the admin preview', :aggregate_failures do
+      msg = 'Review Chapter 71, headings 3207 to 3210, subheading 8703.10 and commodity 0101210000.'
+      html = render_intercept_message(msg, search:)
+
+      expect(html).to have_css('a.govuk-link[href="/search?q=71"][target="_blank"][rel="noopener noreferrer"]', text: 'Chapter 71')
+      expect(html).to have_css('a.govuk-link[href="/search?q=3207"]', text: '3207')
+      expect(html).to have_css('a.govuk-link[href="/search?q=3210"]', text: '3210')
+      expect(html).to have_css('a.govuk-link[href="/search?q=870310"]', text: '8703.10')
+      expect(html).to have_css('a.govuk-link[href="/search?q=0101210000"]', text: '0101210000')
+      expect(html).to have_css('a .govuk-visually-hidden', text: '(opens in new tab)', count: 5)
+    end
+
+    it 'does not linkify code references inside existing markdown links', :aggregate_failures do
+      html = render_intercept_message('[Read about 0101](https://example.com/existing) and Chapter 71', search:)
+
+      expect(html).to have_css('a.govuk-link[href="https://example.com/existing"]', text: 'Read about 0101')
+      expect(html).to have_css('a.govuk-link[href="/search?q=71"]', text: 'Chapter 71')
+      expect(html).not_to have_css('a[href="https://example.com/existing"] a')
+    end
+  end
+end

--- a/spec/lib/trade_tariff_frontend_spec.rb
+++ b/spec/lib/trade_tariff_frontend_spec.rb
@@ -1,6 +1,58 @@
 require 'spec_helper'
 
 RSpec.describe TradeTariffFrontend do
+  describe '.enquiries_email' do
+    it 'returns the default classification enquiries email' do
+      expect(described_class.enquiries_email).to eq('classification.enquiries@hmrc.gov.uk')
+    end
+  end
+
+  describe '.support_email' do
+    context 'with TARIFF_SUPPORT_EMAIL configured' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('TARIFF_SUPPORT_EMAIL' => 'configured@example.com'))
+      end
+
+      it 'returns the configured support email' do
+        expect(described_class.support_email).to eq('configured@example.com')
+      end
+    end
+
+    context 'without TARIFF_SUPPORT_EMAIL configured' do
+      before do
+        stub_const('ENV', ENV.to_hash.except('TARIFF_SUPPORT_EMAIL'))
+      end
+
+      it 'returns the default classification enquiries email' do
+        expect(described_class.support_email).to eq('classification.enquiries@hmrc.gov.uk')
+      end
+    end
+  end
+
+  describe '.webchat_url' do
+    context 'with WEBCHAT_URL configured as a full URL' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('WEBCHAT_URL' => 'https://example.com/webchat'))
+      end
+
+      it 'returns the configured URL' do
+        expect(described_class.webchat_url).to eq('https://example.com/webchat')
+      end
+    end
+
+    context 'with WEBCHAT_URL configured as a webchat slug' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('WEBCHAT_URL' => 'test-online-services-helpdesk'))
+      end
+
+      it 'returns the HMRC webchat URL for the slug' do
+        expect(described_class.webchat_url).to eq(
+          'https://www.tax.service.gov.uk/ask-hmrc/chat/test-online-services-helpdesk',
+        )
+      end
+    end
+  end
+
   describe '.developer_portal_url' do
     around do |example|
       described_class.instance_variable_set(:@base_domain, nil)

--- a/spec/models/goods_nomenclature_code_linkifier_spec.rb
+++ b/spec/models/goods_nomenclature_code_linkifier_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe GoodsNomenclatureCodeLinkifier do
+  def render(html, service_path: '')
+    described_class.new(html, service_path:).render
+  end
+
+  def page(html, service_path: '')
+    Capybara.string(render(html, service_path:))
+  end
+
+  describe '#render' do
+    it 'linkifies a chapter keyword reference' do
+      expect(page('<p>goods of Chapter 71</p>')).to have_link('Chapter 71', href: '/search?q=71')
+    end
+
+    it 'linkifies heading codes using mixed separators', :aggregate_failures do
+      rendered = page('<p>(headings 3207 to 3210, 3212, 3213 or 3215)</p>')
+
+      expect(rendered).to have_link('3207', href: '/search?q=3207')
+      expect(rendered).to have_link('3210', href: '/search?q=3210')
+      expect(rendered).to have_link('3212', href: '/search?q=3212')
+      expect(rendered).to have_link('3213', href: '/search?q=3213')
+      expect(rendered).to have_link('3215', href: '/search?q=3215')
+    end
+
+    it 'linkifies longer goods code references at the end of a sentence' do
+      expect(page('<p>commodity 0101210000.</p>')).to have_link('0101210000', href: '/search?q=0101210000')
+    end
+
+    it 'does not linkify decimal numbers' do
+      expect(page('<p>width exceeds 10.5mm</p>')).not_to have_link('10')
+    end
+
+    it 'does not double-linkify existing links', :aggregate_failures do
+      html = '<p><a href="/foo">3606</a> and chapter 71</p>'
+      rendered = page(html)
+
+      expect(rendered).to have_link('3606', href: '/foo')
+      expect(rendered).to have_link('chapter 71', href: '/search?q=71')
+      expect(rendered).not_to have_css('a a')
+    end
+
+    it 'adds the xi service path when rendering in xi context' do
+      expect(page('<p>Chapter 71</p>', service_path: '/xi')).to have_link('Chapter 71', href: '/xi/search?q=71')
+    end
+
+    it 'marks generated links as new-tab GOV.UK links', :aggregate_failures do
+      rendered = render('<p>Chapter 71</p>')
+
+      expect(rendered).to include('class="govuk-link"')
+      expect(rendered).to include('target="_blank"')
+      expect(rendered).to include('rel="noopener noreferrer"')
+      expect(rendered).to include('<span class="govuk-visually-hidden"> (opens in new tab)</span>')
+    end
+  end
+end

--- a/spec/models/search/internal_search_result_spec.rb
+++ b/spec/models/search/internal_search_result_spec.rb
@@ -433,4 +433,61 @@ RSpec.describe Search::InternalSearchResult do
 
     it { is_expected.to eq('leather handbag') }
   end
+
+  describe '#description_intercept' do
+    it 'returns the description_intercept hash from meta when present' do
+      meta = { 'description_intercept' => { 'excluded' => true, 'message_header' => 'Sending a set', 'message' => 'Sets...' } }
+      result = described_class.new([], meta)
+      expect(result.description_intercept).to eq(meta['description_intercept'])
+    end
+
+    it 'returns nil when no description_intercept in meta' do
+      result = described_class.new([], { 'interactive_search' => {} })
+      expect(result.description_intercept).to be_nil
+    end
+  end
+
+  describe '#blocking_guidance?' do
+    it 'returns true when excluded is true and both message_header and message are present' do
+      meta = { 'description_intercept' => { 'excluded' => true, 'message_header' => 'Sending a set', 'message' => 'Sets should be...' } }
+      result = described_class.new([], meta)
+      expect(result.blocking_guidance?).to be true
+    end
+
+    it 'returns false when excluded is false even if message present' do
+      meta = { 'description_intercept' => { 'excluded' => false, 'message_header' => 'Foo', 'message' => 'Bar' } }
+      result = described_class.new([], meta)
+      expect(result.blocking_guidance?).to be false
+    end
+
+    it 'returns false when message_header is missing' do
+      meta = { 'description_intercept' => { 'excluded' => true, 'message' => 'Only body' } }
+      result = described_class.new([], meta)
+      expect(result.blocking_guidance?).to be false
+    end
+  end
+
+  describe '#description_intercept_message_header' do
+    it 'returns the message_header from the intercept' do
+      meta = { 'description_intercept' => { 'message_header' => 'Sending a set' } }
+      result = described_class.new([], meta)
+      expect(result.description_intercept_message_header).to eq('Sending a set')
+    end
+  end
+
+  describe '#description_intercept_message' do
+    it 'returns the raw message from the intercept' do
+      meta = { 'description_intercept' => { 'message' => 'Sets should be classified...' } }
+      result = described_class.new([], meta)
+      expect(result.description_intercept_message).to eq('Sets should be classified...')
+    end
+  end
+
+  describe '#description_intercept_term' do
+    it 'returns the matched term from the intercept' do
+      meta = { 'description_intercept' => { 'term' => 'toiletries set' } }
+      result = described_class.new([], meta)
+      expect(result.description_intercept_term).to eq('toiletries set')
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[AI-721](https://transformuk.atlassian.net/browse/AI-721)

```mermaid
flowchart TB
    A[Guided search submits query] --> B[Backend checks description intercepts]
    B --> C{Blocking intercept?}
    C -->|Yes| D[Frontend renders blocking guidance page]
    C -->|No| E[Continue existing guided search flow]
```

<img width="1003" height="961" alt="image" src="https://github.com/user-attachments/assets/2db40cff-0f39-4a66-a9eb-eca06557c552" />


### What?

- [x] Add a guided search blocking guidance page for backend description intercept responses.
- [x] Substitute supported intercept guidance placeholders before rendering.
- [x] Render intercept guidance with GOV.UK Frontend typography and automatic commodity code links.
- [x] Preserve the backend request ID across page refreshes.
- [x] Add regression coverage for the blocking guidance flow and intercept guidance rendering.

### Why?

Backend description intercepts can now return trader-facing guidance instead of normal guided search results. The frontend needs to render that guidance consistently, substitute the supported placeholders, and preserve the backend request ID so a trader can quote the same reference after refreshing the page.

### Risk

**Risk level:** 🟢

**Reason for rating:** Guided search is not in production, so this is isolated to a non-production user journey. The change is scoped to backend blocking description intercept responses and is covered by targeted controller, helper, model and config specs.