### PR TITLE
BAU: Add frontend agent docs and style guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,4 +21,5 @@ Guidance:
 - Prefer `govuk-components`, `govuk_design_system_formbuilder`, and GOV.UK Sass helpers before custom markup or CSS.
 - Do not add explicit `require` statements for application constants in normal Rails app code when Zeitwerk can autoload them.
 - Treat commodity display, measures, duties, quotas, Green Lanes, rules of origin, subscriptions, auth/session handling, and backend API calls as high-risk.
+- For duty calculator changes, read `docs/architecture/duty-calculator.md` and verify claims against `app/models/duty_calculator/`, `app/services/duty_calculator/`, and `config/routes/duty_calculator.rb`.
 - Verify generated documentation or Code Wiki output against source files before relying on it.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# Copilot Instructions
+
+Use `docs/README.md` and `docs/architecture/README.md` before suggesting broad changes.
+Use `docs/development-and-delivery.md` and `docs/style-guide.md` for PR, Rails, test, and GOV.UK Frontend conventions.
+
+Project facts:
+
+- Rails 8 frontend application.
+- Public GOV.UK Trade Tariff web journeys.
+- Backend API access through Faraday clients, `ApiEntity`, and API-backed models.
+- UK/XI service context is selected by routing filters and `TradeTariffFrontend::ServiceChooser`.
+- Assets use Propshaft, cssbundling-rails, importmap, Stimulus, Turbo, Sass, and GOV.UK Frontend.
+
+Guidance:
+
+- Keep suggestions narrowly scoped to the requested change.
+- Prefer existing controller, form, presenter, helper, shared partial, and GOV.UK component patterns.
+- Prefer request specs for route/controller behaviour and feature specs for full journeys.
+- Do not expand legacy controller specs where request specs would cover the behaviour better.
+- Treat accessibility, validation copy, labels, hints, page titles, focus order, and responsive behaviour as first-class requirements.
+- Prefer `govuk-components`, `govuk_design_system_formbuilder`, and GOV.UK Sass helpers before custom markup or CSS.
+- Do not add explicit `require` statements for application constants in normal Rails app code when Zeitwerk can autoload them.
+- Treat commodity display, measures, duties, quotas, Green Lanes, rules of origin, subscriptions, auth/session handling, and backend API calls as high-risk.
+- Verify generated documentation or Code Wiki output against source files before relying on it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Read these first:
 
 - `docs/README.md`
 - `docs/architecture/README.md`
+- `docs/architecture/duty-calculator.md` when changing duty calculator journeys or calculation display
 - `docs/development-and-delivery.md`
 - `docs/style-guide.md`
 - `README.md`
@@ -34,6 +35,7 @@ The application is a Rails 8 frontend for the Trade Tariff service. It renders t
 - Application shell: `app/views/layouts/application.html.erb`, `app/views/layouts/_base.html.erb`
 - Backend clients: `config/initializers/backend.rb`, `app/services/client_builder.rb`, `lib/api_entity.rb`
 - Service selection: `lib/routing_filter/service_path_prefix_handler.rb`, `lib/trade_tariff_frontend/service_chooser.rb`
