### PR TITLE
BAU: Validate tariff date query params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
   rescue_from Faraday::TimeoutError, with: :handle_timeout_error
   rescue_from Faraday::ServerError, with: :handle_server_error
   rescue_from ActionDispatch::Http::Parameters::ParseError, with: :handle_params_parse_error
+  rescue_from Search::InvalidDate, with: :handle_invalid_search_date
 
   def url_options
     return super unless search_invoked?
@@ -161,6 +162,24 @@ class ApplicationController < ActionController::Base
   end
 
   alias_method :handle_params_parse_error, :bad_request
+
+  def handle_invalid_search_date(exception)
+    return bad_request(exception) unless request.get? && request.format.html?
+
+    Rails.logger.info(exception.message)
+    redirect_to invalid_date_redirect_options
+  end
+
+  def invalid_date_redirect_options
+    request.path_parameters.except(:day, :month, :year, 'day', 'month', 'year').merge(
+      request.query_parameters.except('day', 'month', 'year'),
+      day: nil,
+      month: nil,
+      year: nil,
+      invalid_date: true,
+      only_path: true,
+    )
+  end
 
   def raise_internal_server_error(exception)
     NewRelic::Agent.notice_error(exception)

--- a/app/models/tariff_date.rb
+++ b/app/models/tariff_date.rb
@@ -3,8 +3,10 @@ class TariffDate < SimpleDelegator
 
   class << self
     def build(date_attributes)
-      date = if valid_date_attributes?(date_attributes)
-               Date.parse(date_attributes.slice(*DATE_KEYS).values.join('-'))
+      date = if complete_date_attributes?(date_attributes)
+               raise Date::Error unless valid_date_attributes?(date_attributes)
+
+               Date.new(*date_attributes.slice(*DATE_KEYS).values.map(&:to_i))
              else
                Time.zone.today
              end
@@ -14,9 +16,17 @@ class TariffDate < SimpleDelegator
 
     private
 
-    def valid_date_attributes?(date_param)
+    def complete_date_attributes?(date_param)
       date_param.present? && date_param.is_a?(Hash) &&
-        DATE_KEYS.all? { |k| date_param[k].present? }
+        DATE_KEYS.all? { |key| date_param[key].present? }
+    end
+
+    def valid_date_attributes?(date_param)
+      DATE_KEYS.all? { |key| numeric_date_attribute?(date_param[key]) }
+    end
+
+    def numeric_date_attribute?(value)
+      value.to_s.match?(/\A\d+\z/)
     end
   end
 

--- a/app/views/search/quotas/_form.html.erb
+++ b/app/views/search/quotas/_form.html.erb
@@ -1,5 +1,6 @@
 <%= form_tag quota_search_path, method: :get, class: "tariff-search quota-search #{@section_css}", id: 'new_search' do |f| %>
   <%= page_header 'Search for quotas' %>
+  <%= render 'shared/invalid_date_error_summary' if params[:invalid_date].present? %>
 
   <div class="govuk-form-group govuk-!-margin-top-6">
     <div class="govuk-inset-text govuk-grid-column-one-half govuk-!-margin-top-0 govuk-!-margin-bottom-0">

--- a/app/views/shared/_invalid_date_error_summary.html.erb
+++ b/app/views/shared/_invalid_date_error_summary.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-error-summary" data-module="govuk-error-summary">
+  <div role="alert">
+    <h2 class="govuk-error-summary__title">There is a problem</h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li><%= govuk_link_to('You must enter a valid date', '#day') %></li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/search/_interactive_search_form.html.erb
+++ b/app/views/shared/search/_interactive_search_form.html.erb
@@ -4,6 +4,8 @@
 
 <div data-guided-search-validation-target="formContent">
 
+<%= render 'shared/invalid_date_error_summary' if params[:invalid_date].present? %>
+
 <% if @search.errors.any? %>
 <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">

--- a/app/views/shared/search/_search_form.html.erb
+++ b/app/views/shared/search/_search_form.html.erb
@@ -1,5 +1,9 @@
 <%= form_tag perform_search_path, method: :get, id: "new_search" do |f| %>
 
+<% if params[:invalid_date].present? && local_assigns[:use_date_picker] %>
+  <%= render 'shared/invalid_date_error_summary' %>
+<% end %>
+
 <% if @search.errors.any? %>
 <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">

