### PR TITLE
OTTIMP-629 Use Data objects

### DIFF
--- a/app/controllers/myott/mycommodities_controller.rb
+++ b/app/controllers/myott/mycommodities_controller.rb
@@ -1,5 +1,7 @@
 module Myott
   class MycommoditiesController < MyottController
+    CommodityCodeCounts = Data.define(:active, :expired, :invalid, :total)
+
     before_action :ensure_subscription, except: %i[new create]
 
     def new
@@ -108,7 +110,7 @@ module Myott
     def counts_from_subscription_metadata
       counts = subscription&.dig(:meta, :counts) || {}
 
-      OpenStruct.new(
+      CommodityCodeCounts.new(
         active: counts.fetch('active', 0),
         expired: counts.fetch('expired', 0),
         invalid: counts.fetch('invalid', 0),

--- a/app/helpers/green_lanes_helper.rb
+++ b/app/helpers/green_lanes_helper.rb
@@ -1,4 +1,6 @@
 module GreenLanesHelper
+  Option = Data.define(:id, :name)
+
   def exemption_checkbox_checked?(resource_id, exemption_code)
     params.dig(:exemptions, resource_id.to_s)
           &.include?(exemption_code)
@@ -57,11 +59,11 @@ module GreenLanesHelper
   end
 
   def yes_no_options
-    [OpenStruct.new(id: 'yes', name: 'Yes'), OpenStruct.new(id: 'no', name: 'No')]
+    [Option.new(id: 'yes', name: 'Yes'), Option.new(id: 'no', name: 'No')]
   end
 
   def yes_no_not_sure_options
-    [OpenStruct.new(id: 'yes', name: 'Yes'), OpenStruct.new(id: 'no', name: 'No'), OpenStruct.new(id: 'not_sure', name: 'Not sure')]
+    [Option.new(id: 'yes', name: 'Yes'), Option.new(id: 'no', name: 'No'), Option.new(id: 'not_sure', name: 'Not sure')]
   end
 
   def prettify_category(category)

--- a/app/models/duty_calculator/option.rb
+++ b/app/models/duty_calculator/option.rb
@@ -1,0 +1,7 @@
+module DutyCalculator
+  class Option < Data.define(:id, :name, :disabled)
+    def initialize(id:, name:, disabled: false)
+      super(id:, name:, disabled:)
+    end
+  end
+end

--- a/app/models/duty_calculator/steps/additional_code.rb
+++ b/app/models/duty_calculator/steps/additional_code.rb
@@ -58,7 +58,7 @@ module DutyCalculator
       end
 
       def build_option(code, overlay)
-        OpenStruct.new(
+        Option.new(
           id: code,
           name: "#{code} - #{overlay}".html_safe,
         )

--- a/app/models/duty_calculator/steps/annual_turnover.rb
+++ b/app/models/duty_calculator/steps/annual_turnover.rb
@@ -46,8 +46,8 @@ module DutyCalculator
 
       def options
         [
-          OpenStruct.new(id: 'yes', name: "My company's turnover was less than #{ukims_annual_turnover}"),
-          OpenStruct.new(id: 'no', name: "My company's turnover was #{ukims_annual_turnover} or more"),
+          Option.new(id: 'yes', name: "My company's turnover was less than #{ukims_annual_turnover}"),
+          Option.new(id: 'no', name: "My company's turnover was #{ukims_annual_turnover} or more"),
         ]
       end
     end

--- a/app/models/duty_calculator/steps/certificate_of_origin.rb
+++ b/app/models/duty_calculator/steps/certificate_of_origin.rb
@@ -2,8 +2,8 @@ module DutyCalculator
   module Steps
     class CertificateOfOrigin < Steps::Base
       OPTIONS = [
-        OpenStruct.new(id: 'yes', name: 'Yes, I have a valid Certificate of Origin'),
-        OpenStruct.new(id: 'no', name: 'No, I do not have a valid Certificate of Origin'),
+        Option.new(id: 'yes', name: 'Yes, I have a valid Certificate of Origin'),
+        Option.new(id: 'no', name: 'No, I do not have a valid Certificate of Origin'),
       ].freeze
 
       STEPS_TO_REMOVE_FROM_SESSION = %w[document_code excise].freeze

--- a/app/models/duty_calculator/steps/document_code.rb
+++ b/app/models/duty_calculator/steps/document_code.rb
@@ -19,7 +19,7 @@ module DutyCalculator
 
       def options_for(source)
         send("#{source}_available_documents").map do |doc|
-          OpenStruct.new(id: doc[:code], name: doc[:description])
+          Option.new(id: doc[:code], name: doc[:description])
         end
       end
 

--- a/app/models/duty_calculator/steps/excise.rb
+++ b/app/models/duty_calculator/steps/excise.rb
@@ -22,7 +22,7 @@ module DutyCalculator
           code = additional_code['code'].sub('X', '')
           overlay = "#{additional_code['overlay']} (X#{code})".html_safe
 
-          OpenStruct.new(
+          Option.new(
             id: code,
             name: overlay,
             disabled: code.in?(DISABLED_ADDITIONAL_CODES),

--- a/app/models/duty_calculator/steps/final_use.rb
+++ b/app/models/duty_calculator/steps/final_use.rb
@@ -36,8 +36,8 @@ module DutyCalculator
 
       def options
         [
-          OpenStruct.new(id: 'yes', name: I18n.t("final_use.#{current_route}.yes_option")),
-          OpenStruct.new(id: 'no', name: I18n.t("final_use.#{current_route}.no_option")),
+          Option.new(id: 'yes', name: I18n.t("final_use.#{current_route}.yes_option")),
+          Option.new(id: 'no', name: I18n.t("final_use.#{current_route}.no_option")),
         ]
       end
 

--- a/app/models/duty_calculator/steps/import_destination.rb
+++ b/app/models/duty_calculator/steps/import_destination.rb
@@ -3,8 +3,8 @@ module DutyCalculator
     class ImportDestination < Steps::Base
       # We call England, Scotland or Wales (GB) as UK beacuse that is how we named the backend source when the service is the UK version
       OPTIONS = [
-        OpenStruct.new(id: 'UK', name: 'England, Scotland or Wales (GB)'),
-        OpenStruct.new(id: 'XI', name: 'Northern Ireland'),
+        Option.new(id: 'UK', name: 'England, Scotland or Wales (GB)'),
+        Option.new(id: 'XI', name: 'Northern Ireland'),
       ].freeze
 
       STEPS_TO_REMOVE_FROM_SESSION = %w[

--- a/app/models/duty_calculator/steps/trader_scheme.rb
+++ b/app/models/duty_calculator/steps/trader_scheme.rb
@@ -15,8 +15,8 @@ module DutyCalculator
 
       def options
         [
-          OpenStruct.new(id: 'yes', name: trader_scheme_bullet_point_true.to_s),
-          OpenStruct.new(id: 'no', name: trader_scheme_bullet_point_no.to_s),
+          Option.new(id: 'yes', name: trader_scheme_bullet_point_true.to_s),
+          Option.new(id: 'no', name: trader_scheme_bullet_point_no.to_s),
         ].freeze
       end
 

--- a/app/models/duty_calculator/steps/vat.rb
+++ b/app/models/duty_calculator/steps/vat.rb
@@ -15,7 +15,7 @@ module DutyCalculator
 
       def vat_options
         applicable_vat_options.map do |k, v|
-          OpenStruct.new(id: k, name: v)
+          Option.new(id: k, name: v)
         end
       end
 

--- a/app/models/meursing_lookup/steps/tree.rb
+++ b/app/models/meursing_lookup/steps/tree.rb
@@ -1,6 +1,8 @@
 module MeursingLookup
   module Steps
     module Tree
+      Option = Data.define(:id, :name)
+
       extend ActiveSupport::Concern
 
       included do
@@ -19,7 +21,7 @@ module MeursingLookup
 
       def options
         current_meursing_code_level.each_key.map do |key|
-          OpenStruct.new(id: key, name: key)
+          Option.new(id: key, name: key)
         end
       end
 

--- a/app/models/rules_of_origin/steps/product_specific_rules.rb
+++ b/app/models/rules_of_origin/steps/product_specific_rules.rb
@@ -25,7 +25,7 @@ module RulesOfOrigin
     private
 
       def none_option
-        Struct.new(:resource_id, :rule, :footnotes)
+        Data.define(:resource_id, :rule, :footnotes)
               .new('none', none_option_text, [])
       end
 

--- a/app/models/rules_of_origin/steps/subdivisions.rb
+++ b/app/models/rules_of_origin/steps/subdivisions.rb
@@ -53,7 +53,7 @@ module RulesOfOrigin
       end
 
       def other_option
-        Struct.new(:resource_id, :subdivision).new('other', other_option_text)
+        Data.define(:resource_id, :subdivision).new('other', other_option_text)
       end
 
       def other_option_text

--- a/app/models/search/blank_result.rb
+++ b/app/models/search/blank_result.rb
@@ -1,0 +1,3 @@
+class Search
+  BlankResult = Data.define(:sections, :chapters, :headings, :commodities)
+end

--- a/app/models/search/goods_nomenclature_match.rb
+++ b/app/models/search/goods_nomenclature_match.rb
@@ -1,8 +1,6 @@
-require 'ostruct'
-
 class Search
   class GoodsNomenclatureMatch < BaseMatch
-    BLANK_RESULT = OpenStruct.new(
+    BLANK_RESULT = Search::BlankResult.new(
       sections: [], chapters: [], headings: [], commodities: [],
     )
 

--- a/app/models/search/reference_match.rb
+++ b/app/models/search/reference_match.rb
@@ -1,10 +1,8 @@
-require 'ostruct'
-
 class Search
   include ApiEntity
 
   class ReferenceMatch < BaseMatch
-    BLANK_RESULT = OpenStruct.new(
+    BLANK_RESULT = Search::BlankResult.new(
       sections: [], chapters: [], headings: [], commodities: [],
     )
 

--- a/app/services/commodity_codes_extraction_service.rb
+++ b/app/services/commodity_codes_extraction_service.rb
@@ -1,5 +1,5 @@
 class CommodityCodesExtractionService
-  Result = Struct.new(:success?, :codes, :error_message)
+  Result = Data.define(:success?, :codes, :error_message)
   COMMODITY_CODES_COLUMN = 'A'.freeze
 
   def initialize(file)

--- a/app/services/simplified_procedural_code_measure_fetcher_service.rb
+++ b/app/services/simplified_procedural_code_measure_fetcher_service.rb
@@ -1,57 +1,65 @@
 class SimplifiedProceduralCodeMeasureFetcherService
+  Result = Data.define(
+    :measures,
+    :goods_nomenclature_label,
+    :goods_nomenclature_item_ids,
+    :validity_start_date,
+    :validity_end_date,
+    :validity_start_dates,
+    :by_date_options,
+    :by_code,
+    :simplified_procedural_code,
+    :no_data,
+  )
+
   def initialize(params)
     @simplified_procedural_code = params[:simplified_procedural_code]
     @validity_start_date = params[:validity_start_date]
-    @result = OpenStruct.new do
-      attr_accessor :measures,
-                    :goods_nomenclature_label,
-                    :goods_nomenclature_item_ids,
-                    :validity_start_date,
-                    :validity_end_date,
-                    :validity_start_dates,
-                    :by_date_options,
-                    :by_code,
-                    :simplified_procedural_code,
-                    :no_data
-    end
   end
 
   def call
-    if simplified_procedural_code
-      by_code
-    else
-      by_date
-    end
-
-    result
+    simplified_procedural_code ? by_code : by_date
   end
 
   private
 
-  attr_reader :simplified_procedural_code, :result
+  attr_reader :simplified_procedural_code
 
   def all
     @all ||= SimplifiedProceduralCodeMeasure.all
   end
 
   def by_code
-    result.measures = SimplifiedProceduralCodeMeasure.by_code(simplified_procedural_code)
-    first_measure = result.measures.first
+    measures = SimplifiedProceduralCodeMeasure.by_code(simplified_procedural_code)
+    first_measure = measures.first
 
-    result.goods_nomenclature_label = first_measure&.goods_nomenclature_label
-    result.goods_nomenclature_item_ids = first_measure&.goods_nomenclature_item_ids
-    result.by_code = true
-    result.no_data = result.measures.all?(&:no_data?)
-    result.simplified_procedural_code = simplified_procedural_code
+    Result.new(
+      measures:,
+      goods_nomenclature_label: first_measure&.goods_nomenclature_label,
+      goods_nomenclature_item_ids: first_measure&.goods_nomenclature_item_ids,
+      validity_start_date: nil,
+      validity_end_date: nil,
+      validity_start_dates: nil,
+      by_date_options: nil,
+      by_code: true,
+      simplified_procedural_code:,
+      no_data: measures.all?(&:no_data?),
+    )
   end
 
   def by_date
-    result.measures = SimplifiedProceduralCodeMeasure.by_validity_start_and_end_date(validity_start_date, validity_end_date)
-    result.validity_start_dates = validity_start_dates
-    result.validity_start_date = validity_start_date
-    result.validity_end_date = validity_end_date
-    result.by_date_options = by_date_options
-    result.by_code = false
+    Result.new(
+      measures: SimplifiedProceduralCodeMeasure.by_validity_start_and_end_date(validity_start_date, validity_end_date),
+      goods_nomenclature_label: nil,
+      goods_nomenclature_item_ids: nil,
+      validity_start_date:,
+      validity_end_date:,
+      validity_start_dates:,
+      by_date_options:,
+      by_code: false,
+      simplified_procedural_code: nil,
+      no_data: nil,
+    )
   end
 
   def validity_start_date

--- a/spec/helpers/green_lanes_helper_spec.rb
+++ b/spec/helpers/green_lanes_helper_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe GreenLanesHelper, type: :helper do
                       cat_1_assessments: [assessment_1, assessment_2])
     end
 
-    let(:assessment_1) { OpenStruct.new(category_assessment_id: 1) }
-    let(:assessment_2) { OpenStruct.new(category_assessment_id: 2) }
+    let(:assessment_1) { { resource_id: 1 } }
+    let(:assessment_2) { { resource_id: 2 } }
 
     context 'when result is "3"' do
       it 'renders exemptions_card' do

--- a/spec/models/duty_calculator/steps/additional_code_spec.rb
+++ b/spec/models/duty_calculator/steps/additional_code_spec.rb
@@ -173,11 +173,11 @@ RSpec.describe DutyCalculator::Steps::AdditionalCode, :step, :user_session do
   describe '#options_for_select' do
     let(:expected_options) do
       [
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: '2600',
           name: '2600 - The product I am importing is COVID-19 critical',
         ),
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: '2601',
           name: '2601 - The product I am importing is not COVID-19 critical',
         ),

--- a/spec/models/duty_calculator/steps/document_code_spec.rb
+++ b/spec/models/duty_calculator/steps/document_code_spec.rb
@@ -47,11 +47,11 @@ RSpec.describe DutyCalculator::Steps::DocumentCode, :step, :user_session do
       let(:source) { 'uk' }
       let(:expected_options) do
         [
-          OpenStruct.new(
+          DutyCalculator::Option.new(
             id: 'C990',
             name: 'C990 - ',
           ),
-          OpenStruct.new(
+          DutyCalculator::Option.new(
             id: 'None',
             name: 'None of the above',
           ),

--- a/spec/models/duty_calculator/steps/excise_spec.rb
+++ b/spec/models/duty_calculator/steps/excise_spec.rb
@@ -138,47 +138,47 @@ RSpec.describe DutyCalculator::Steps::Excise, :step, :user_session do
   describe '#options' do
     let(:expected_options) do
       [
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: '520',
           name: 'Light oil: unrebated (unmarked) – other unrebated light oil (X520)',
           disabled: false,
         ),
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: '522',
           name: 'Light oil: rebated – unleaded petrol (X522)',
           disabled: false,
         ),
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: '541',
           name: 'Heavy oil: unrebated (unmarked, including Diesel Engine Road Vehicle (DERV) or road fuel extender and unmarked kerosene or unmarked gas oil for which no marking waiver has been granted) (X541)',
           disabled: false,
         ),
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: '542',
           name: 'Heavy oil: kerosene to be used as motor fuel off road or in an excepted vehicle (X542)',
           disabled: false,
         ),
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: '551',
           name: 'Heavy oil: kerosene (marked or unmarked under marking waiver, including heavy oil aviation turbine fuel) to be used other than as motor fuel off-road or in an excepted vehicle (X551)',
           disabled: false,
         ),
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: '556',
           name: 'Heavy oil: gas oil (marked or unmarked under marking waiver) (X556)',
           disabled: false,
         ),
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: '561',
           name: 'Heavy oil: fuel oil (unmarked) (X561)',
           disabled: false,
         ),
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: '570',
           name: 'Heavy oil: other (unmarked) (X570)',
           disabled: false,
         ),
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: '441',
           name: 'Heavy oil: fuel oil (unmarked) (X441)',
           disabled: true,

--- a/spec/models/duty_calculator/steps/final_use_spec.rb
+++ b/spec/models/duty_calculator/steps/final_use_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe DutyCalculator::Steps::FinalUse, :step, :user_session do
   describe '#options' do
     let(:expected) do
       [
-        OpenStruct.new(id: 'yes', name: I18n.t("final_use.#{locale_key}.yes_option")),
-        OpenStruct.new(id: 'no', name: I18n.t("final_use.#{locale_key}.no_option")),
+        DutyCalculator::Option.new(id: 'yes', name: I18n.t("final_use.#{locale_key}.yes_option")),
+        DutyCalculator::Option.new(id: 'no', name: I18n.t("final_use.#{locale_key}.no_option")),
       ]
     end
 

--- a/spec/models/duty_calculator/steps/vat_spec.rb
+++ b/spec/models/duty_calculator/steps/vat_spec.rb
@@ -50,15 +50,15 @@ RSpec.describe DutyCalculator::Steps::Vat, :step, :user_session do
 
     let(:expected_options) do
       [
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: 'VATR',
           name: 'VAT reduced rate 5% (5.0)',
         ),
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: 'VATZ',
           name: 'VAT zero rate (0.0)',
         ),
-        OpenStruct.new(
+        DutyCalculator::Option.new(
           id: 'VAT',
           name: 'Value added tax (20.0)',
         ),

--- a/spec/presenters/grouped_measures_presenter_spec.rb
+++ b/spec/presenters/grouped_measures_presenter_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe GroupedMeasuresPresenter do
   end
 
   let(:service_chooser) { class_double(TradeTariffFrontend::ServiceChooser, uk?: true) }
-  let(:measure_a) { OpenStruct.new(key: 'a') }
-  let(:measure_b) { OpenStruct.new(key: 'b') }
+  let(:measure_a) { Data.define(:key).new('a') }
+  let(:measure_b) { Data.define(:key).new('b') }
 
   describe '#uk_sections' do
     it 'returns UK sections in display order' do

--- a/spec/presenters/heading_commodity_presenter_spec.rb
+++ b/spec/presenters/heading_commodity_presenter_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe HeadingCommodityPresenter do
   describe '#root_commodities' do
     subject(:root_commodities) { described_class.new(commodities).root_commodities }
 
-    let(:root_commodity) { OpenStruct.new(root: true) }
-    let(:non_root_commodity) { OpenStruct.new(root: false) }
+    let(:root_commodity) { Data.define(:root).new(true) }
+    let(:non_root_commodity) { Data.define(:root).new(false) }
     let(:commodities) { [root_commodity, non_root_commodity] }
 
     it 'returns commodities that have root identication' do

--- a/spec/views/simplified_procedural_values/_by_code.html.erb_spec.rb
+++ b/spec/views/simplified_procedural_values/_by_code.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'simplified_procedural_values/_by_code', type: :view do
   subject { render }
 
   before do
-    result = OpenStruct.new(
+    result = Data.define(:measures, :simplified_procedural_code, :goods_nomenclature_label, :goods_nomenclature_item_ids, :no_data).new(
       measures: [measure],
       simplified_procedural_code: measure.resource_id,
       goods_nomenclature_label: measure.goods_nomenclature_label,

--- a/spec/views/simplified_procedural_values/_by_date.html.erb_spec.rb
+++ b/spec/views/simplified_procedural_values/_by_date.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'simplified_procedural_values/_by_date', type: :view do
   let(:measure) { build(:simplified_procedural_code_measure, validity_start_date: '2023-01-01', validity_end_date: '2023-01-31') }
 
   before do
-    result = OpenStruct.new(
+    result = Data.define(:measures, :validity_start_date, :validity_end_date, :validity_start_dates, :by_date_options).new(
       measures: [measure],
       validity_start_date: measure.validity_start_date,
       validity_end_date: measure.validity_end_date,

--- a/spec/views/simplified_procedural_values/index.html.erb_spec.rb
+++ b/spec/views/simplified_procedural_values/index.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'simplified_procedural_values/index', type: :view do
   let(:measure) { build(:simplified_procedural_code_measure) }
 
   before do
-    result = OpenStruct.new(
+    result = SimplifiedProceduralCodeMeasureFetcherService::Result.new(
       measures: [measure],
       goods_nomenclature_label: measure.goods_nomenclature_label,
       goods_nomenclature_item_ids: measure.goods_nomenclature_item_ids,


### PR DESCRIPTION
## What:
Replaces usage of Struct and OpenStruct with [Data](https://docs.ruby-lang.org/en/3.2/Data.html)
- instances of OpenStruct converted to use Data.define

## Why:
Data objects are immutable and more performant that OpenStructs.

## Ticket:
[<!-- Link to the relevant Jira/ticket, or 'N/A' if not applicable -->](https://transformuk.atlassian.net/browse/OTTIMP-629)

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Like for like change with improved performance
