### PR TITLE
BAU: Handle malformed analytics cookie

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -3,10 +3,14 @@ module AnalyticsHelper
   COOKIES_POLICY_NAME = 'cookies_policy'.freeze
 
   def analytics_allowed?
-    if cookies[COOKIES_POLICY_NAME].nil?
-      false
-    else
-      !!JSON.parse(cookies[COOKIES_POLICY_NAME]).fetch('usage', false)
-    end
+    cookie = cookies[COOKIES_POLICY_NAME]
+    return false if cookie.nil?
+
+    policy = JSON.parse(cookie)
+    return false unless policy.is_a?(Hash)
+
+    !!policy.fetch('usage', false)
+  rescue JSON::ParserError
+    false
   end
 end

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe AnalyticsHelper, type: :helper do
 
         it { expect(helper.analytics_allowed?).to be false }
       end
+
+      context 'when the consent cookie is malformed' do
+        let(:value) { '{"usage":true"' }
+
+        it { expect(helper.analytics_allowed?).to be false }
+      end
     end
   end
 end


### PR DESCRIPTION
## What?

Handle malformed `cookies_policy` values in `AnalyticsHelper#analytics_allowed?` by treating them as analytics disabled rather than raising `JSON::ParserError` during layout rendering.

Adds helper coverage for malformed cookie JSON.

## Why?

Malformed cookie values can be sent by clients and should not cause page rendering to fail with a 500. If the cookie cannot be parsed, the safest behaviour is to avoid loading analytics.

## Risk

Green - narrow helper change. The fallback is conservative: malformed or non-object cookie values disable analytics only for that request.