### PR TITLE
OTTIMP-633 Remove token check when unsubscribing

### DIFF
--- a/app/controllers/myott/unsubscribes_controller.rb
+++ b/app/controllers/myott/unsubscribes_controller.rb
@@ -32,7 +32,7 @@ module Myott
 
     def subscription
       if params[:id]
-        @subscription ||= Subscription.find(params[:id], user_id_token)
+        @subscription ||= Subscription.find(params[:id], nil, { allow_nil_token: true })
       end
     end
 

--- a/app/models/concerns/authenticatable_api_entity.rb
+++ b/app/models/concerns/authenticatable_api_entity.rb
@@ -4,7 +4,7 @@ module AuthenticatableApiEntity
 
   module ClassMethods
     def find(id, token, options = {})
-      return nil if token.nil? && !Rails.env.development?
+      return nil if token.nil? && !options[:allow_nil_token] && !Rails.env.development?
 
       super(id, options, headers(token))
     rescue Faraday::UnauthorizedError => e

--- a/spec/models/concerns/authenticatable_api_entity_spec.rb
+++ b/spec/models/concerns/authenticatable_api_entity_spec.rb
@@ -124,6 +124,27 @@ RSpec.describe AuthenticatableApiEntity do
 
         expect(mock_api).not_to have_received(:get)
       end
+
+      context 'with allow_nil_token option' do
+        it 'makes API call with nil token when option is enabled' do
+          test_class.find(entity_id, nil, allow_nil_token: true)
+
+          expect(mock_api).to have_received(:get)
+            .with('/test/123', { allow_nil_token: true }, { authorization: 'Bearer ' })
+        end
+
+        it 'returns entity instance when option is enabled' do
+          result = test_class.find(entity_id, nil, allow_nil_token: true)
+
+          expect(result).to be_a(test_class)
+        end
+
+        it 'still returns nil when option is disabled' do
+          test_class.find(entity_id, nil, allow_nil_token: false)
+
+          expect(mock_api).not_to have_received(:get)
+        end
+      end
     end
 
     context 'when API returns unauthorized error' do


### PR DESCRIPTION
## What:
Remove the check that a user token is available when sending a find subscription request to the backend from the unsubscribe controller.

## Why:
Unsubscribing from a MyOTT subscription should be possible without being logged in. This goes together with https://github.com/trade-tariff/trade-tariff-backend/pull/3219

## Ticket:
https://transformuk.atlassian.net/browse/OTTIMP-633

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Allows anyone to unsubscribe another user if they have the correct link, but this is the expected behaviour.
