### PR TITLE
BAU: Update ECS task capacity

### DIFF
--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -2,7 +2,7 @@ region        = "eu-west-2"
 environment   = "production"
 cpu           = 2048
 memory        = 4096
-service_count = 4
+service_count = 3
 min_capacity  = 3
 max_capacity  = 16
 

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -2,8 +2,8 @@ region        = "eu-west-2"
 environment   = "staging"
 cpu           = 1024
 memory        = 2048
-service_count = 4
-min_capacity  = 3
+service_count = 1
+min_capacity  = 1
 max_capacity  = 8
 
 enable_alarms = false


### PR DESCRIPTION
## What:
- Reduced `min_capacity` from 3 to 1 in staging
- Reduced `service_count` from 4 to 3 in prod

## Why:
- Terraform drift was identified: staging was already running with a minimum of 1 task in AWS.
- Observed metrics show:
Max CPU usage ~35%
Max memory usage ~56%
- These values indicate that a single task is sufficient without resource pressure, meaning current settings are over-provisioned.
- Autoscaling is enabled, so `service_count` effectively acts as a baseline and does not limit scaling. Aligning it with `min_capacity` simplifies configuration and reduces unnecessary resource allocation.

## Ticket:
BAU

## Risk:

**Risk level:** 🟢 
**Reason for rating:**

- Change is based on observed production metrics and existing runtime behaviour.
- Staging is already operating successfully with the proposed configuration.
- Autoscaling remains in place to handle any unexpected load increase.