### PR TITLE
Improve usage of form builder helpers

### DIFF
--- a/app/views/duty_calculator/steps/additional_codes/show.html.erb
+++ b/app/views/duty_calculator/steps/additional_codes/show.html.erb
@@ -6,11 +6,11 @@
   <h1 class="govuk-heading-xl">Describe your goods in more detail</h1>
 
   <% if @step.applicable_additional_codes.dig('uk', @step.measure_type_id).present? %>
-    <%= f.govuk_collection_select :additional_code_uk, @step.options_for_select_for(source: 'uk'), :id, :name, options: { prompt: true }, label: { text: 'Select Additional code', class: 'govuk-label govuk-label--s' }, hint: { text: "To trade this commodity in the United Kingdom, you need to specify an additional 4 digits, known as an additional code. This affects the #{@step.measure_type_description_for(source: 'uk')}." } %>
+    <%= f.govuk_collection_select :additional_code_uk, @step.options_for_select_for(source: 'uk'), :id, :name, options: { prompt: true }, label: { text: 'Select Additional code', size: 's' }, hint: { text: "To trade this commodity in the United Kingdom, you need to specify an additional 4 digits, known as an additional code. This affects the #{@step.measure_type_description_for(source: 'uk')}." } %>
   <% end %>
 
   <% if @step.applicable_additional_codes.dig('xi', @step.measure_type_id).present? %>
-    <%= f.govuk_collection_select :additional_code_xi, @step.options_for_select_for(source: 'xi'), :id, :name, options: { prompt: true }, label: { text: 'Select Additional code', class: 'govuk-label govuk-label--s' }, hint: { text: "To trade this commodity in Northern Ireland, you need to specify an additional 4 digits, known as an additional code. This affects the #{@step.measure_type_description_for(source: 'xi')}." } %>
+    <%= f.govuk_collection_select :additional_code_xi, @step.options_for_select_for(source: 'xi'), :id, :name, options: { prompt: true }, label: { text: 'Select Additional code', size: 's' }, hint: { text: "To trade this commodity in Northern Ireland, you need to specify an additional 4 digits, known as an additional code. This affects the #{@step.measure_type_description_for(source: 'xi')}." } %>
   <% end %>
   <%= f.govuk_submit %>
 

--- a/app/views/duty_calculator/steps/customs_value/show.html.erb
+++ b/app/views/duty_calculator/steps/customs_value/show.html.erb
@@ -16,9 +16,9 @@
       new_tab: '', visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text
     ) %>
   </p>
-  <%= f.govuk_text_field :monetary_value, width: 'one-quarter', label: { text: 'What is the value in GBP of the goods being imported?', class: 'govuk-label govuk-label--s' }, prefix_text: '£' %>
-  <%= f.govuk_text_field :shipping_cost, width: 'one-quarter', label: { text: 'Optionally, what is the shipping cost?', class: 'govuk-label govuk-label--s' },  hint: { text: 'Only costs up to the place of introduction of the imported goods into the UK border need to be included.' }, prefix_text: '£' %>
-  <%= f.govuk_text_field :insurance_cost, width: 'one-quarter', label: { text: 'Optionally, what is the cost of insuring the goods?', class: 'govuk-label govuk-label--s' },  hint: { text: 'Only insurance costs up to the place of introduction of the imported goods into the UK border need to be included.' }, prefix_text: '£' %>
+  <%= f.govuk_text_field :monetary_value, width: 'one-quarter', label: { text: 'What is the value in GBP of the goods being imported?', size: 's' }, prefix_text: '£' %>
+  <%= f.govuk_text_field :shipping_cost, width: 'one-quarter', label: { text: 'Optionally, what is the shipping cost?', size: 's' },  hint: { text: 'Only costs up to the place of introduction of the imported goods into the UK border need to be included.' }, prefix_text: '£' %>
+  <%= f.govuk_text_field :insurance_cost, width: 'one-quarter', label: { text: 'Optionally, what is the cost of insuring the goods?', size: 's' },  hint: { text: 'Only insurance costs up to the place of introduction of the imported goods into the UK border need to be included.' }, prefix_text: '£' %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/duty_calculator/steps/measure_amount/show.html.erb
+++ b/app/views/duty_calculator/steps/measure_amount/show.html.erb
@@ -16,9 +16,9 @@
 
   <% f.object.applicable_measure_units.each do |key, values| %>
     <% if key.upcase == DutyCalculator::Api::BaseComponent::RETAIL_PRICE_UNIT %>
