### PR TITLE
BAU: Include search context in feedback

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -3,7 +3,10 @@ class FeedbackController < ApplicationController
                 :disable_switch_service_banner
 
   def new
-    session[:feedback_referrer] = request.referer
+    session[:feedback_referrer] = feedback_url
+    session[:feedback_query] = feedback_query
+    session[:feedback_request_id] = feedback_request_id
+
     @feedback = Feedback.new
     @feedback.page_useful = params[:page_useful]
   end
@@ -12,6 +15,8 @@ class FeedbackController < ApplicationController
     @feedback = Feedback.new(feedback_params)
     @feedback.authenticity_token = params[:authenticity_token]
     @feedback.referrer = session[:feedback_referrer]
+    @feedback.query = session[:feedback_query]
+    @feedback.request_id = session[:feedback_request_id]
 
     return redirect_to(find_commodity_path) unless @feedback.valid_page_useful_options?
 
@@ -28,11 +33,34 @@ class FeedbackController < ApplicationController
 
   def thanks
     @referrer = session.delete(:feedback_referrer)
+    session.delete(:feedback_query)
+    session.delete(:feedback_request_id)
   end
 
   private
 
   def feedback_params
     params.require(:feedback).permit(:message, :telephone, :page_useful)
+  end
+
+  def feedback_url
+    params[:feedback_url].presence || request.referer
+  end
+
+  def feedback_query
+    params[:feedback_query].presence || referrer_query_param('q')
+  end
+
+  def feedback_request_id
+    params[:feedback_request_id].presence || referrer_query_param('request_id')
+  end
+
+  def referrer_query_param(key)
+    return if request.referer.blank?
+
+    uri = URI.parse(request.referer)
+    Rack::Utils.parse_query(uri.query)[key]
+  rescue URI::InvalidURIError
+    nil
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,6 +78,26 @@ module ApplicationHelper
     request.base_url + request.path
   end
 
+  def feedback_path_with_context(options = {})
+    feedback_path(feedback_context_params.merge(options))
+  end
+
+  def feedback_context_params
+    {
+      feedback_url: request.original_url,
+      feedback_query: feedback_search_query,
+      feedback_request_id: feedback_search_request_id,
+    }.compact
+  end
+
+  def feedback_search_query
+    @search&.q.presence || params[:q].presence
+  end
+
+  def feedback_search_request_id
+    @search&.request_id.presence || params[:request_id].presence
+  end
+
   def pretty_date_range(start_date, end_date)
     pretty_end_date = end_date ? "<br>to #{end_date.to_formatted_s(:rfc822)}" : ''
 

--- a/app/mailers/frontend_mailer.rb
+++ b/app/mailers/frontend_mailer.rb
@@ -8,6 +8,8 @@ class FrontendMailer < ActionMailer::Base
   def new_feedback(feedback)
     @message = feedback.message
     @url = feedback.referrer
+    @query = feedback.query
+    @request_id = feedback.request_id
     @page_useful = feedback.page_useful
 
     mail subject: 'Trade Tariff Feedback'

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -5,7 +5,7 @@ class Feedback
 
   include ActiveModel::Model
 
-  attr_accessor :message, :telephone, :authenticity_token, :referrer, :page_useful
+  attr_accessor :message, :telephone, :authenticity_token, :referrer, :page_useful, :query, :request_id
 
   validates :message, presence: true,
                       length: { minimum: 10, maximum: 500 }

--- a/app/views/frontend_mailer/new_feedback.html.erb
+++ b/app/views/frontend_mailer/new_feedback.html.erb
@@ -6,4 +6,12 @@
   <p>URL: <%= @url %></p>
 <% end %>
 
+<% if @query %>
+  <p>Query: <%= @query %></p>
+<% end %>
+
+<% if @request_id %>
+  <p>Request ID: <%= @request_id %></p>
+<% end %>
+
 <p>Found this page useful: <%= @page_useful if @page_useful %></p>

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -46,7 +46,7 @@
       <ul class="govuk-footer__list">
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods">Ask HMRC for advice on classifying your goods</a></li>
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries">Imports and exports: general enquiries</a></li>
-        <li class="govuk-footer__list-item"><%= govuk_link_to 'Feedback', feedback_path, class: "govuk-footer__link" %></li>
+        <li class="govuk-footer__list-item"><%= govuk_link_to 'Feedback', feedback_path_with_context, class: "govuk-footer__link" %></li>
         <li class="govuk-footer__list-item"><%= govuk_link_to 'Enquiry Form', product_experience_enquiry_form_path, class: "govuk-footer__link" %></li>
       </ul>
     </div>

