### PR TITLE
BAU: Opt database apps into full deploy migrations

### DIFF
--- a/.github/workflows/deploy-to-development-full.yml
+++ b/.github/workflows/deploy-to-development-full.yml
@@ -35,11 +35,13 @@ jobs:
           {
             "name": "tariff-backend",
             "repo": "trade-tariff/trade-tariff-backend",
+            "migrate": true,
             "service-names": ["backend-uk", "backend-xi", "worker-uk", "worker-xi"]
           },
           {
             "name": "tariff-admin",
             "repo": "trade-tariff/trade-tariff-admin",
+            "migrate": true,
             "service-names": ["admin"]
           },
           {
@@ -49,6 +51,7 @@ jobs:
           }
         ]
       test-flavour: tariff
+      migrate: true
     secrets:
       ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## What

Opt database-backed apps into full deploy migrations under the new `deploy-multi-ecs` convention.

## Why

The reusable workflow now treats migrations as an explicit per-app opt-in, so callers need to mark only apps that can run the Rails migration action. This workflow also enables the global migration flag so backend/admin opt-ins can take effect.