+- Duty calculator: `config/routes/duty_calculator.rb`, `app/controllers/duty_calculator/`, `app/models/duty_calculator/`, `app/services/duty_calculator/`
 - Controllers: `app/controllers/`
 - API-backed models: `app/models/`
 - Presenters/decorators: `app/presenters/`, `app/decorators/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Agent Instructions
+
+Use these instructions for Codex and other agentic coding tools working in this repository.
+
+## Start Here
+
+Read these first:
+
+- `docs/README.md`
+- `docs/architecture/README.md`
+- `docs/development-and-delivery.md`
+- `docs/style-guide.md`
+- `README.md`
+
+The application is a Rails 8 frontend for the Trade Tariff service. It renders the public web journeys, talks to Trade Tariff Backend APIs with Faraday, and runs in UK or XI service mode through URL/service selection.
+
+## Working Rules
+
+- Keep scope tight and prefer the existing Rails, presenter, helper, and partial patterns.
+- Verify generated or AI-suggested claims against source code and tests.
+- Do not add explicit `require` statements for application constants in normal Rails app code when Zeitwerk can autoload them. Initializers and `lib/` boot paths can be different; follow existing patterns.
+- Prefer request specs for route/controller behaviour. Do not expand legacy controller specs where a request spec would cover the behaviour better.
+- Use feature specs for full user journeys, view specs for complex templates, helper specs for helper-only logic, and JavaScript specs for Stimulus/browser behaviour.
+- Treat GOV.UK Frontend, accessibility, page titles, labels, hints, validation errors, and focus order as part of the behaviour, not cosmetic detail.
+- Prefer `govuk-components`, `govuk_design_system_formbuilder`, and existing shared partials before hand-rolling GOV.UK markup.
+- Keep Sass changes narrow. Use GOV.UK Sass variables, mixins, spacing, and typography before adding custom values.
+- Run project commands directly by default. If you use Nix/direnv locally, `direnv exec <repo-path> <command>` is also fine.
+- Use `rg` for code search.
+- Treat commodity display, measures, duties, quotas, rules of origin, Green Lanes, subscriptions, auth/session handling, and backend API calls as high-risk areas.
+
+## Key Entry Points
+
+- Routes: `config/routes.rb`, `config/routes/duty_calculator.rb`
+- Application shell: `app/views/layouts/application.html.erb`, `app/views/layouts/_base.html.erb`
+- Backend clients: `config/initializers/backend.rb`, `app/services/client_builder.rb`, `lib/api_entity.rb`
+- Service selection: `lib/routing_filter/service_path_prefix_handler.rb`, `lib/trade_tariff_frontend/service_chooser.rb`
+- Controllers: `app/controllers/`
+- API-backed models: `app/models/`
+- Presenters/decorators: `app/presenters/`, `app/decorators/`
+- Forms: `app/forms/`
+- GOV.UK helpers and shared partials: `app/helpers/`, `app/views/shared/`
+- Assets and JavaScript: `app/assets/stylesheets/`, `app/javascript/`
+- Tests: `spec/requests/`, `spec/features/`, `spec/views/`, `spec/helpers/`, `spec/javascript/`
+- CI and deployment: `.github/workflows/`
+
+## PR Notes
+
+- Use the PR template in `.github/pull_request_template.md`.
+- Use `BAU` as the ticket prefix when there is no Jira story.
+- Include risk, manual evidence, accessibility impact, and test commands when changing user-facing pages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,4 +24,5 @@ Useful docs:
 - `docs/architecture/system-overview.md`
 - `docs/architecture/request-routing.md`
 - `docs/architecture/backend-api-client.md`
+- `docs/architecture/duty-calculator.md`
 - `docs/architecture/frontend-rendering.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Claude Code Instructions
+
+Use `docs/README.md` as the first repository map and `docs/architecture/README.md` for runtime boundaries.
+
+This is a Rails 8 frontend for the Trade Tariff service. It renders public GOV.UK journeys and consumes Trade Tariff Backend APIs through Faraday-backed API entities. UK/XI service behaviour is selected through URL/service routing and `TradeTariffFrontend::ServiceChooser`.
+
+Before changing code:
+
+- Identify the route, controller, model/API entity, presenter/helper, view partial, asset, and tests involved.
+- Verify generated explanations against source files.
+- Prefer request specs for route/controller behaviour; do not expand legacy controller specs where a request spec is the better fit.
+- Use feature specs for full journeys, view specs for complex templates, helper specs for isolated helper logic, and JavaScript specs for Stimulus/browser behaviour.
+- Prefer `govuk-components`, `govuk_design_system_formbuilder`, and existing shared partials before custom GOV.UK markup.
+- Treat accessibility, validation copy, page titles, hints, labels, focus order, and service navigation state as behaviour.
+- Do not add explicit `require` statements for application constants in normal Rails app code when Zeitwerk can autoload them.
+- Read the relevant docs before editing commodity display, measures, duties, quotas, rules of origin, Green Lanes, subscriptions, auth/session handling, or backend API calls.
+- Run project commands directly by default. If you use Nix/direnv locally, `direnv exec <repo-path> <command>` is also fine.
+- Use `rg` for code search.
+
+Useful docs:
+
+- `docs/development-and-delivery.md`
+- `docs/style-guide.md`
+- `docs/architecture/system-overview.md`
+- `docs/architecture/request-routing.md`
+- `docs/architecture/backend-api-client.md`
+- `docs/architecture/frontend-rendering.md`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -24,4 +24,5 @@ Useful docs:
 - `docs/architecture/system-overview.md`
 - `docs/architecture/request-routing.md`
 - `docs/architecture/backend-api-client.md`
+- `docs/architecture/duty-calculator.md`
 - `docs/architecture/frontend-rendering.md`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,27 @@
