### PR TITLE
BAU: Grant stale branch cleanup permissions

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -23,7 +23,7 @@ on:
           - 'false'
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Grant the stale pull request cleanup workflow `contents: write`

### Why?

The reusable stale cleanup workflow now deletes stale branch refs as well as closing stale pull requests. The caller workflow needs to grant `contents: write` so the reusable workflow can delete eligible branches.

### Risk

**Risk level:** 🟢

**Reason for rating:** GitHub Actions permission update for an existing scheduled maintenance workflow.