### PR TITLE
BAU: Reuse expanded internal search query

### DIFF
--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -90,7 +90,11 @@ module InteractiveSearchable
 
   def redirect_to_interactive_blocking
     redirect_to perform_search_path(
-      search_params.to_h.merge(interactive_search: 'true', request_id: @search.request_id),
+      search_params.to_h.merge(
+        interactive_search: 'true',
+        request_id: @search.request_id,
+        expanded_query: @results.expanded_query,
+      ).compact,
     )
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -13,6 +13,7 @@ class SearchController < ApplicationController
     @search.interactive_search = params[:interactive_search] == 'true'
     @search.answers = params[:answers] if params[:answers].present?
     @search.request_id = params[:request_id].presence || SecureRandom.uuid
+    @search.expanded_query = params[:expanded_query].presence
 
     if interactive_search?
       perform_interactive_search
@@ -122,6 +123,7 @@ class SearchController < ApplicationController
       :as_of,
       :interactive_search,
       :request_id,
+      :expanded_query,
       :current_question,
       :current_options,
       answers: %i[question options answer],

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -15,7 +15,8 @@ class Search
                 :resource_id,
                 :interactive_search,
                 :answers,
-                :request_id
+                :request_id,
+                :expanded_query
 
   delegate :today?, to: :date
 
@@ -130,6 +131,7 @@ class Search
       params = { q:, as_of: date.to_fs(:db) }
       params[:answers] = answers if answers.present?
       params[:request_id] = request_id if request_id.present?
+      params[:expanded_query] = expanded_query if expanded_query.present?
 
       response = self.class.api.post(path, MultiJson.dump(params), 'Content-Type' => 'application/json') do |request|
         request.options.timeout = TradeTariffFrontend::ServiceTimeout.timeout_for('/internal/search')
@@ -146,7 +148,7 @@ class Search
   end
 
   def interactive_search_cache_key
-    digest = Digest::SHA256.hexdigest(MultiJson.dump({ q:, answers:, as_of: date.to_fs(:db) }))
+    digest = Digest::SHA256.hexdigest(MultiJson.dump({ q:, answers:, as_of: date.to_fs(:db), expanded_query: }))
     "interactive_search/#{digest}"
   end
 end

--- a/app/models/search/internal_search_result.rb
+++ b/app/models/search/internal_search_result.rb
@@ -93,6 +93,10 @@ class Search
       meta&.dig('interactive_search', 'query')
     end
 
+    def expanded_query
+      meta&.dig('interactive_search', 'expanded_query')
+    end
+
     def description_intercept
       meta&.dig('description_intercept')
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -92,7 +92,7 @@
   </div>
 
   <% unless @feedback %>
-    <%= render 'shared/feedback_useful_banner', show_divider: @interactive_search_page %>
+    <%= render 'shared/feedback_useful_banner' %>
   <% end %>
 
   <footer id="footer" class="govuk-footer govuk-!-display-none-print" role="contentinfo">

--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -27,6 +27,7 @@
       <%= hidden_field_tag :q, @search.q %>
       <%= hidden_field_tag :interactive_search, 'true' %>
       <%= hidden_field_tag :request_id, @search.request_id %>
