### PR TITLE
BAU: Align internal search timeouts

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -127,7 +127,9 @@ class Search
       params[:answers] = answers if answers.present?
       params[:request_id] = request_id if request_id.present?
 
-      response = self.class.api.post(path, MultiJson.dump(params), 'Content-Type' => 'application/json')
+      response = self.class.api.post(path, MultiJson.dump(params), 'Content-Type' => 'application/json') do |request|
+        request.options.timeout = TradeTariffFrontend::ServiceTimeout.timeout_for('/internal/search')
+      end
       body = response.body.is_a?(Hash) ? response.body : JSON.parse(response.body)
       parsed_data = TariffJsonapiParser.new(body).parse
       parsed_data = [] unless parsed_data.is_a?(Array)

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,6 +1,7 @@
-ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] ||= '15'
-
 require 'trade_tariff_frontend/service_timeout'
+
+ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] ||= TradeTariffFrontend::ServiceTimeout::DEFAULT_TIMEOUT.to_s
+ENV['RACK_TIMEOUT_PATH_OVERRIDES'] ||= TradeTariffFrontend::ServiceTimeout::DEFAULT_PATH_OVERRIDES
 
 if defined?(Rack::Timeout)
   Rails.application.config.middleware.delete Rack::Timeout

--- a/lib/trade_tariff_frontend/service_timeout.rb
+++ b/lib/trade_tariff_frontend/service_timeout.rb
@@ -1,36 +1,46 @@
 module TradeTariffFrontend
   class ServiceTimeout
-    DEFAULT_PATH_OVERRIDES = '/uk/search:50,/xi/search:50,/search:50'.freeze
+    DEFAULT_TIMEOUT = 15
+    DEFAULT_PATH_OVERRIDES = '/uk/search:50,/xi/search:50,/search:50,/internal/search:50'.freeze
+
+    class << self
+      def timeout_for(path)
+        path_timeouts.each do |prefix, seconds|
+          return seconds if path.start_with?(prefix)
+        end
+
+        default_timeout
+      end
+
+      def default_timeout
+        ENV.fetch('RACK_TIMEOUT_SERVICE_TIMEOUT', DEFAULT_TIMEOUT).to_i
+      end
+
+      def path_timeouts
+        parse_path_timeouts
+      end
+
+      private
+
+      def parse_path_timeouts
+        ENV.fetch('RACK_TIMEOUT_PATH_OVERRIDES', DEFAULT_PATH_OVERRIDES)
+           .split(',')
+           .filter_map do |entry|
+             parts = entry.strip.split(':')
+             next if parts.length < 2
+
+             [parts[0], parts[1].to_i]
+           end
+      end
+    end
 
     def initialize(app)
       @app = app
-      @default_timeout = ENV.fetch('RACK_TIMEOUT_SERVICE_TIMEOUT', '15').to_i
-      @path_timeouts = parse_path_timeouts
     end
 
     def call(env)
-      timeout = timeout_for(env['PATH_INFO'])
+      timeout = self.class.timeout_for(env['PATH_INFO'])
       ::Timeout.timeout(timeout) { @app.call(env) }
-    end
-
-    private
-
-    def timeout_for(path)
-      @path_timeouts.each do |prefix, seconds|
-        return seconds if path.start_with?(prefix)
-      end
-      @default_timeout
-    end
-
-    def parse_path_timeouts
-      ENV.fetch('RACK_TIMEOUT_PATH_OVERRIDES', DEFAULT_PATH_OVERRIDES)
-         .split(',')
-         .filter_map do |entry|
-           parts = entry.strip.split(':')
-           next if parts.length < 2
-
-           [parts[0], parts[1].to_i]
-         end
     end
   end
 end

--- a/spec/lib/trade_tariff_frontend/service_timeout_spec.rb
+++ b/spec/lib/trade_tariff_frontend/service_timeout_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe TradeTariffFrontend::ServiceTimeout do
         expect(Timeout).to have_received(:timeout).with(50)
       end
 
+      it 'applies 50s timeout to /internal/search' do
+        middleware.call('PATH_INFO' => '/internal/search')
+        expect(Timeout).to have_received(:timeout).with(50)
+      end
+
       it 'applies default timeout to non-search paths' do
         middleware.call('PATH_INFO' => '/uk/commodities/1234')
         expect(Timeout).to have_received(:timeout).with(15)

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -235,6 +235,29 @@ RSpec.describe Search do
       it 'contains results' do
         expect(perform_search).to be_any
       end
+
+      it 'uses the shared service timeout for the internal search request' do
+        captured_env = nil
+        connection = Faraday.new(url: TradeTariffFrontend::ServiceChooser.api_host) do |faraday|
+          faraday.options.timeout = 10
+          faraday.adapter :test do |stub|
+            stub.post('/internal/uk/search') do |env|
+              captured_env = env
+              [
+                200,
+                { 'content-type' => 'application/json; charset=utf-8' },
+                internal_response_body.to_json,
+              ]
+            end
+          end
+        end
+
+        allow(described_class).to receive(:api).and_return(connection)
+
+        perform_search
+
+        expect(captured_env.request.timeout).to eq(50)
+      end
     end
 
     context 'when interactive_search is true and response is empty' do


### PR DESCRIPTION
### Jira link

N/A

```mermaid
flowchart TB
    A[Frontend /search request] --> B[Search model]
    B --> C{Interactive search enabled?}
    C -->|Yes| D[POST /internal/:service/search]
    C -->|No| E[POST /api/:service/search]
    D --> F[Use shared 50s search request timeout]
    E --> G[Use default 10s client timeout]
```

### What?

- [x] Add `/internal/search:50` to the default timeout path overrides
- [x] Share the Rack timeout path override configuration through `TradeTariffFrontend::ServiceTimeout.timeout_for`
- [x] Set the longer timeout directly on the internal search POST request
- [x] Leave the API client `open_timeout` at 5 seconds and ordinary request timeout at 10 seconds
- [x] Rely on Zeitwerk autoloading for app code rather than adding explicit requires
- [x] Add coverage for Rack timeout defaults and internal search request timeout handling

### Why?

Internal interactive search requests can keep the backend connection open for up to 50 seconds. The frontend already allows long-running `/search` requests, but the API client request timeout was still 10 seconds, so interactive search could fail before the frontend request timeout was reached.

`open_timeout` only covers establishing the connection to the backend. The slow path here is waiting for the internal search response after the connection has opened, so the open timeout remains unchanged.

### Ticket

N/A

### Risk

**Risk level:** 🟠

**Reason for rating:** This changes timeout behaviour for a backend search call in a user-facing search journey. The change is scoped to the internal search POST request and covered by focused RSpec examples.