### PR TITLE
Add LaunchDarkly feature flag DSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} AS builder
 
 WORKDIR /build
 
-RUN apk add --no-cache build-base linux-headers git yarn tzdata yaml-dev openssl-dev && \
+RUN apk add --no-cache build-base linux-headers git yarn tzdata yaml-dev openssl-dev zlib-dev && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem 'redis'
 # AWS
 gem 'aws-actionmailer-ses'
 
+# Feature flags
+gem 'launchdarkly-server-sdk'
+
 group :development do
   gem 'letter_opener'
   gem 'rubocop-govuk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
+    benchmark (0.5.0)
     bigdecimal (4.1.2)
     bootsnap (1.24.3)
       msgpack (~> 1.2)
@@ -164,6 +165,7 @@ GEM
     date (3.5.1)
     diff-lcs (1.6.2)
     docile (1.4.1)
+    domain_name (0.6.20240107)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
@@ -265,6 +267,11 @@ GEM
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     htmlentities (4.4.2)
+    http (6.0.3)
+      http-cookie (~> 1.0)
+      llhttp (~> 0.6.1)
+    http-cookie (1.1.6)
+      domain_name (~> 0.5)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
@@ -300,16 +307,30 @@ GEM
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     language_server-protocol (3.17.0.5)
+    launchdarkly-server-sdk (8.13.0)
+      benchmark (~> 0.1, >= 0.1.1)
+      concurrent-ruby (~> 1.1)
+      http (>= 4.4.0, < 7.0.0)
+      json (~> 2.3)
+      ld-eventsource (= 2.6.0)
+      observer (~> 0.1.2)
+      openssl (>= 3.1.2, < 5.0)
+      semantic (~> 1.6)
+      zlib (~> 3.1)
     launchy (3.1.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
       logger (~> 1.6)
+    ld-eventsource (2.6.0)
+      concurrent-ruby (~> 1.0)
+      http (>= 4.4.1, < 7.0.0)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
     lint_roller (1.1.0)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    llhttp (0.6.1)
     logger (1.7.0)
     lograge (0.14.0)
       actionpack (>= 4)
@@ -367,6 +388,8 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    observer (0.1.2)
+    openssl (4.0.2)
     ostruct (0.6.3)
     pagy (9.4.0)
     parallel (1.28.0)
@@ -542,6 +565,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
     securerandom (0.4.1)
+    semantic (1.6.1)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
     shellany (0.0.1)
@@ -599,6 +623,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.5)
+    zlib (3.2.3)
 
 PLATFORMS
   arm64-darwin-23
@@ -633,6 +658,7 @@ DEPENDENCIES
   inline_svg
   jwt
   kaminari
+  launchdarkly-server-sdk
   letter_opener
   lograge
   logstash-event

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
   include BasicSessionAuth
   include CacheHelper
+  include FeatureFlaggable
 
   before_action :maintenance_mode_if_active
 

--- a/app/controllers/concerns/feature_flaggable.rb
+++ b/app/controllers/concerns/feature_flaggable.rb
@@ -5,6 +5,24 @@ module FeatureFlaggable
     helper_method :feature_enabled?, :feature_disabled?
   end
 
+  module ClassMethods
+    # Declares that this controller (or specific actions) requires a feature flag
+    # to be enabled. Sets up a before_action that raises FeatureUnavailable when
+    # the flag is off. Accepts the same options as before_action.
+    #
+    # Examples:
+    #   class GreenLanesController < ApplicationController
+    #     feature_gate :green_lanes
+    #   end
+    #
+    #   class MyController < ApplicationController
+    #     feature_gate :my_feature, only: :new_action
+    #   end
+    def feature_gate(flag, **options)
+      before_action(**options) { require_feature!(flag) }
+    end
+  end
+
   # Returns true when the named flag is enabled. Available in views.
   #
   # Example:
@@ -19,10 +37,7 @@ module FeatureFlaggable
   end
 
   # Raises FeatureUnavailable when the named flag is disabled.
-  # Use in before_action to gate controller actions behind a feature flag.
-  #
-  # Example:
-  #   before_action { require_feature!(:green_lanes) }
+  # Use directly in a before_action block, or prefer the feature_gate class macro.
   def require_feature!(flag)
     raise TradeTariffFrontend::FeatureUnavailable unless feature_enabled?(flag)
   end

--- a/app/controllers/concerns/feature_flaggable.rb
+++ b/app/controllers/concerns/feature_flaggable.rb
@@ -1,0 +1,29 @@
+module FeatureFlaggable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :feature_enabled?, :feature_disabled?
+  end
+
+  # Returns true when the named flag is enabled. Available in views.
+  #
+  # Example:
+  #   <% if feature_enabled?(:green_lanes) %>
+  def feature_enabled?(flag)
+    TradeTariffFrontend::FeatureFlag.enabled?(flag)
+  end
+
+  # Returns true when the named flag is disabled. Available in views.
+  def feature_disabled?(flag)
+    TradeTariffFrontend::FeatureFlag.disabled?(flag)
+  end
+
+  # Raises FeatureUnavailable when the named flag is disabled.
+  # Use in before_action to gate controller actions behind a feature flag.
+  #
+  # Example:
+  #   before_action { require_feature!(:green_lanes) }
+  def require_feature!(flag)
+    raise TradeTariffFrontend::FeatureUnavailable unless feature_enabled?(flag)
+  end
+end

--- a/app/controllers/concerns/feature_flaggable.rb
+++ b/app/controllers/concerns/feature_flaggable.rb
@@ -24,21 +24,32 @@ module FeatureFlaggable
   end
 
   # Returns true when the named flag is enabled. Available in views.
+  # Passes an anonymous session key to LaunchDarkly so percentage rollout rules
+  # hash the same visitor into the same bucket on every request.
   #
   # Example:
   #   <% if feature_enabled?(:green_lanes) %>
   def feature_enabled?(flag)
-    TradeTariffFrontend::FeatureFlag.enabled?(flag)
+    TradeTariffFrontend::FeatureFlag.enabled?(flag, user_key: ld_anonymous_user_key)
   end
 
   # Returns true when the named flag is disabled. Available in views.
   def feature_disabled?(flag)
