### PR TITLE
Replace deprecated colour usage

### DIFF
--- a/app/assets/stylesheets/src/_colors.scss
+++ b/app/assets/stylesheets/src/_colors.scss
@@ -3,7 +3,7 @@ $chapter-code-bg: #d1d2e6;
 $heading-code-bg: #b3d9ee;
 $commodity-code-bg: #abeae5;
 $table-header-bg: #e1e8e8;
-$table-sub-border: govuk-tint(govuk-colour("black"), 95%);
+$table-sub-border: govuk-colour("black", $variant: "tint-95");
 
 $tariff-inset-background-color-meursing: #e9f4f9;
 $tariff-inset-border-left-color-meursing: #098dc1;

--- a/app/assets/stylesheets/src/_downloadable-document.scss
+++ b/app/assets/stylesheets/src/_downloadable-document.scss
@@ -18,7 +18,7 @@
       stroke      : govuk-functional-colour(border);
       margin-right: 0.5em;
       border      : 1px solid govuk-functional-colour(border);
-      box-shadow  : 4px 4px govuk-tint(govuk-colour("black"), 25%);
+      box-shadow  : 4px 4px govuk-colour("black", $variant: "tint-25");
       max-width   : 64px;
       max-height  : 80px;
     }

--- a/app/assets/stylesheets/src/_feedback_useful_banner.scss
+++ b/app/assets/stylesheets/src/_feedback_useful_banner.scss
@@ -3,7 +3,7 @@
   border-top: 1px solid govuk-functional-colour(border);
 
   &__inner {
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
     border-bottom: 1px solid govuk-functional-colour(border);
     padding: govuk-spacing(4);
     margin: 0;

--- a/app/assets/stylesheets/src/_interactive-search.scss
+++ b/app/assets/stylesheets/src/_interactive-search.scss
@@ -27,7 +27,7 @@
 }
 
 .interactive-results__other-heading {
-  border-top: 1px solid govuk-tint(govuk-colour("black"), 80%);
+  border-top: 1px solid govuk-colour("black", $variant: "tint-80");
   padding-top: govuk-spacing(4);
 }
 
