### PR TITLE
OTTIMP-639 Clear stale commodity code

### DIFF
--- a/app/controllers/product_experience/enquiry_form_controller.rb
+++ b/app/controllers/product_experience/enquiry_form_controller.rb
@@ -194,16 +194,7 @@ module ProductExperience
 
       route_attributes =
         if data['category'] == 'classification'
-          {
-            goods_product: data['goods_product'],
-            goods_made_of: data['goods_made_of'],
-            goods_used_for: data['goods_used_for'],
-            goods_function: data['goods_function'],
-            goods_processed: data['goods_processed'],
-            goods_packaged: data['goods_packaged'],
-            has_commodity_code: data['has_commodity_code'],
-            commodity_code: data['commodity_code'],
-          }
+          classification_submission_attributes(data)
         else
           {
             enquiry_description: data['query'],
@@ -211,6 +202,20 @@ module ProductExperience
         end
 
       common_attributes.merge(route_attributes).compact
+    end
+
+    def classification_submission_attributes(data)
+      attributes = {
+        goods_product: data['goods_product'],
+        goods_made_of: data['goods_made_of'],
+        goods_used_for: data['goods_used_for'],
+        goods_function: data['goods_function'],
+        goods_processed: data['goods_processed'],
+        goods_packaged: data['goods_packaged'],
+        has_commodity_code: data['has_commodity_code'],
+      }
+      attributes[:commodity_code] = data['commodity_code'] if data['has_commodity_code'] == 'yes'
+      attributes
     end
   end
 end

--- a/app/models/product_experience/enquiry_form_journey.rb
+++ b/app/models/product_experience/enquiry_form_journey.rb
@@ -7,7 +7,15 @@ module ProductExperience
     class << self
       def normalized_data(field, previous_data, answers)
         data = previous_data.to_h.merge(answers.to_h).stringify_keys
-        field == 'category' ? data_for_category(data) : data
+
+        case field
+        when 'category'
+          data_for_category(data)
+        when 'commodity_code'
+          data_for_commodity_code(data)
+        else
+          data
+        end
       end
 
       def next_field(current, data = {})
@@ -61,6 +69,12 @@ module ProductExperience
         else
           data
         end
+      end
+
+      def data_for_commodity_code(data)
+        return data if data['has_commodity_code'] == 'yes'
+
+        data.except('commodity_code')
       end
 
       def classification?(data)

--- a/spec/controllers/product_experience/enquiry_form_controller_spec.rb
+++ b/spec/controllers/product_experience/enquiry_form_controller_spec.rb
@@ -147,6 +147,34 @@ RSpec.describe ProductExperience::EnquiryFormController, :aggregate_failures, ty
       expect(ProductExperience::EnquiryFormDraftStore.read(draft_id)).to be_nil
     end
 
+    it 'does not submit a stale commodity code when the user has answered no' do
+      start_draft(
+        category: 'classification',
+        goods_product: 'Steel bar',
+        goods_made_of: 'Steel',
+        has_commodity_code: 'no',
+        commodity_code: '9403208090',
+        email_address: 'trader@example.com',
+      )
+      allow(EnquiryForm).to receive(:create!)
+        .and_return({ 'resource_id' => 'HDJ2123F' })
+
+      post :submit_form, params: { submission_token: submission_token }
+
+      expect(EnquiryForm).to have_received(:create!).with(
+        satisfy do |attributes|
+          expect(attributes).to include(
+            email: 'trader@example.com',
+            enquiry_category: 'classification',
+            goods_product: 'Steel bar',
+            goods_made_of: 'Steel',
+            has_commodity_code: 'no',
+          )
+          expect(attributes).not_to include(:commodity_code)
+        end,
+      )
+    end
+
     it 'preserves the draft when the API does not return a reference' do
       allow(EnquiryForm).to receive(:create!)
         .and_return({ 'resource_id' => nil })

--- a/spec/features/enquiry_form_revised_flow_spec.rb
+++ b/spec/features/enquiry_form_revised_flow_spec.rb
@@ -142,6 +142,48 @@ RSpec.describe 'Revised enquiry form flow', :aggregate_failures, type: :feature 
     )
   end
 