-      <%= f.govuk_text_field key.downcase.to_sym, width: 'one-quarter', label: { text: values['unit_question'], class: 'govuk-label govuk-label--s' }, hint: { text: values['unit_hint'] }, prefix_text: values['unit']  %>
+      <%= f.govuk_text_field key.downcase.to_sym, width: 'one-quarter', label: { text: values['unit_question'], size: 's' }, hint: { text: values['unit_hint'] }, prefix_text: values['unit']  %>
     <% else %>
-      <%= f.govuk_text_field key.downcase.to_sym, width: 'one-quarter', label: { text: values['unit_question'], class: 'govuk-label govuk-label--s' }, hint: { text: values['unit_hint'] }, suffix_text: values['unit']  %>
+      <%= f.govuk_text_field key.downcase.to_sym, width: 'one-quarter', label: { text: values['unit_question'], size: 's' }, hint: { text: values['unit_hint'] }, suffix_text: values['unit']  %>
     <% end %>
   <% end %>
 

--- a/app/views/duty_calculator/steps/meursing_additional_codes/show.html.erb
+++ b/app/views/duty_calculator/steps/meursing_additional_codes/show.html.erb
@@ -17,7 +17,7 @@
 
   <%= f.govuk_text_field :meursing_additional_code,
     width: 'one-quarter',
-    label: { text: 'Enter the 3-digit additional code', class: 'govuk-label govuk-label--s' },
+    label: { text: 'Enter the 3-digit additional code', size: 's' },
     hint: { text:  meursing_lookup_hint_text }, prefix_text: '7'  %>
 
   <%= f.govuk_submit %>

--- a/app/views/green_lanes/check_your_answers/show.html.erb
+++ b/app/views/green_lanes/check_your_answers/show.html.erb
@@ -27,14 +27,14 @@
 
     <p>The details you have provided determine category of your goods.</p>
 
-    <%= form_with url: green_lanes_results_path(category: @resulting_category) do %>
+    <%= form_with url: green_lanes_results_path(category: @resulting_category), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= hidden_field_tag :commodity_code, @commodity_code %>
       <%= hidden_field_tag :country_of_origin, params[:country_of_origin] %>
       <%= hidden_field_tag :moving_date, params[:moving_date] %>
       <%= hidden_field_tag :c1ex, @c1ex %>
       <%= hidden_field_tag :c2ex, @c2ex %>
       <%= hidden_field_tag :ans, @answers.to_json %>
-      <%= submit_tag "Continue", class: 'govuk-button govuk-!-margin-top-2' %>
+      <%= f.govuk_submit class: 'govuk-!-margin-top-2' %>
     <% end %>
   </div>
 </div>

--- a/app/views/green_lanes/eligibility_results/_not_yet_eligible.html.erb
+++ b/app/views/green_lanes/eligibility_results/_not_yet_eligible.html.erb
@@ -35,8 +35,8 @@
       Depending on the specific composition and origin of your goods, you may need to check if exemptions apply before your category can be determined.
     </p>
 
-    <%= form_with url: green_lanes_your_goods_path, method: :get, local: true do %>
-      <%= submit_tag "Continue", class: "govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-4" %>
+    <%= form_with url: green_lanes_your_goods_path, method: :get, local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_submit class: "govuk-!-margin-top-2 govuk-!-margin-bottom-4" %>
     <% end %>
   </div>
 </div>

--- a/app/views/green_lanes/eligibility_results/_you_may_be_eligible.html.erb
+++ b/app/views/green_lanes/eligibility_results/_you_may_be_eligible.html.erb
@@ -35,8 +35,8 @@
       Depending on the specific composition and origin of your goods, you may need to check if exemptions apply before your category can be determined.
     </p>
 
-    <%= form_with url: green_lanes_your_goods_path, method: :get, local: true do %>
-      <%= submit_tag "Continue", class: "govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-4" %>
+    <%= form_with url: green_lanes_your_goods_path, method: :get, local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_submit class: "govuk-!-margin-top-2 govuk-!-margin-bottom-4" %>
     <% end %>
   </div>
 </div>

--- a/app/views/green_lanes/moving_requirements/new.html.erb
+++ b/app/views/green_lanes/moving_requirements/new.html.erb
@@ -50,7 +50,7 @@
         segments: { day: '3', month: '2', year: '1' } # This prevents casting the segments to Integer (3i, 2i, 1i)
         %>
 
