### PR TITLE
HMRC-2248: add slack observability topic

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,7 +20,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2248-add-slack-observability-topic |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.1.0 |
 
 ## Resources
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,7 @@
 # trade-tariff-frontend terraform
 
 Terraform to deploy the service into AWS.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -19,7 +20,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2248-add-slack-observability-topic |
 
 ## Resources
 
@@ -33,6 +34,7 @@ Terraform to deploy the service into AWS.
 | [aws_secretsmanager_secret_version.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_sns_topic.slack_observability_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
 | [aws_sns_topic.slack_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
 | [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
@@ -44,6 +46,7 @@ Terraform to deploy the service into AWS.
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CloudWatch alarms for the service. Defaults to `true`. | `bool` | `true` | no |
+| <a name="input_enable_observability_alerts"></a> [enable\_observability\_alerts](#input\_enable\_observability\_alerts) | n/a | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | `5` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -9,3 +9,5 @@ max_capacity  = 16
 # Temporarily pinned autoscaling cooldown values in Production to preserve existing behaviour while testing changes in dev and staging
 scale_in_cooldown  = 0
 scale_out_cooldown = 0
+
+enable_observability_alerts = true

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -5,3 +5,5 @@ memory        = 2048
 service_count = 4
 min_capacity  = 3
 max_capacity  = 8
+
+enable_alarms = false

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -40,3 +40,8 @@ data "aws_secretsmanager_secret_version" "ecs_tls_certificate" {
 data "aws_sns_topic" "slack_topic" {
   name = "slack-topic"
 }
+
+data "aws_sns_topic" "slack_observability_topic" {
+  count = var.enable_observability_alerts ? 1 : 0
+  name  = "slack-observability-topic"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2248-add-slack-observability-topic"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.1.0"
 
   region = var.region
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.0.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2248-add-slack-observability-topic"
 
   region = var.region
 
@@ -47,5 +47,6 @@ module "service" {
   enable_alarms       = var.enable_alarms
   cpu_alarm_threshold = 85
 
-  sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
+  sns_topic_arns               = [data.aws_sns_topic.slack_topic.arn]
+  observability_sns_topic_arns = var.enable_observability_alerts ? [data.aws_sns_topic.slack_observability_topic[0].arn] : null
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,6 +47,11 @@ variable "enable_alarms" {
   default     = true
 }
 
+variable "enable_observability_alerts" {
+  type    = bool
+  default = false
+}
+
 variable "scale_in_cooldown" {
   description = "Prevents aggressive scale-in by enforcing a waiting period after tasks are removed."
   type        = number


### PR DESCRIPTION
## What:
- Bumps ECS service module ref to pick up new `observability_sns_topic_arns` variable
- Adds `data.aws_sns_topic.slack_observability_topic` lookup
- Passes `observability_sns_topic_arns` to ECS service module callers

- Disables ECS alarms for staging

This routes `ecs_capacity_loss` and `ecs_high_cpu` to `#production-observability` and keeps `service_count` in `#production-alerts`.

## Why:
- Reduces noise in `#production-alerts` by moving degraded-but-not-down signals to the observability channel. On-call engineers see only alarms requiring immediate action in the main channel.

- Making too much noise in the `non-production-alerts` channel

## Ticket:
[HMRC-2248](https://transformuk.atlassian.net/browse/HMRC-2248)

## Risk:

**Risk level:**  🟢

**Reason for rating:**
Low risk but worth verifying. The `slack-observability-topic` SNS topic and its Lambda must exist before applying; otherwise, the data source lookup will fail at plan time. Confirm the modules repo PR is merged and module version bumped before applying this.