### PR TITLE
Fix search link

### DIFF
--- a/app/views/search/_commodity.html.erb
+++ b/app/views/search/_commodity.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell commodity-result">
-    <%= govuk_link_to('', commodity_path(commodity, request_id: @search.request_id), aria_describedby: "code-for-commodity-#{commodity.id}", visually_hidden_suffix: "(code #{commodity.code})") do %>
+    <%= govuk_link_to(commodity_path(commodity, request_id: @search.request_id), aria_describedby: "code-for-commodity-#{commodity.id}", visually_hidden_suffix: "(code #{commodity.code})") do %>
       <% if commodity.ancestor_descriptions.present? %>
         <%= descriptions_with_other_handling(commodity) %>
       <% else %>

--- a/spec/views/search/_commodity.html.erb_spec.rb
+++ b/spec/views/search/_commodity.html.erb_spec.rb
@@ -1,8 +1,10 @@
 RSpec.describe 'search/_commodity', type: :view do
-  subject { render }
+  subject(:rendered) { render }
+
+  let(:request_id) { 'search-request-123' }
 
   before do
-    assign(:search, build(:search, q: 'test'))
+    assign(:search, build(:search, q: 'test', request_id:))
     allow(view).to receive(:commodity).and_return(commodity)
   end
 
@@ -16,5 +18,11 @@ RSpec.describe 'search/_commodity', type: :view do
     let(:commodity) { build(:commodity, description: 'Horses') }
 
     it { is_expected.to have_css('td.govuk-table__cell > a', text: 'Horses') }
+
+    it 'renders a commodity link with the expected href' do
+      link = Capybara.string(rendered).find('td.commodity-result a', text: 'Horses')
+
+      expect(link[:href]).to eq(commodity_path(commodity, request_id:))
+    end
   end
 end


### PR DESCRIPTION
## What:
There was an error in a recent change to use govuk_link_to helper. This has now been fixed and a test has been added.

## Why:
The search results page links for commodities was redirecting users to the same search page.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Fixes a regression and includes a unit test.