-    TradeTariffFrontend::FeatureFlag.disabled?(flag)
+    TradeTariffFrontend::FeatureFlag.disabled?(flag, user_key: ld_anonymous_user_key)
   end
 
   # Raises FeatureUnavailable when the named flag is disabled.
   # Use directly in a before_action block, or prefer the feature_gate class macro.
   def require_feature!(flag)
     raise TradeTariffFrontend::FeatureUnavailable unless feature_enabled?(flag)
+  end
+
+  private
+
+  # Stable anonymous identifier for this visitor's session.
+  # Generated once on first flag evaluation and stored in the session for
+  # the lifetime of that session. Carries no PII.
+  def ld_anonymous_user_key
+    session[:ld_anonymous_id] ||= SecureRandom.uuid
   end
 end

--- a/config/initializers/launch_darkly.rb
+++ b/config/initializers/launch_darkly.rb
@@ -1,0 +1,17 @@
+sdk_key = ENV.fetch('LAUNCHDARKLY_SDK_KEY', '')
+
+config = LaunchDarkly::Config.new(
+  offline: sdk_key.blank?,
+  logger: Rails.logger,
+  log_level: Logger::WARN,
+)
+
+client = LaunchDarkly::LDClient.new(sdk_key, config)
+
+unless client.initialized?
+  Rails.logger.warn('LaunchDarkly client did not initialize in time; flag evaluations will use REGISTRY defaults')
+end
+
+Rails.application.config.launch_darkly_client = client
+
+at_exit { Rails.application.config.launch_darkly_client&.close }

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -185,8 +185,8 @@ expected baseline for most tests.
 
 ### Environment variable
 
-| Variable              | Required | Description                                                                                           |
-| --------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| Variable               | Required | Description                                                                                           |
+| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
 | `LAUNCHDARKLY_SDK_KEY` | No       | Server-side SDK key. When absent, offline mode is used and all flags return their `REGISTRY` defaults. |
 
 ### Migrating an existing ENV-based flag

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -185,9 +185,9 @@ expected baseline for most tests.
 
 ### Environment variable
 
-| Variable | Required | Description |
-|---|---|---|
-| `LAUNCHDARKLY_SDK_KEY` | No | Server-side SDK key. When absent, offline mode is used and all flags return their `REGISTRY` defaults. |
+| Variable              | Required | Description                                                                                           |
+| --------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `LAUNCHDARKLY_SDK_KEY` | No       | Server-side SDK key. When absent, offline mode is used and all flags return their `REGISTRY` defaults. |
 
 ### Migrating an existing ENV-based flag
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -92,16 +92,39 @@ end
 `FeatureFlag.enabled?` calls `LDClient#variation` with:
 
 1. **Flag key** — the symbol name as a string, e.g. `"my_new_feature"`.
-2. **Evaluation context** — an application-level LaunchDarkly context (not
-   user-level, since this is a public service). It carries two custom
-   attributes that can be used in LaunchDarkly targeting rules:
-   - `service` — `"uk"` or `"xi"`, reflecting the active service variant.
-   - `environment` — the value of the `ENVIRONMENT` env var (e.g.
-     `"production"`, `"staging"`, `"development"`).
+2. **Evaluation context** — see below.
 3. **Default value** — the value from `REGISTRY` for that flag.
 
 The default is returned whenever LaunchDarkly cannot be reached (network error,
 slow start-up, or offline mode — see below).
+
+### Evaluation context
+
+Every flag evaluation sends a **multi-context** to LaunchDarkly carrying two
+independent dimensions:
+
+**`application` context** — fixed attributes about the deployment:
+- `service` — `"uk"` or `"xi"`, reflecting the active service variant.
+- `environment` — the value of the `ENVIRONMENT` env var (e.g. `"production"`,
+  `"staging"`, `"development"`).
+
+Use this context in LaunchDarkly targeting rules to scope a flag to a specific
+environment or service without encoding that logic into the flag name itself,
+e.g. "enable this flag only when `environment` is `staging`".
+
+**`user` context** — an anonymous, session-scoped identifier:
+- A UUID generated once per session and stored in `session[:ld_anonymous_id]`.
+- Marked `anonymous: true`; carries no PII.
+- Stable for the lifetime of the session, so the same visitor consistently lands
+  in the same percentage bucket on every request.
+
+Use this context in LaunchDarkly targeting rules for **percentage rollouts** —
+e.g. "enable for 10% of users". LaunchDarkly hashes the user key into a bucket,
+so rollout decisions are consistent per visitor rather than random per request.
+
+When `FeatureFlag.enabled?` is called outside a request context (e.g. from a
+background job or a Rake task), pass `user_key: nil` (the default) and only the
+`application` context is sent — no multi-context is built.
 
 ### Offline mode
 
@@ -150,9 +173,12 @@ expected baseline for most tests.
 
 1. Create the flag in the LaunchDarkly dashboard with the same key used in
    `REGISTRY` (snake_case, e.g. `my_new_feature`).
