### PR TITLE
BAU: Extend stale PR threshold

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -8,7 +8,7 @@ on:
       stale_days:
         description: Days without pull request activity before closure
         required: false
-        default: '14'
+        default: '30'
       keep_label:
         description: Label exempting a pull request from closure
         required: false
@@ -30,6 +30,6 @@ jobs:
   close-stale:
     uses: trade-tariff/trade-tariff-tools/.github/workflows/close-stale-pull-requests-reusable.yml@main
     with:
-      stale_days: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stale_days != '' && fromJSON(github.event.inputs.stale_days) || 14 }}
+      stale_days: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stale_days != '' && fromJSON(github.event.inputs.stale_days) || 30 }}
       keep_label: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.keep_label != '' && github.event.inputs.keep_label || 'keep' }}
       dry_run: ${{ github.event_name != 'schedule' && (github.event.inputs.dry_run != 'false') }}


### PR DESCRIPTION
## What:
Extends the stale pull request closure threshold in the frontend workflow from 14 days to 30 days.

## Why:
Keeps the frontend stale PR policy aligned with the backend threshold extension.

## Ticket:
N/A

## Risk:

**Risk level:** Green

**Reason for rating:**
Low-risk GitHub Actions configuration change. It only changes the age threshold passed to the existing reusable stale PR workflow.