### PR TITLE
BAU: Handle malformed search params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,7 @@ class ApplicationController < ActionController::Base
   end
 
   def search_attributes
-    params.fetch(:search, params).permit(
+    search_attribute_params.permit(
       :q,
       :resource_id,
       :country,
@@ -74,6 +74,12 @@ class ApplicationController < ActionController::Base
       :year,
       :as_of,
     ).to_h
+  end
+
+  def search_attribute_params
+    search_params = params[:search]
+
+    search_params.respond_to?(:permit) ? search_params : params
   end
 
   def set_layout

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -113,7 +113,7 @@ class SearchController < ApplicationController
   end
 
   def search_attributes
-    params.fetch(:search, params).permit(
+    search_attribute_params.permit(
       :q,
       :resource_id,
       :country,

--- a/spec/requests/find_commodities_controller_spec.rb
+++ b/spec/requests/find_commodities_controller_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe FindCommoditiesController, type: :request do
     it { is_expected.to have_http_status :ok }
     it { is_expected.to have_attributes content_type: %r{text/html} }
 
+    context 'with a malformed search param' do
+      let(:params) { { search: 'coffee beans' } }
+
+      it { is_expected.to have_http_status :ok }
+    end
+
     context 'with an invalid date flag' do
       let(:params) { { invalid_date: true, day: '22', month: '0', year: '2026' } }
 


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Add request coverage for a string `search` parameter on the find commodity page.
- [x] Guard shared search attribute parsing so only parameter objects receive `permit`.
- [x] Reuse the same guard for the search controller's richer search params.

### Why?

Production logs showed `NoMethodError: undefined method 'permit' for an instance of String` when malformed requests sent `search` as a scalar value. This makes malformed input fall back to the safe top-level params path instead of raising a 500.

### Risk

**Risk level:** 🟢

**Reason for rating:** Small defensive parameter handling change with focused request coverage.