-2. Configure targeting rules using the `service` and `environment` context
-   attributes if needed (e.g. "on for environment = staging only").
-3. The application polls LaunchDarkly continuously; changes take effect within
+2. To target by environment or service, add rules on the **`application`**
+   context kind using the `environment` or `service` attributes.
+3. To do a percentage rollout, add a rule on the **`user`** context kind and
+   set the percentage. LaunchDarkly will consistently hash each anonymous
+   session UUID into the same bucket.
+4. The application polls LaunchDarkly continuously; changes take effect within
    seconds without a deploy.
 
 ### Environment variable

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,150 @@
+# Feature flags
+
+Feature flags are evaluated via [LaunchDarkly](https://launchdarkly.com). The
+integration lives in `lib/trade_tariff_frontend/feature_flag.rb` and is
+designed so that developers never need to interact with the LaunchDarkly SDK
+directly.
+
+## Quick start
+
+### Declaring a flag
+
+All flags must be declared in `REGISTRY` before use. Add an entry with a safe
+default — the value returned when LaunchDarkly is unreachable or the SDK key
+is not configured:
+
+```ruby
+# lib/trade_tariff_frontend/feature_flag.rb
+REGISTRY = {
+  my_new_feature: false,  # off by default
+  # ...
+}.freeze
+```
+
+The flag key must match the flag key configured in the LaunchDarkly dashboard.
+
+### Checking a flag
+
+From anywhere in the application:
+
+```ruby
+TradeTariffFrontend::FeatureFlag.enabled?(:my_new_feature)  # => true / false
+TradeTariffFrontend::FeatureFlag.disabled?(:my_new_feature) # => false / true
+```
+
+From a controller or view (available via the `FeatureFlaggable` concern, which
+is included in `ApplicationController`):
+
+```erb
+<% if feature_enabled?(:my_new_feature) %>
+  <%# render the new thing %>
+<% end %>
+```
+
+```ruby
+# app/controllers/my_controller.rb
+before_action { require_feature!(:my_new_feature) }
+```
+
+`require_feature!` raises `TradeTariffFrontend::FeatureUnavailable` when the
+flag is off, which prevents the action from running.
+
+### Guarding a whole controller
+
+```ruby
+class MyNewController < ApplicationController
+  before_action { require_feature!(:my_new_feature) }
+
+  def index
+    # only reached when my_new_feature is on
+  end
+end
+```
+
+---
+
+## How it works
+
+### Evaluation
+
+`FeatureFlag.enabled?` calls `LDClient#variation` with:
+
+1. **Flag key** — the symbol name as a string, e.g. `"my_new_feature"`.
+2. **Evaluation context** — an application-level LaunchDarkly context (not
+   user-level, since this is a public service). It carries two custom
+   attributes that can be used in LaunchDarkly targeting rules:
+   - `service` — `"uk"` or `"xi"`, reflecting the active service variant.
+   - `environment` — the value of the `ENVIRONMENT` env var (e.g.
+     `"production"`, `"staging"`, `"development"`).
+3. **Default value** — the value from `REGISTRY` for that flag.
+
+The default is returned whenever LaunchDarkly cannot be reached (network error,
+slow start-up, or offline mode — see below).
+
+### Offline mode
+
+When `LAUNCHDARKLY_SDK_KEY` is absent or blank the SDK client is initialised in
+offline mode. `variation` then returns the `REGISTRY` default for every flag
+without making any network calls. This means:
+
+- Local development works without a LaunchDarkly account or SDK key.
+- Test suites run without any external dependencies.
+- All flags default to **off** (safe) unless the registry says otherwise.
+
+### Unknown flags
+
+Calling `enabled?` or `disabled?` with a flag name not in `REGISTRY` raises
+`TradeTariffFrontend::FeatureFlag::UnknownFlagError` immediately. This catches
+typos at development time rather than silently returning `false` at runtime.
+
+---
+
+## Testing
+
+### Stubs
+
+Use `stub_feature_flag` (available in all specs via `spec/support/feature_flags.rb`):
+
+```ruby
+# Enable a flag for the duration of one example
+stub_feature_flag(:my_new_feature)                    # enabled: true is the default
+stub_feature_flag(:my_new_feature, enabled: true)
+stub_feature_flag(:my_new_feature, enabled: false)
+```
+
+Other flags are unaffected and continue to return their `REGISTRY` defaults.
+
+### Without stubs
+
+In specs that do not call `stub_feature_flag`, every flag returns its `REGISTRY`
+default (offline mode). If the default is `false`, the flag is off. This is the
+expected baseline for most tests.
+
+---
+
+## Operations
+
+### Setting a flag in LaunchDarkly
+
+1. Create the flag in the LaunchDarkly dashboard with the same key used in
+   `REGISTRY` (snake_case, e.g. `my_new_feature`).
+2. Configure targeting rules using the `service` and `environment` context
+   attributes if needed (e.g. "on for environment = staging only").
+3. The application polls LaunchDarkly continuously; changes take effect within
+   seconds without a deploy.
+
+### Environment variable
+
+| Variable | Required | Description |
+|---|---|---|
+| `LAUNCHDARKLY_SDK_KEY` | No | Server-side SDK key. When absent, offline mode is used and all flags return their `REGISTRY` defaults. |
+
+### Migrating an existing ENV-based flag
+
+The existing `TradeTariffFrontend.green_lanes_enabled?` style methods continue
+to work. To migrate one to LaunchDarkly:
+
+1. Ensure the flag is in `REGISTRY`.
+2. Replace the `ENV` check at each call site with `FeatureFlag.enabled?(:flag)`.
+3. Remove the old method from `lib/trade_tariff_frontend.rb`.
+4. Remove the corresponding env var from deployment configuration.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -104,6 +104,7 @@ Every flag evaluation sends a **multi-context** to LaunchDarkly carrying two
 independent dimensions:
 
 **`application` context** — fixed attributes about the deployment:
+
 - `service` — `"uk"` or `"xi"`, reflecting the active service variant.
 - `environment` — the value of the `ENVIRONMENT` env var (e.g. `"production"`,
   `"staging"`, `"development"`).
@@ -113,6 +114,7 @@ environment or service without encoding that logic into the flag name itself,
 e.g. "enable this flag only when `environment` is `staging`".
 
 **`user` context** — an anonymous, session-scoped identifier:
+
 - A UUID generated once per session and stored in `session[:ld_anonymous_id]`.
 - Marked `anonymous: true`; carries no PII.
 - Stable for the lifetime of the session, so the same visitor consistently lands

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -185,8 +185,8 @@ expected baseline for most tests.
 
 ### Environment variable
 
-| Variable               | Required | Description                                                                                           |
-| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| Variable               | Required | Description                                                                                            |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
 | `LAUNCHDARKLY_SDK_KEY` | No       | Server-side SDK key. When absent, offline mode is used and all flags return their `REGISTRY` defaults. |
 
 ### Migrating an existing ENV-based flag

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -43,19 +43,41 @@ is included in `ApplicationController`):
 
 ```ruby
 # app/controllers/my_controller.rb
-before_action { require_feature!(:my_new_feature) }
+feature_gate :my_new_feature
 ```
 
