### PR TITLE
Add ID to duty calculator block for analytics

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -156,7 +156,7 @@ module ApplicationHelper
     link_description = "work out the duties and taxes applicable to the import of commodity #{code}"
     link_url = import_date_path(commodity_code: declarable_code)
 
-    link_to link_description, link_url, id: 'duty-calculator-link'
+    govuk_link_to link_description, link_url, id: 'duty-calculator-link'
   end
 
   def month_name_and_year(month, year)

--- a/app/views/measures/grouped/_tariff_duty_calculator_link.html.erb
+++ b/app/views/measures/grouped/_tariff_duty_calculator_link.html.erb
@@ -1,4 +1,4 @@
-<div class="measure-inset">
+<div class="measure-inset" id="duty-calculator">
   <%= image_tag('calculator.png', alt: 'Tariff duty calculator') %>
   <div>
     <p>


### PR DESCRIPTION
## What:
Adds an ID to the duty calculator section that appears on commodity pages

## Why:
This will allow an analytics event to be added that is triggered when this element is visible.

## Ticket:
https://transformuk.atlassian.net/browse/OTTIMP-597

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Only for analytics