--- a/app/views/myott/unsubscribes/confirmation.html.erb
+++ b/app/views/myott/unsubscribes/confirmation.html.erb
@@ -18,7 +18,7 @@
             You can now close this window.
           </p>
           <p class="govuk-body">
-            <%= govuk_link_to 'What did you think of this service?', feedback_path, no_visited_state: true %>
+            <%= govuk_link_to 'What did you think of this service?', feedback_path_with_context, no_visited_state: true %>
             (takes 30 seconds)
           </p>
         <% end %>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -61,7 +61,7 @@
     </ol>
 
     <h2 class="govuk-heading-s" id="leave-feedback">Leave feedback</h2>
-    <p><%= govuk_link_to 'Leave feedback or suggestions for improvements to this service.', feedback_path %></p>
+    <p><%= govuk_link_to 'Leave feedback or suggestions for improvements to this service.', feedback_path_with_context %></p>
 
     <h2 class="govuk-heading-s" id="getting-help">Getting help from HMRC if you need to find a commodity code</h2>
     <p>If you <%= govuk_link_to 'cannot find the right commodity code for your goods', help_find_commodity_path %>, you can contact HMRC for advice or for a decision on your goods.</p>

--- a/app/views/shared/_feedback_banner.html.erb
+++ b/app/views/shared/_feedback_banner.html.erb
@@ -1,7 +1,7 @@
 <% unless @feedback %>
   <div class="tariff-feedback-banner">
     <%= govuk_phase_banner(tag: { text: local_assigns.fetch(:tag_text, 'FEEDBACK') }) do %>
-      Tell us what you think - your <%= govuk_link_to 'feedback', feedback_path %> will help us improve.
+      Tell us what you think - your <%= govuk_link_to 'feedback', feedback_path_with_context %> will help us improve.
     <% end %>
   </div>
 <% end %>

--- a/app/views/shared/_feedback_useful_banner.html.erb
+++ b/app/views/shared/_feedback_useful_banner.html.erb
@@ -11,17 +11,17 @@
 
       <ul class="govuk-footer__inline-list">
         <li class="govuk-footer__inline-list-item">
-          <%= govuk_button_link_to 'Yes', feedback_path(page_useful: 'yes'), secondary: true %>
+          <%= govuk_button_link_to 'Yes', feedback_path_with_context(page_useful: 'yes'), secondary: true %>
         </li>
         <li class="govuk-footer__inline-list-item">
-          <%= govuk_button_link_to 'No', feedback_path(page_useful: 'no'), secondary: true %>
+          <%= govuk_button_link_to 'No', feedback_path_with_context(page_useful: 'no'), secondary: true %>
         </li>
       </ul>
     </div>
     <div class="govuk-footer__meta-item">
       <ul class="govuk-footer__inline-list">
         <li class="govuk-footer__inline-list-item">
-          <%= govuk_button_link_to 'Report a problem with this page', feedback_path, secondary: true, class: 'report-problem' %>
+          <%= govuk_button_link_to 'Report a problem with this page', feedback_path_with_context, secondary: true, class: 'report-problem' %>
         </li>
       </ul>
     </div>

--- a/spec/factories/feedback_factory.rb
+++ b/spec/factories/feedback_factory.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     message { 'Hello world' }
     referrer { 'https://example.com' }
     page_useful { 'yes' }
+    query { 'leather handbags' }
+    request_id { 'test-request-id' }
 
     trait :with_authenticity_token do
       authenticity_token do

--- a/spec/requests/feedback_controller_spec.rb
+++ b/spec/requests/feedback_controller_spec.rb
@@ -113,4 +113,53 @@ RSpec.describe FeedbackController, type: :request do
       end
     end
   end
+
+  describe 'feedback from POST search results' do
+    let(:message) { 'Search feedback with context' }
+    let(:authenticity_token) { 'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw' }
+
+    before do
+      stub_api_request('search', :post).to_return(
+        jsonapi_response(:search, {
+          type: 'fuzzy_match',
+          goods_nomenclature_match: { chapters: [], headings: [], commodities: [], sections: [] },
+          reference_match: { chapters: [], headings: [], commodities: [], sections: [] },
+        }),
+      )
+    end
+
+    it 'sends the search URL, query and request id to support when the URL has no query param', :aggregate_failures do
+      post perform_search_path, params: { q: 'leather handbags', request_id: 'search-request-123' }
+
+      expect(response).to have_http_status(:ok)
+      expect(request.original_url).to eq('http://www.example.com/search')
+
+      feedback_hrefs = Nokogiri::HTML(response.body)
+                              .css('a[href^="/feedback?"]')
+                              .map { |link| link['href'] }
+
+      expect(feedback_hrefs).not_to be_empty
+      feedback_hrefs.each do |href|
+        feedback_params = Rack::Utils.parse_query(URI.parse(href).query)
+
+        expect(feedback_params).to include(
+          'feedback_url' => 'http://www.example.com/search',
+          'feedback_query' => 'leather handbags',
+          'feedback_request_id' => 'search-request-123',
+        )
+      end
+
+      get feedback_hrefs.first
+      post feedbacks_path, params: {
+        feedback: { message: },
+        authenticity_token:,
+      }
+
+      email_body = ActionMailer::Base.deliveries.last.body.to_s
+
+      expect(email_body).to include('URL: http://www.example.com/search')
+      expect(email_body).to include('Query: leather handbags')
+      expect(email_body).to include('Request ID: search-request-123')
+    end
+  end
 end

