### PR TITLE
AI-334: Show strong confidence for exact guided search match

### DIFF
--- a/app/models/search/internal_search_result.rb
+++ b/app/models/search/internal_search_result.rb
@@ -7,6 +7,7 @@ class Search
       'Subheading' => 'subheadings',
     }.freeze
     KNOWN_CONFIDENCE_LEVELS = %w[strong good possible unlikely].freeze
+    HIGHEST_CONFIDENCE_LEVEL = KNOWN_CONFIDENCE_LEVELS.first
 
     attr_reader :type, :meta
 
@@ -50,6 +51,13 @@ class Search
 
     def confident_results
       @results.select { |r| r.try(:confidence).present? }
+    end
+
+    def display_confidence_for(result)
+      confidence = result.try(:confidence).to_s.downcase
+      return confidence if KNOWN_CONFIDENCE_LEVELS.include?(confidence)
+
+      HIGHEST_CONFIDENCE_LEVEL if exact_match? && result == @results.first
     end
 
     def all_unknown_confidence?

--- a/app/views/search/_interactive_results_content.html.erb
+++ b/app/views/search/_interactive_results_content.html.erb
@@ -46,7 +46,7 @@
                 new_tab: true %>
           </div>
           <div class="interactive-result__confidence">
-            <%= render_confidence_meter(result.try(:confidence)) %>
+            <%= render_confidence_meter(@results.display_confidence_for(result)) %>
           </div>
         </div>
       <% end %>

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe CommoditiesController, type: :controller do
         it { is_expected.to redirect_to heading_path('0101') }
       end
 
-
       context 'with non-declarable commodity id provided',
               vcr: { cassette_name: 'commodities#show_0101999999' } do
         subject(:do_request) { get :show, params: { id: '0101999999' } }

--- a/spec/models/search/internal_search_result_spec.rb
+++ b/spec/models/search/internal_search_result_spec.rb
@@ -203,6 +203,34 @@ RSpec.describe Search::InternalSearchResult do
     end
   end
 
+  describe '#display_confidence_for' do
+    subject(:display_confidence) { result.display_confidence_for(result.all.first) }
+
+    context 'when the result has a known confidence' do
+      let(:result) { described_class.new([commodity_attrs('confidence' => 'Good')]) }
+
+      it { is_expected.to eq('good') }
+    end
+
+    context 'when an exact match has no confidence' do
+      let(:result) { described_class.new([commodity_attrs('score' => nil, 'confidence' => nil)]) }
+
+      it { is_expected.to eq('strong') }
+    end
+
+    context 'when an exact match has unknown confidence' do
+      let(:result) { described_class.new([commodity_attrs('score' => nil, 'confidence' => 'unknown')]) }
+
+      it { is_expected.to eq('strong') }
+    end
+
+    context 'when a scored result has unknown confidence' do
+      let(:result) { described_class.new([commodity_attrs('confidence' => 'unknown')]) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#size' do
     it 'delegates to all' do
       result = described_class.new([commodity_attrs, heading_attrs, chapter_attrs])

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -123,6 +123,32 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
 
   describe 'confidence meter' do
     it { is_expected.to have_css('.confidence-indicator') }
+
+    context 'when the only exact match has no confidence ranking' do
+      let(:results) do
+        Search::InternalSearchResult.new(
+          [
+            {
+              'goods_nomenclature_item_id' => '2007919930',
+              'producline_suffix' => GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
+              'goods_nomenclature_class' => 'Commodity',
+              'description' => 'Containing less than 70% by weight of sugar',
+              'formatted_description' => 'Containing less than 70% by weight of sugar',
+              'self_text' => 'Citrus marmalade and jam products',
+              'classification_description' => 'Citrus fruit jam',
+              'full_description' => 'Citrus fruit jam with less than 70% sugar',
+              'heading_description' => 'Jams and marmalades',
+              'declarable' => true,
+              'score' => nil,
+              'confidence' => nil,
+            },
+          ],
+          meta,
+        )
+      end
+
+      it { is_expected.to have_css('.confidence-indicator.confidence-strong', text: 'Strong result') }
+    end
   end
 
   describe 'confidence explainer' do


### PR DESCRIPTION
### Jira link

[AI-334](https://transformuk.atlassian.net/browse/AI-334)

### What?

- [x] Render single exact-match guided search results with the highest confidence meter state when the backend does not return a recognised confidence ranking
- [x] Preserve returned confidence rankings when the backend provides one
- [x] Keep the generic unknown confidence fallback for non-exact-match results
- [x] Add focused model and view specs for exact-match confidence display

### Why?

Guided search exact commodity matches can be returned without a confidence ranking. The result page was passing that missing value straight to the confidence meter, so the SVG used the unknown needle even though the only result is an exact match.

Treating that single exact match as `strong` keeps the confidence meter aligned with the result ordering while leaving scored result confidence unchanged.

### Risk

**Risk level:** 🟠

**Reason for rating:** This changes search UI result rendering for guided search exact matches. It is scoped to the confidence meter display for single exact matches and leaves backend confidence rankings unchanged when they are present.