+  it 'clears a possible commodity code when the user changes their answer to no' do
+    visit product_experience_enquiry_form_path
+
+    choose 'Classification'
+    click_button 'Continue'
+
+    fill_in 'What is the product?', with: 'Steel bar'
+    fill_in 'What is it made of?', with: 'Steel'
+    click_button 'Continue'
+
+    choose 'Yes'
+    fill_in 'Possible commodity code', with: '9403208090'
+    choose 'No'
+    click_button 'Continue'
+
+    fill_in 'Email address', with: 'trader@example.com'
+    click_button 'Continue'
+
+    expect(page).to have_css 'h1', text: 'Check your answers before submitting your form'
+    expect(page).to have_content 'Do you already have a possible commodity code?'
+    expect(page).to have_content 'No'
+    expect(page).not_to have_content 'Possible commodity code'
+    expect(page).not_to have_content '9403208090'
+
+    click_button 'Submit'
+
+    expect(page).to have_css 'h1', text: 'Your request has been submitted'
+
+    expect(EnquiryForm).to have_received(:create!).with(
+      satisfy do |attributes|
+        expect(attributes).to include(
+          email: 'trader@example.com',
+          enquiry_category: 'classification',
+          goods_product: 'Steel bar',
+          goods_made_of: 'Steel',
+          has_commodity_code: 'no',
+        )
+        expect(attributes).not_to include(:commodity_code)
+      end,
+    )
+  end
+
   it 'clears route-specific answers and collects required answers when the category route changes from check answers' do
     visit product_experience_enquiry_form_path
 

--- a/spec/models/product_experience/enquiry_form_journey_spec.rb
+++ b/spec/models/product_experience/enquiry_form_journey_spec.rb
@@ -55,6 +55,24 @@ RSpec.describe ProductExperience::EnquiryFormJourney, :aggregate_failures do
 
       expect(data).to eq('category' => 'origin')
     end
+
+    it 'removes the possible commodity code when the user changes their answer to no' do
+      data = described_class.normalized_data(
+        'commodity_code',
+        {
+          'category' => 'classification',
+          'has_commodity_code' => 'yes',
+          'commodity_code' => '9403208090',
+        },
+        { 'has_commodity_code' => 'no' },
+      )
+
+      expect(data).to include(
+        'category' => 'classification',
+        'has_commodity_code' => 'no',
+      )
+      expect(data).not_to include('commodity_code')
+    end
   end
 
   describe '.next_field' do


### PR DESCRIPTION
## What:

Clear any previously entered possible commodity code when a classification enquiry is changed from “Yes” to “No” on the possible commodity code step.

Also defensively prevents a stale `commodity_code` value from being included in the backend submission payload when `has_commodity_code` is `no`.

## Why:

Live testing found that a user could enter a possible commodity code, change the answer to “No”, and still see the old code on the check-your-answers page. That stale value could also be submitted if it remained in the draft state.

## Ticket:

[OTTIMP-639](https://transformuk.atlassian.net/browse/OTTIMP-639)

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Narrow enquiry-form state cleanup for one classification field pair. The change removes stale data earlier in the journey and adds a defensive submission guard, with model, controller, feature, full RSpec, RuboCop, and local frontend-to-backend browser verification.

## Verification:

- `bundle exec rspec spec/models/product_experience/enquiry_form_journey_spec.rb spec/controllers/product_experience/enquiry_form_controller_spec.rb`
- `bundle exec rspec spec/features/enquiry_form_revised_flow_spec.rb`
- `bundle exec rspec` — 5723 examples, 0 failures, 4 pending
- `bundle exec rubocop` — 1101 files inspected, no offenses
- Backend compatibility check on current backend `origin/main`:
  - `PGHOST=127.0.0.1 PGPORT=15432 REDIS_URL=redis://127.0.0.1:16379 ELASTICSEARCH_URL=http://127.0.0.1:9200 bundle exec rspec spec/requests/api/v2/enquiry_form/submissions_controller_spec.rb spec/services/enquiry_form/csv_generator_service_spec.rb spec/workers/enquiry_form/send_submission_email_worker_spec.rb` — 19 examples, 0 failures
- Local E2E browser verification against real local frontend and backend:
  - “Yes” path submitted reference `N5KR683D`; backend cache included `commodity_code: 9403208090`; Notify preview and CSV included the possible commodity code.
  - “No” path entered `9403208091`, switched to “No”, submitted reference `64E7XGMW`; CYA did not show stale code; backend cache did not include `commodity_code`; Notify preview omitted the possible commodity code block; CSV left the final possible-code cell empty.