-`require_feature!` raises `TradeTariffFrontend::FeatureUnavailable` when the
-flag is off, which prevents the action from running.
+`feature_gate` sets up a `before_action` that raises
+`TradeTariffFrontend::FeatureUnavailable` when the flag is off, preventing the
+action from running. It accepts the same options as `before_action`:
+
+```ruby
+feature_gate :my_new_feature, only: :show
+feature_gate :my_new_feature, except: %i[index show]
+```
 
 ### Guarding a whole controller
 
 ```ruby
 class MyNewController < ApplicationController
-  before_action { require_feature!(:my_new_feature) }
+  feature_gate :my_new_feature
 
   def index
+    # only reached when my_new_feature is on
+  end
+end
+```
+
+### Guarding specific actions
+
+```ruby
+class MyController < ApplicationController
+  feature_gate :my_new_feature, only: :new_action
+
+  def existing_action
+    # always reachable
+  end
+
+  def new_action
     # only reached when my_new_feature is on
   end
 end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -3,6 +3,7 @@ module TradeTariffFrontend
   DEFAULT_SUPPORT_EMAIL = DEFAULT_ENQUIRIES_EMAIL
   WEBCHAT_BASE_URL = 'https://www.tax.service.gov.uk/ask-hmrc/chat/'.freeze
 
+  autoload :FeatureFlag,    'trade_tariff_frontend/feature_flag'
   autoload :Presenter,      'trade_tariff_frontend/presenter'
   autoload :ServiceChooser, 'trade_tariff_frontend/service_chooser'
   autoload :ViewContext,    'trade_tariff_frontend/view_context'

--- a/lib/trade_tariff_frontend/feature_flag.rb
+++ b/lib/trade_tariff_frontend/feature_flag.rb
@@ -77,7 +77,7 @@ module TradeTariffFrontend
     #
     # Rebuilt per-call because service_choice is thread-local (set per request).
     private_class_method def self.evaluation_context(user_key: nil)
-      app_context = LaunchDarkly::LDContext.create(
+      app_context = LaunchDarkly::LDContext.create( # rubocop:disable Rails/SaveBang
         kind: 'application',
         key: 'trade-tariff-frontend',
         service: TradeTariffFrontend::ServiceChooser.service_choice&.to_s || 'uk',
@@ -86,7 +86,7 @@ module TradeTariffFrontend
 
       return app_context if user_key.nil?
 
-      user_context = LaunchDarkly::LDContext.create(
+      user_context = LaunchDarkly::LDContext.create( # rubocop:disable Rails/SaveBang
         kind: 'user',
         key: user_key,
         anonymous: true,

--- a/lib/trade_tariff_frontend/feature_flag.rb
+++ b/lib/trade_tariff_frontend/feature_flag.rb
@@ -43,34 +43,56 @@ module TradeTariffFrontend
     # Returns true when the named flag is enabled in LaunchDarkly.
     # Falls back to the REGISTRY default when LD is offline or unavailable.
     # Raises UnknownFlagError for flag names not in REGISTRY (catches typos early).
-    def self.enabled?(flag)
+    #
+    # Pass user_key to enable percentage-based rollouts. LaunchDarkly hashes the
+    # key into a bucket so the same visitor consistently sees the same result.
+    # The FeatureFlaggable concern supplies this automatically from the session;
+    # callers outside a request context can omit it (application context only).
+    def self.enabled?(flag, user_key: nil)
       flag = flag.to_sym
       raise UnknownFlagError, flag unless REGISTRY.key?(flag)
 
-      client.variation(flag.to_s, evaluation_context, REGISTRY[flag])
+      client.variation(flag.to_s, evaluation_context(user_key:), REGISTRY[flag])
     end
 
-    def self.disabled?(flag)
-      !enabled?(flag)
+    def self.disabled?(flag, user_key: nil)
+      !enabled?(flag, user_key:)
     end
 
     private_class_method def self.client
       Rails.application.config.launch_darkly_client
     end
 
-    # Application-level context sent to LaunchDarkly with each flag evaluation.
-    # Includes service (uk/xi) and environment as custom attributes so LD targeting
-    # rules can target specific environments or service variants without encoding
-    # that logic into flag names.
+    # Builds the LaunchDarkly evaluation context for a flag check.
     #
-    # This is rebuilt per-call because service_choice is thread-local (set per request).
-    private_class_method def self.evaluation_context
-      LaunchDarkly::LDContext.create(
+    # Always includes an application context carrying service (uk/xi) and
+    # environment, so targeting rules can scope flags to specific deployments
+    # without encoding that logic into flag names.
+    #
+    # When user_key is present a second anonymous user context is added, forming
+    # a multi-context. LaunchDarkly uses the user key to hash visitors into
+    # percentage buckets, enabling consistent gradual rollouts to a fraction of
+    # real users. The key carries no PII — it is an anonymous UUID generated
+    # once per session by the FeatureFlaggable concern.
+    #
+    # Rebuilt per-call because service_choice is thread-local (set per request).
+    private_class_method def self.evaluation_context(user_key: nil)
+      app_context = LaunchDarkly::LDContext.create(
         kind: 'application',
         key: 'trade-tariff-frontend',
         service: TradeTariffFrontend::ServiceChooser.service_choice&.to_s || 'uk',
         environment: TradeTariffFrontend.environment,
       )
+
+      return app_context if user_key.nil?
+
+      user_context = LaunchDarkly::LDContext.create(
+        kind: 'user',
+        key: user_key,
+        anonymous: true,
+      )
+
+      LaunchDarkly::LDContext.create_multi([app_context, user_context])
     end
   end
 end

--- a/lib/trade_tariff_frontend/feature_flag.rb
+++ b/lib/trade_tariff_frontend/feature_flag.rb
@@ -1,0 +1,76 @@
+module TradeTariffFrontend
+  # Thin wrapper around LaunchDarkly for feature flag evaluation.
+  #
+  # All flags must be declared in REGISTRY with a safe default. The default is
+  # returned whenever LaunchDarkly is unreachable (offline mode, network error,
+  # or test environment without a configured SDK key).
+  #
+  # Usage:
+  #   TradeTariffFrontend::FeatureFlag.enabled?(:green_lanes)   # => true/false
+  #   TradeTariffFrontend::FeatureFlag.disabled?(:green_lanes)  # => false/true
+  #
+  # In controllers and views (via FeatureFlaggable concern):
+  #   feature_enabled?(:green_lanes)
+  #   feature_disabled?(:green_lanes)
+  #   before_action { require_feature!(:green_lanes) }
+  #
+  # In tests (via FeatureFlagHelpers):
+  #   stub_feature_flag(:green_lanes, enabled: true)
+  module FeatureFlag
+    # Declare every feature flag here with its safe default value.
+    # The default is used when LaunchDarkly is offline or unreachable.
+    # Conventions:
+    #   - Use snake_case symbols matching the LaunchDarkly flag key.
+    #   - Default to false (off) unless the feature is safe to expose everywhere.
+    REGISTRY = {
+      green_lanes: false,
+      interactive_search: false,
+      roo_wizard: false,
+      single_trade_window: false,
+      webchat: false,
+      welsh: false,
+    }.freeze
+
+    class UnknownFlagError < StandardError
+      def initialize(flag)
+        super(
+          "Unknown feature flag: #{flag.inspect}. " \
+          'Register it in TradeTariffFrontend::FeatureFlag::REGISTRY before use.',
+        )
+      end
+    end
+
+    # Returns true when the named flag is enabled in LaunchDarkly.
+    # Falls back to the REGISTRY default when LD is offline or unavailable.
+    # Raises UnknownFlagError for flag names not in REGISTRY (catches typos early).
+    def self.enabled?(flag)
+      flag = flag.to_sym
+      raise UnknownFlagError, flag unless REGISTRY.key?(flag)
+
+      client.variation(flag.to_s, evaluation_context, REGISTRY[flag])
+    end
+
+    def self.disabled?(flag)
+      !enabled?(flag)
+    end
+
+    private_class_method def self.client
+      Rails.application.config.launch_darkly_client
+    end
+
+    # Application-level context sent to LaunchDarkly with each flag evaluation.
+    # Includes service (uk/xi) and environment as custom attributes so LD targeting
+    # rules can target specific environments or service variants without encoding
+    # that logic into flag names.
+    #
+    # This is rebuilt per-call because service_choice is thread-local (set per request).
+    private_class_method def self.evaluation_context
+      LaunchDarkly::LDContext.create(
+        kind: 'application',
+        key: 'trade-tariff-frontend',
+        service: TradeTariffFrontend::ServiceChooser.service_choice&.to_s || 'uk',
+        environment: TradeTariffFrontend.environment,
+      )
+    end
+  end
+end

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe CommoditiesController, type: :controller do
         it { is_expected.to redirect_to heading_path('0101') }
       end
 
-
       context 'with non-declarable commodity id provided',
               vcr: { cassette_name: 'commodities#show_0101999999' } do
         subject(:do_request) { get :show, params: { id: '0101999999' } }

--- a/spec/controllers/concerns/feature_flaggable_spec.rb
+++ b/spec/controllers/concerns/feature_flaggable_spec.rb
@@ -91,4 +91,23 @@ RSpec.describe FeatureFlaggable, type: :controller do
       expect(controller.feature_disabled?(:green_lanes)).to be true
     end
   end
+
+  describe '#ld_anonymous_user_key' do
+    # Use the gated action: feature_gate :green_lanes calls require_feature!
+    # which calls feature_enabled? which calls ld_anonymous_user_key.
+    before { stub_feature_flag(:green_lanes, enabled: true) }
+
+    it 'generates a UUID and stores it in the session on the first flag check' do
+      get :gated
+      expect(session[:ld_anonymous_id]).to match(/\A[0-9a-f-]{36}\z/)
+    end
+
+    it 'reuses the same key across requests within the same session' do
+      get :gated
+      first_key = session[:ld_anonymous_id]
+
+      get :gated
+      expect(session[:ld_anonymous_id]).to eq(first_key)
+    end
+  end
 end

--- a/spec/controllers/concerns/feature_flaggable_spec.rb
+++ b/spec/controllers/concerns/feature_flaggable_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+RSpec.describe FeatureFlaggable, type: :controller do
+  # Anonymous controller that includes the concern under test.
+  # Rails' anonymous controller support gives us a real request cycle.
+  controller(ApplicationController) do
+    feature_gate :green_lanes, only: :gated
+    feature_gate :welsh, only: :welsh_only
+
+    def gated
+      render plain: 'gated action'
+    end
+
+    def welsh_only
+      render plain: 'welsh only action'
+    end
+
+    def open
+      render plain: 'open action'
+    end
+  end
+
+  before do
+    routes.draw do
+      get 'gated'     => 'anonymous#gated'
+      get 'welsh_only' => 'anonymous#welsh_only'
+      get 'open'      => 'anonymous#open'
+    end
+  end
+
+  describe '.feature_gate' do
+    context 'when the flag is enabled' do
+      before { stub_feature_flag(:green_lanes, enabled: true) }
+
+      it 'allows the gated action to proceed' do
+        get :gated
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when the flag is disabled' do
+      before { stub_feature_flag(:green_lanes, enabled: false) }
+
+      it 'raises FeatureUnavailable for the gated action' do
+        expect { get :gated }.to raise_error(TradeTariffFrontend::FeatureUnavailable)
+      end
+    end
+
+    context 'with only: option — other actions are unaffected' do
+      before { stub_feature_flag(:green_lanes, enabled: false) }
+
+      it 'does not gate actions not listed in only:' do
+        get :open
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'with multiple feature_gate declarations on different actions' do
+      # Proves that gates are independent: green_lanes on :gated does not bleed
+      # into :welsh_only, and welsh on :welsh_only does not affect :gated.
+      before do
+        stub_feature_flag(:green_lanes, enabled: true)
+        stub_feature_flag(:welsh, enabled: false)
+      end
+
+      it 'allows :gated when its flag (green_lanes) is on' do
+        get :gated
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'blocks :welsh_only when its flag (welsh) is off' do
+        expect { get :welsh_only }.to raise_error(TradeTariffFrontend::FeatureUnavailable)
+      end
+    end
+  end
+
+  describe '#feature_enabled?' do
+    before { stub_feature_flag(:green_lanes, enabled: true) }
+
+    it 'returns true when the flag is on' do
+      get :open
+      expect(controller.feature_enabled?(:green_lanes)).to be true
+    end
+  end
+
+  describe '#feature_disabled?' do
+    before { stub_feature_flag(:green_lanes, enabled: false) }
+
+    it 'returns true when the flag is off' do
+      get :open
+      expect(controller.feature_disabled?(:green_lanes)).to be true
+    end
+  end
+end

--- a/spec/controllers/concerns/feature_flaggable_spec.rb
+++ b/spec/controllers/concerns/feature_flaggable_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe FeatureFlaggable, type: :controller do
 
   before do
     routes.draw do
-      get 'gated'     => 'anonymous#gated'
+      get 'gated' => 'anonymous#gated'
       get 'welsh_only' => 'anonymous#welsh_only'
-      get 'open'      => 'anonymous#open'
+      get 'open' => 'anonymous#open'
     end
   end
 

--- a/spec/lib/trade_tariff_frontend/feature_flag_spec.rb
+++ b/spec/lib/trade_tariff_frontend/feature_flag_spec.rb
@@ -53,12 +53,22 @@ RSpec.describe TradeTariffFrontend::FeatureFlag do
       end
     end
 
-    context 'when building the evaluation context' do
+    context 'when building the evaluation context without a user_key' do
+      it 'sends a single application context (not a multi-context) to LaunchDarkly' do
+        expect(ld_client).to receive(:variation) do |_flag, context, _default|
+          expect(context.multi_kind?).to be false
+          expect(context.kind).to eq('application')
+          false
+        end
+
+        feature_flag.enabled?(:green_lanes)
+      end
+
       it 'passes the current service to LaunchDarkly' do
         allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('xi')
 
         expect(ld_client).to receive(:variation) do |_flag, context, _default|
-          expect(context.individual_context(0).get_value('service')).to eq('xi')
+          expect(context.get_value('service')).to eq('xi')
           false
         end
 
@@ -69,11 +79,47 @@ RSpec.describe TradeTariffFrontend::FeatureFlag do
         allow(TradeTariffFrontend).to receive(:environment).and_return('staging')
 
         expect(ld_client).to receive(:variation) do |_flag, context, _default|
-          expect(context.individual_context(0).get_value('environment')).to eq('staging')
+          expect(context.get_value('environment')).to eq('staging')
           false
         end
 
         feature_flag.enabled?(:green_lanes)
+      end
+    end
+
+    context 'when building the evaluation context with a user_key' do
+      let(:user_key) { 'test-anonymous-uuid' }
+
+      it 'sends a multi-context to LaunchDarkly' do
+        expect(ld_client).to receive(:variation) do |_flag, context, _default|
+          expect(context.multi_kind?).to be true
+          false
+        end
+
+        feature_flag.enabled?(:green_lanes, user_key:)
+      end
+
+      it 'includes the application context in the multi-context' do
+        expect(ld_client).to receive(:variation) do |_flag, context, _default|
+          app = context.individual_context('application')
+          expect(app).not_to be_nil
+          expect(app.key).to eq('trade-tariff-frontend')
+          false
+        end
+
+        feature_flag.enabled?(:green_lanes, user_key:)
+      end
+
+      it 'includes an anonymous user context carrying the key' do
+        expect(ld_client).to receive(:variation) do |_flag, context, _default|
+          user = context.individual_context('user')
+          expect(user).not_to be_nil
+          expect(user.key).to eq(user_key)
+          expect(user.get_value('anonymous')).to be true
+          false
+        end
+
+        feature_flag.enabled?(:green_lanes, user_key:)
       end
     end
   end

--- a/spec/lib/trade_tariff_frontend/feature_flag_spec.rb
+++ b/spec/lib/trade_tariff_frontend/feature_flag_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+
+RSpec.describe TradeTariffFrontend::FeatureFlag do
+  subject(:feature_flag) { described_class }
+
+  let(:ld_client) { Rails.application.config.launch_darkly_client }
+
+  describe '.enabled?' do
+    context 'when LaunchDarkly returns true for the flag' do
+      before do
+        allow(ld_client).to receive(:variation).with('green_lanes', anything, false).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(feature_flag.enabled?(:green_lanes)).to be true
+      end
+    end
+
+    context 'when LaunchDarkly returns false for the flag' do
+      before do
+        allow(ld_client).to receive(:variation).with('green_lanes', anything, false).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(feature_flag.enabled?(:green_lanes)).to be false
+      end
+    end
+
+    context 'with a string flag name' do
+      before do
+        allow(ld_client).to receive(:variation).with('green_lanes', anything, false).and_return(true)
+      end
+
+      it 'accepts strings as well as symbols' do
+        expect(feature_flag.enabled?('green_lanes')).to be true
+      end
+    end
+
+    context 'with an unknown flag name' do
+      it 'raises UnknownFlagError' do
+        expect { feature_flag.enabled?(:nonexistent_flag) }
+          .to raise_error(TradeTariffFrontend::FeatureFlag::UnknownFlagError, /nonexistent_flag/)
+      end
+    end
+
+    context 'when LaunchDarkly is offline (no SDK key configured)' do
+      it 'returns the REGISTRY default for the flag' do
+        # In test/dev without a LAUNCHDARKLY_SDK_KEY the client runs in offline
+        # mode and variation() returns the default value we pass — the REGISTRY default.
+        expect(feature_flag.enabled?(:green_lanes)).to be(
+          TradeTariffFrontend::FeatureFlag::REGISTRY[:green_lanes],
+        )
+      end
+    end
+
+    context 'when building the evaluation context' do
+      it 'passes the current service to LaunchDarkly' do
+        allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('xi')
+
+        expect(ld_client).to receive(:variation) do |_flag, context, _default|
+          expect(context.individual_context(0).get_value('service')).to eq('xi')
+          false
+        end
+
+        feature_flag.enabled?(:green_lanes)
+      end
+
+      it 'passes the current environment to LaunchDarkly' do
+        allow(TradeTariffFrontend).to receive(:environment).and_return('staging')
+
+        expect(ld_client).to receive(:variation) do |_flag, context, _default|
+          expect(context.individual_context(0).get_value('environment')).to eq('staging')
+          false
+        end
+
+        feature_flag.enabled?(:green_lanes)
+      end
+    end
+  end
+
+  describe '.disabled?' do
+    it 'is the inverse of enabled?' do
+      allow(ld_client).to receive(:variation).and_return(true)
+      expect(feature_flag.disabled?(:green_lanes)).to be false
+    end
+
+    it 'raises UnknownFlagError for unknown flags' do
+      expect { feature_flag.disabled?(:nonexistent_flag) }
+        .to raise_error(TradeTariffFrontend::FeatureFlag::UnknownFlagError)
+    end
+  end
+
+  describe 'REGISTRY' do
+    it 'declares all flags with boolean defaults' do
+      expect(TradeTariffFrontend::FeatureFlag::REGISTRY).to be_a(Hash)
+      expect(TradeTariffFrontend::FeatureFlag::REGISTRY).not_to be_empty
+
+      TradeTariffFrontend::FeatureFlag::REGISTRY.each do |flag, default|
+        expect([true, false]).to include(default), "Expected #{flag} to have a boolean default"
+      end
+    end
+  end
+end

--- a/spec/lib/trade_tariff_frontend/feature_flag_spec.rb
+++ b/spec/lib/trade_tariff_frontend/feature_flag_spec.rb
@@ -54,79 +54,106 @@ RSpec.describe TradeTariffFrontend::FeatureFlag do
     end
 
     context 'when building the evaluation context without a user_key' do
-      it 'sends a single application context (not a multi-context) to LaunchDarkly' do
-        expect(ld_client).to receive(:variation) do |_flag, context, _default|
-          expect(context.multi_kind?).to be false
-          expect(context.kind).to eq('application')
-          false
-        end
-
+      before do
+        allow(ld_client).to receive(:variation).and_return(false)
         feature_flag.enabled?(:green_lanes)
       end
 
-      it 'passes the current service to LaunchDarkly' do
+      it 'does not build a multi-context' do
+        expect(ld_client).to have_received(:variation).with(
+          anything,
+          satisfy { |ctx| !ctx.multi_kind? },
+          anything,
+        )
+      end
+
+      it 'uses the application kind' do
+        expect(ld_client).to have_received(:variation).with(
+          anything,
+          satisfy { |ctx| ctx.kind == 'application' },
+          anything,
+        )
+      end
+    end
+
+    context 'when the current service is xi' do
+      before do
         allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return('xi')
-
-        expect(ld_client).to receive(:variation) do |_flag, context, _default|
-          expect(context.get_value('service')).to eq('xi')
-          false
-        end
-
+        allow(ld_client).to receive(:variation).and_return(false)
         feature_flag.enabled?(:green_lanes)
       end
 
-      it 'passes the current environment to LaunchDarkly' do
+      it 'passes the xi service to LaunchDarkly in the context' do
+        expect(ld_client).to have_received(:variation).with(
+          anything,
+          satisfy { |ctx| ctx.get_value('service') == 'xi' },
+          anything,
+        )
+      end
+    end
+
+    context 'when the environment is staging' do
+      before do
         allow(TradeTariffFrontend).to receive(:environment).and_return('staging')
-
-        expect(ld_client).to receive(:variation) do |_flag, context, _default|
-          expect(context.get_value('environment')).to eq('staging')
-          false
-        end
-
+        allow(ld_client).to receive(:variation).and_return(false)
         feature_flag.enabled?(:green_lanes)
+      end
+
+      it 'passes the staging environment to LaunchDarkly in the context' do
+        expect(ld_client).to have_received(:variation).with(
+          anything,
+          satisfy { |ctx| ctx.get_value('environment') == 'staging' },
+          anything,
+        )
       end
     end
 
     context 'when building the evaluation context with a user_key' do
       let(:user_key) { 'test-anonymous-uuid' }
 
+      before do
+        allow(ld_client).to receive(:variation).and_return(false)
+        feature_flag.enabled?(:green_lanes, user_key:)
+      end
+
       it 'sends a multi-context to LaunchDarkly' do
-        expect(ld_client).to receive(:variation) do |_flag, context, _default|
-          expect(context.multi_kind?).to be true
-          false
-        end
-
-        feature_flag.enabled?(:green_lanes, user_key:)
+        expect(ld_client).to have_received(:variation).with(
+          anything,
+          satisfy(&:multi_kind?),
+          anything,
+        )
       end
 
-      it 'includes the application context in the multi-context' do
-        expect(ld_client).to receive(:variation) do |_flag, context, _default|
-          app = context.individual_context('application')
-          expect(app).not_to be_nil
-          expect(app.key).to eq('trade-tariff-frontend')
-          false
-        end
-
-        feature_flag.enabled?(:green_lanes, user_key:)
+      it 'includes the application context with the correct key' do
+        expect(ld_client).to have_received(:variation).with(
+          anything,
+          satisfy { |ctx| ctx.individual_context('application')&.key == 'trade-tariff-frontend' },
+          anything,
+        )
       end
 
-      it 'includes an anonymous user context carrying the key' do
-        expect(ld_client).to receive(:variation) do |_flag, context, _default|
-          user = context.individual_context('user')
-          expect(user).not_to be_nil
-          expect(user.key).to eq(user_key)
-          expect(user.get_value('anonymous')).to be true
-          false
-        end
+      it 'includes a user context with the provided key' do
+        expect(ld_client).to have_received(:variation).with(
+          anything,
+          satisfy { |ctx| ctx.individual_context('user')&.key == user_key },
+          anything,
+        )
+      end
 
-        feature_flag.enabled?(:green_lanes, user_key:)
+      it 'marks the user context as anonymous' do
+        expect(ld_client).to have_received(:variation).with(
+          anything,
+          satisfy { |ctx| ctx.individual_context('user')&.get_value('anonymous') == true },
+          anything,
+        )
       end
     end
   end
 
   describe '.disabled?' do
+    before { allow(ld_client).to receive(:variation).and_return(true) }
+
     it 'is the inverse of enabled?' do
-      allow(ld_client).to receive(:variation).and_return(true)
       expect(feature_flag.disabled?(:green_lanes)).to be false
     end
 
@@ -137,13 +164,13 @@ RSpec.describe TradeTariffFrontend::FeatureFlag do
   end
 
   describe 'REGISTRY' do
-    it 'declares all flags with boolean defaults' do
-      expect(TradeTariffFrontend::FeatureFlag::REGISTRY).to be_a(Hash)
-      expect(TradeTariffFrontend::FeatureFlag::REGISTRY).not_to be_empty
+    it 'is a non-empty hash' do
+      expect(TradeTariffFrontend::FeatureFlag::REGISTRY).to be_a(Hash).and(be_present)
+    end
 
-      TradeTariffFrontend::FeatureFlag::REGISTRY.each do |flag, default|
-        expect([true, false]).to include(default), "Expected #{flag} to have a boolean default"
-      end
+    it 'has boolean defaults for every flag' do
+      non_boolean = TradeTariffFrontend::FeatureFlag::REGISTRY.reject { |_, v| [true, false].include?(v) }
+      expect(non_boolean).to be_empty
     end
   end
 end

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -10,7 +10,7 @@ module FeatureFlagHelpers
     # Only stub the named flag. Calls for any other flag are not intercepted and
     # fall through to the real implementation (which returns REGISTRY defaults in
     # offline mode), so multiple stub_feature_flag calls in one example compose cleanly.
-    allow(TradeTariffFrontend::FeatureFlag).to receive(:enabled?).with(flag.to_sym).and_return(enabled)
+    allow(TradeTariffFrontend::FeatureFlag).to receive(:enabled?).with(flag.to_sym, any_args).and_return(enabled)
   end
 end
 

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -7,7 +7,9 @@ module FeatureFlagHelpers
   #   stub_feature_flag(:welsh)                      # enabled: true is the default
   #   stub_feature_flag(:roo_wizard, enabled: false)
   def stub_feature_flag(flag, enabled: true)
-    allow(TradeTariffFrontend::FeatureFlag).to receive(:enabled?).and_call_original
+    # Only stub the named flag. Calls for any other flag are not intercepted and
+    # fall through to the real implementation (which returns REGISTRY defaults in
+    # offline mode), so multiple stub_feature_flag calls in one example compose cleanly.
     allow(TradeTariffFrontend::FeatureFlag).to receive(:enabled?).with(flag.to_sym).and_return(enabled)
   end
 end

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -1,0 +1,17 @@
+module FeatureFlagHelpers
+  # Stubs a specific feature flag for the duration of an example.
+  # Other flags continue to delegate to the real implementation.
+  #
+  # Examples:
+  #   stub_feature_flag(:green_lanes, enabled: true)
+  #   stub_feature_flag(:welsh)                      # enabled: true is the default
+  #   stub_feature_flag(:roo_wizard, enabled: false)
+  def stub_feature_flag(flag, enabled: true)
+    allow(TradeTariffFrontend::FeatureFlag).to receive(:enabled?).and_call_original
+    allow(TradeTariffFrontend::FeatureFlag).to receive(:enabled?).with(flag.to_sym).and_return(enabled)
+  end
+end
+
+RSpec.configure do |config|
+  config.include FeatureFlagHelpers
+end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -5,26 +5,26 @@ Terraform to deploy the service into AWS.
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.97.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [aws_iam_policy.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_document.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_lb_target_group.this_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
@@ -40,7 +40,7 @@ Terraform to deploy the service into AWS.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CloudWatch alarms for the service. Defaults to `true`. | `bool` | `true` | no |


### PR DESCRIPTION
## What:
Integrates LaunchDarkly as the feature flag backend with a thin DSL that keeps LD details out of application code. Adds `feature_gate`, `feature_enabled?`, and `feature_disabled?` helpers to every controller and view. All flags are declared in a central `REGISTRY` constant with safe defaults.

## Why:
Replaces ad-hoc `ENV['FLAG'].to_s == 'true'` checks scattered across `lib/trade_tariff_frontend.rb` with a proper feature flag system that supports dynamic toggling without deploys, environment/service targeting, and percentage rollouts.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Purely additive — no existing behaviour changes. The SDK runs in offline mode when `LAUNCHDARKLY_SDK_KEY` is absent, returning the same `false` defaults as the ENV-based flags would. Existing `TradeTariffFrontend.green_lanes_enabled?` methods are untouched.

───────────────────────────────────────────────────

## Usage

**Declare a flag** (once, in `REGISTRY`):
```ruby
# lib/trade_tariff_frontend/feature_flag.rb
REGISTRY = {
  my_new_feature: false,
}.freeze
```

**Check in controllers/views:**
```erb
<% if feature_enabled?(:my_new_feature) %>…<% end %>
```

**Gate an entire controller or specific actions:**
```ruby
class MyController < ApplicationController
  feature_gate :my_new_feature               # all actions
  feature_gate :my_new_feature, only: :show  # specific action
