### PR TITLE
AI-334: Show exact guided search matches as results

### DIFF
--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -30,7 +30,7 @@ module InteractiveSearchable
 
   def route_interactive_results
     if @results.exact_match?
-      redirect_to url_for @results.to_param.merge(url_options).merge(request_id: @search.request_id, only_path: true)
+      render_interactive_results
     elsif @results.has_pending_question?
       render_interactive_question
     elsif @results.blocking_guidance?

--- a/app/forms/interactive_search_form.rb
+++ b/app/forms/interactive_search_form.rb
@@ -2,7 +2,7 @@ class InteractiveSearchForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  MAX_QUERY_LENGTH = 500
+  MAX_QUERY_LENGTH = 1000
   MIN_QUERY_LENGTH = 2
 
   attribute :q, :string

--- a/app/javascript/controllers/guided_search_validation_controller.js
+++ b/app/javascript/controllers/guided_search_validation_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 
-const MAX_QUERY_LENGTH = 500
+const MAX_QUERY_LENGTH = 1000
 const MIN_QUERY_LENGTH = 2
 
 export default class extends Controller {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,7 +348,7 @@ en:
             q:
               blank: Enter a search term
               too_short: Search term must be at least 2 characters
-              too_long: Search term must be 500 characters or fewer
+              too_long: Search term must be 1000 characters or fewer
             answer:
               blank: Select an option
         duty_calculator/steps/import_date:

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -358,9 +358,9 @@ RSpec.describe SearchController, type: :controller do
           do_response
         end
 
-        it { is_expected.to have_http_status(:redirect) }
-        it { expect(response.location).to include(commodity_path('0101210000')) }
-        it { expect(response.location).to include('request_id=') }
+        it { is_expected.to have_http_status(:ok) }
+        it { is_expected.to render_template(:interactive_results) }
+        it { expect(assigns(:results).all).to contain_exactly(an_object_having_attributes(goods_nomenclature_item_id: '0101210000')) }
       end
 
       context 'when all questions are answered' do

--- a/spec/forms/interactive_search_form_spec.rb
+++ b/spec/forms/interactive_search_form_spec.rb
@@ -36,20 +36,20 @@ RSpec.describe InteractiveSearchForm, type: :model do
     end
 
     context 'when query is at maximum length' do
-      subject(:form) { described_class.new(q: 'a' * 500) }
+      subject(:form) { described_class.new(q: 'a' * 1000) }
 
       it { is_expected.to be_valid }
     end
 
     context 'when query exceeds maximum length' do
-      subject(:form) { described_class.new(q: 'a' * 501) }
+      subject(:form) { described_class.new(q: 'a' * 1001) }
 
       it { is_expected.not_to be_valid }
 
       it 'adds a length error' do
         form.valid?
 
-        expect(form.errors[:q]).to include('Search term must be 500 characters or fewer')
+        expect(form.errors[:q]).to include('Search term must be 1000 characters or fewer')
       end
     end
   end
@@ -68,7 +68,7 @@ RSpec.describe InteractiveSearchForm, type: :model do
     end
 
     it 'does not truncate long queries before validation' do
-      query = 'x' * 501
+      query = 'x' * 1001
 
       expect(described_class.new(q: query).q).to eq(query)
     end

--- a/spec/javascript/controllers/guided_search_validation_controller_spec.js
+++ b/spec/javascript/controllers/guided_search_validation_controller_spec.js
@@ -112,11 +112,11 @@ describe('GuidedSearchValidationController', () => {
       expect(document.querySelector('.govuk-error-summary').textContent).toContain('Search term must be at least 2 characters');
     });
 
-    it('shows error when input exceeds 500 characters', async () => {
-      await setup({textareaValue: 'a'.repeat(501)});
+    it('shows error when input exceeds 1000 characters', async () => {
+      await setup({textareaValue: 'a'.repeat(1001)});
       submitForm();
 
-      expect(document.querySelector('.govuk-error-summary').textContent).toContain('Search term must be 500 characters or fewer');
+      expect(document.querySelector('.govuk-error-summary').textContent).toContain('Search term must be 1000 characters or fewer');
     });
 
     it('accepts exactly 2 characters', async () => {
@@ -127,8 +127,8 @@ describe('GuidedSearchValidationController', () => {
       expect(form.querySelector('[data-guided-search-validation-target="formContent"]').classList.contains('govuk-!-display-none')).toBe(true);
     });
 
-    it('accepts exactly 500 characters', async () => {
-      await setup({textareaValue: 'a'.repeat(500)});
+    it('accepts exactly 1000 characters', async () => {
+      await setup({textareaValue: 'a'.repeat(1000)});
       submitForm();
 
       expect(document.querySelector('.govuk-error-summary')).toBeNull();

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe Search do
 
     context 'when internal API returns 422 validation error' do
       let(:search) do
-        s = described_class.new(q: 'a' * 501)
+        s = described_class.new(q: 'a' * 1001)
         s.interactive_search = true
         s
       end
@@ -289,7 +289,7 @@ RSpec.describe Search do
             {
               'status' => '422',
               'title' => 'Invalid query',
-              'detail' => 'Query exceeds maximum length of 500 characters',
+              'detail' => 'Query exceeds maximum length of 1000 characters',
               'source' => { 'pointer' => '/data/attributes/q' },
             },
           ],
@@ -314,7 +314,7 @@ RSpec.describe Search do
 
       it 'hydrates errors on the search model' do
         search.perform
-        expect(search.errors[:q]).to include('Query exceeds maximum length of 500 characters')
+        expect(search.errors[:q]).to include('Query exceeds maximum length of 1000 characters')
       end
     end
 


### PR DESCRIPTION
### Jira link

[AI-334](https://transformuk.atlassian.net/browse/AI-334)

### What?

- [x] Increase guided search client-side and server-side frontend validation from 500 to 1000 characters
- [x] Update the guided search validation error copy to mention 1000 characters
- [x] Render guided search exact matches as the interactive results page instead of redirecting directly to the commodity page
- [x] Update form, controller, model, and JavaScript specs for the new behaviour

### Why?

Guided search needs to accept longer user search inputs, and exact matches should be shown as a single guided search answer so the results journey remains consistent.

### Risk

**Risk level:** 🟠

**Reason for rating:** This changes search UI result rendering for guided search exact matches. It is scoped to guided search, leaves classic search redirects unchanged, and is covered by focused controller, form, model, and JavaScript specs.