### PR TITLE
AI-721: Preserve guided search dates between questions

### DIFF
--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -26,6 +26,11 @@
       <%= hidden_field_tag :q, @search.q %>
       <%= hidden_field_tag :interactive_search, 'true' %>
       <%= hidden_field_tag :request_id, @search.request_id %>
+      <% if @search.day_month_and_year_set? %>
+        <%= hidden_field_tag :year, @search.year %>
+        <%= hidden_field_tag :month, @search.month %>
+        <%= hidden_field_tag :day, @search.day %>
+      <% end %>
 
       <% @results.answered_questions.each do |qa| %>
         <%= hidden_field_tag "answers[][question]", qa['question'] %>

--- a/spec/views/search/interactive_question.html.erb_spec.rb
+++ b/spec/views/search/interactive_question.html.erb_spec.rb
@@ -2,9 +2,11 @@ RSpec.describe 'search/interactive_question', type: :view do
   subject { render }
 
   before do
-    assign(:search, Search.new(q: 'citrus jam', request_id: 'test-uuid-123', interactive_search: true))
+    assign(:search, search)
     assign(:results, Search::InternalSearchResult.new([], meta))
   end
+
+  let(:search) { Search.new('q' => 'citrus jam', 'request_id' => 'test-uuid-123', 'interactive_search' => true) }
 
   let(:meta) do
     {
@@ -20,4 +22,26 @@ RSpec.describe 'search/interactive_question', type: :view do
 
   it { is_expected.to have_css('h1', text: 'Search for a commodity') }
   it { is_expected.to have_link('Cancel', href: find_commodity_path) }
+
+  context 'when the guided search was started for a historical date' do
+    let(:search) do
+      Search.new(
+        'q' => 'citrus jam',
+        'request_id' => 'test-uuid-123',
+        'interactive_search' => true,
+        'day' => '27',
+        'month' => '3',
+        'year' => '2021',
+      )
+    end
+
+    it 'carries the date into the answer submission form' do
+      render
+
+      expect(rendered)
+        .to have_css('input[type="hidden"][name="day"][value="27"]', visible: :hidden)
+        .and have_css('input[type="hidden"][name="month"][value="3"]', visible: :hidden)
+        .and have_css('input[type="hidden"][name="year"][value="2021"]', visible: :hidden)
+    end
+  end
 end


### PR DESCRIPTION
## What:

Preserve the selected `day`, `month`, and `year` fields when a guided search moves from the initial search form to a follow-up question.

Adds a view spec proving historical date fields are carried into the guided-search answer form.

## Why:

The initial guided search request included the selected date, so the internal search cache key varied by `as_of`. The follow-up question form dropped those date fields, causing subsequent answer submissions to fall back to today's date and reuse the same cache path across different historical dates.

## Ticket:

https://transformuk.atlassian.net/browse/AI-721

## Risk:

**Risk level:** 🟢 Green

**Reason for rating:**

Small hidden-field preservation fix in the guided-search question form. No new backend calls, no cache topology changes, and covered by focused view/controller/model specs.