### PR TITLE
Use govuk_back_link helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,13 +126,13 @@ module ApplicationHelper
     tag.p(content) if content.present?
   end
 
-  def back_link(url, text = t('navigation.back'), **options)
-    options = options.merge(class: 'govuk-back-link')
+  def back_link(url, **options)
+    html_attributes = {}
     if options.delete(:javascript)
-      options[:onclick] = 'window.history.go(-1); return false;'
+      html_attributes[:onclick] = 'window.history.go(-1); return false;'
     end
 
-    link_to text, url, **options
+    govuk_back_link(href: url, html_attributes:)
   end
 
   def glossary_term(term)

--- a/app/views/green_lanes/applicable_exemptions/cat_1_exemptions_questions.html.erb
+++ b/app/views/green_lanes/applicable_exemptions/cat_1_exemptions_questions.html.erb
@@ -1,6 +1,4 @@
-<% content_for :back_link do %>
-  <% back_link back_link_path %>
-<% end %>
+<% content_for :back_link, back_link(back_link_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/green_lanes/applicable_exemptions/cat_2_exemptions_questions.html.erb
+++ b/app/views/green_lanes/applicable_exemptions/cat_2_exemptions_questions.html.erb
@@ -1,6 +1,4 @@
-<% content_for :back_link do %>
-  <% back_link back_link_path %>
-<% end %>
+<% content_for :back_link, back_link(back_link_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/green_lanes/eligibilities/new.html.erb
+++ b/app/views/green_lanes/eligibilities/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :back_link do %>
-  <% back_link green_lanes_start_path(commodity_code: @commodity_code) %>
+  <%= back_link green_lanes_start_path(commodity_code: @commodity_code) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/green_lanes/eligibility_results/new.html.erb
+++ b/app/views/green_lanes/eligibility_results/new.html.erb
@@ -1,5 +1,3 @@
-<% content_for :back_link do %>
-  <% back_link green_lanes_eligibility_path %>
-<% end %>
+<% content_for :back_link, back_link(green_lanes_eligibility_path) %>
 
 <%= render @result %>

--- a/app/views/green_lanes/moving_requirements/new.html.erb
+++ b/app/views/green_lanes/moving_requirements/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :back_link do %>
-  <% back_link green_lanes_start_path(commodity_code: @commodity_code) %>
+  <%= back_link green_lanes_start_path(commodity_code: @commodity_code) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/green_lanes/starts/new.html.erb
+++ b/app/views/green_lanes/starts/new.html.erb
@@ -1,6 +1,4 @@
-<% content_for :back_link do %>
-  <% back_link home_path %>
-<% end %>
+<% content_for :back_link, back_link(home_path) %>
 
 <div class="govuk-grid-row">
 

--- a/app/views/myott/preferences/edit.html.erb
+++ b/app/views/myott/preferences/edit.html.erb
@@ -1,7 +1,7 @@
 <% myott_page_title "Select chapters", error: flash.now[:alert] %>
 
 <% content_for :back_link do %>
-  <% back_link session[:all_tariff_updates] ? check_your_answers_myott_stop_press_path : myott_stop_press_path %>
+  <%= back_link session[:all_tariff_updates] ? check_your_answers_myott_stop_press_path : myott_stop_press_path %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/myott/preferences/new.html.erb
+++ b/app/views/myott/preferences/new.html.erb
@@ -1,12 +1,10 @@
 <% myott_page_title "Set preferences", error: @form.errors.any? %>
 
+<% content_for :back_link, back_link(myott_path) %>
+
 <div class="govuk-body">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% content_for :back_link do %>
-        <% back_link myott_path %>
-      <% end %>
-
       <%= form_with model: @form, url: myott_stop_press_preferences_path, method: :post, local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
         <%= f.govuk_error_summary %>
         <h1 class="govuk-heading-l">Set subscription preferences</h1>

--- a/app/views/myott/stop_presses/check_your_answers.html.erb
+++ b/app/views/myott/stop_presses/check_your_answers.html.erb
@@ -1,7 +1,7 @@
 <% myott_page_title "Review selection", error: flash.now[:alert] %>
 
 <% content_for :back_link do %>
-  <% back_link session[:all_tariff_updates] ? new_myott_stop_press_preferences_path : edit_myott_stop_press_preferences_path %>
+  <%= back_link session[:all_tariff_updates] ? new_myott_stop_press_preferences_path : edit_myott_stop_press_preferences_path %>
 <% end %>
 
 <div class="govuk-body myott-subscriptions">

--- a/app/views/pages/glossary/show.html.erb
+++ b/app/views/pages/glossary/show.html.erb
@@ -1,4 +1,6 @@
-<%= back_link (request.referer || help_path), javascript: true %>
+<% content_for :back_link do %>
+  <%= back_link (request.referer || help_path), javascript: true %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/rules_of_origin_proof_requirements.html.erb
+++ b/app/views/pages/rules_of_origin_proof_requirements.html.erb
@@ -1,4 +1,6 @@
-<%= back_link request.referer || find_commodity_path, javascript: true %>
+<% content_for :back_link do %>
+  <%= back_link request.referer || find_commodity_path, javascript: true %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/rules_of_origin_proof_verification.html.erb
+++ b/app/views/pages/rules_of_origin_proof_verification.html.erb
@@ -1,4 +1,6 @@
-<%= back_link request.referer || find_commodity_path, javascript: true %>
+<% content_for :back_link do %>
+  <%= back_link request.referer || find_commodity_path, javascript: true %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/rules_of_origin/product_specific_rules/index.html.erb
+++ b/app/views/rules_of_origin/product_specific_rules/index.html.erb
@@ -1,4 +1,6 @@
-<%= back_link request.referer || find_commodity_path, javascript: true %>
+<% content_for :back_link do %>
+  <%= back_link request.referer || find_commodity_path, javascript: true %>
+<% end %>
 
 <%= page_header "Commodity #{@commodity.goods_nomenclature_item_id}", false %>
 

--- a/app/views/rules_of_origin/proofs/index.html.erb
+++ b/app/views/rules_of_origin/proofs/index.html.erb
@@ -1,4 +1,6 @@
-<%= back_link request.referer || find_commodity_path, javascript: true %>
+<% content_for :back_link do %>
+  <%= back_link request.referer || find_commodity_path, javascript: true %>
+<% end %>
 
 <%= page_header 'Proofs of origin for all trade agreements', 'Rules of origin' %>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -283,25 +283,24 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe '#back_link' do
-    context 'without text label' do
-      subject { back_link '/back-page' }
+    context 'without javascript' do
+      it 'calls govuk_back_link with correct attributes' do
+        allow(helper).to receive(:govuk_back_link).with(href: '/back-page', html_attributes: {}).and_call_original
 
-      it { is_expected.to have_link 'Back', href: '/back-page' }
-      it { is_expected.to have_css 'a.govuk-back-link' }
-      it { is_expected.not_to have_css 'a[onclick]' }
-    end
+        result = helper.back_link('/back-page')
 
-    context 'with text label' do
-      subject { back_link '/back-page', 'Go back' }
-
-      it { is_expected.to have_link 'Go back', href: '/back-page' }
-      it { is_expected.to have_css 'a.govuk-back-link' }
+        expect(result).to be_present
+      end
     end
 
     context 'with javascript' do
-      subject { back_link '/back', javascript: true }
+      it 'calls govuk_back_link with onclick attribute' do
+        allow(helper).to receive(:govuk_back_link).with(href: '/back', html_attributes: { onclick: 'window.history.go(-1); return false;' }).and_call_original
 
-      it { is_expected.to have_css 'a[onclick]' }
+        result = helper.back_link('/back', javascript: true)
+
+        expect(result).to be_present
+      end
     end
   end
 

--- a/spec/views/pages/glossary/show.html.erb_spec.rb
+++ b/spec/views/pages/glossary/show.html.erb_spec.rb
@@ -8,6 +8,5 @@ RSpec.describe 'pages/glossary/show', type: :view do
   let(:glossary) { Pages::Glossary.new term }
   let(:term) { 'max_nom' }
 
-  it { is_expected.to have_link 'Back' }
   it { is_expected.to have_css '.govuk-grid-column-two-thirds p', text: /NOM/i }
 end

--- a/spec/views/rules_of_origin/product_specific_rules/index.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/product_specific_rules/index.html.erb_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe 'rules_of_origin/product_specific_rules/index', type: :view do
     }.index_by(&:id)
   end
 
-  it { is_expected.to have_link 'Back' }
-
   it { is_expected.to have_css 'h1', text: %r{Commodity \d{10}} }
   it { is_expected.not_to have_css '.govuk-caption-xl' }
 

--- a/spec/views/rules_of_origin/proofs/index.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/proofs/index.html.erb_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe 'rules_of_origin/proofs/index', type: :view do
 
   let(:schemes) { build_list :rules_of_origin_scheme, 3, proof_count: 2 }
 
-  it { is_expected.to have_link 'Back' }
-
   it { is_expected.to have_css 'h1', text: 'Proofs of origin for all trade agreements' }
   it { is_expected.to have_css '.govuk-caption-xl', text: 'Rules of origin' }
 


### PR DESCRIPTION
## What:
Uses [govuk_back_link](https://govuk-components.x-govuk.org/components/back-link/) helper. 
The use of the back_link helper has been retained, but the method now uses the govuk helper.
Call sites have been updated to use `=` to render and moved into the back_link content_for block where that was missing

## Why:
Ensures consistent usage and retains the javascript option for progressive enhancement.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
Mostly like for like with some minor change in some instances where the location of the link has been changed slightly to be consistent.