end
```

**In tests:**
```ruby
stub_feature_flag(:my_new_feature)                 # enabled
stub_feature_flag(:my_new_feature, enabled: false) # disabled
```

## Evaluation context

Every flag evaluation sends a **multi-context** to LaunchDarkly:

- **`application` context** — carries `service` (uk/xi) and `environment`. Use for targeting by deployment, e.g. "only on staging".
- **`user` context** — carries an anonymous UUID from `session[:ld_anonymous_id]`, stable for the session lifetime. Use for percentage rollouts — LaunchDarkly hashes the key consistently so the same visitor always lands in the same bucket.

## Test plan

- [ ] 23 specs across `feature_flag_spec.rb` and `feature_flaggable_spec.rb` cover: enabled/disabled, string vs symbol, unknown flags, offline defaults, single vs multi-context, anonymous user key generation and reuse, `feature_gate` with `only:`, and multi-flag independence
- [ ] 696 controller examples pass unchanged
- [ ] Without `LAUNCHDARKLY_SDK_KEY`: app boots in offline mode, all flags return REGISTRY defaults (false)
- [ ] With `LAUNCHDARKLY_SDK_KEY`: LD client connects on boot, flag changes take effect without a deploy
- [ ] `stub_feature_flag` can be called multiple times in one example without stubs interfering with each other