### PR TITLE
BAU: Include date of trade in feedback context

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -6,6 +6,7 @@ class FeedbackController < ApplicationController
     session[:feedback_referrer] = feedback_url
     session[:feedback_query] = feedback_query
     session[:feedback_request_id] = feedback_request_id
+    session[:feedback_date] = feedback_date
 
     @feedback = Feedback.new
     @feedback.page_useful = params[:page_useful]
@@ -17,6 +18,7 @@ class FeedbackController < ApplicationController
     @feedback.referrer = session[:feedback_referrer]
     @feedback.query = session[:feedback_query]
     @feedback.request_id = session[:feedback_request_id]
+    @feedback.date = session[:feedback_date]
 
     return redirect_to(find_commodity_path) unless @feedback.valid_page_useful_options?
 
@@ -35,6 +37,7 @@ class FeedbackController < ApplicationController
     @referrer = session.delete(:feedback_referrer)
     session.delete(:feedback_query)
     session.delete(:feedback_request_id)
+    session.delete(:feedback_date)
   end
 
   private
@@ -56,11 +59,31 @@ class FeedbackController < ApplicationController
   end
 
   def referrer_query_param(key)
-    return if request.referer.blank?
+    referrer_query_params[key]
+  end
+
+  def referrer_query_params
+    return {} if request.referer.blank?
 
     uri = URI.parse(request.referer)
-    Rack::Utils.parse_query(uri.query)[key]
+    Rack::Utils.parse_query(uri.query || '')
   rescue URI::InvalidURIError
+    {}
+  end
+
+  def feedback_date
+    params[:feedback_date].presence || referrer_date_param
+  end
+
+  def referrer_date_param
+    referrer_date_from_day_month_year.presence || referrer_query_param('as_of')
+  end
+
+  def referrer_date_from_day_month_year
+    return unless referrer_query_params.values_at('day', 'month', 'year').all?(&:present?)
+
+    TariffDate.build(referrer_query_params.slice('year', 'month', 'day')).to_fs(:db)
+  rescue Date::Error
     nil
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,6 +87,7 @@ module ApplicationHelper
       feedback_url: request.original_url,
       feedback_query: feedback_search_query,
       feedback_request_id: feedback_search_request_id,
+      feedback_date: feedback_search_date,
     }.compact
   end
 
@@ -96,6 +97,21 @@ module ApplicationHelper
 
   def feedback_search_request_id
     @search&.request_id.presence || params[:request_id].presence
+  end
+
+  def feedback_search_date
+    return if params[:invalid_date].present?
+    return @search.date.to_fs(:db) if @search&.filtered_by_date?
+
+    feedback_date_from_day_month_year
+  end
+
+  def feedback_date_from_day_month_year
+    return unless params.values_at(:day, :month, :year).all?(&:present?)
+
+    TariffDate.build(params.permit(:year, :month, :day).to_h).to_fs(:db)
+  rescue Date::Error
+    nil
   end
 
   def pretty_date_range(start_date, end_date)

--- a/app/mailers/frontend_mailer.rb
+++ b/app/mailers/frontend_mailer.rb
@@ -10,6 +10,7 @@ class FrontendMailer < ActionMailer::Base
     @url = feedback.referrer
     @query = feedback.query
     @request_id = feedback.request_id
+    @date = feedback.date
     @page_useful = feedback.page_useful
 
     mail subject: 'Trade Tariff Feedback'

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -5,7 +5,7 @@ class Feedback
 
   include ActiveModel::Model
 
-  attr_accessor :message, :telephone, :authenticity_token, :referrer, :page_useful, :query, :request_id
+  attr_accessor :message, :telephone, :authenticity_token, :referrer, :page_useful, :query, :request_id, :date
 
   validates :message, presence: true,
                       length: { minimum: 10, maximum: 500 }

--- a/app/views/frontend_mailer/new_feedback.html.erb
+++ b/app/views/frontend_mailer/new_feedback.html.erb
@@ -14,4 +14,8 @@
   <p>Request ID: <%= @request_id %></p>
 <% end %>
 
+<% if @date %>
+  <p>Date of trade: <%= @date %></p>
+<% end %>
+
 <p>Found this page useful: <%= @page_useful if @page_useful %></p>

--- a/spec/factories/feedback_factory.rb
+++ b/spec/factories/feedback_factory.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     page_useful { 'yes' }
     query { 'leather handbags' }
     request_id { 'test-request-id' }
+    date { '2026-06-05' }
 
     trait :with_authenticity_token do
       authenticity_token do

--- a/spec/requests/feedback_controller_spec.rb
+++ b/spec/requests/feedback_controller_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe FeedbackController, type: :request do
       )
     end
 
-    it 'sends the search URL, query and request id to support when the URL has no query param', :aggregate_failures do
-      post perform_search_path, params: { q: 'leather handbags', request_id: 'search-request-123' }
+    it 'sends the search URL, query, request id and date of trade to support when the URL has no query param', :aggregate_failures do
+      post perform_search_path, params: { q: 'leather handbags', request_id: 'search-request-123', day: '5', month: '6', year: '2026' }
 
       expect(response).to have_http_status(:ok)
       expect(request.original_url).to eq('http://www.example.com/search')
@@ -146,6 +146,7 @@ RSpec.describe FeedbackController, type: :request do
           'feedback_url' => 'http://www.example.com/search',
           'feedback_query' => 'leather handbags',
           'feedback_request_id' => 'search-request-123',
+          'feedback_date' => '2026-06-05',
         )
       end
 
@@ -160,6 +161,7 @@ RSpec.describe FeedbackController, type: :request do
       expect(email_body).to include('URL: http://www.example.com/search')
       expect(email_body).to include('Query: leather handbags')
       expect(email_body).to include('Request ID: search-request-123')
+      expect(email_body).to include('Date of trade: 2026-06-05')
     end
   end
 end

--- a/spec/requests/find_commodities_controller_spec.rb
+++ b/spec/requests/find_commodities_controller_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe FindCommoditiesController, type: :request do
     include_context 'with latest news stubbed'
     include_context 'with news updates stubbed'
 
-    before { get find_commodity_path(params) }
+    before do
+      allow(TradeTariffFrontend).to receive(:interactive_search_enabled?).and_return(false)
+      get find_commodity_path(params)
+    end
 
     let(:params) { {} }
 
@@ -22,6 +25,8 @@ RSpec.describe FindCommoditiesController, type: :request do
 
     context 'with an invalid date flag' do
       let(:params) { { invalid_date: true, day: '22', month: '0', year: '2026' } }
+
+      it { is_expected.to have_http_status :ok }
 
       it 'renders a GOV.UK error summary' do
         expect(response.body).to match(/govuk-error-summary.*You must enter a valid date/m)


### PR DESCRIPTION
## What:
Include the search date of trade in feedback links and support emails.

Also avoid extracting a feedback date while an invalid date search page is rendering.

## Why:
Support already received the search query and request id, but not the selected date of trade.

The invalid-date guard stops the feedback link helper from calling `@search.date` while the page is intentionally showing invalid date values back to the user.

## Ticket:
BAU

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Small feedback-context bug fix with request spec coverage. No change to tariff calculations, search results, or trader-facing commodity interpretation.