### PR TITLE
BAU: Preserve expanded query on answer validation

### DIFF
--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -131,8 +131,9 @@ module InteractiveSearchable
       'interactive_search' => {
         'request_id' => params[:request_id],
         'query' => params[:q],
+        'expanded_query' => params[:expanded_query],
         'answers' => answers + [current],
-      },
+      }.compact,
     }
 
     Search::InternalSearchResult.new([], meta)

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -416,6 +416,34 @@ RSpec.describe SearchController, type: :controller do
         it { expect(assigns(:search).expanded_query).to eq('pure-bred breeding horses') }
       end
 
+      context 'when answer validation fails after query expansion' do
+        render_views
+
+        let(:params) do
+          {
+            q: 'horses',
+            expanded_query: 'pure-bred breeding horses',
+            interactive_search: 'true',
+            request_id: 'abc-123',
+            current_question: 'What type of horse?',
+            current_options: %w[Racing Breeding].to_json,
+            interactive_search_form: { answer: '' },
+          }
+        end
+
+        before { do_response }
+
+        it { is_expected.to have_http_status(:ok) }
+        it { is_expected.to render_template(:interactive_question) }
+
+        it 'preserves the expanded query for the next answer submission' do
+          expect(response.body).to have_css(
+            'input[type="hidden"][name="expanded_query"][value="pure-bred breeding horses"]',
+            visible: :hidden,
+          )
+        end
+      end
+
       context 'when backend returns only unknown confidence results' do
         render_views
 


### PR DESCRIPTION
## What:

- [x] Preserve `expanded_query` in the interactive search meta rebuilt after answer validation fails.
- [x] Add controller coverage proving the re-rendered question form includes the hidden `expanded_query` field.

## Why:

When a guided search answer fails validation, the controller rebuilds an `InternalSearchResult` from submitted params and re-renders the question. Without carrying `expanded_query` into that synthetic meta, the next valid submit loses the cached expansion and asks the backend to expand the same query again.

## Risk:

**Risk level:** 🟢

**Reason for rating:** This affects the guided search flow, which is not enabled in production yet. The change is limited to preserving an already-submitted hidden field through an answer validation failure.