-        <%= f.submit "Continue", class: "govuk-button" %>
+        <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>

--- a/app/views/green_lanes/moving_requirements/new.html.erb
+++ b/app/views/green_lanes/moving_requirements/new.html.erb
@@ -38,15 +38,12 @@
                                     },
                               class: 'govuk-!-width-one-half' %>
 
-      <%= f.label :commodity_code, "When is the internal movement of goods taking place?", class: 'govuk-heading-m',
-                  for: 'green_lanes_moving_requirements_form_moving_date_3' %>
-
       <%= f.govuk_date_field :moving_date,
         maxlength_enabled: true,
         hint: { text: "Arrangements can change over time. If you do not know the date of movement and want to check arrangements currently in place, enter today's date.",
                       class: 'govuk-body-l'
               },
-        legend: nil,
+        legend: { text: 'When is the internal movement of goods taking place?', size: 'm' },
         segments: { day: '3', month: '2', year: '1' } # This prevents casting the segments to Integer (3i, 2i, 1i)
         %>
 

--- a/app/views/green_lanes/moving_requirements/new.html.erb
+++ b/app/views/green_lanes/moving_requirements/new.html.erb
@@ -17,10 +17,12 @@
                              label: { text: "What is the commodity code?", size: 'm'},
                              hint: { text: "Commodity codes are internationally recognised reference numbers that describe specific goods.
                                             You must enter the full 10-digit code, including any zeros at the end.
-                                            <br><br/> For example: <br><br/>
-                                              <li> If your code is '010121', enter it as '0101210000' </li>
-                                              <li> If your code is '01012100', enter it as '0101210000' </li>
-                                            <br><br/>
+                                            <br><br/> For example: <br><br>
+                                              <ul class='govuk-list govuk-list--bullet'>
+                                                <li> If your code is '010121', enter it as '0101210000' </li>
+                                                <li> If your code is '01012100', enter it as '0101210000' </li>
+                                              </ul>
+                                            <br>
                                             You can use the Online Tariff to " \
                                           "<a href='https://www.gov.uk/trade-tariff' target='_blank' rel='noopener noreferrer'>search for a commodity (opens in a new tab).</a>".html_safe
                                    },

--- a/app/views/green_lanes/moving_requirements/new.html.erb
+++ b/app/views/green_lanes/moving_requirements/new.html.erb
@@ -24,7 +24,7 @@
                                             You can use the Online Tariff to " \
                                           "<a href='https://www.gov.uk/trade-tariff' target='_blank' rel='noopener noreferrer'>search for a commodity (opens in a new tab).</a>".html_safe
                                    },
-                             class: 'govuk-!-width-one-half' %>
+                             width: 'one-half' %>
 
       <%= f.govuk_collection_select :country_of_origin,
                               GreenLanes::CategoryAssessmentSearch.country_options,

--- a/app/views/myott/mycommodities/new.html.erb
+++ b/app/views/myott/mycommodities/new.html.erb
@@ -45,7 +45,7 @@
         </div>
 
         <div class="govuk-button-group">
-          <%= f.submit "Continue", class: "govuk-button govuk-!-margin-top-4" %>
+          <%= f.govuk_submit class: "govuk-!-margin-top-4" %>
           <% if current_subscription('my_commodities') %>
             <%= govuk_link_to 'Cancel', myott_mycommodities_path, class: 'govuk-!-margin-left-4', no_visited_state: true %>
           <% else %>

--- a/app/views/myott/preferences/edit.html.erb
+++ b/app/views/myott/preferences/edit.html.erb
@@ -11,7 +11,7 @@
       <div class="govuk-body myott-subscriptions">
         <p>Products are broken down into sections and chapters. Sections broadly group products, while chapters get more specific. You can choose to be updated about as many chapters as you like.</p>
         <%= render partial: 'checkbox_toggles' %>
-        <%= form_with url: myott_stop_press_preferences_path, method: :patch, local: true do %>
+        <%= form_with url: myott_stop_press_preferences_path, method: :patch, local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
           <div class="govuk-accordion" data-module="govuk-accordion" id="section-chapter-accordion">
             <% @all_sections_chapters.each do |section, chapters| %>
               <div class="govuk-accordion__section <%= section.resource_id == "1" ? 'govuk-accordion__section--expanded' : ''%>" id="accordion-section-<%=section.resource_id%>">
