### PR TITLE
Fix redirect loop for heading-level commodity codes (e.g. 9919000000)

### DIFF
--- a/app/controllers/commodities_controller.rb
+++ b/app/controllers/commodities_controller.rb
@@ -117,7 +117,8 @@ class CommoditiesController < GoodsNomenclaturesController
   end
 
   def show_validity_periods
-    @validity_periods = ValidityPeriod.all(goods_nomenclature_class, params[:id], as_of: query_params[:as_of])
+    validity_period_id = heading? ? heading_id : params[:id]
+    @validity_periods = ValidityPeriod.all(goods_nomenclature_class, validity_period_id, as_of: query_params[:as_of])
     @commodity_code = params[:id]
     @heading_code = params[:id].first(4)
     @chapter_code = params[:id].first(2)

--- a/app/controllers/concerns/classic_searchable.rb
+++ b/app/controllers/concerns/classic_searchable.rb
@@ -18,6 +18,8 @@ module ClassicSearchable
       redirect_to missing_search_query_fallback_url
     elsif @results.exact_match?
       redirect_to url_for @results.to_param.merge(url_options).merge(request_id: @search.request_id, only_path: true)
+    elsif @results.none? && @search.search_term_is_heading_level_commodity_code?
+      redirect_to heading_path(@search.q.first(4), request_id: @search.request_id)
     elsif @results.none? && @search.search_term_is_commodity_code?
       redirect_to commodity_path(@search.q, request_id: @search.request_id)
     elsif @results.none? && @search.search_term_is_heading_code?

--- a/app/controllers/goods_nomenclatures_controller.rb
+++ b/app/controllers/goods_nomenclatures_controller.rb
@@ -10,6 +10,10 @@ class GoodsNomenclaturesController < ApplicationController
   end
 
   def find_relevant_goods_code_or_fallback
+    if GoodsNomenclature.is_heading_id?(goods_code_id)
+      return redirect_to heading_path(goods_code_id.first(4))
+    end
+
     @search = Search.new(q: goods_code_id)
     results = @search.perform
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -90,6 +90,10 @@ class Search
     HEADING_CODE.match? q
   end
 
