### PR TITLE
HMRC-2262: Add frontend search request correlation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -125,6 +125,8 @@ class ApplicationController < ActionController::Base
 
   def append_info_to_payload(payload)
     super
+    payload[:request_id] = request.request_id
+    payload[:search_request_id] = @search&.request_id
     payload[:user_agent] = request.env['HTTP_USER_AGENT']
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,8 +102,11 @@ Rails.application.configure do
   config.lograge.formatter = Lograge::Formatters::Logstash.new
   config.lograge.custom_options = lambda do |event|
     {
+      request_id: event.payload[:request_id],
+      search_request_id: event.payload[:search_request_id],
+      user_agent: event.payload[:user_agent],
       params: event.payload[:params].except('controller', 'action', 'format', 'utf8'),
-    }
+    }.compact
   end
 
   config.lograge.ignore_actions = [

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -23,4 +23,19 @@ RSpec.describe ApplicationController, type: :controller do
     it { expect(response.headers['Pragma']).to eq('no-cache') }
     it { expect(response.headers['Expires']).to eq('-1') }
   end
+
+  describe '#append_info_to_payload' do
+    it 'adds frontend and search request ids to the logging payload' do
+      request.request_id = 'frontend-request-id'
+      controller.instance_variable_set(:@search, Search.new(q: '94036099', request_id: 'search-request-id'))
+
+      payload = {}
+      controller.send(:append_info_to_payload, payload)
+
+      expect(payload).to include(
+        request_id: 'frontend-request-id',
+        search_request_id: 'search-request-id',
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[HMRC-2262](https://transformuk.atlassian.net/browse/HMRC-2262)

### What?

- [x] Add the frontend request id to the controller logging payload
- [x] Add the generated or supplied search request id to the controller logging payload
- [x] Include both fields, plus user agent, in production Lograge custom options

### Why?

Operators need to correlate a frontend /search request with backend search instrumentation. The frontend already generates and sends a search request id, but that id was not present in the frontend production request log.

### Risk

**Risk level:** Low

**Reason for rating:** Observability-only change. Search behaviour and redirects are unchanged.