+# Gemini Instructions
+
+Use `docs/README.md` as the first repository map and `docs/architecture/README.md` for runtime boundaries.
+
+This is a Rails 8 frontend for the Trade Tariff service. It renders public GOV.UK journeys and consumes Trade Tariff Backend APIs through Faraday-backed API entities. UK/XI service behaviour is selected through URL/service routing and `TradeTariffFrontend::ServiceChooser`.
+
+Before changing code:
+
+- Identify the route, controller, model/API entity, presenter/helper, view partial, asset, and tests involved.
+- Verify generated explanations against source files.
+- Prefer request specs for route/controller behaviour; do not expand legacy controller specs where a request spec is the better fit.
+- Use feature specs for full journeys, view specs for complex templates, helper specs for isolated helper logic, and JavaScript specs for Stimulus/browser behaviour.
+- Prefer `govuk-components`, `govuk_design_system_formbuilder`, and existing shared partials before custom GOV.UK markup.
+- Treat accessibility, validation copy, page titles, hints, labels, focus order, and service navigation state as behaviour.
+- Do not add explicit `require` statements for application constants in normal Rails app code when Zeitwerk can autoload them.
+- Read the relevant docs before editing commodity display, measures, duties, quotas, rules of origin, Green Lanes, subscriptions, auth/session handling, or backend API calls.
+- Run project commands directly by default. If you use Nix/direnv locally, `direnv exec <repo-path> <command>` is also fine.
+- Use `rg` for code search.
+
+Useful docs:
+
+- `docs/development-and-delivery.md`
+- `docs/style-guide.md`
+- `docs/architecture/system-overview.md`
+- `docs/architecture/request-routing.md`
+- `docs/architecture/backend-api-client.md`
+- `docs/architecture/frontend-rendering.md`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ bundle exec guard
 
 This will run the appropriate test suite for the file you are working on.
 
+## Understanding the codebase
+
+Start with [docs/README.md](docs/README.md) for the documentation map, [docs/architecture/README.md](docs/architecture/README.md) for the main runtime boundaries, and [docs/style-guide.md](docs/style-guide.md) for Ruby, Rails, GOV.UK Frontend, testing, and PR conventions.
+
 ## Troubleshooting
 
 Sometimes, when trying to load the front page, you get the error:

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This directory is the starting point for understanding the Trade Tariff Frontend
 ## Start Here
 
 - [Architecture](architecture/README.md) explains the main runtime boundaries and where to read the code.
+- [Duty calculator architecture](architecture/duty-calculator.md) maps the import duty calculation journey, option construction, and high-risk decision points.
 - [Development and delivery](development-and-delivery.md) summarises local setup, checks, PR, and deployment conventions.
 - [Style guide](style-guide.md) covers Ruby/Rails, tests, GOV.UK Frontend components, and PR review expectations.
 - [Code Wiki guide](code-wiki.md) explains how to use generated repository documentation safely.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# Trade Tariff Frontend Documentation
+
+This directory is the starting point for understanding the Trade Tariff Frontend codebase. It is written for humans and AI coding tools that need a stable map before reading individual files.
+
+## Start Here
+
+- [Architecture](architecture/README.md) explains the main runtime boundaries and where to read the code.
+- [Development and delivery](development-and-delivery.md) summarises local setup, checks, PR, and deployment conventions.
+- [Style guide](style-guide.md) covers Ruby/Rails, tests, GOV.UK Frontend components, and PR review expectations.
+- [Code Wiki guide](code-wiki.md) explains how to use generated repository documentation safely.
+- Existing domain notes: [Rules of Origin](../doc/rules_of_origin.md).
+
+## Operational Entry Points
+
+- `README.md` covers local setup, backend configuration, assets, and test commands.
+- `.env.development` contains local development defaults.
+- `.github/workflows/ci.yml` shows the current lint, Brakeman, asset precompile, and RSpec checks.
+- `.github/pull_request_template.md` is the current PR template and risk guide.
+- `package.json` lists JavaScript, Sass, accessibility, and browser-test scripts.
+
+## AI Tooling Notes
+
+AI tools should use this index before making code changes. Prefer source-backed claims and cite the relevant file paths in answers, reviews, and plans. When generated documentation disagrees with source code, treat source code, tests, and local docs as authoritative.
+
+Shared tool entrypoints:
+
+- `AGENTS.md` for Codex and other agentic coding tools.
+- `CLAUDE.md` for Claude Code.
+- `GEMINI.md` for Gemini CLI-style tools.
+- `.github/copilot-instructions.md` for GitHub Copilot.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -7,6 +7,7 @@ These pages give a code-level map of the Trade Tariff Frontend. They describe st
 - [System overview](system-overview.md)
 - [Request routing](request-routing.md)
 - [Backend API client](backend-api-client.md)
+- [Duty calculator](duty-calculator.md)
 - [Frontend rendering](frontend-rendering.md)
 
 ## Source Anchors
@@ -19,6 +20,8 @@ Start from these files when verifying architecture claims:
 - `config/routes/duty_calculator.rb`
 - `config/initializers/backend.rb`
 - `app/services/client_builder.rb`
