### PR TITLE
Parallelise frontend RSpec suite

### DIFF
--- a/.github/bin/trufflehog
+++ b/.github/bin/trufflehog
@@ -1,11 +1,59 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-tmp_file="$(mktemp)"
-trap 'rm -f "$tmp_file"' EXIT
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker is required to run the TruffleHog pre-commit scan." >&2
+  exit 1
+fi
 
-curl -fsSL \
-  https://raw.githubusercontent.com/trade-tariff/trade-tariff-tools/main/scripts/trufflehog-pre-commit.sh \
-  -o "$tmp_file"
+scan_dir="${1:-$(pwd)}"
+image="${TRUFFLEHOG_IMAGE:-}"
+exclude_detectors="${TRUFFLEHOG_EXCLUDE_DETECTORS:-Box}"
 
-bash "$tmp_file" "$(pwd)"
+if [ -z "${image:-}" ]; then
+  image="trufflesecurity/trufflehog:latest"
+fi
+
+if [ -z "$image" ]; then
+  echo "Error: TruffleHog image is not set" >&2
+  exit 1
+fi
+
+if [ ! -d "$scan_dir" ]; then
+  echo "Error: scan directory does not exist: $scan_dir" >&2
+  exit 1
+fi
+
+scan_dir="$(cd "$scan_dir" && pwd)"
+exclude_file="$(mktemp)"
+trap 'rm -f "$exclude_file"' EXIT
+
+cat > "$exclude_file" <<'PATTERNS'
+(^|/).git(/|$)
+(^|/).terraform(/|$)
+(^|/).terragrunt-cache(/|$)
+PATTERNS
+
+if [ -f "$scan_dir/.trufflehog-exclude-paths.txt" ]; then
+  cat "$scan_dir/.trufflehog-exclude-paths.txt" >> "$exclude_file"
+fi
+
+docker_args=(
+  run
+  --rm
+  -v "$scan_dir:/workdir:ro"
+  -v "$exclude_file:/trufflehog-exclude-paths.txt:ro"
+  -w /workdir
+  -i
+  "$image"
+  filesystem /workdir
+  --exclude-paths=/trufflehog-exclude-paths.txt
+  --results=verified,unknown
+  --fail
+)
+
+if [ -n "$exclude_detectors" ]; then
+  docker_args+=(--exclude-detectors="$exclude_detectors")
+fi
+
+exec docker "${docker_args[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,8 @@ jobs:
 
       - run: bin/rails assets:precompile
 
-      - run: bundle exec rspec
+      - name: Run tests
+        env:
+          PARALLEL_TEST_PROCESSORS: "5"
+          SKIP_PARALLEL_TEST_PREPARE: "true"
+        run: bundle exec rspec

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
+--require ./spec/parallel_rspec
 --require spec_helper

--- a/.trufflehog-exclude-paths.txt
+++ b/.trufflehog-exclude-paths.txt
@@ -1,5 +1,6 @@
-^node_modules/
-^public/packs/
-^terraform/\.terraform/
-^vendor/bundle/
-^tmp/
+(^|/)node_modules/
+(^|/)public/packs/
+(^|/)terraform/\.terraform/
+(^|/)vendor/bundle/
+(^|/)tmp/
+(^|/)public/roo_origin_reference_documents/

--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ group :test do
   gem 'cuprite'
   gem 'factory_bot_rails'
   gem 'forgery'
+  gem 'parallel_tests'
   gem 'rails-controller-testing', github: 'rails/rails-controller-testing', branch: 'master'
   gem 'rspec-rails'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,8 @@ GEM
     ostruct (0.6.3)
     pagy (9.4.0)
     parallel (1.28.0)
+    parallel_tests (5.7.0)
+      parallel
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -639,6 +641,7 @@ DEPENDENCIES
   multi_json
   newrelic_rpm
   nokogiri
+  parallel_tests
   propshaft
   pry-rails
   puma

--- a/spec/parallel_rspec.rb
+++ b/spec/parallel_rspec.rb
@@ -1,0 +1,27 @@
+require 'English'
+
+if ENV['PARALLEL_RSPEC_CHILD'] != 'true' && !ENV.key?('TEST_ENV_NUMBER')
+  if ARGV.any?
+    ENV['PARALLEL_RSPEC_CHILD'] = 'true'
+  else
+    workers = Integer(ENV.fetch('PARALLEL_TEST_PROCESSORS', 5))
+
+    unless ENV['SKIP_PARALLEL_TEST_PREPARE'] == 'true'
+      system('bin/rails', 'assets:precompile')
+      exit($CHILD_STATUS.exitstatus || 1) unless $CHILD_STATUS.success?
+    end
+
+    exec(
+      { 'PARALLEL_RSPEC_CHILD' => 'true' },
+      'bundle',
+      'exec',
+      'parallel_test',
+      '-n',
+      workers.to_s,
+      '--type',
+      'rspec',
+      '--serialize-stdout',
+      'spec',
+    )
+  end
+end


### PR DESCRIPTION
## What:
Added parallel RSpec support to `tariff-frontend`

## Why:
Reduces frontend test feedback time while keeping the normal focused test workflow unchanged

## Ticket:
[HMRC-2292](https://transformuk.atlassian.net/browse/HMRC-2292)

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
Only affects test/developer tooling and CI test execution