--- a/spec/controllers/search_controller_quotas_spec.rb
+++ b/spec/controllers/search_controller_quotas_spec.rb
@@ -112,5 +112,25 @@ RSpec.describe SearchController, type: :controller, vcr: { cassette_name: 'searc
         expect(response.body).to match(/Sorry, there is a problem with the search query. Please specify one or more search criteria./)
       end
     end
+
+    context 'with an invalid date flag' do
+      render_views
+
+      before do
+        get :quota_search, params: { invalid_date: true }, format: :html
+      end
+
+      it 'renders a GOV.UK error summary' do
+        expect(response.body).to match(/govuk-error-summary.*You must enter a valid date/m)
+      end
+
+      it 'links the error summary to the date input' do
+        expect(response.body).to match(/govuk-error-summary.*href="#day"/m)
+      end
+
+      it 'marks the date input as invalid' do
+        expect(response.body).to match(/govuk-form-group--error.*id="day".*govuk-input--error/m)
+      end
+    end
   end
 end

--- a/spec/models/tariff_date_spec.rb
+++ b/spec/models/tariff_date_spec.rb
@@ -36,6 +36,34 @@ RSpec.describe TariffDate do
 
       it { is_expected.to eq(Time.zone.today) }
     end
+
+    context 'when passing impossible date attributes' do
+      let(:date_attributes) do
+        {
+          'year' => '2026',
+          'month' => '02',
+          'day' => '31',
+        }
+      end
+
+      it 'raises an invalid date error' do
+        expect { tariff_date }.to raise_error(Date::Error)
+      end
+    end
+
+    context 'when passing non-numeric date attributes' do
+      let(:date_attributes) do
+        {
+          'year' => '2026',
+          'month' => 'May',
+          'day' => '22',
+        }
+      end
+
+      it 'raises an invalid date error' do
+        expect { tariff_date }.to raise_error(Date::Error)
+      end
+    end
   end
 
   describe '#to_param' do

--- a/spec/requests/find_commodities_controller_spec.rb
+++ b/spec/requests/find_commodities_controller_spec.rb
@@ -7,9 +7,31 @@ RSpec.describe FindCommoditiesController, type: :request do
     include_context 'with latest news stubbed'
     include_context 'with news updates stubbed'
 
-    before { get find_commodity_path }
+    before { get find_commodity_path(params) }
+
+    let(:params) { {} }
 
     it { is_expected.to have_http_status :ok }
     it { is_expected.to have_attributes content_type: %r{text/html} }
+
+    context 'with an invalid date flag' do
+      let(:params) { { invalid_date: true, day: '22', month: '0', year: '2026' } }
+
+      it 'renders a GOV.UK error summary' do
+        expect(response.body).to match(/govuk-error-summary.*You must enter a valid date/m)
+      end
+
+      it 'links the error summary to the date input' do
+        expect(response.body).to match(/govuk-error-summary.*href="#day"/m)
+      end
+
+      it 'marks the date input as invalid' do
+        expect(response.body).to match(/govuk-form-group--error.*id="day".*govuk-input--error/m)
+      end
+
+      it 'keeps the submitted date values in the form' do
+        expect(response.body).to match(/id="day"[^>]*value="22".*id="month"[^>]*value="0".*id="year"[^>]*value="2026"/m)
+      end
+    end
   end
 end

--- a/spec/requests/heading_spec.rb
+++ b/spec/requests/heading_spec.rb
@@ -11,6 +11,32 @@ RSpec.describe 'Heading page', type: :request do
   end
 
   context 'when requesting as as HTML' do
+    context 'with invalid date query parameters' do
+      before do
+        get heading_path('0101', day: ')', month: '5', year: '2026')
+      end
+
+      it 'redirects back to the heading with the invalid date flag' do
+        expect(response).to redirect_to('/headings/0101?invalid_date=true')
+      end
+
+      it 'loads the heading after redirect' do
+        VCR.use_cassette('headings#show') do
+          follow_redirect!
+        end
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'does not show the invalid date form error after redirect' do
+        VCR.use_cassette('headings#show') do
+          follow_redirect!
+        end
+
+        expect(response.body).not_to include('You must enter a valid date')
+      end
+    end
+
     context 'with a regular heading' do
       before do
         VCR.use_cassette('geographical_areas#countries') do

--- a/spec/views/find_commodities/show_interactive.html.erb_spec.rb
+++ b/spec/views/find_commodities/show_interactive.html.erb_spec.rb
@@ -59,6 +59,22 @@ RSpec.describe 'find_commodities/show_interactive', type: :view do
 
   describe 'date picker' do
     it { is_expected.to have_text('When are you planning to trade the products?') }
+
+    context 'with an invalid date flag' do
+      before do
+        view.params[:invalid_date] = 'true'
+        view.params[:day] = '22'
+        view.params[:month] = '0'
+        view.params[:year] = '2026'
+      end
+
+      it { is_expected.to have_css('.govuk-error-summary', text: 'You must enter a valid date') }
+      it { is_expected.to have_css('.govuk-error-summary a[href="#day"]', text: 'You must enter a valid date') }
+      it { is_expected.to have_css('.govuk-form-group--error #day.govuk-input--error') }
+      it { is_expected.to have_css('#day[value="22"]') }
+      it { is_expected.to have_css('#month[value="0"]') }
+      it { is_expected.to have_css('#year[value="2026"]') }
+    end
   end
 
   describe 'submit button' do


### PR DESCRIPTION
# Jira link

BAU

<img width="1185" height="1414" alt="image" src="https://github.com/user-attachments/assets/93e25459-d67b-47fe-98ee-d4dfc56a2017" />

<img width="1107" height="899" alt="image" src="https://github.com/user-attachments/assets/1a8db20a-fef6-484b-aca5-56ff51ea3f41" />



## What?

I have:

- [x] Changed tariff date query parsing to validate complete `day`, `month`, and `year` params strictly.
- [x] Stopped malformed date query params from bubbling out as `Search::InvalidDate` 5xx responses on content pages.
- [x] Redirected invalid HTML date queries back to the same path with `invalid_date=true` set, without using a user-controlled URL string.
- [x] Added a shared GOV.UK error summary for date-picker forms that links to the day field.
- [x] Added the same invalid-date summary to the guided search UI.
- [x] Preserved submitted invalid date values in guided and non-guided search forms so users can correct them.
- [x] Kept pages without a date picker as a sanitising redirect only, so they do not show an unfixable form error.

## Why?

I am doing this because:

- Scanner traffic and malformed copied URLs can send non-date values in `day`, `month`, or `year`.
- Those params were parsed before validation, which could turn bad input into a frontend 500.
- Date input should be treated as validation: where a date form is present, users should see the normal GOV.UK error summary and field error state.
- Valid date params remain sticky through existing URL helper behaviour; invalid date values are only cleared by the generic content-page rescue to avoid redirect loops on pages with no date form.

## Risk

**Risk level:** 🟢

**Reason for rating:** Narrow validation and rendering change around existing date query params. Valid dates and missing dates keep their existing behaviour; malformed complete dates now become validation state instead of 5xx responses.