+- `app/models/duty_calculator/`
+- `app/services/duty_calculator/`
 - `lib/api_entity.rb`
 - `lib/trade_tariff_frontend.rb`
 - `lib/trade_tariff_frontend/service_chooser.rb`

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,32 @@
+# Architecture
+
+These pages give a code-level map of the Trade Tariff Frontend. They describe stable boundaries rather than every controller, model, or template.
+
+## Pages
+
+- [System overview](system-overview.md)
+- [Request routing](request-routing.md)
+- [Backend API client](backend-api-client.md)
+- [Frontend rendering](frontend-rendering.md)
+
+## Source Anchors
+
+Start from these files when verifying architecture claims:
+
+- `Gemfile`
+- `package.json`
+- `config/routes.rb`
+- `config/routes/duty_calculator.rb`
+- `config/initializers/backend.rb`
+- `app/services/client_builder.rb`
+- `lib/api_entity.rb`
+- `lib/trade_tariff_frontend.rb`
+- `lib/trade_tariff_frontend/service_chooser.rb`
+- `lib/routing_filter/service_path_prefix_handler.rb`
+- `app/views/layouts/application.html.erb`
+- `app/assets/stylesheets/application.sass.scss`
+- `app/javascript/application.js`
+
+## Internal Context
+
+The frontend depends on Trade Tariff Backend for tariff data and on wider OTT platform conventions for delivery. Treat this repository, CI configuration, and the backend API contract as authoritative where external notes disagree.

--- a/docs/architecture/backend-api-client.md
+++ b/docs/architecture/backend-api-client.md
@@ -1,0 +1,42 @@
+# Backend API Client
+
+The frontend consumes Trade Tariff Backend APIs rather than storing most tariff data locally.
+
+## Client Setup
+
+`config/initializers/backend.rb` creates UK and XI clients with `ClientBuilder`. The builder configures Faraday with:
+
+- JSON API accept header
+- retry behaviour for safe requests
+- HTTP caching through Rails cache when available
+- persistent Net::HTTP adapter
+- JSON response parsing
+- user agent containing the frontend revision
+
+Key files:
+
+- `config/initializers/backend.rb`
+- `app/services/client_builder.rb`
+- `lib/trade_tariff_frontend/service_chooser.rb`
+
+## API Entities
+
+`lib/api_entity.rb` gives API-backed models ActiveModel-style behaviour and common request helpers. Models under `app/models/` use those helpers to call backend endpoints, parse JSON:API responses, expose relationships, and hydrate validation errors from backend responses.
+
+When changing API-backed behaviour:
+
+- Check the backend endpoint contract and fixtures.
+- Update or add VCR fixtures where specs make HTTP-like backend calls.
+- Keep error handling visible to users through GOV.UK error summaries, field errors, or service error pages as appropriate.
+- Treat 404, 403, 401, timeout, and invalid JSON cases as behaviour that may need tests.
+
+## Source Anchors
+
+- `lib/api_entity.rb`
+- `lib/tariff_jsonapi_parser.rb`
+- `app/models/commodity.rb`
+- `app/models/measure.rb`
+- `app/models/search.rb`
+- `app/services/client_builder.rb`
+- `spec/support/vcr.rb`
+- `spec/support/api_responses_helper.rb`

