### PR TITLE
HMRC-2261: Add structured frontend search failure logging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -128,6 +128,7 @@ class ApplicationController < ActionController::Base
     payload[:request_id] = request.request_id
     payload[:search_request_id] = @search&.request_id
     payload[:user_agent] = request.env['HTTP_USER_AGENT']
+    payload.merge!(@handled_exception_log_context) if defined?(@handled_exception_log_context) && @handled_exception_log_context.present?
   end
 
   def set_path_info
@@ -187,9 +188,42 @@ class ApplicationController < ActionController::Base
   end
 
   def raise_internal_server_error(exception)
-    NewRelic::Agent.notice_error(exception)
-    Rails.logger.error(exception.message)
+    @handled_exception_log_context = handled_exception_log_context(exception)
+    NewRelic::Agent.notice_error(exception, custom_params: @handled_exception_log_context)
+    Rails.logger.error(@handled_exception_log_context.to_json)
     redirect_to '/500', status: :internal_server_error
+  end
+
+  def handled_exception_log_context(exception)
+    {
+      exception_class: exception.class.name,
+      exception_message: exception.message,
+      search_request_id: @search&.request_id,
+    }.merge(faraday_response_log_context(exception)).compact
+  end
+
+  def faraday_response_log_context(exception)
+    response = exception.respond_to?(:response) ? exception.response : nil
+    return {} unless response
+
+    response = response[:response] || response['response'] || response
+    body, body_truncated = truncated_backend_response_body(response[:body] || response['body'])
+
+    {
+      backend_status: response[:status] || response['status'],
+      backend_url: (response[:url] || response['url'])&.to_s,
+      backend_response_body: body,
+      backend_response_body_truncated: body_truncated,
+    }.compact
+  end
+
+  def truncated_backend_response_body(body)
+    return [nil, nil] if body.nil?
+
+    value = body.is_a?(String) ? body : body.to_json
+    return [nil, nil] if value.blank?
+
+    [value.first(500), value.length > 500]
   end
 
   alias_method :handle_connection_failed, :raise_internal_server_error

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,6 +106,12 @@ Rails.application.configure do
       search_request_id: event.payload[:search_request_id],
       user_agent: event.payload[:user_agent],
       params: event.payload[:params].except('controller', 'action', 'format', 'utf8'),
+      exception_class: event.payload[:exception_class],
+      exception_message: event.payload[:exception_message],
+      backend_status: event.payload[:backend_status],
+      backend_url: event.payload[:backend_url],
+      backend_response_body: event.payload[:backend_response_body],
+      backend_response_body_truncated: event.payload[:backend_response_body_truncated],
     }.compact
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -37,5 +37,32 @@ RSpec.describe ApplicationController, type: :controller do
         search_request_id: 'search-request-id',
       )
     end
+
+    it 'adds structured details for handled Faraday errors' do
+      error = Faraday::ServerError.new(
+        'the server responded with status 500',
+        response: {
+          status: 500,
+          body: { 'errors' => [{ 'detail' => 'backend exploded' }] },
+          url: URI('https://backend.example.test/api/uk/search'),
+        },
+      )
+
+      controller.instance_variable_set(:@search, Search.new(q: '94036099', request_id: 'search-request-id'))
+      controller.instance_variable_set(:@handled_exception_log_context, controller.send(:handled_exception_log_context, error))
+
+      payload = {}
+      controller.send(:append_info_to_payload, payload)
+
+      expect(payload).to include(
+        exception_class: 'Faraday::ServerError',
+        exception_message: 'the server responded with status 500',
+        search_request_id: 'search-request-id',
+        backend_status: 500,
+        backend_url: 'https://backend.example.test/api/uk/search',
+        backend_response_body: { 'errors' => [{ 'detail' => 'backend exploded' }] }.to_json,
+        backend_response_body_truncated: false,
+      )
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-2261](https://transformuk.atlassian.net/browse/HMRC-2261)

### What?

- [x] Capture structured metadata for handled Faraday search failures in the frontend
- [x] Include exception class, message, search request id, backend status, backend URL, and truncated backend body in the logging payload
- [x] Pass those fields through production Lograge custom options
- [x] Send the same structured context to New Relic error notices

### Why?

The frontend was turning backend search failures into a generic 500 log line. Operators could see the route and params, but not whether the failure was a timeout, connection failure, or backend server error. This makes the handled error path leave enough structured context for production triage.

### Risk

**Risk level:** Low

**Reason for rating:** Observability-only change to handled error logging. User-facing error handling still redirects to /500. Backend response bodies are truncated before logging.