--- a/spec/views/frontend_mailer/new_feedback.html.erb_spec.rb
+++ b/spec/views/frontend_mailer/new_feedback.html.erb_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe 'frontend_mailer/new_feedback', type: :view do
 
   before do
     assign(:message, feedback.message)
+    assign(:query, feedback.query)
+    assign(:request_id, feedback.request_id)
     render
   end
 
@@ -17,11 +19,15 @@ RSpec.describe 'frontend_mailer/new_feedback', type: :view do
     before do
       assign(:message, feedback.message)
       assign(:url, feedback.referrer)
+      assign(:query, feedback.query)
+      assign(:request_id, feedback.request_id)
       render
     end
 
     it { expect(rendered).to include(feedback.message) }
     it { expect(rendered).to include(feedback.referrer) }
+    it { expect(rendered).to include(feedback.query) }
+    it { expect(rendered).to include(feedback.request_id) }
   end
 
   context 'with page useful option' do

--- a/spec/views/myott/unsubscribes/confirmation.html.erb_spec.rb
+++ b/spec/views/myott/unsubscribes/confirmation.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'myott/unsubscribes/confirmation.html.erb', type: :view do
     end
 
     it 'links "What did you think of this service?" to the in-app feedback path' do
-      expect(rendered).to have_link('What did you think of this service?', href: feedback_path)
+      expect(rendered).to have_link('What did you think of this service?', href: %r{\A/feedback\?})
     end
   end
 end

--- a/spec/views/shared/_feedback_banner.html.erb_spec.rb
+++ b/spec/views/shared/_feedback_banner.html.erb_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'shared/_feedback_banner', type: :view do
 
   it { is_expected.to have_css('.govuk-tag', text: 'FEEDBACK') }
   it { is_expected.to have_text('Tell us what you think') }
-  it { is_expected.to have_link('feedback', href: feedback_path) }
+  it { is_expected.to have_link('feedback', href: %r{\A/feedback\?}) }
 
   context 'with a custom tag text' do
     subject { render partial: 'shared/feedback_banner', locals: { tag_text: 'BETA' } }

--- a/spec/views/shared/_feedback_useful_banner.html.erb_spec.rb
+++ b/spec/views/shared/_feedback_useful_banner.html.erb_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe 'shared/_feedback_useful_banner', type: :view do
   subject { render partial: 'shared/feedback_useful_banner' }
 
   it { is_expected.to have_text('Is this page useful?') }
-  it { is_expected.to have_link('Yes', href: feedback_path(page_useful: 'yes')) }
-  it { is_expected.to have_link('No', href: feedback_path(page_useful: 'no')) }
-  it { is_expected.to have_link('Report a problem with this page', href: feedback_path) }
+  it { is_expected.to have_link('Yes', href: %r{\A/feedback\?.*page_useful=yes}) }
+  it { is_expected.to have_link('No', href: %r{\A/feedback\?.*page_useful=no}) }
+  it { is_expected.to have_link('Report a problem with this page', href: %r{\A/feedback\?}) }
 
   it 'does not render a divider by default' do
     render partial: 'shared/feedback_useful_banner'


### PR DESCRIPTION
## What:

Feedback links now carry the current page URL, search query, and search request id through to the feedback submission. The support email includes those fields so POST-based search result feedback is still actionable even when `q` is not present in the browser URL.

This updates the shared feedback banners, footer feedback link, help page feedback link, and MyOTT unsubscribe feedback link to use the same context-aware path helper.

## Why:

Search submissions now use POST, which keeps the search query out of the result page URL. The previous feedback flow only relied on the referrer URL, so support could receive feedback for `/search` without the submitted query or request id.

## Ticket:

BAU

## Risk:

**Risk level:** 🟢

**Reason for rating:**

This is a narrow feedback instrumentation change. It does not alter search results, backend search calls, tariff presentation, or the feedback form UI; it only preserves existing context for support emails and has targeted request/view coverage.