--- a/docs/architecture/duty-calculator.md
+++ b/docs/architecture/duty-calculator.md
@@ -1,0 +1,121 @@
+# Duty Calculator
+
+This page maps the duty calculator architecture. It folds in the useful structure from the local `duty_calculator_architecture.pdf` guide and verifies it against the current source.
+
+The calculator does not own tariff data. It orchestrates a legal and product decision journey around backend measures:
+
+1. identify the trade route and service context
+2. collect the facts needed for that route
+3. select the UK, XI, or comparison model
+4. build duty options from applicable measures
+5. evaluate formula components
+6. explain the result to the user
+
+## Entry Points
+
+- Routes: `config/routes/duty_calculator.rb`
+- Step controllers: `app/controllers/duty_calculator/steps/`
+- Step models: `app/models/duty_calculator/steps/`
+- Session state: `app/models/duty_calculator/user_session.rb`
+- API-backed entities: `app/models/duty_calculator/api/`
+- Option construction: `app/models/duty_calculator/duty_calculator.rb`, `app/services/duty_calculator/duty_options/`
+- ROW to NI comparison: `app/models/duty_calculator/row_to_ni_duty_calculator.rb`, `app/services/duty_calculator/duty_options/chooser.rb`
+- Formula evaluation: `app/services/duty_calculator/expression_evaluators/`
+- Result views: `app/views/duty_calculator/steps/duty/`
+- Link from commodity pages: `app/views/measures/grouped/_tariff_duty_calculator_link.html.erb`
+
+## Journey Shape
+
+The route file defines a step-by-step journey:
+
+- import date
+- import destination
+- country of origin
+- customs value
+- trader scheme
+- final use
+- certificate of origin
+- annual turnover
+- planned processing
+- measure amount
+- VAT
+- confirmation
+- interstitial
+- duty result
+- additional codes, Meursing additional codes, excise, and document codes when required
+
+Each step has a controller and usually a model under `DutyCalculator::Steps`. `DutyCalculator::Steps::Base` provides common step behaviour, session cleanup, and previous/next path expectations. `DutyCalculator::Steps::BaseController` handles session integrity, commodity context, GOV.UK form builder setup, commodity not-found redirects, and common helpers.
+
+## Session and Route Decisions
+
+`DutyCalculator::UserSession` stores journey answers in `session['answers']` and exposes route predicates such as:
+
+- `ni_to_gb_route?`
+- `gb_to_ni_route?`
+- `eu_to_ni_route?`
+- `row_to_gb_route?`
+- `row_to_ni_route?`
+- `deltas_applicable?`
+- `meursing_route?`
+
+This is the main place to check before changing question order, route branching, or whether UK/XI data is used. `deltas_applicable?` is especially sensitive because it controls whether ROW to NI logic compares UK and XI duty outcomes.
+
+## Option Construction
+
+`DutyCalculator::DutyCalculator` builds an `OptionCollection` from applicable backend measures. It starts from default options, maps each applicable measure type to a duty option class, merges additional duty rows, and includes the relevant VAT measure.
+
+Duty option classes live under `app/services/duty_calculator/duty_options/` and cover categories such as:
+
+- third-country tariff
+- tariff preference
+- quota
+- suspension
+- waiver
+- anti-dumping, countervailing, safeguard, excise, and other additional duties
+
+Preferences, quotas, and suspensions are usually alternative options. Remedies, VAT, excise, and some additional duties can be additive rows on top of the selected base duty option.
+
+## Formula Evaluation
+
+Expression evaluators under `app/services/duty_calculator/expression_evaluators/` convert measure components and trader inputs into calculated rows. They cover ad valorem percentages, measurement units, compound expressions, retail price, alcohol volume, sucrose, SPQ, and VAT.
+
+Compound expressions are high risk. `ExpressionEvaluators::Compound` evaluates component operators and conjunction operators. The current code treats tariff `MAX` and `MIN` operators according to the domain semantics used by the backend data, not plain English wording.
+
+## ROW to NI Comparison
+
+ROW to NI can compare UK and XI outcomes. `DutyCalculator::RowToNiDutyCalculator` builds comparable options from UK and XI option collections, then `DutyOptions::Chooser` selects the UK option when the absolute delta is within 3% of customs value; otherwise it selects the XI option.
+
+When changing this area, test:
+
+- UK-only option categories
+- XI-only option categories
+- duplicate third-country tariff options
+- footnote suffixes explaining why an option was selected
+- customs value inputs used by the 3% comparison
+
+## Testing
+
+Duty calculator coverage is spread across:
+
+- `spec/controllers/duty_calculator/steps/`
+- `spec/models/duty_calculator/`
+- `spec/services/duty_calculator/`
+- `spec/helpers/duty_calculator/`
+- `spec/decorators/duty_calculator/`
+- `spec/fixtures/duty_calculator/`
+- `spec/support/shared_examples/a_duty_calculator.rb`
+
+For PRs, include the smallest relevant unit specs plus a journey-level or controller spec when route branching, step order, session state, or rendered explanations change.
+
+## Review Risk
+
+Treat duty calculator changes as high risk when they affect:
+
+- route branching or session predicates
+- measure filtering or applicable option selection
+- additional codes, document codes, certificates, quotas, Meursing, VAT, excise, or remedies
+- formula component evaluation
+- UK/XI comparison and 3% delta logic
+- copy explaining why a trader has no duty, a waiver, or a selected option
+
+Manual PR evidence should include the route exercised, commodity code, origin, destination, import date, key answers, and the visible result or explanation.

--- a/docs/architecture/frontend-rendering.md
+++ b/docs/architecture/frontend-rendering.md
@@ -1,0 +1,37 @@
+# Frontend Rendering
+
+The frontend renders Rails ERB templates with GOV.UK Frontend, `govuk-components`, and `govuk_design_system_formbuilder`.
+
+## Layout and Shell
+
+`app/views/layouts/application.html.erb` defines the main document shell:
+
+- GOV.UK template class and skip link
+- application and print stylesheets
+- importmap JavaScript tags
+- cookie banner, header, service navigation, feedback banners, search form, footer, and GTM hooks
+
+`app/views/layouts/_base.html.erb` supplies default page metadata, canonical URL, service navigation, and footer content.
+
+## Views and Partials
+
+Most visible behaviour lives in ERB partials under `app/views/`. Prefer the existing shared partials and helper methods before adding new template structures.
+
+Common entry points:
+
+- `app/views/shared/`
+- `app/views/measures/`
+- `app/views/commodities/`
+- `app/views/headings/`
+- `app/views/search/`
+- `app/views/green_lanes/`
+- `app/views/rules_of_origin/`
+- `app/views/myott/`
+
+## Assets
+
+`app/assets/stylesheets/application.sass.scss` imports GOV.UK Frontend, selected GOV.UK Publishing Components styles, and service-specific Sass modules under `app/assets/stylesheets/src/`.
+
+Use GOV.UK Sass mixins, spacing, typography, colours, and component classes before introducing custom CSS. Keep custom Sass scoped to a named component or journey.
+
+JavaScript is loaded from `app/javascript/application.js` through importmap. Use existing Stimulus/controller patterns for interactive behaviour and keep non-essential behaviour progressive-enhancement friendly.