+      <%= hidden_field_tag :expanded_query, @results.expanded_query if @results.expanded_query.present? %>
       <% if @search.day_month_and_year_set? %>
         <%= hidden_field_tag :year, @search.year %>
         <%= hidden_field_tag :month, @search.month %>

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -381,6 +381,7 @@ RSpec.describe SearchController, type: :controller do
         let(:params) do
           {
             q: 'horses',
+            expanded_query: 'pure-bred breeding horses',
             interactive_search: 'true',
             request_id: 'abc-123',
             answers: [
@@ -412,6 +413,7 @@ RSpec.describe SearchController, type: :controller do
 
         it { is_expected.to have_http_status(:ok) }
         it { is_expected.to render_template(:interactive_results) }
+        it { expect(assigns(:search).expanded_query).to eq('pure-bred breeding horses') }
       end
 
       context 'when backend returns only unknown confidence results' do

--- a/spec/models/search/internal_search_result_spec.rb
+++ b/spec/models/search/internal_search_result_spec.rb
@@ -434,6 +434,14 @@ RSpec.describe Search::InternalSearchResult do
     it { is_expected.to eq('leather handbag') }
   end
 
+  describe '#expanded_query' do
+    subject { described_class.new([commodity_attrs], meta).expanded_query }
+
+    let(:meta) { { 'interactive_search' => { 'expanded_query' => 'leather handbag travel bag' } } }
+
+    it { is_expected.to eq('leather handbag travel bag') }
+  end
+
   describe '#description_intercept' do
     it 'returns the description_intercept hash from meta when present' do
       meta = { 'description_intercept' => { 'excluded' => true, 'message_header' => 'Sending a set', 'message' => 'Sets...' } }

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -298,6 +298,20 @@ RSpec.describe Search do
 
         expect(captured_env.request.timeout).to eq(50)
       end
+
+      it 'sends the cached expanded query to internal search when present' do
+        stub = stub_api_request('search', :post, internal: true)
+          .with { |request| JSON.parse(request.body)['expanded_query'] == 'portable data processing machine' }
+          .to_return(status: 200,
+                     body: internal_response_body.to_json,
+                     headers: { 'content-type' => 'application/json; charset=utf-8' })
+
+        search = described_class.new(q: 'laptop', expanded_query: 'portable data processing machine')
+        search.interactive_search = true
+        search.perform
+
+        expect(stub).to have_been_requested
+      end
     end
 
     context 'when interactive_search is true and response is empty' do

--- a/spec/views/layout/application.html.erb_spec.rb
+++ b/spec/views/layout/application.html.erb_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe 'layouts/application', type: :view do
   context 'when rendering an interactive search page' do
     before { assign(:interactive_search_page, true) }
 
-    it 'uses the standard feedback useful banner with a divider', :aggregate_failures do
+    it 'uses the standard feedback useful banner without an extra divider', :aggregate_failures do
       render
 
       expect(rendered).to have_css('.feedback-useful-banner')
-      expect(rendered).to have_css('.feedback-useful-banner__divider')
+      expect(rendered).not_to have_css('.feedback-useful-banner__divider')
       expect(rendered).not_to have_css('.app-feedback-useful-banner')
     end
   end

--- a/spec/views/search/interactive_question.html.erb_spec.rb
+++ b/spec/views/search/interactive_question.html.erb_spec.rb
@@ -16,12 +16,22 @@ RSpec.describe 'search/interactive_question', type: :view do
         'answers' => [
           { 'question' => 'What type of fruit?', 'options' => %w[Citrus Berry], 'answer' => nil },
         ],
+        'expanded_query' => 'citrus fruit jam marmalade preserve',
       },
     }
   end
 
   it { is_expected.to have_css('h1', text: 'Search for a commodity') }
   it { is_expected.to have_link('Cancel', href: find_commodity_path) }
+
+  it 'carries the expanded query into the answer submission form' do
+    render
+
+    expect(rendered).to have_css(
+      'input[type="hidden"][name="expanded_query"][value="citrus fruit jam marmalade preserve"]',
+      visible: :hidden,
+    )
+  end
 
   context 'when the guided search was started for a historical date' do
     let(:search) do


### PR DESCRIPTION
## What:

- [x] Store `expanded_query` on `Search` and include it in internal search requests/cache keys.
- [x] Expose `expanded_query` from `Search::InternalSearchResult`.
- [x] Add the expanded query as a hidden field on the interactive question form.
- [x] Preserve the expanded query on blocking-guidance redirects.
- [x] Stop rendering the extra feedback useful banner divider for interactive search pages.

## Why:

Guided search follow-up submissions repeat the internal search request for each answered question. Carrying the expanded query through the form lets the backend reuse it instead of running query expansion for the same original search term on every iteration.

The loading state also had a visual mismatch: first submissions showed one feedback separator, while follow-up submissions showed two. Removing the interactive-page divider keeps the separator count consistent.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** This affects the guided search flow, which is not enabled in production yet. The API parameter is additive and the UI separator change is limited to interactive search pages.