### PR TITLE
AI-863: Fix guided search help link

### DIFF
--- a/app/views/search/_interactive_results_sidebar.html.erb
+++ b/app/views/search/_interactive_results_sidebar.html.erb
@@ -10,7 +10,7 @@
           <%= govuk_link_to "What are commodity codes?", "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods", class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
         <li class="gem-c-related-navigation__link">
-          <%= govuk_link_to "Guidance on difficult to classify goods", "https://www.gov.uk/guidance/finding-commodity-codes-for-imports-or-exports", class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
+          <%= govuk_link_to "Guidance on difficult to classify goods", "https://www.trade-tariff.service.gov.uk/help", class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>
         </li>
         <li class="gem-c-related-navigation__link">
           <%= govuk_link_to "How to import goods", "https://www.gov.uk/import-goods-into-uk", class: 'gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--other' %>

--- a/spec/views/search/_interactive_no_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_no_results_content.html.erb_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'search/_interactive_no_results_content', type: :view do
   describe 'sidebar' do
     it { is_expected.to have_text('Help and guidance') }
     it { is_expected.to have_link('What are commodity codes?') }
-    it { is_expected.to have_link('Guidance on difficult to classify goods') }
+    it { is_expected.to have_link('Guidance on difficult to classify goods', href: 'https://www.trade-tariff.service.gov.uk/help') }
     it { is_expected.to have_link('Ask for help on classifying your goods') }
   end
 

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
   describe 'sidebar' do
     it { is_expected.to have_text('Help and guidance') }
     it { is_expected.to have_link('What are commodity codes?') }
-    it { is_expected.to have_link('Guidance on difficult to classify goods') }
+    it { is_expected.to have_link('Guidance on difficult to classify goods', href: 'https://www.trade-tariff.service.gov.uk/help') }
     it { is_expected.to have_link('Ask for help on classifying your goods') }
 
     context 'when webchat is enabled' do


### PR DESCRIPTION
## What changed

Updated the guided search results sidebar so the "Guidance on difficult to classify goods" link points to the Trade Tariff help page instead of the GOV.UK guidance page.

## Why

AI-863 reports the intercept/guided search help link sending users to the wrong destination. The page should send users to `https://www.trade-tariff.service.gov.uk/help`.

## Risk

Low. This is a single href change with view coverage for the destination.