### PR TITLE
OTTIMP-517 Reinstate PR line-count check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,25 @@ env:
   PYTHON_VERSION: 3
 
 jobs:
+  check-pr-lines:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: trade-tariff/trade-tariff-tools/.github/actions/check-pr-lines@main
+        with:
+          threshold: 600
+          exclude-paths: |
+            db/
+            data/
+            docs/
+            terraform/versions.tf
+            *.md
+            *.lock
+            .github
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What:

- Reinstate the `check-pr-lines` CI job that was temporarily removed for the enquiry form PR.
- Restore the 600-line threshold and the previous excluded paths.

## Why:

The enquiry form PR has merged, so the repository should have the PR size guard back in place for future changes.

## Ticket:

OTTIMP-517 follow-up

## Risk:

**Risk level:** 🟠

**Reason for rating:**
This changes CI gating only and has no runtime application impact. It is marked amber because it restores a workflow check that can fail future oversized PRs.

## Verification:

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'workflow yaml parses'"`
- `pre-commit run check-yaml --files .github/workflows/ci.yml`
- `pre-commit run actionlint-docker --files .github/workflows/ci.yml`