### PR TITLE
BAU: Submit classic search form with POST

### DIFF
--- a/app/views/shared/search/_search_form.html.erb
+++ b/app/views/shared/search/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag perform_search_path, method: :get, id: "new_search" do |f| %>
+<%= form_tag perform_search_path, method: :post, id: "new_search" do |f| %>
 
 <% if params[:invalid_date].present? && local_assigns[:use_date_picker] %>
   <%= render 'shared/invalid_date_error_summary' %>

--- a/spec/views/shared/search/_search_form.html.erb_spec.rb
+++ b/spec/views/shared/search/_search_form.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe 'shared/search/_search_form', type: :view do
+  subject(:rendered_form) do
+    render partial: 'shared/search/search_form'
+    rendered
+  end
+
+  before do
+    assign(:search, build(:search))
+  end
+
+  it 'submits searches with POST' do
+    expect(rendered_form).to have_css('form#new_search[method="post"][action="/search"]')
+  end
+end


### PR DESCRIPTION
## What

- Change the shared classic search form to submit to `/search` with `POST`.
- Keep the existing frontend-to-backend search plumbing unchanged; the frontend already calls the backend search API with `POST`.
- Add a view spec covering the form method.

## Why

The WAF `SQLi_QUERYARGUMENTS` managed rule was historically excluded because free-text search terms were sent as query parameters and caused false positives. Submitting the classic search form with `POST` removes normal user-entered search text from the public query string before we re-enable that WAF protection.

## Ordering

Merge and deploy this PR before removing the `SQLi_QUERYARGUMENTS` exclusion in the platform WAF configuration.

The follow-up platform PR must not merge until this frontend change has been deployed.
