### PR TITLE
Revert Chapter headings table conversion

### DIFF
--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -11,11 +11,11 @@
 <%= render 'shared/callouts/chapter', chapter: @chapter %>
 
 <section class="headings">
-  <%= govuk_table(classes: 'section-browser') do |table| %>
-    <% table.with_body do %>
+  <table class="section-browser govuk-table">
+    <tbody>
       <%= render @headings %>
-    <% end %>
-  <% end %>
+    </tbody>
+  </table>
 </section>
 
 <%= render 'shared/notes', section_note: @chapter.section.section_note, chapter_note: @chapter.chapter_note %>

--- a/app/views/headings/_heading.html.erb
+++ b/app/views/headings/_heading.html.erb
@@ -6,7 +6,7 @@
       </div>
     </td>
     <td class="govuk-table__cell">
-      <%= govuk_link_to heading_path(heading, request.query_parameters.symbolize_keys), heading.formatted_description.html_safe, visually_hidden_prefix: "Heading #{heading.display_short_code}:" %>
+      <%= govuk_link_to heading.formatted_description.html_safe, heading_path(heading, request.query_parameters.symbolize_keys), visually_hidden_prefix: "Heading #{heading.display_short_code}:" %>
     </td>
   </tr>
 <% else %>


### PR DESCRIPTION
## What:
Converting this table to use govuk_table was causing issues where a partial was being used to render each heading.
This change has been reverted.
Also fixes a use of govuk_link_to that had arguments the wrong way round

## Why:
Fixes a rendering issue

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Fixes a bug