### PR TITLE
OTTIMP-615: Implement live issues card filtering layout

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -65,3 +65,4 @@ $govuk-images-path: '/govuk-frontend/dist/govuk/assets/images/';
 @import 'src/mycommodities';
 @import 'src/app-card';
 @import 'src/cards';
+@import 'src/live_issues';

--- a/app/assets/stylesheets/src/_live_issues.scss
+++ b/app/assets/stylesheets/src/_live_issues.scss
@@ -1,0 +1,76 @@
+.live-issues__filter-panel {
+  margin-bottom: govuk-spacing(4);
+}
+
+.live-issues__result-count {
+  color: govuk-colour("black");
+  display: inline-block;
+  margin-left: govuk-spacing(3);
+  text-decoration: none;
+}
+
+.live-issues__filter-panel-content {
+  padding-top: govuk-spacing(3);
+}
+
+.live-issues__filter-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: govuk-spacing(3);
+}
+
+.live-issues__active-filters {
+  margin-bottom: govuk-spacing(4);
+}
+
+.live-issues__active-filters-heading {
+  margin-bottom: govuk-spacing(2);
+}
+
+.live-issues__active-filter-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: govuk-spacing(2);
+  list-style: none;
+  margin: 0 0 govuk-spacing(2);
+  padding: 0;
+}
+
+.live-issues__active-filter {
+  background: govuk-colour("black", $variant: "tint-95");
+  border: 1px solid govuk-colour("black", $variant: "tint-80");
+  display: inline-block;
+  padding: govuk-spacing(1) govuk-spacing(2);
+  text-decoration: none;
+}
+
+.live-issues__card {
+  margin-bottom: govuk-spacing(4);
+}
+
+.live-issues__card-meta,
+.live-issues__card-issue {
+  display: block;
+}
+
+.live-issues__card-meta {
+  @include govuk-font($size: 16, $weight: regular);
+}
+
+.live-issues__commodity-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: govuk-spacing(1) govuk-spacing(2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.live-issues__markdown {
+  p:last-child,
+  ul:last-child,
+  ol:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/app/controllers/live_issues_controller.rb
+++ b/app/controllers/live_issues_controller.rb
@@ -1,15 +1,34 @@
 class LiveIssuesController < ApplicationController
+  LIVE_ISSUES_PER_PAGE = 4
+
   before_action :disable_switch_service_banner,
                 :disable_search_form
 
   def index
-    @sort_direction = sort_direction
-    @live_issues = LiveIssue.sorted_by_status(@sort_direction)
+    @sort = sort
+    @applied_sort = applied_sort
+    @status_filters = status_filters
+    filtered_live_issues = LiveIssue.filtered(statuses: @status_filters, sort: @sort)
+    @live_issues_count = filtered_live_issues.size
+    @live_issues = Kaminari.paginate_array(filtered_live_issues, total_count: @live_issues_count)
+                            .page(params[:page])
+                            .per(LIVE_ISSUES_PER_PAGE)
   end
 
 private
 
-  def sort_direction
-    params[:sort] == 'desc' ? 'desc' : 'asc'
+  def applied_sort
+    LiveIssue::SUPPORTED_SORTS.include?(params[:sort]) ? params[:sort] : nil
+  end
+
+  def sort
+    LiveIssue::SUPPORTED_SORTS.include?(params[:sort]) ? params[:sort] : LiveIssue::DEFAULT_SORT
+  end
+
+  def status_filters
+    Array(params[:status]).filter_map { |status|
+      normalized_status = status.to_s.downcase
+      normalized_status if LiveIssue::SUPPORTED_STATUSES.include?(normalized_status)
+    }.uniq
   end
 end

--- a/app/helpers/live_issue_helper.rb
+++ b/app/helpers/live_issue_helper.rb
@@ -1,19 +1,21 @@
 module LiveIssueHelper
+  SORT_LABELS = {
+    'updated_desc' => 'live_issues.sort.updated_desc',
+    'updated_asc' => 'live_issues.sort.updated_asc',
+  }.freeze
+
+  STATUS_FILTER_LABELS = {
+    'active' => 'live_issues.status_filters.active',
+    'resolved' => 'live_issues.status_filters.resolved',
+  }.freeze
+
+  STATUS_LABELS = {
+    'active' => 'live_issues.status_labels.active',
+    'resolved' => 'live_issues.status_labels.resolved',
+  }.freeze
+
   def markdown_field(markdown)
-    raw Kramdown::Document.new(markdown).to_html
-  end
-
-  def live_issue_status_sort_link(sort_direction)
-    current_direction = sort_direction == 'desc' ? 'desc' : 'asc'
-    next_direction = current_direction == 'asc' ? 'desc' : 'asc'
-
-    link_to live_issues_path(sort: next_direction), class: 'govuk-link govuk-link--no-visited-state' do
-      safe_join([
-        'Status',
-        tag.span(sort_arrow(current_direction), aria: { hidden: true }),
-        tag.span("sorted #{sort_direction_label(current_direction)}", class: 'govuk-visually-hidden'),
-      ], ' ')
-    end
+    govspeak(markdown)
   end
 
   def live_issue_from_to_date(live_issue)
@@ -23,13 +25,63 @@ module LiveIssueHelper
     "#{from} - #{to}"
   end
 
-private
+  def live_issue_updated_at(live_issue)
+    return t('live_issues.card.not_available') if live_issue.updated_at.blank?
 
-  def sort_arrow(direction)
-    (direction == 'desc' ? '&#8595;' : '&#8593;').html_safe
+    live_issue.updated_at.to_date.to_formatted_s(:long)
+  rescue ArgumentError, NoMethodError
+    t('live_issues.card.not_available')
   end
 
-  def sort_direction_label(direction)
-    direction == 'desc' ? 'descending' : 'ascending'
+  def live_issue_sort_label(sort)
+    t(SORT_LABELS.fetch(sort, SORT_LABELS.fetch(LiveIssue::DEFAULT_SORT)))
+  end
+
+  def live_issue_status_filter_label(status)
+    normalized_status = status.to_s.downcase
+    label_key = STATUS_FILTER_LABELS[normalized_status]
+
+    label_key ? t(label_key) : status.to_s
+  end
+
+  def live_issue_status_filter_selected?(status_filters, status)
+    Array(status_filters).include?(status)
+  end
+
+  def live_issue_active_filter_labels(status_filters:, sort:)
+    labels = []
+    labels << t('live_issues.filters.sort_chip', label: live_issue_sort_label(sort)).delete_prefix('× ') if sort.present?
+
+    Array(status_filters).each do |status|
+      labels << t('live_issues.filters.status_chip', label: live_issue_status_label(status)).delete_prefix('× ')
+    end
+
+    labels
+  end
+
+  def live_issue_status_label(status)
+    normalized_status = status.to_s.downcase
+    return t(STATUS_LABELS.fetch('active')) if normalized_status.start_with?('active')
+    return t(STATUS_LABELS.fetch('resolved')) if normalized_status.start_with?('resolved')
+
+    status
+  end
+
+  def live_issue_status_tag_class(status)
+    normalized_status = status.to_s.downcase
+    return 'govuk-tag--yellow' if normalized_status.start_with?('active')
+    return 'govuk-tag--green' if normalized_status.start_with?('resolved')
+
+    ''
+  end
+
+  def live_issue_filter_path_without_sort
+    live_issues_path(status: @status_filters.presence)
+  end
+
+  def live_issue_filter_path_without_status(status)
+    remaining_statuses = Array(@status_filters) - [status]
+
+    live_issues_path(sort: @applied_sort, status: remaining_statuses.presence)
   end
 end

--- a/app/models/live_issue.rb
+++ b/app/models/live_issue.rb
@@ -1,6 +1,10 @@
 class LiveIssue
   include UkOnlyApiEntity
 
+  DEFAULT_SORT = 'updated_desc'.freeze
+  SUPPORTED_SORTS = %w[updated_desc updated_asc].freeze
+  SUPPORTED_STATUSES = %w[active resolved].freeze
+
   attr_accessor :title,
                 :description,
                 :status,
@@ -11,13 +15,53 @@ class LiveIssue
                 :updated_at
 
   class << self
+    def filtered(statuses: [], sort: nil)
+      selected_statuses = normalized_statuses(statuses)
+      issues = filter_by_status(all, selected_statuses)
+
+      sort_by_last_updated(issues, normalized_sort(sort))
+    end
+
     def sorted_by_status(sort_direction = 'asc')
       all.sort_by do |live_issue|
-        [status_sort_rank(live_issue, sort_direction), -updated_at_sort_value(live_issue)]
+        [status_sort_rank(live_issue, sort_direction), -(updated_at_sort_value(live_issue) || 0)]
       end
     end
 
   private
+
+    def filter_by_status(issues, statuses)
+      return issues if statuses.empty? || statuses.size == SUPPORTED_STATUSES.size
+
+      issues.select do |live_issue|
+        statuses.any? { |status| live_issue.status.to_s.downcase.start_with?(status) }
+      end
+    end
+
+    def normalized_sort(sort)
+      SUPPORTED_SORTS.include?(sort) ? sort : DEFAULT_SORT
+    end
+
+    def normalized_statuses(statuses)
+      Array(statuses).filter_map { |status|
+        normalized_status = status.to_s.downcase
+        normalized_status if SUPPORTED_STATUSES.include?(normalized_status)
+      }.uniq
+    end
+
+    def sort_by_last_updated(issues, sort)
+      issues.sort_by do |live_issue|
+        sort_value = updated_at_sort_value(live_issue)
+        missing_timestamp = sort_value.nil? ? 1 : 0
+        comparable_timestamp = sort_value || 0
+
+        if sort == 'updated_asc'
+          [missing_timestamp, comparable_timestamp]
+        else
+          [missing_timestamp, -comparable_timestamp]
+        end
+      end
+    end
 
     def status_sort_rank(live_issue, sort_direction)
       active_status = live_issue.status.to_s.casecmp('active').zero?
@@ -30,11 +74,11 @@ class LiveIssue
     end
 
     def updated_at_sort_value(live_issue)
-      return 0 if live_issue.updated_at.blank?
+      return if live_issue.updated_at.blank?
 
       live_issue.updated_at.to_time.to_i
     rescue ArgumentError, NoMethodError
-      0
+      nil
     end
   end
 end

--- a/app/views/live_issues/_card.html.erb
+++ b/app/views/live_issues/_card.html.erb
@@ -1,0 +1,43 @@
+<article class="govuk-summary-card live-issues__card">
+  <div class="govuk-summary-card__title-wrapper">
+    <h2 class="govuk-summary-card__title">
+      <span class="live-issues__card-meta"><%= t('live_issues.card.last_updated', date: live_issue_updated_at(live_issue)) %></span>
+      <span class="live-issues__card-issue"><%= t('live_issues.card.issue', title: live_issue.title) %></span>
+    </h2>
+  </div>
+
+  <div class="govuk-summary-card__content">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t('live_issues.card.description') %></dt>
+        <dd class="govuk-summary-list__value live-issues__markdown"><%= markdown_field(live_issue.description) %></dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t('live_issues.card.commodities_affected') %></dt>
+        <dd class="govuk-summary-list__value">
+          <%= render partial: 'commodities', locals: { live_issue: live_issue } %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t('live_issues.card.status') %></dt>
+        <dd class="govuk-summary-list__value">
+          <strong class="govuk-tag <%= live_issue_status_tag_class(live_issue.status) %>">
+            <%= live_issue_status_label(live_issue.status) %>
+          </strong>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t('live_issues.card.recommendation') %></dt>
+        <dd class="govuk-summary-list__value live-issues__markdown"><%= markdown_field(live_issue.suggested_action) %></dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t('live_issues.card.date_of_effect') %></dt>
+        <dd class="govuk-summary-list__value"><%= live_issue_from_to_date(live_issue) %></dd>
+      </div>
+    </dl>
+  </div>
+</article>

--- a/app/views/live_issues/_commodities.html.erb
+++ b/app/views/live_issues/_commodities.html.erb
@@ -1,17 +1,19 @@
 <% if live_issue.commodities.empty? %>
   <p class="govuk-body">
-    None affected
+    <%= t('live_issues.commodities.none') %>
   </p>
 <% elsif live_issue.commodities.size > 1 %>
-<%= govuk_details(summary_text: "#{live_issue.commodities.count} commodities affected") do %>
-  <% live_issue.commodities.each do |commodity_code| %>
-    <p class="govuk-body">
-      <%= govuk_link_to(commodity_code, "/commodities/#{commodity_code}") %>
-    </p>
+  <%= govuk_details(summary_text: t('live_issues.commodities.count', count: live_issue.commodities.count)) do %>
+    <ul class="live-issues__commodity-list">
+      <% live_issue.commodities.each do |commodity_code| %>
+        <li>
+          <%= govuk_link_to(commodity_code, "/commodities/#{commodity_code}") %>
+        </li>
+      <% end %>
+    </ul>
   <% end %>
-<% end %>
 <% else %>
-<p class="govuk-body">
-  <%= govuk_link_to(live_issue.commodities.first, "/commodities/#{live_issue.commodities.first}") %>
-</p>
+  <p class="govuk-body">
+    <%= govuk_link_to(live_issue.commodities.first, "/commodities/#{live_issue.commodities.first}") %>
+  </p>
 <% end %>

--- a/app/views/live_issues/_filters.html.erb
+++ b/app/views/live_issues/_filters.html.erb
@@ -1,0 +1,71 @@
+<details class="govuk-details live-issues__filter-panel" <%= 'open' if @status_filters.present? || @applied_sort.present? %>>
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text"><%= t('live_issues.filters.summary') %></span>
+    <span class="live-issues__result-count"><%= t('live_issues.results.count', count: @live_issues_count) %></span>
+  </summary>
+
+  <div class="govuk-details__text live-issues__filter-panel-content">
+    <%= form_with url: live_issues_path, method: :get, local: true do %>
+      <fieldset class="govuk-fieldset govuk-!-margin-bottom-4">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          <%= t('live_issues.filters.sort_by') %>
+        </legend>
+
+        <div class="govuk-radios govuk-radios--small">
+          <% LiveIssue::SUPPORTED_SORTS.each do |sort| %>
+            <div class="govuk-radios__item">
+              <%= radio_button_tag :sort, sort, @sort == sort, class: 'govuk-radios__input', id: "sort_#{sort}" %>
+              <%= label_tag "sort_#{sort}", live_issue_sort_label(sort), class: 'govuk-label govuk-radios__label' %>
+            </div>
+          <% end %>
+        </div>
+      </fieldset>
+
+      <fieldset class="govuk-fieldset govuk-!-margin-bottom-4">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          <%= t('live_issues.filters.status') %>
+        </legend>
+
+        <div class="govuk-checkboxes govuk-checkboxes--small">
+          <% LiveIssue::SUPPORTED_STATUSES.each do |status| %>
+            <div class="govuk-checkboxes__item">
+              <%= check_box_tag 'status[]', status, live_issue_status_filter_selected?(@status_filters, status), class: 'govuk-checkboxes__input', id: "status_#{status}" %>
+              <%= label_tag "status_#{status}", live_issue_status_filter_label(status), class: 'govuk-label govuk-checkboxes__label' %>
+            </div>
+          <% end %>
+        </div>
+      </fieldset>
+
+      <div class="live-issues__filter-actions">
+        <%= button_tag t('live_issues.filters.apply'), type: 'submit', name: nil, class: 'govuk-button govuk-!-margin-bottom-0', data: { module: 'govuk-button' } %>
+        <%= govuk_link_to t('live_issues.filters.clear'), live_issues_path, no_visited_state: true %>
+      </div>
+    <% end %>
+  </div>
+</details>
+
+<p class="govuk-body-s live-issues__showing-count">
+  <%= t('live_issues.results.showing', count: @live_issues_count) %>
+</p>
+
+<% if @applied_sort.present? || @status_filters.present? %>
+  <div class="live-issues__active-filters">
+    <h2 class="govuk-heading-s live-issues__active-filters-heading"><%= t('live_issues.filters.active_heading') %></h2>
+
+    <ul class="live-issues__active-filter-list">
+      <% if @applied_sort.present? %>
+        <li>
+          <%= link_to t('live_issues.filters.sort_chip', label: live_issue_sort_label(@applied_sort)), live_issue_filter_path_without_sort, class: 'live-issues__active-filter govuk-link govuk-link--no-visited-state' %>
+        </li>
+      <% end %>
+
+      <% @status_filters.each do |status| %>
+        <li>
+          <%= link_to t('live_issues.filters.status_chip', label: live_issue_status_label(status)), live_issue_filter_path_without_status(status), class: 'live-issues__active-filter govuk-link govuk-link--no-visited-state' %>
+        </li>
+      <% end %>
+    </ul>
+
+    <%= govuk_link_to t('live_issues.filters.clear'), live_issues_path, no_visited_state: true %>
+  </div>
+<% end %>

--- a/app/views/live_issues/index.html.erb
+++ b/app/views/live_issues/index.html.erb
@@ -1,6 +1,6 @@
 <%= page_header do %>
   <h1 class="govuk-heading-xl">
-    Live Issues Log
+    <%= t('live_issues.title') %>
   </h1>
 <% end %>
 
@@ -8,34 +8,18 @@
   <%= generate_breadcrumbs t('breadcrumb.live_issues'), [[t('breadcrumb.news'), '/news']] %>
 <% end %>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Issue</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Description</th>
-      <th scope="col" class="govuk-table__header">Commodities</th>
-      <th scope="col" class="govuk-table__header"><%= live_issue_status_sort_link(@sort_direction) %></th>
-      <th scope="col" class="govuk-table__header">Dates</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Suggested action</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-  <% @live_issues.each do |live_issue| %>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header"> <%= live_issue.title %>
-        <div class="govuk-!-font-size-14 govuk-!-margin-top-5 govuk-!-text-colour-muted">
-          Last updated: <br>
-            <%= live_issue.updated_at.to_date.to_formatted_s(:long) %>
-        </div>
-      </th>
-      <td class="govuk-table__cell"> <%= markdown_field(live_issue.description) %> </td>
-      <td class="govuk-table__cell">
-        <%= render partial: 'commodities', locals: { live_issue: live_issue } %>
-      </td>
-      <td class="govuk-table__cell"><%= live_issue.status %></td>
-      <td class="govuk-table__cell"><%= live_issue_from_to_date(live_issue) %></td>
-      <td class="govuk-table__cell"><%= markdown_field(live_issue.suggested_action) %></td>
-    </tr>
+<div class="live-issues">
+  <%= render 'filters' %>
+
+  <% if @live_issues.any? %>
+    <div class="live-issues__list">
+      <% @live_issues.each do |live_issue| %>
+        <%= render 'card', live_issue: live_issue %>
+      <% end %>
+    </div>
+
+    <%= paginate @live_issues %>
+  <% else %>
+    <p class="govuk-body"><%= t('live_issues.empty') %></p>
   <% end %>
-  </tbody>
-</table>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,6 +245,48 @@ en:
       ending: Changes to end date
       classification: Changes to classification
       unsubscribe: Unsubscribe
+  live_issues:
+    title: Live issues log
+    empty: No live issues match the selected filters.
+    results:
+      count:
+        one: 1 result
+        other: "%{count} results"
+      showing:
+        one: Showing 1 issue logged
+        other: "Showing %{count} issues logged"
+    filters:
+      summary: Filter and sort
+      sort_by: Sort by
+      status: Status
+      apply: Apply
+      clear: Clear filters
+      active_heading: Active filters and sorting
+      sort_chip: "× Sort by: %{label}"
+      status_chip: "× Status: %{label}"
+    sort:
+      updated_desc: Last updated (newest)
+      updated_asc: Last updated (oldest)
+    status_filters:
+      active: Active
+      resolved: Resolved
+    status_labels:
+      active: Active issue
+      resolved: Issue resolved
+    card:
+      last_updated: "Last updated: %{date}"
+      issue: "Issue: %{title}"
+      description: Description
+      commodities_affected: Commodities affected
+      status: Status
+      recommendation: Recommendation
+      date_of_effect: Date of effect
+      not_available: Not available
+    commodities:
+      none: None
+      count:
+        one: 1 commodity
+        other: "%{count} commodities"
 
   navigation:
     back: Back

--- a/spec/controllers/live_issues_controller_spec.rb
+++ b/spec/controllers/live_issues_controller_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe LiveIssuesController, type: :controller do
   subject(:perform_request) { get :index, params: params }
 
   let(:params) { {} }
-  let(:sorted_live_issues) { build_list(:live_issue, 2) }
+  let(:filtered_live_issues) { build_list(:live_issue, 2) }
 
   before do
-    allow(LiveIssue).to receive(:sorted_by_status).and_return(sorted_live_issues)
+    allow(LiveIssue).to receive(:filtered).and_return(filtered_live_issues)
     perform_request
   end
 
@@ -17,29 +17,60 @@ RSpec.describe LiveIssuesController, type: :controller do
     expect(response).to render_template(:index)
   end
 
-  it 'assigns the sorted live issues with the default sort direction', :aggregate_failures do
-    expect(assigns(:live_issues)).to eq(sorted_live_issues)
-    expect(assigns(:sort_direction)).to eq('asc')
-    expect(LiveIssue).to have_received(:sorted_by_status).with('asc')
+  it 'assigns filtered live issues with default filter state', :aggregate_failures do
+    expect(assigns(:live_issues).to_a).to eq(filtered_live_issues)
+    expect(assigns(:live_issues_count)).to eq(2)
+    expect(assigns(:sort)).to eq('updated_desc')
+    expect(assigns(:applied_sort)).to be_nil
+    expect(assigns(:status_filters)).to eq([])
+    expect(LiveIssue).to have_received(:filtered).with(statuses: [], sort: 'updated_desc')
   end
 
-  context 'when sorting the status column descending' do
-    let(:params) { { sort: 'desc' } }
+  context 'when sorting by oldest updated first' do
+    let(:params) { { sort: 'updated_asc' } }
 
-    it 'passes the descending sort direction to the model', :aggregate_failures do
-      expect(assigns(:live_issues)).to eq(sorted_live_issues)
-      expect(assigns(:sort_direction)).to eq('desc')
-      expect(LiveIssue).to have_received(:sorted_by_status).with('desc')
+    it 'passes the sort to the model', :aggregate_failures do
+      expect(assigns(:sort)).to eq('updated_asc')
+      expect(assigns(:applied_sort)).to eq('updated_asc')
+      expect(LiveIssue).to have_received(:filtered).with(statuses: [], sort: 'updated_asc')
     end
   end
 
-  context 'when an unknown sort direction is provided' do
+  context 'when filtering by status' do
+    let(:params) { { status: %w[active resolved] } }
+
+    it 'passes selected statuses to the model', :aggregate_failures do
+      expect(assigns(:status_filters)).to eq(%w[active resolved])
+      expect(LiveIssue).to have_received(:filtered).with(statuses: %w[active resolved], sort: 'updated_desc')
+    end
+  end
+
+  context 'when a single status value is provided' do
+    let(:params) { { status: 'active' } }
+
+    it 'normalizes the status to an array', :aggregate_failures do
+      expect(assigns(:status_filters)).to eq(%w[active])
+      expect(LiveIssue).to have_received(:filtered).with(statuses: %w[active], sort: 'updated_desc')
+    end
+  end
+
+  context 'when unknown filter values are provided' do
     let(:params) { { sort: 'sideways' } }
 
-    it 'falls back to the default status sort', :aggregate_failures do
-      expect(assigns(:live_issues)).to eq(sorted_live_issues)
-      expect(assigns(:sort_direction)).to eq('asc')
-      expect(LiveIssue).to have_received(:sorted_by_status).with('asc')
+    it 'falls back to default filter state', :aggregate_failures do
+      expect(assigns(:sort)).to eq('updated_desc')
+      expect(assigns(:applied_sort)).to be_nil
+      expect(assigns(:status_filters)).to eq([])
+      expect(LiveIssue).to have_received(:filtered).with(statuses: [], sort: 'updated_desc')
+    end
+  end
+
+  context 'when unknown status filters are provided' do
+    let(:params) { { status: %w[active archived] } }
+
+    it 'ignores unsupported statuses', :aggregate_failures do
+      expect(assigns(:status_filters)).to eq(%w[active])
+      expect(LiveIssue).to have_received(:filtered).with(statuses: %w[active], sort: 'updated_desc')
     end
   end
 end

--- a/spec/features/live_issues_spec.rb
+++ b/spec/features/live_issues_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+RSpec.describe 'Live issues log', :js, type: :feature do
+  let(:active_newer) do
+    build(
+      :live_issue,
+      title: 'Active newer',
+      status: 'Active',
+      commodities: %w[0806101005 0808309000],
+      updated_at: '2026-02-13T12:00:00Z',
+    )
+  end
+
+  let(:active_older) do
+    build(
+      :live_issue,
+      title: 'Active older',
+      status: 'Active',
+      commodities: [],
+      updated_at: '2026-01-09T12:00:00Z',
+    )
+  end
+
+  let(:resolved_issue) do
+    build(
+      :live_issue,
+      title: 'Resolved issue',
+      status: 'Resolved',
+      commodities: [],
+      updated_at: '2026-01-01T12:00:00Z',
+    )
+  end
+
+  let(:live_issues) { [active_newer, resolved_issue, active_older] }
+
+  before do
+    allow(LiveIssue).to receive(:all).and_return(live_issues)
+  end
+
+  it 'renders card results with closed filters by default' do
+    visit live_issues_path
+
+    expect(page).to have_content('Live issues log')
+    expect(page).to have_css('.govuk-summary-card', count: 3)
+    expect(page).to have_no_css('table.govuk-table')
+    expect(page).to have_checked_field('Last updated (newest)')
+    expect(page).to have_unchecked_field('Active')
+    expect(page).to have_css('.live-issues__result-count', text: '3 results')
+    expect(page).to have_no_css('.live-issues__active-filter')
+  end
+
+  it 'applies status filters and last updated sorting through the form' do
+    visit live_issues_path
+
+    find('summary', text: 'Filter and sort').click
+    choose 'Last updated (oldest)'
+    check 'Active'
+    click_button 'Apply'
+
+    expect(page).to have_current_path(live_issues_path(sort: 'updated_asc', status: %w[active]), ignore_query: false)
+    expect(page).to have_checked_field('Last updated (oldest)')
+    expect(page).to have_checked_field('Active')
+    expect(page).to have_css('.live-issues__active-filter', text: 'Sort by: Last updated (oldest)')
+    expect(page).to have_css('.live-issues__active-filter', text: 'Status: Active issue')
+    expect(page).to have_css('.govuk-summary-card', count: 2)
+    expect(page).to have_css('.govuk-summary-card:first-of-type', text: 'Active older')
+    expect(page).to have_no_content('Resolved issue')
+  end
+
+  context 'with more than one page of live issues' do
+    let(:live_issues) do
+      (1..5).map do |index|
+        build(
+          :live_issue,
+          title: "Issue #{index}",
+          status: 'Active',
+          updated_at: Time.zone.parse("2026-02-#{index.to_s.rjust(2, '0')}").iso8601,
+        )
+      end
+    end
+
+    it 'paginates the card results' do
+      visit live_issues_path
+
+      expect(page).to have_css('.live-issues__result-count', text: '5 results')
+      expect(page).to have_css('.govuk-summary-card', count: 4)
+      expect(page).to have_css('.govuk-pagination')
+
+      click_link 'Next'
+
+      expect(page).to have_current_path(live_issues_path(page: 2), ignore_query: false)
+      expect(page).to have_css('.govuk-summary-card', count: 1)
+      expect(page).to have_content('Issue 1')
+    end
+  end
+end

--- a/spec/helpers/live_issue_helper_spec.rb
+++ b/spec/helpers/live_issue_helper_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe LiveIssueHelper, type: :helper do
     let(:expected_html) { "<p>This is <strong>bold</strong> text.</p>\n" }
 
     it { is_expected.to eq(expected_html) }
+
+    context 'with unsafe html' do
+      let(:markdown) { '<script>alert(1)</script><a href="javascript:alert(1)" onclick="alert(1)">bad</a>' }
+
+      it 'sanitizes the output', :aggregate_failures do
+        expect(markdown_field).not_to include('<script>')
+        expect(markdown_field).not_to include('javascript:')
+        expect(markdown_field).not_to include('onclick')
+      end
+    end
   end
 
   describe '#live_issue_from_to_date' do
@@ -28,43 +38,98 @@ RSpec.describe LiveIssueHelper, type: :helper do
     end
   end
 
-  describe '#live_issue_status_sort_link' do
-    subject(:sort_link) { Capybara.string(helper.live_issue_status_sort_link(sort_direction)) }
+  describe '#live_issue_updated_at' do
+    subject(:live_issue_updated_at) { helper.live_issue_updated_at(live_issue) }
 
-    context 'when the status column is sorted ascending' do
-      let(:sort_direction) { 'asc' }
+    let(:live_issue) { build(:live_issue, updated_at:) }
 
-      it 'links to the descending sort direction' do
-        expect(sort_link).to have_link(href: live_issues_path(sort: 'desc'))
-      end
+    context 'when updated_at is present' do
+      let(:updated_at) { Time.zone.parse('2026-02-13') }
 
-      it 'shows the status label' do
-        expect(sort_link).to have_link('Status', href: live_issues_path(sort: 'desc'))
-      end
-
-      it 'shows the ascending arrow' do
-        expect(sort_link).to have_css('span[aria-hidden="true"]', text: '↑')
-      end
-
-      it 'shows the ascending helper text' do
-        expect(sort_link).to have_css('.govuk-visually-hidden', text: 'sorted ascending')
-      end
+      it { is_expected.to eq('13 February 2026') }
     end
 
-    context 'when the status column is sorted descending' do
-      let(:sort_direction) { 'desc' }
+    context 'when updated_at is missing' do
+      let(:updated_at) { nil }
 
-      it 'links to the ascending sort direction' do
-        expect(sort_link).to have_link(href: live_issues_path(sort: 'asc'))
-      end
+      it { is_expected.to eq('Not available') }
+    end
+  end
 
-      it 'shows the descending arrow' do
-        expect(sort_link).to have_css('span[aria-hidden="true"]', text: '↓')
-      end
+  describe '#live_issue_sort_label' do
+    it 'labels newest-first sorting' do
+      expect(helper.live_issue_sort_label('updated_desc')).to eq('Last updated (newest)')
+    end
 
-      it 'shows the descending helper text' do
-        expect(sort_link).to have_css('.govuk-visually-hidden', text: 'sorted descending')
-      end
+    it 'labels oldest-first sorting' do
+      expect(helper.live_issue_sort_label('updated_asc')).to eq('Last updated (oldest)')
+    end
+
+    it 'falls back to newest-first sorting for unknown values' do
+      expect(helper.live_issue_sort_label('sideways')).to eq('Last updated (newest)')
+    end
+  end
+
+  describe '#live_issue_status_filter_label' do
+    it 'labels active issue filters' do
+      expect(helper.live_issue_status_filter_label('active')).to eq('Active')
+    end
+
+    it 'labels resolved issue filters' do
+      expect(helper.live_issue_status_filter_label('resolved')).to eq('Resolved')
+    end
+  end
+
+  describe '#live_issue_status_filter_selected?' do
+    it 'returns true when the status is selected' do
+      expect(helper.live_issue_status_filter_selected?(%w[active], 'active')).to be(true)
+    end
+
+    it 'returns false when the status is not selected' do
+      expect(helper.live_issue_status_filter_selected?(%w[resolved], 'active')).to be(false)
+    end
+  end
+
+  describe '#live_issue_active_filter_labels' do
+    it 'includes sort and status labels' do
+      expect(
+        helper.live_issue_active_filter_labels(
+          status_filters: %w[active],
+          sort: 'updated_desc',
+        ),
+      ).to eq([
+        'Sort by: Last updated (newest)',
+        'Status: Active issue',
+      ])
+    end
+
+    it 'omits the sort label when no sort has been applied' do
+      expect(
+        helper.live_issue_active_filter_labels(
+          status_filters: %w[resolved],
+          sort: nil,
+        ),
+      ).to eq(['Status: Issue resolved'])
+    end
+  end
+
+  describe '#live_issue_status_label' do
+    it 'labels active issues' do
+      expect(helper.live_issue_status_label('Active')).to eq('Active issue')
+    end
+
+    it 'labels resolved issues' do
+      expect(helper.live_issue_status_label('Resolved')).to eq('Issue resolved')
+    end
+  end
+
+  describe '#live_issue_status_tag_class' do
+    it 'uses a yellow tag for active issues' do
+      expect(helper.live_issue_status_tag_class('Active')).to eq('govuk-tag--yellow')
+    end
+
+    it 'uses a green tag for resolved issues' do
+      expect(helper.live_issue_status_tag_class('Resolved')).to eq('govuk-tag--green')
     end
   end
 end

--- a/spec/models/live_issue_spec.rb
+++ b/spec/models/live_issue_spec.rb
@@ -1,4 +1,90 @@
 RSpec.describe LiveIssue do
+  describe '.filtered' do
+    let(:resolved_newer) { build(:live_issue, title: 'Resolved newer', status: 'Resolved', updated_at: '2025-07-16T12:00:00Z') }
+    let(:active_older) { build(:live_issue, title: 'Active older', status: 'Active', updated_at: '2025-07-14T12:00:00Z') }
+    let(:resolved_older) { build(:live_issue, title: 'Resolved older', status: 'Resolved', updated_at: '2025-07-13T12:00:00Z') }
+    let(:active_newer) { build(:live_issue, title: 'Active newer', status: 'Active issue', updated_at: '2025-07-15T12:00:00Z') }
+    let(:active_without_timestamp) { build(:live_issue, title: 'Active without timestamp', status: 'Active', updated_at: nil) }
+    let(:live_issues) do
+      [
+        resolved_newer,
+        active_older,
+        resolved_older,
+        active_newer,
+        active_without_timestamp,
+      ]
+    end
+
+    before do
+      allow(described_class).to receive(:all).and_return(live_issues)
+    end
+
+    it 'sorts by last updated newest first by default' do
+      expect(described_class.filtered(statuses: [], sort: nil).map(&:title)).to eq([
+        'Resolved newer',
+        'Active newer',
+        'Active older',
+        'Resolved older',
+        'Active without timestamp',
+      ])
+    end
+
+    it 'sorts by last updated oldest first' do
+      expect(described_class.filtered(statuses: [], sort: 'updated_asc').map(&:title)).to eq([
+        'Resolved older',
+        'Active older',
+        'Active newer',
+        'Resolved newer',
+        'Active without timestamp',
+      ])
+    end
+
+    it 'filters active issues' do
+      expect(described_class.filtered(statuses: %w[active], sort: nil).map(&:title)).to eq([
+        'Active newer',
+        'Active older',
+        'Active without timestamp',
+      ])
+    end
+
+    it 'filters resolved issues' do
+      expect(described_class.filtered(statuses: %w[resolved], sort: nil).map(&:title)).to eq([
+        'Resolved newer',
+        'Resolved older',
+      ])
+    end
+
+    it 'returns all issues when all supported statuses are selected' do
+      expect(described_class.filtered(statuses: %w[active resolved], sort: nil).map(&:title)).to eq([
+        'Resolved newer',
+        'Active newer',
+        'Active older',
+        'Resolved older',
+        'Active without timestamp',
+      ])
+    end
+
+    it 'ignores unsupported statuses' do
+      expect(described_class.filtered(statuses: %w[archived], sort: nil).map(&:title)).to eq([
+        'Resolved newer',
+        'Active newer',
+        'Active older',
+        'Resolved older',
+        'Active without timestamp',
+      ])
+    end
+
+    it 'falls back to newest first for unsupported sorts' do
+      expect(described_class.filtered(statuses: [], sort: 'sideways').map(&:title)).to eq([
+        'Resolved newer',
+        'Active newer',
+        'Active older',
+        'Resolved older',
+        'Active without timestamp',
+      ])
+    end
+  end
+
   describe '.sorted_by_status' do
     let(:resolved_newer) { build(:live_issue, title: 'Resolved newer', status: 'Resolved', updated_at: '2025-07-16T12:00:00Z') }
     let(:active_older) { build(:live_issue, title: 'Active older', status: 'Active', updated_at: '2025-07-14T12:00:00Z') }

--- a/spec/views/live_issues/index.html.erb_spec.rb
+++ b/spec/views/live_issues/index.html.erb_spec.rb
@@ -1,20 +1,108 @@
 require 'spec_helper'
 
 RSpec.describe 'live_issues/index', type: :view do
-  subject { render }
+  subject(:rendered_page) { Capybara.string(rendered) }
 
-  before do
-    assign :live_issues, [
-      build(
-        :live_issue,
-        updated_at: Time.zone.parse('2025-07-15'),
-      ),
-    ]
-    assign :sort_direction, 'asc'
+  let(:live_issues) { [active_issue, resolved_issue] }
+  let(:live_issues_count) { live_issues.size }
+  let(:sort) { 'updated_desc' }
+  let(:applied_sort) { 'updated_desc' }
+  let(:status_filters) { %w[active] }
+
+  let(:active_issue) do
+    build(
+      :live_issue,
+      title: 'Missing Japan Preference',
+      description: 'The **DCTS** measure was deleted.',
+      suggested_action: 'Declare the **MFN** rate.',
+      commodities: %w[0806101005 0808309000],
+      status: 'Active issue',
+      date_discovered: Time.zone.parse('2026-01-06'),
+      date_resolved: nil,
+      updated_at: Time.zone.parse('2026-02-13'),
+    )
   end
 
-  it { is_expected.to have_css 'th > div', text: '15 July 2025' }
-  it { is_expected.to have_css 'h1#kramdown', text: 'Kramdown' }
-  it { is_expected.to have_link 'Status', href: live_issues_path(sort: 'desc') }
-  it { is_expected.to render_template 'live_issues/_commodities' }
+  let(:resolved_issue) do
+    build(
+      :live_issue,
+      title: 'DCTS Deleted Measure',
+      description: 'Resolved issue description.',
+      suggested_action: 'None',
+      commodities: [],
+      status: 'Resolved',
+      date_discovered: Time.zone.parse('2025-12-01'),
+      date_resolved: Time.zone.parse('2026-01-01'),
+      updated_at: Time.zone.parse('2026-01-02'),
+    )
+  end
+
+  before do
+    assign :live_issues, Kaminari.paginate_array(live_issues, total_count: live_issues_count).page(1).per(4)
+    assign :live_issues_count, live_issues_count
+    assign :sort, sort
+    assign :applied_sort, applied_sort
+    assign :status_filters, status_filters
+
+    render
+  end
+
+  it 'renders the live issues heading' do
+    expect(rendered_page).to have_css('h1', text: 'Live issues log')
+  end
+
+  it 'renders a filter and sort form', :aggregate_failures do
+    expect(rendered_page).to have_css('details.live-issues__filter-panel summary', text: 'Filter and sort')
+    expect(rendered_page).to have_css('.live-issues__result-count', text: '2 results')
+    expect(rendered_page).to have_css('form[action="/live_issues"][method="get"]')
+    expect(rendered_page).to have_field('Last updated (newest)', type: 'radio', checked: true)
+    expect(rendered_page).to have_field('Last updated (oldest)', type: 'radio', checked: false)
+    expect(rendered_page).to have_field('Active', type: 'checkbox', checked: true)
+    expect(rendered_page).to have_field('Resolved', type: 'checkbox', checked: false)
+  end
+
+  it 'renders applied filter tags', :aggregate_failures do
+    expect(rendered_page).to have_css('.live-issues__active-filter', text: '× Sort by: Last updated (newest)')
+    expect(rendered_page).to have_css('.live-issues__active-filter', text: 'Status: Active issue')
+    expect(rendered_page).to have_link('Clear filters', href: live_issues_path)
+  end
+
+  it 'renders live issues as summary cards', :aggregate_failures do
+    expect(rendered_page).to have_no_css('table.govuk-table')
+    expect(rendered_page).to have_css('.govuk-summary-card', count: 2)
+    expect(rendered_page).to have_css('.govuk-summary-card__title', text: 'Missing Japan Preference')
+    expect(rendered_page).to have_css('.live-issues__card-meta', text: 'Last updated: 13 February 2026')
+    expect(rendered_page).to have_css('.live-issues__card-issue', text: 'Issue: Missing Japan Preference')
+    expect(rendered_page).to have_css('.govuk-summary-list__key', text: 'Description')
+    expect(rendered_page).to have_css('.govuk-summary-list__key', text: 'Commodities affected')
+    expect(rendered_page).to have_css('.govuk-summary-list__key', text: 'Status')
+    expect(rendered_page).to have_css('.govuk-summary-list__key', text: 'Recommendation')
+    expect(rendered_page).to have_css('.govuk-summary-list__key', text: 'Date of effect')
+    expect(rendered_page).to have_css('.govuk-tag--green', text: 'Issue resolved')
+  end
+
+  it 'renders markdown content inside card values', :aggregate_failures do
+    expect(rendered_page).to have_css('.govuk-summary-list__value strong', text: 'DCTS')
+    expect(rendered_page).to have_css('.govuk-summary-list__value strong', text: 'MFN')
+  end
+
+  it 'keeps progressive disclosure for multiple commodities', :aggregate_failures do
+    expect(rendered_page).to have_css('.govuk-details__summary-text', text: '2 commodities')
+    expect(rendered_page).to have_css('.live-issues__commodity-list')
+  end
+
+  it 'renders the commodities partial' do
+    expect(view).to render_template(partial: 'live_issues/_commodities')
+  end
+
+  context 'when there are no live issues after filtering' do
+    let(:live_issues) { [] }
+    let(:live_issues_count) { 0 }
+    let(:applied_sort) { nil }
+    let(:status_filters) { %w[resolved] }
+
+    it 'renders an empty state' do
+      expect(rendered_page).to have_css('.govuk-body', text: 'No live issues match the selected filters.')
+    end
+  end
 end


### PR DESCRIPTION
## What:

Implements the approved Option 1 live issues log layout:

- replaces the table-style live issues list with GOV.UK summary cards
- adds a filter and sort panel for last-updated sort and active/resolved status filters
- adds applied filter chips, result counts, pagination, responsive card styling, and commodity disclosure layout
- moves new live issues copy into I18n and adds nil-date/XSS-safe rendering coverage
- adds browser-level feature coverage for the live issues workflow

## Why:

OTTIMP-615 asks for the MyOTT updates/news experience to use the approved card display with filtering panel so tariff users can scan updates more easily across desktop and mobile.

## Ticket:

https://transformuk.atlassian.net/browse/OTTIMP-615

## Risk:

**Risk level:** 🟠

**Reason for rating:**
This changes a trader-facing content presentation and filtering flow for live issues. The change is scoped to `/live_issues`, uses GOV.UK components, keeps the existing backend API shape, and is covered by model/controller/helper/view specs plus a browser feature spec.

───────────────────────────────────────────────────

## Validation:

- `bundle exec brakeman`
- `pre-commit run --all-files --show-diff-on-failure`
- `yarn install --frozen-lockfile`
- `bin/rails assets:precompile`
- `bundle exec rspec` (`5768 examples, 0 failures, 4 pending`)

## Manual verification:

Run locally and verify `/live_issues` against the Option 1 PDF screens, including default card layout, filter open state, applied filters, pagination, and mobile wrapping.