--- a/docs/architecture/request-routing.md
+++ b/docs/architecture/request-routing.md
@@ -1,0 +1,35 @@
+# Request Routing
+
+The main route map is `config/routes.rb`. Duty calculator routes are split into `config/routes/duty_calculator.rb` and loaded with `draw('duty_calculator')`.
+
+## Service Context
+
+The app supports UK and XI service contexts. Service context affects backend API host selection, currency, page styling, and service-specific routes.
+
+Key files:
+
+- `lib/routing_filter/service_path_prefix_handler.rb`
+- `lib/trade_tariff_frontend/service_chooser.rb`
+- `config/routes.rb`
+- `app/helpers/service_helper.rb`
+
+`TradeTariffFrontend::ServiceChooser` reads `API_SERVICE_BACKEND_URL_OPTIONS`, tracks the current service in thread-local state, and returns the appropriate Faraday client.
+
+## Route Groups
+
+Important route groups in `config/routes.rb`:
+
+- static help, privacy, terms, cookies, tools, news, and glossary pages
+- search, suggestions, A-Z, browse, sections, chapters, headings, subheadings, and commodities
+- measure type preference code pages
+- additional code, certificate, footnote, quota, chemical, and simplified procedural value searches
+- MyOTT subscription journeys
+- enquiry form journey
+- rules of origin journey
+- Green Lanes simplified processes eligibility journey
+- exchange rates, available only in UK service mode
+- health checks, CSP reports, errors, redirects, and catch-all 404 handling
+
+## Testing Routing Changes
+
+For route/controller behaviour, prefer request specs under `spec/requests/`. Use concrete paths or route helpers. Add feature specs when the change affects a complete user journey or visible navigation state.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -29,6 +29,7 @@ Treat these areas as high risk and verify behaviour with source-backed tests and
 
 - commodity, heading, subheading, and section rendering
 - measure, duty, quota, certificate, and preference display
+- duty calculator route decisions, formula evaluation, and UK/XI comparison logic
 - rules of origin and Green Lanes journeys
 - search and autocomplete behaviour
 - backend API request/response handling

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -1,0 +1,36 @@
+# System Overview
+
+Trade Tariff Frontend is the public web application for the UK Trade Tariff service. It renders GOV.UK-styled user journeys for search, browse, commodity detail pages, measures, quota lookups, rules of origin, Green Lanes, exchange rates, news, feedback, subscriptions, and related tools.
+
+## Runtime Shape
+
+- Rails 8 application running on Puma.
+- Backend data comes from Trade Tariff Backend through Faraday clients.
+- API-backed models include `ApiEntity` rather than Active Record persistence.
+- UK and XI service mode is selected through route filtering and `TradeTariffFrontend::ServiceChooser`.
+- Redis is used in production.
+- Assets are built with Propshaft, cssbundling-rails, importmap, Stimulus, Turbo, Sass, and GOV.UK Frontend.
+
+## Main Code Areas
+
+- `app/controllers/` maps web requests to API-backed models, forms, presenters, and views.
+- `app/models/` contains API-backed domain objects and local form/session models.
+- `app/forms/` contains form objects for search and multi-step journeys.
+- `app/presenters/` and `app/decorators/` prepare display-specific behaviour for templates.
+- `app/helpers/` contains view helpers, including GOV.UK-specific helpers.
+- `app/views/` contains ERB templates and shared partials.
+- `app/assets/stylesheets/` contains GOV.UK imports plus service-specific Sass.
+- `app/javascript/` contains JavaScript entrypoints and controllers.
+- `spec/` contains RSpec, Capybara, VCR/WebMock, view/helper specs, and JavaScript tests.
+
+## High-Risk Areas
+
+Treat these areas as high risk and verify behaviour with source-backed tests and manual evidence:
+
+- commodity, heading, subheading, and section rendering
+- measure, duty, quota, certificate, and preference display
+- rules of origin and Green Lanes journeys
+- search and autocomplete behaviour
+- backend API request/response handling
+- subscriptions, cookies, auth/session handling, and feedback
+- accessibility and GOV.UK Design System conformance

