### PR TITLE
BAU: Handle news item not-found responses

### DIFF
--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -1,6 +1,7 @@
 class NewsItemsController < ApplicationController
   before_action :disable_search_form,
                 :disable_switch_service_banner
+  rescue_from Faraday::ResourceNotFound, with: :handle_resource_not_found
 
   def index
     @news_collections = News::Collection.all
@@ -33,4 +34,8 @@ private
           .symbolize_keys
   end
   helper_method :news_index_params
+
+  def handle_resource_not_found
+    redirect_to not_found_path
+  end
 end

--- a/spec/requests/news_items_controller_spec.rb
+++ b/spec/requests/news_items_controller_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe NewsItemsController, type: :request do
 
       it { is_expected.to have_http_status :ok }
     end
+
+    context 'when the backend returns not found' do
+      before do
+        allow(News::Item).to receive(:updates_page)
+          .with(no_args)
+          .and_raise(Faraday::ResourceNotFound, 'not found')
+      end
+
+      let(:make_request) { get news_items_path }
+
+      it { is_expected.to redirect_to(not_found_path) }
+    end
   end
 
   describe 'GET #show' do
@@ -56,5 +68,15 @@ RSpec.describe NewsItemsController, type: :request do
 
     it { is_expected.to have_http_status :ok }
     it { is_expected.to have_attributes content_type: %r{text/html} }
+
+    context 'when the backend returns not found' do
+      before do
+        allow(News::Item).to receive(:find)
+          .with(news_item.slug)
+          .and_raise(Faraday::ResourceNotFound, 'not found')
+      end
+
+      it { is_expected.to redirect_to(not_found_path) }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Add request coverage for backend not-found responses on news index and show pages.
- [x] Rescue `Faraday::ResourceNotFound` in `NewsItemsController`.
- [x] Redirect news not-found cases to the existing not-found route.

### Why?

Production logs showed frontend requests where backend 404s for news item paths were still being surfaced through exception handling. This makes expected not-found responses explicit in the owning controller.

### Risk

**Risk level:** 🟢

**Reason for rating:** Only handles backend not-found exceptions in the news controller and uses the existing not-found route.

### Validation

- [x] `bundle exec rspec spec/requests/news_items_controller_spec.rb`