@@ -63,7 +63,7 @@
 
 // Devolved nations panel - grey background matching gem-c-devolved-nations
 .app-devolved-nations {
-  background: govuk-tint(govuk-colour("black"), 95%);
+  background: govuk-colour("black", $variant: "tint-95");
   margin-bottom: govuk-spacing(3);
   padding: govuk-spacing(3);
 

--- a/app/assets/stylesheets/src/_panel.scss
+++ b/app/assets/stylesheets/src/_panel.scss
@@ -10,7 +10,7 @@
   }
 
   &--grey {
-    background-color: govuk-tint(govuk-colour("black"), 95%);
+    background-color: govuk-colour("black", $variant: "tint-95");
   }
 
   .govuk-warning-text {

--- a/app/assets/stylesheets/src/_rules_of_origin.scss
+++ b/app/assets/stylesheets/src/_rules_of_origin.scss
@@ -40,7 +40,7 @@
 
 .rules-of-origin-met-message {
   padding: govuk-spacing(3);
-  background-color: govuk-tint(govuk-colour("black"), 95%);
+  background-color: govuk-colour("black", $variant: "tint-95");
   margin-bottom: 2em;
 
   p {

--- a/app/assets/stylesheets/src/_simplified_procedural_values.scss
+++ b/app/assets/stylesheets/src/_simplified_procedural_values.scss
@@ -1,4 +1,4 @@
 .simplified-procedural-values-form {
-  background-color: govuk-tint(govuk-colour("black"), 95%);
+  background-color: govuk-colour("black", $variant: "tint-95");
   padding: govuk-spacing(2);
 }

--- a/app/assets/stylesheets/src/_tariff-breadcrumbs.scss
+++ b/app/assets/stylesheets/src/_tariff-breadcrumbs.scss
@@ -4,7 +4,7 @@
   margin: govuk-spacing(4) 0 govuk-spacing(7) 0;
   @include govuk-clearfix;
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 
   .full-code {
     width: 171px;

--- a/app/assets/stylesheets/src/_typography.scss
+++ b/app/assets/stylesheets/src/_typography.scss
@@ -23,7 +23,7 @@ blockquote {
   padding: govuk-spacing(2);
   margin-left: 0;
   margin-right: 0;
-  background-color: govuk-tint(govuk-colour("black"), 95%);
+  background-color: govuk-colour("black", $variant: "tint-95");
 }
 
 .tariff-body-subtext {

--- a/app/assets/stylesheets/src/vendor/govuk_publishing_components/print-link.scss
+++ b/app/assets/stylesheets/src/vendor/govuk_publishing_components/print-link.scss
@@ -27,7 +27,7 @@ $gem-c-print-link-background-height: 18px;
   }
 
   &:hover {
-    background-color: govuk-tint(govuk-colour("black"), 95%);
+    background-color: govuk-colour("black", $variant: "tint-95");
   }
 }
 

--- a/app/assets/stylesheets/src/vendor/step-by-step-nav.scss
+++ b/app/assets/stylesheets/src/vendor/step-by-step-nav.scss
@@ -7,7 +7,7 @@ $stroke-width: 2px;
 $stroke-width-large: 3px;
 $number-circle-size: 26px;
 $number-circle-size-large: 35px;
-$top-border: solid 2px govuk-tint(govuk-colour("black"), 80%);
+$top-border: solid 2px govuk-colour("black", $variant: "tint-80");
 
 @mixin step-nav-vertical-line ($line-style: solid) {
   content: "";
@@ -15,7 +15,7 @@ $top-border: solid 2px govuk-tint(govuk-colour("black"), 80%);
   z-index: 2;
   width: 0;
   height: 100%;
-  border-left: $line-style $stroke-width govuk-tint(govuk-colour("black"), 80%);
+  border-left: $line-style $stroke-width govuk-colour("black", $variant: "tint-80");
   background: govuk-colour("white");
 }
 
@@ -146,7 +146,7 @@ $top-border: solid 2px govuk-tint(govuk-colour("black"), 80%);
     margin-left: math.div($number-circle-size, 4);
     width: math.div($number-circle-size, 2);
     height: 0;
-    border-bottom: solid $stroke-width govuk-tint(govuk-colour("black"), 80%);
+    border-bottom: solid $stroke-width govuk-colour("black", $variant: "tint-80");
   }
 
   &:after {
@@ -210,7 +210,7 @@ $top-border: solid 2px govuk-tint(govuk-colour("black"), 80%);
 
 .app-step-nav__circle--number {
   @include step-nav-font(16, $weight: bold, $line-height: 23px);
-  border: solid $stroke-width govuk-tint(govuk-colour("black"), 80%);
+  border: solid $stroke-width govuk-colour("black", $variant: "tint-80");
 
   .app-step-nav--large & {
     @include step-nav-font(16, $tablet-size: 19, $weight: bold, $line-height: 23px, $tablet-line-height: 30px);
@@ -422,7 +422,7 @@ $top-border: solid 2px govuk-tint(govuk-colour("black"), 80%);
 .app-step-nav__context {
   display: inline-block;
   font-weight: normal;
-  color: govuk-tint(govuk-colour("black"), 25%);
+  color: govuk-colour("black", $variant: "tint-25");
 
   &:before {
     content: " \2013\00a0"; // dash followed by &nbsp;

--- a/app/views/simplified_procedural_values/_by_date.html.erb
+++ b/app/views/simplified_procedural_values/_by_date.html.erb
@@ -11,7 +11,7 @@
   <h2 class="govuk-heading-s">Rates for period <%= date_range_message(@result.validity_start_date, @result.validity_end_date) %></h2>
   <p>Simplified procedure value rates change every 14 days. You may only use the rate that applies to the produce you are importing within the correct 14-day period.</p>
 
-  <div class="govuk-form-group.simplified-procedural-values-form">
+  <div class="govuk-form-group simplified-procedural-values-form">
     <p>Select unit price period start date</p>
     <%= form_with(url: simplified_procedural_values_path, method: "get") do |f| %>
       <%= f.select :validity_start_date, @result.by_date_options, { selected: @result.validity_start_date }, { class: "govuk-select" } %>


### PR DESCRIPTION
## What:
Replace usage of govuk-tint and "light-grey" colour.
Also fixes an element where class names were mistakenly joined with a `.` on the simplified procedure value rates page
| Before | After |
| --- | --- |
| <img width="642" height="402" alt="Screenshot 2026-05-29 at 15 49 45" src="https://github.com/user-attachments/assets/d80bedf4-d898-4c30-9285-57ef1f7db3f6" /> | <img width="677" height="454" alt="Screenshot 2026-05-29 at 15 50 06" src="https://github.com/user-attachments/assets/a940f019-1090-4e4c-b1fe-90612796a7d6" /> |

## Why:
The govuk-tint method has been removed from govuk-frontend, and the "light-grey" colour has been deprecated
https://github.com/alphagov/govuk-frontend/discussions/6353

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Minor style fixes