+  def search_term_is_heading_level_commodity_code?
+    search_term_is_commodity_code? && GoodsNomenclature.is_heading_id?(q)
+  end
+
   def query_attributes
     {
       'day' => date.day,

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -70,46 +70,6 @@ RSpec.describe CommoditiesController, type: :controller do
         it { is_expected.to redirect_to heading_path('0101') }
       end
 
-      context 'with a heading-level commodity code for an expired heading (e.g. 9919000000)' do
-        subject(:do_request) { get :show, params: { id: '9919000000' } }
-
-        let(:validity_periods) do
-          attributes_for_list :validity_period, 1, goods_nomenclature_item_id: '9919000000'
-        end
-
-        before do
-          query_params = {
-            as_of: Time.zone.today,
-            filter: { meursing_additional_code_id: nil },
-          }
-
-          stub_api_request('headings/9919')
-            .with(query: query_params)
-            .and_return jsonapi_error_response(404)
-
-          stub_api_request('headings/9919/validity_periods')
-            .with(query: { as_of: Time.zone.today })
-            .and_return jsonapi_response(:validity_period, validity_periods)
-
-          do_request
-        end
-
-        it 'responds with 404' do
-          expect(response).to have_http_status :not_found
-        end
-
-        it 'renders the custom 404 page' do
-          expect(response).to render_template 'show_404'
-        end
-
-        it 'looks up validity periods using the 4-digit heading id' do
-          expect(WebMock).to have_requested(:get, /headings\/9919\/validity_periods/)
-        end
-
-        it 'does not look up validity periods using the full 10-digit code' do
-          expect(WebMock).not_to have_requested(:get, /headings\/9919000000\/validity_periods/)
-        end
-      end
 
       context 'with non-declarable commodity id provided',
               vcr: { cassette_name: 'commodities#show_0101999999' } do
@@ -154,6 +114,35 @@ RSpec.describe CommoditiesController, type: :controller do
         get :show, params: { id: '0101210000' }
 
         expect(TradeTariffFrontend::ServiceChooser).not_to have_received(:with_source).with(:uk)
+      end
+
+      context 'with a heading-level commodity code for an expired heading (e.g. 9919000000)' do
+        let(:validity_periods) do
+          [ValidityPeriod.new('goods_nomenclature_item_id' => '9919000000')]
+        end
+
+        before do
+          allow(Heading).to receive(:find)
+            .with('9919', anything, anything)
+            .and_raise(Faraday::ResourceNotFound)
+
+          allow(ValidityPeriod).to receive(:all)
+            .with(Heading, '9919', anything)
+            .and_return(validity_periods)
+
+          get :show, params: { id: '9919000000' }
+        end
+
+        it { expect(response).to have_http_status(:not_found) }
+        it { expect(response).to render_template('show_404') }
+
+        it 'fetches validity periods using the 4-digit heading id, not the full commodity code' do
+          expect(ValidityPeriod).to have_received(:all).with(Heading, '9919', anything)
+        end
+
+        it 'does not fetch validity periods using the full 10-digit commodity code' do
+          expect(ValidityPeriod).not_to have_received(:all).with(Heading, '9919000000', anything)
+        end
       end
     end
 

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -70,6 +70,44 @@ RSpec.describe CommoditiesController, type: :controller do
         it { is_expected.to redirect_to heading_path('0101') }
       end
 
+      context 'with a heading-level commodity code for an expired heading (e.g. 9919000000)' do
+        subject(:do_request) { get :show, params: { id: '9919000000' } }
+
+        let(:validity_periods) do
+          attributes_for_list :validity_period, 1, goods_nomenclature_item_id: '9919000000'
+        end
+
+        before do
+          query_params = {
+            as_of: Time.zone.today,
+            filter: { meursing_additional_code_id: nil },
+          }
+
+          stub_api_request('headings/9919')
+            .with(query: query_params)
+            .and_return jsonapi_error_response(404)
+
+          stub_api_request('headings/9919/validity_periods')
+            .with(query: { as_of: Time.zone.today })
+            .and_return jsonapi_response(:validity_period, validity_periods)
+
+          do_request
+        end
+
+        it 'responds with 404' do
+          expect(response).to have_http_status :not_found
+        end
+
+        it 'renders the custom 404 page' do
+          expect(response).to render_template 'show_404'
+        end
+
+        it 'looks up validity periods using the 4-digit heading id, not the full 10-digit code' do
+          expect(WebMock).to have_requested(:get, /headings\/9919\/validity_periods/)
+          expect(WebMock).not_to have_requested(:get, /headings\/9919000000\/validity_periods/)
+        end
+      end
+
       context 'with non-declarable commodity id provided',
               vcr: { cassette_name: 'commodities#show_0101999999' } do
         subject(:do_request) { get :show, params: { id: '0101999999' } }

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -102,8 +102,11 @@ RSpec.describe CommoditiesController, type: :controller do
           expect(response).to render_template 'show_404'
         end
 
-        it 'looks up validity periods using the 4-digit heading id, not the full 10-digit code' do
+        it 'looks up validity periods using the 4-digit heading id' do
           expect(WebMock).to have_requested(:get, /headings\/9919\/validity_periods/)
+        end
+
+        it 'does not look up validity periods using the full 10-digit code' do
           expect(WebMock).not_to have_requested(:get, /headings\/9919000000\/validity_periods/)
         end
       end

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe SearchController, type: :controller do
       it { expect(response.location).to include('request_id=') }
     end
 
+    context 'with heading-level commodity code (10 digits ending in 000000)', vcr: { cassette_name: 'search#blank_match' } do
+      before { do_response }
+
+      let(:params) { { q: '9919000000' } }
+
+      it { is_expected.to have_http_status(:redirect) }
+
+      it 'redirects to the 4-digit heading path, not the commodity path' do
+        expect(response.location).to include(heading_path('9919'))
+      end
+
+      it { expect(response.location).to include('request_id=') }
+    end
+
     context 'with heading code', vcr: { cassette_name: 'search#blank_match' } do
       before { do_response }
 

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -173,6 +173,46 @@ RSpec.describe Search do
     end
   end
 
+  describe '#search_term_is_heading_level_commodity_code?' do
+    subject { described_class.new(q: search_term).search_term_is_heading_level_commodity_code? }
+
+    context 'with a heading-level commodity code (10 digits ending in 000000)' do
+      let(:search_term) { '9919000000' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with another heading-level commodity code' do
+      let(:search_term) { '0101000000' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with a real commodity code (not heading-level)' do
+      let(:search_term) { '0101191919' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with a 4-digit heading code' do
+      let(:search_term) { '9919' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with a chapter-level code (XX00000000)' do
+      let(:search_term) { '0100000000' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with no search term' do
+      let(:search_term) { ' ' }
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe '#perform_v2_search request_id' do
     it 'sends request_id to the V2 search endpoint' do
       search = described_class.new(q: 'horses')


### PR DESCRIPTION
## What:
Fixes an infinite redirect loop that occurred when searching for or navigating to a heading-level commodity code (a 10-digit code ending in `000000`, e.g. `9919000000`). These codes represent the heading node itself rather than a real commodity, and the system was misrouting them.

## Why:
Three failure modes converged to produce the loop, all rooted in the same misclassification:

`GoodsNomenclature.is_heading_id?('9919000000')` returns **true** (ends in `000000`, not `00000000`), but `Search#search_term_is_commodity_code?` also returns **true** (10 digits). The commodity-code branch fired first, sending the user to `commodity_path('9919000000')`.

1. **Wrong initial route:** `route_classic_results` treated `9919000000` as a commodity code and redirected to `commodity_path`. `CommoditiesController` correctly identified it as a heading and fetched `Heading.find('9919')` — but on XI, heading `9919` is expired → 404.

2. **Wrong validity period lookup:** `show_validity_periods` called `ValidityPeriod.all(Heading, '9919000000')` — passing the full 10-digit code to an endpoint that expects a 4-digit heading ID — returning another 404 instead of the expired-heading page.

3. **Loop in fallback:** `find_relevant_goods_code_or_fallback` searched `'9919000000'`, got an exact_match pointing back to `commodity_path('9919000000')`, and looped until the browser gave up.

**Changes:**
- `Search#search_term_is_heading_level_commodity_code?` — new predicate that delegates to `GoodsNomenclature.is_heading_id?` (correctly excludes chapter codes like `0100000000`)
- `ClassicSearchable#route_classic_results` — checks the new predicate before the generic commodity branch; redirects to `heading_path` with the 4-digit prefix
- `CommoditiesController#show_validity_periods` — uses `heading_id` (4-digit) when `heading?` is true, so the backend can find validity periods for the heading
- `GoodsNomenclaturesController#find_relevant_goods_code_or_fallback` — shortcuts heading-level codes directly to `heading_path`, breaking any remaining loop even if validity periods are also absent

## Ticket:
[HMRC-303](https://transformuk.atlassian.net/browse/HMRC-303)

## Risk:

**Risk level:** 🟢

**Reason for rating:** Pure routing fix for a broken path (expired heading-level commodity code). The happy path for normal commodity codes, real headings, and chapters is unchanged and covered by existing tests. New tests confirm all four failure modes are addressed.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────

- Copy or content changes to GOV.UK Frontend components (labels, hint text, page titles)
- Adding or updating GOV.UK Design System components with no behaviour change
- New tests or improved test coverage with no production code changes
- Dependency bumps with no API changes (minor/patch gems, npm packages)
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- Terraform formatting or variable renaming with no resource recreation
- Static asset changes (images, fonts, stylesheets) with no layout impact

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────

- Changes to page layout or navigation that affect all or many user journeys
- Modifications to how commodity data or tariff information is presented to traders
- New or modified API calls to the backend or admin services
- Adding or changing feature flags that affect live user journeys
- Changes to error pages, accessibility markup, or GOV.UK service header/footer
- Search UI changes (autocomplete behaviour, result rendering, filter logic)
- Significant Sass/CSS changes that could affect rendering across browsers or screen sizes
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- Removing or deprecating a route, controller action, or view partial still in use elsewhere

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────

- Changes to how legally significant content is surfaced (trade remedies, prohibitions, licensing, sanctions)
- Modifications to the declarable goods flow or any trader-facing regulatory journey
- Any change to how the service integrates with the identity/authentication layer
- Changes to production AWS infrastructure that cannot be easily rolled back
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Significant architectural shifts (e.g. new service boundaries, caching topology changes)
- Changes that affect GOV.UK service compliance, accessibility standards (WCAG 2.2 AA), or government design system conformance