### PR TITLE
Add socket-level timeouts to Faraday connections

### DIFF
--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -36,6 +36,8 @@ class ClientBuilder
         conn.request :retry, RETRY_DEFAULTS.merge(Rails.configuration.x.http.retry_options)
         conn.use :http_cache, store: @cache, logger: Rails.logger if @cache
         conn.response :raise_error
+        conn.options.open_timeout = 5
+        conn.options.timeout = 10
         conn.ssl.verify = false
         conn.ssl.ca_file = cert_path
         conn.adapter :net_http_persistent

--- a/app/services/duty_calculator/client_builder.rb
+++ b/app/services/duty_calculator/client_builder.rb
@@ -41,6 +41,8 @@ module DutyCalculator
         faraday.use Faraday::FollowRedirects::Middleware
         faraday.response :logger if ENV['DEBUG_REQUESTS']
         faraday.request :retry, RETRY_DEFAULTS.merge(Rails.configuration.x.http.retry_options)
+        faraday.options.open_timeout = 5
+        faraday.options.timeout = 10
         faraday.ssl.verify = false
         faraday.ssl.ca_file = cert_path
         faraday.adapter :net_http_persistent


### PR DESCRIPTION
### Jira link

N/A (production bug fix)

### What?

Add \`open_timeout\` (5s) and \`timeout\` (10s) to both Faraday connection builders.

### Why?

Neither \`ClientBuilder\` configured socket-level timeouts, meaning a hung backend could block a Puma thread indefinitely at the OS I/O level. The only safety net was the \`ServiceTimeout\` rack middleware, which wraps each request in Ruby's \`Timeout.timeout\`.

When that fires it raises \`Timeout::ExitException\` — a subclass of \`Exception\`, not \`StandardError\` — in the blocked thread. This tears unsafely through the entire Faraday middleware stack:

- \`faraday-http-cache\` may be interrupted mid-write, corrupting cache entries
- \`net-http-persistent\` can be left with broken connections that get reused on the next request
- Every \`rescue StandardError\` in the stack is bypassed, so there is no clean error page

With socket-level timeouts configured, \`net-http\` raises \`Net::ReadTimeout\` / \`Net::OpenTimeout\` at the OS level (safe, no thread interruption). Faraday converts these to \`Faraday::TimeoutError\`, which the existing \`rescue_from Faraday::TimeoutError\` handler in \`ApplicationController\` catches cleanly, and the retry middleware can retry safely.

The \`ServiceTimeout\` middleware remains as a hard backstop for non-Faraday slow paths, but should rarely fire now that Faraday bails out at the socket level first.

### Risk

**Risk level:** 🟢

**Reason for rating:** Only adds timeouts that were missing. The only observable change is that requests to a hung backend now fail faster (10s) and cleanly rather than eventually crashing unsafely after 15s. Covered by the existing error handling path.