### PR TITLE
OTTIMP-634 Handle measure end date removal

### DIFF
--- a/app/helpers/myott/grouped_measure_commodity_changes_helper.rb
+++ b/app/helpers/myott/grouped_measure_commodity_changes_helper.rb
@@ -1,0 +1,20 @@
+module Myott
+  module GroupedMeasureCommodityChangesHelper
+    def commodity_change_link(goods_nomenclature_item_id, change)
+      govuk_link_to(
+        commodity_change_link_text(change),
+        commodity_path(goods_nomenclature_item_id, **change.commodity_link_params),
+        target: '_blank',
+        rel: 'noopener',
+        visually_hidden_suffix: Govuk::Components.config.default_link_new_tab_text,
+      )
+    end
+
+    def commodity_change_link_text(change)
+      date_of_effect_visible = change.date_of_effect_visible
+      return 'View commodity' if date_of_effect_visible.blank?
+
+      "View commodity on #{date_of_effect_visible}"
+    end
+  end
+end

--- a/app/presenters/myott/impacted_measure_change_presenter.rb
+++ b/app/presenters/myott/impacted_measure_change_presenter.rb
@@ -19,13 +19,17 @@ module Myott
 
     def date_of_effect
       Date.parse(self['date_of_effect']).to_fs
+    rescue Date::Error # date can be text
+      self['date_of_effect']
     end
 
     def date_of_effect_visible
-      parsed_date_of_effect_visible.to_fs
+      parsed_date_of_effect_visible&.to_fs
     end
 
     def commodity_link_params
+      return {} if parsed_date_of_effect_visible.nil?
+
       {
         day: parsed_date_of_effect_visible.day,
         month: parsed_date_of_effect_visible.month,
@@ -41,7 +45,10 @@ module Myott
     private
 
     def parsed_date_of_effect_visible
-      @parsed_date_of_effect_visible ||= Date.parse(self['date_of_effect_visible'])
+      date = self['date_of_effect_visible']
+      return if date.blank?
+
+      @parsed_date_of_effect_visible ||= Date.parse(date)
     end
   end
 end

--- a/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
+++ b/app/views/myott/grouped_measure_commodity_changes/_impacted_measures.html.erb
@@ -27,9 +27,7 @@
         <% end %>
         <td class="govuk-table__cell"><%= change.date_of_effect %></td>
         <td class="govuk-table__cell">
-          <%= govuk_link_to(commodity_path(@grouped_measure_commodity_changes.goods_nomenclature_item_id, **change.commodity_link_params), target: '_blank', rel: 'noopener') do %>
-            View commodity on <%= change.date_of_effect_visible %> <%= govuk_visually_hidden("(opens in new tab)") %>
-          <% end %>
+          <%= commodity_change_link(@grouped_measure_commodity_changes.goods_nomenclature_item_id, change) %>
         </td>
       </tr>
     <% end %>

--- a/spec/views/myott/grouped_measure_commodity_changes/show.html.erb_spec.rb
+++ b/spec/views/myott/grouped_measure_commodity_changes/show.html.erb_spec.rb
@@ -31,8 +31,12 @@ RSpec.describe 'myott/grouped_measure_commodity_changes/show.html.erb', type: :v
   before do
     assign(:grouped_measure_commodity_changes, grouped_measure_commodity_change)
     allow(view).to receive(:as_of).and_return(Date.new(2025, 11, 21))
-    allow(view).to receive(:commodity_path) do |id, params|
-      "/commodities/#{id}?day=#{params[:day]}&month=#{params[:month]}&year=#{params[:year]}"
+    allow(view).to receive(:commodity_path) do |id, params = {}|
+      if params.present?
+        "/commodities/#{id}?day=#{params[:day]}&month=#{params[:month]}&year=#{params[:year]}"
+      else
+        "/commodities/#{id}"
+      end
     end
     render
   end
@@ -101,6 +105,20 @@ RSpec.describe 'myott/grouped_measure_commodity_changes/show.html.erb', type: :v
 
     it 'shows N/A when the additional code is missing' do
       expect(rendered).to include('N/A')
+    end
+  end
+
+  context 'when date_of_effect_visible is nil' do
+    let(:impacted_measures) do
+      {
+        'Preferential tariff quota' => [
+          { 'date_of_effect' => '2025-12-01', 'date_of_effect_visible' => nil, 'change_type' => 'Measure will begin' },
+        ],
+      }
+    end
+
+    it 'renders the link without the word on' do
+      expect(rendered).to have_link('View commodity', href: '/commodities/1234567890')
     end
   end
 end


### PR DESCRIPTION
## What:
Handles API change for MyOTT that allows date_of_effect field to be text where a measure end date is being removed.

## Why:
What we currently show is misleading. Content from the API is being updated to be clearer about the change.

| Before | After 
| --- | --- | 
| <img width="1043" height="232" alt="Screenshot 2026-06-02 at 14 17 44" src="https://github.com/user-attachments/assets/383665db-02b1-452b-b53f-ddaf4fe9dbe2" /> | <img width="1012" height="238" alt="Screenshot 2026-06-02 at 14 16 47" src="https://github.com/user-attachments/assets/dbb872aa-1148-4089-91d6-c4866357ddee" /> |

## Ticket:
https://transformuk.atlassian.net/browse/OTTIMP-634

## Risk:

**Risk level:** 🟢

**Reason for rating:**
This is a defensive change to handle an API change
