### PR TITLE
OTTIMP-610 Use canonical enquiry form submissions endpoint

### DIFF
--- a/app/models/enquiry_form.rb
+++ b/app/models/enquiry_form.rb
@@ -1,7 +1,7 @@
 class EnquiryForm
   include ApiEntity
 
-  set_singular_path 'enquiry_form/revised_submissions'
+  set_singular_path 'enquiry_form/submissions'
 
   attr_accessor :name, :company_name, :job_title, :email, :enquiry_category, :enquiry_description
 

--- a/spec/models/enquiry_form_spec.rb
+++ b/spec/models/enquiry_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EnquiryForm do
 
     context 'when the request is successful' do
       before do
-        stub_api_request('enquiry_form/revised_submissions', :post)
+        stub_api_request('enquiry_form/submissions', :post)
           .with(
             body: hash_including(
               data: {


### PR DESCRIPTION
## What:

- Point the frontend enquiry form model back to the canonical backend path: `enquiry_form/submissions`.
- Update the model spec to expect the canonical endpoint.

## Why:

The backend cleanup now serves the new enquiry form payload from the original submissions endpoint and keeps `revised_submissions` only as a temporary alias. This frontend change removes the need for the revised-prefixed endpoint from the live frontend flow.

Dependency: merge and deploy backend PR #3231 first: https://github.com/trade-tariff/trade-tariff-backend/pull/3231

After this frontend change is merged and deployed, the remaining backend `revised_submissions` alias can be removed in a follow-up PR.

## Ticket:

OTTIMP-610

## Risk:

**Risk level:** 🟠

**Reason for rating:**

This changes the backend API path used when users submit the live enquiry form. The change is very small, but it depends on backend PR #3231 being deployed first so the canonical endpoint accepts the revised payload.

## Verification:

- `bundle exec rspec spec/models/enquiry_form_spec.rb`
- `bin/rails assets:precompile`
- `bundle exec rspec spec/models/enquiry_form_spec.rb spec/features/enquiry_form_revised_flow_spec.rb`
- `bundle exec rubocop app/models/enquiry_form.rb spec/models/enquiry_form_spec.rb`
- Local browser E2E against backend PR #3231: completed a classification enquiry and received reference `PWQY329E`; backend cache showed the expected revised payload sent through `enquiry_form/submissions`.

## Accessibility impact:

No user-facing markup, copy, validation, focus order, or GOV.UK component behaviour changes.