### PR TITLE
Use hidden instead of inline display:none

### DIFF
--- a/app/javascript/controllers/anchor_controller.js
+++ b/app/javascript/controllers/anchor_controller.js
@@ -1,13 +1,9 @@
-/* global $ */
-
 import {Controller} from '@hotwired/stimulus';
 
 export default class extends Controller {
   static targets = ['modal'];
 
   initialize() {
-    // All the HTML for modal pop-ups are generated already and need to be hidden on the page
-    $('#import-measure-references, #export-measure-references').hide();
     document.addEventListener('click', this.handleClickOutsideOpenModal.bind(this));
     document.addEventListener('keydown', this.handleEscapePressWithOpenModal.bind(this));
     this.isModalOpen = false;

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -26,13 +26,14 @@
           If you have any questions or need assistance, use our <%= govuk_link_to 'enquiry form', product_experience_enquiry_form_path %>.
         </p>
 
-      <div style="display: none;">
+      <div hidden>
         <%= f.govuk_phone_field :telephone,
                              label: { text: 'Telephone (Do not fill out)',
                                       hidden: true },
                              width: 20,
                              max_chars: 100 %>
       </div>
+
 
       <%= f.hidden_field :page_useful %>
 

--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -103,7 +103,7 @@
   <% end %>
 <% end %>
 
-<div id="import-measure-references">
+<div id="import-measure-references" hidden>
   <%= render partial: 'measures/measure_references',
               collection: declarable_import_measures,
               as: 'measure',
@@ -134,7 +134,7 @@
   <% end %>
 </div>
 
-<div id="export-measure-references">
+<div id="export-measure-references" hidden>
   <% if uk_declarable&.export_measures&.any? %>
       <%= render partial: 'measures/measure_references',
               collection: uk_declarable.export_measures,

--- a/app/views/shared/_unknown_quota_definition.html.erb
+++ b/app/views/shared/_unknown_quota_definition.html.erb
@@ -1,6 +1,6 @@
 <%= link_to 'Unknown quota definition', '#unknown-quota-definition',
             class: 'reference numerical govuk-visually-hidden',
-            style: 'display: none',
+            hidden: true,
             title: 'Opens in a popup',
             data: { popup_ref: "unknown-quota-definition" } %>
 


### PR DESCRIPTION
## What:
Use if inline style tags causes a CSP violation.
- Markup for modals on commodities page should be hidden in page load so we can use hidden instead of hiding via JS
- Honeypot field on feedback form can use hidden
- Placeholder link for quota definition can use hidden

## Why:
To stop noise from CSP violations in logs

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Behaviour is unchanged