@@ -20,7 +20,7 @@
               </div>
             <% end %>
           </div>
-          <%= submit_tag "Continue", class: "govuk-button govuk-!-margin-top-4" %>
+          <%= f.govuk_submit class: "govuk-!-margin-top-4" %>
         <% end %>
       </div>
     </div>

--- a/app/views/myott/preferences/new.html.erb
+++ b/app/views/myott/preferences/new.html.erb
@@ -21,7 +21,7 @@
           <%= f.govuk_radio_button :preference, Myott::StopPressPreferenceForm::SELECT_CHAPTERS, label: { text: "Select the tariff chapters I am interested in" } %>
           <%= f.govuk_radio_button :preference, Myott::StopPressPreferenceForm::ALL_CHAPTERS, label: { text: "All tariff chapter updates" } %>
         <% end %>
-        <%= f.submit "Continue", class: "govuk-button govuk-!-margin-top-4" %>
+        <%= f.govuk_submit class: "govuk-!-margin-top-4" %>
       <% end %>
     </div>
   </div>

--- a/app/views/myott/stop_presses/check_your_answers.html.erb
+++ b/app/views/myott/stop_presses/check_your_answers.html.erb
@@ -16,14 +16,14 @@
       </p>
 
       <div data-controller="chapter-selection">
-        <%= form_with url: subscribe_myott_stop_press_path, method: :post, local: true do %>
+        <%= form_with url: subscribe_myott_stop_press_path, method: :post, local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
           <%= render 'details_selected_sections_chapters', selected_sections_chapters: @selected_sections_chapters %>
           <%= govuk_link_to "Edit your chapter preferences", edit_myott_stop_press_preferences_path %>
           <%= govuk_section_break(size: 'l', visible: true) %>
 
           <h2 class="govuk-heading-m">Confirm your selection</h2>
           <p>If you are happy with the selected chapters, continue to confirm your selection.</p>
-          <p><%= submit_tag "Continue", class: "govuk-button govuk-!-margin-top-4" %></p>
+          <p><%= f.govuk_submit class: "govuk-!-margin-top-4" %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/myott/unsubscribes/my_commodities.html.erb
+++ b/app/views/myott/unsubscribes/my_commodities.html.erb
@@ -22,7 +22,7 @@
         <%= f.govuk_radio_button :decision, 'true', label: { text: "Yes" } %>
         <%= f.govuk_radio_button :decision, 'false', label: { text: "No" } %>
       <% end %>
-      <%= f.submit "Confirm", class: "govuk-button" %>
+      <%= f.govuk_submit "Confirm" %>
     <% end %>
   </div>
 </div>

--- a/app/views/myott/unsubscribes/stop_press.html.erb
+++ b/app/views/myott/unsubscribes/stop_press.html.erb
@@ -19,8 +19,8 @@
     <p>It can take up to 24 hours to remove this email address from our system.</p>
     <p>If you do not want to unsubscribe, close this page.</p>
 
-    <%= form_with url: myott_unsubscribe_path(params[:id]), method: :delete, local: true do %>
-      <%= submit_tag "Unsubscribe", class: "govuk-button govuk-button--warning govuk-!-margin-top-4" %>
+    <%= form_with url: myott_unsubscribe_path(params[:id]), method: :delete, local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_submit "Unsubscribe", class: "govuk-button--warning govuk-!-margin-top-4" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## What:
- Adds form builder to existing simple forms
- Uses size and width arguments instead of specifying the class
- Use govuk_submit helper instead of f.submit in a few forms
- Improves green lanes form in a couple of ways:
  - converts a label to a legend which is better for accessibility
  - adds govuk classes for list so it is indented and fits page better (especially where there is a validation error)

| Before | After | 
| --- | --- |
| <img width="679" height="539" alt="Screenshot 2026-05-29 at 14 07 44" src="https://github.com/user-attachments/assets/36f81558-c9d6-47e4-9779-97bcf099cdc6" /> | <img width="695" height="536" alt="Screenshot 2026-05-29 at 14 07 49" src="https://github.com/user-attachments/assets/f7058165-c7d2-4d32-a835-ae683180323e" /> |

## Why:
More consistent use of helpers and improves a11y

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Like for like (or with enhanced accessibility) changes
