### PR TITLE
Fix vat width variable

### DIFF
--- a/app/assets/stylesheets/src/_variables.scss
+++ b/app/assets/stylesheets/src/_variables.scss
@@ -22,13 +22,13 @@ $commodity-code-width-desktop: 110px;
 $breadcrumb-indent: 15px;
 $breadcrumb-indent-desktop: 25px;
 
-$vat-width-desktop: 105px;
+$vat-width-desktop: 80px;
 $duty-width-desktop: 145px;
 $supplementary-units-width-desktop: 120px;
 $commodity-tree-info-width-desktop: 514px;
 
 $identifier-width: $chapter-code-width+$heading-code-width+$commodity-code-width + 10px;
-$identifier-width-desktop: $chapter-code-width+$heading-code-width+$commodity-code-width-desktop+$vat-width-desktop+$duty-width-desktop+$supplementary-units-width-desktop;
+$identifier-width-desktop: $chapter-code-width+$heading-code-width+$commodity-code-width-desktop+$vat-width-desktop+$duty-width-desktop+$supplementary-units-width-desktop + 25px;
 $identifier-width-desktop-uk: 130px;
 $identifier-width-desktop-xi: 130px;
 


### PR DESCRIPTION
## What:
Fixes display issue with hierarchy tables that was causing the header to wrap.

| Before | After |
| --- | --- |
| <img width="994" height="332" alt="Screenshot 2026-06-08 at 15 33 02" src="https://github.com/user-attachments/assets/c8a665f9-74a2-4e05-a08e-78beb3fd8fbd" /> | <img width="977" height="334" alt="Screenshot 2026-06-08 at 15 29 12" src="https://github.com/user-attachments/assets/03b0ae3c-4ace-4beb-9feb-18fde71870e7" /> |

The $vat-width-desktop variable was being used to set the width of the column but this width was incorrect.
It has been updated and the definition of `$identifier-width-desktop` updated to account for the change.

## Why:
Fixes a display issue

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Display change