--- a/docs/code-wiki.md
+++ b/docs/code-wiki.md
@@ -1,0 +1,52 @@
+# Google Code Wiki
+
+[Google Code Wiki](https://codewiki.google/) is a hosted public-preview tool that generates structured documentation for public repositories. It can help map unfamiliar code, but it is not authoritative.
+
+Use it as an exploration aid for this repository:
+
+- Open `https://codewiki.google/`.
+- Search for or import `trade-tariff/trade-tariff-frontend`.
+- Use generated pages and chat answers to find candidate files and concepts.
+- Verify important claims against this repository before making changes.
+
+## What To Trust
+
+Good Code Wiki use cases:
+
+- Getting a first-pass map of unfamiliar code.
+- Finding likely entry points for a feature area.
+- Asking high-level questions before reading source files.
+- Comparing generated diagrams with local architecture docs.
+
+Do not treat generated output as authoritative for:
+
+- legally significant tariff content
+- measure, duty, quota, certificate, rules of origin, or Green Lanes behaviour
+- backend API contracts and error semantics
+- security, auth, cookies, and secret-handling behaviour
+- accessibility compliance or GOV.UK Design System conformance
+- production operations or rollback instructions
+
+For those areas, verify against source code, tests, local docs, backend API docs, and GitHub Actions.
+
+## Local Verification Anchors
+
+Start with:
+
+- [Documentation index](README.md)
+- [Architecture index](architecture/README.md)
+- [Style guide](style-guide.md)
+- `config/routes.rb`
+- `app/controllers/`
+- `app/models/`
+- `app/forms/`
+- `app/presenters/`
+- `app/helpers/`
+- `app/views/`
+- `app/assets/stylesheets/`
+- `app/javascript/`
+- `spec/`
+
+## Keeping Local Docs Useful
+
+When changing a subsystem, update the smallest relevant doc page. Prefer linking to existing docs over copying long explanations. If Code Wiki gives a useful generated explanation, convert only the verified, stable parts into local docs.

--- a/docs/development-and-delivery.md
+++ b/docs/development-and-delivery.md
@@ -1,0 +1,57 @@
+# Development and Delivery
+
+This page summarises team and platform conventions for this repository. Verify current implementation in source, tests, and workflow files before changing behaviour.
+
+## Local Development
+
+The repo README is the source of truth for setup. In normal local development you need:
+
+- Ruby and Bundler matching `.ruby-version`.
+- Node and Yarn.
+- Chrome or Chrome for Testing for browser-based specs.
+- A Trade Tariff Backend API endpoint, usually configured through `API_SERVICE_BACKEND_URL_OPTIONS`.
+- Pre-commit hooks installed and enabled.
+
+Useful commands:
+
+```sh
+bin/setup
+bin/rails start
+bin/rails assets:precompile
+bundle exec rspec
+yarn jest
+yarn axxy
+```
+
+`bin/rails assets:precompile` is required before many specs because view and feature specs depend on compiled assets.
+
+## Pull Requests
+
+Use `.github/pull_request_template.md`. Include:
+
+- what changed and why
+- the Jira ticket, or `BAU` when there is no story
+- risk level and reason
+- test commands and results
+- manual evidence for visible journeys
+- accessibility impact for UI changes
+- backend API, environment variable, or deployment implications
+
+Follow the existing team convention of branch names that describe the work or ticket, for example `AI-123-short-description` or `BAU-short-description`.
+
+## Checks
+
+Current CI checks are defined in `.github/workflows/ci.yml`:
+
+- Brakeman
+- pre-commit hooks
+- asset precompile
+- RSpec
+
+Other workflows cover CodeQL, deployment, preview environments, labels, and service stop/start operations. Check `.github/workflows/` before changing CI/CD or deployment behaviour.
+
+## Deployments
+
+Deployment is handled by GitHub Actions. Development, staging, production, and preview environment workflows live in `.github/workflows/`.
+
+Frontend changes can affect GOV.UK compliance, accessibility, SEO metadata, analytics, service navigation, and user-visible tariff interpretation. Call out those effects explicitly in PRs.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -88,6 +88,7 @@ Needs team discussion:
 
 - search result behaviour, autocomplete, or navigation changes
 - changes to commodity, measure, duty, quota, or certificate display
+- duty calculator route branching, option construction, or rendered explanations
 - backend API call changes
 - broad Sass/layout changes
 - error pages, header, footer, cookies, auth/session, analytics, or accessibility changes

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,101 @@
+# Ruby, Rails, and GOV.UK Frontend Style Guide
+
+This guide is for contributors and reviewers opening PRs in Trade Tariff Frontend. It complements the repo README, PR template, GOV.UK Design System guidance, and existing code patterns.
+
+## PR Review Baseline
+
+Every PR should make it easy to answer:
+
+- What user need or maintenance need does this serve?
+- Which route, controller, model/API entity, presenter/helper, view, asset, and spec files changed?
+- Does it change legally significant tariff information or how traders interpret it?
+- Does it change accessibility, copy, validation, analytics, service navigation, or responsive layout?
+- What test and manual evidence proves the change?
+
+Use `BAU` as the ticket when there is no Jira story.
+
+## Ruby and Rails
+
+- Follow the existing Rails conventions before introducing new patterns.
+- Prefer small, named methods when they clarify domain decisions in measures, quotas, rules of origin, Green Lanes, or search.
+- Keep controllers thin: load data, handle redirects/errors, and choose views. Move display decisions to presenters/helpers and form validation to form objects.
+- Do not add explicit `require` statements for application constants in normal Rails app code when Zeitwerk can autoload them. Initializers and boot-time `lib/` files can require dependencies where needed.
+- Prefer keyword arguments for option-heavy methods.
+- Prefer `Data.define` for simple immutable value objects. Do not introduce `Struct`.
+- Avoid `OpenStruct` in new code.
+- Keep API-backed model changes aligned with `ApiEntity` and backend JSON:API contracts.
+- Use route helpers rather than hard-coded internal URLs in Ruby code and templates.
+- Keep environment variable additions documented in the PR and make defaults explicit where safe.
+
+## Views and GOV.UK Components
+
+- Prefer `govuk-components` helpers, `govuk_design_system_formbuilder`, and existing shared partials before custom markup.
+- Use GOV.UK component classes and macros as documented; do not approximate component HTML by memory.
+- Treat labels, legends, hints, error messages, page titles, breadcrumbs, back links, and focus order as behaviour.
+- Put one primary `<h1>` on a page and keep page title text aligned with the visible heading.
+- Use fieldsets and legends for grouped controls.
+- Render validation errors through GOV.UK error summaries and field-level errors.
+- Keep links descriptive outside their surrounding sentence.
+- Avoid custom ARIA unless native HTML or GOV.UK component semantics cannot express the interaction.
+- Keep progressive enhancement intact: critical content and form submissions must work without JavaScript where practical.
+
+## Sass and Frontend Assets
+
+- Use GOV.UK Sass variables, mixins, spacing, typography, and colour helpers before custom values.
+- Keep Sass scoped to a component, journey, or existing module under `app/assets/stylesheets/src/`.
+- Do not use colour alone to convey meaning.
+- Check small screens, print styles where relevant, and long tariff descriptions or commodity codes.
+- Avoid broad overrides of GOV.UK classes unless the change is intentional, tested, and called out in the PR.
+
+## JavaScript
+
+- Keep JavaScript as progressive enhancement.
+- Use existing Stimulus/controller patterns and importmap entrypoints.
+- Add JavaScript tests under `spec/javascript/` for behaviour that can regress without a full browser spec.
+- Use accessibility tests or feature specs when JavaScript changes focus management, disclosure, autocomplete, modals, or keyboard behaviour.
+
+## Testing
+
+- Prefer request specs for route/controller behaviour.
+- Use feature specs for end-to-end user journeys and visible page behaviour.
+- Use view specs for complex templates or conditional rendering.
+- Use helper specs for helper-only behaviour.
+- Use model/form specs for validation, parsing, and API-backed object behaviour.
+- Use VCR/WebMock fixtures for backend API interactions and keep fixtures focused on the scenario.
+- Compile assets before running specs that depend on views or browser rendering.
+
+Useful commands:
+
+```sh
+bin/rails assets:precompile
+bundle exec rspec
+yarn jest
+yarn axxy
+bundle exec brakeman
+pre-commit run --all-files --show-diff-on-failure
+```
+
+## Risk Heuristics
+
+Generally low risk:
+
+- copy changes that do not alter legal meaning
+- isolated GOV.UK component updates with equivalent behaviour
+- tests and documentation
+- small refactors with unchanged public behaviour
+
+Needs team discussion:
+
+- search result behaviour, autocomplete, or navigation changes
+- changes to commodity, measure, duty, quota, or certificate display
+- backend API call changes
+- broad Sass/layout changes
+- error pages, header, footer, cookies, auth/session, analytics, or accessibility changes
+
+Requires explicit senior approval:
+
+- legally significant tariff interpretation changes
+- declarable goods journey changes
+- auth/session or credential handling changes
+- production infrastructure or deployment behaviour changes that are hard to roll back
+- changes that put WCAG 2.2 AA or GOV.UK Design System conformance at risk


### PR DESCRIPTION
## What:

Adds progressive-disclosure documentation for agents and developers working in the frontend repo:

- root agent entrypoints for Codex/agent tools, Claude, Gemini, and Copilot
- `docs/README.md` as the documentation map
- architecture notes for routing, backend API clients, frontend rendering, and duty calculator structure
- duty calculator guidance covering the step journey, session predicates, option construction, formula evaluation, ROW to NI comparison, and review risk
- development/delivery notes for setup, checks, PRs, and deployments
- a Ruby/Rails and GOV.UK Frontend style guide for PR authors and reviewers
- a README pointer to the new docs

## Why:

The backend already has agent-oriented docs that help tools and developers build an accurate mental model before changing code. This ports the useful pattern to the frontend and adapts it to Rails views, API-backed models, GOV.UK Frontend components, accessibility, frontend assets, duty calculator behaviour, and PR risk review.

The duty calculator page incorporates the useful structure from the local `duty_calculator_architecture.pdf` guide without committing the binary PDF. The resulting docs are source-backed against the current frontend duty calculator files.

## Ticket:

BAU

## Risk:

**Risk level:** Green

**Reason for rating:**

Documentation-only change. No production code, routes, assets, dependencies, or runtime configuration changed.