### PR TITLE
BAU Refine duty calculator planned processing markup and shared copy

### DIFF
--- a/app/helpers/duty_calculator/ukims_helper.rb
+++ b/app/helpers/duty_calculator/ukims_helper.rb
@@ -67,7 +67,7 @@ NOTE
       if after_cut_off_date?
         'Find out more about the Windsor Framework'
       else
-        'Explore the topic'
+        t('duty_calculator.shared.explore_topic_title')
       end
     end
 

--- a/app/views/duty_calculator/steps/additional_codes/show.html.erb
+++ b/app/views/duty_calculator/steps/additional_codes/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @step, url: additional_codes_path do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
   <h1 class="govuk-heading-xl">Describe your goods in more detail</h1>
 
   <% if @step.applicable_additional_codes.dig('uk', @step.measure_type_id).present? %>

--- a/app/views/duty_calculator/steps/annual_turnover/show.html.erb
+++ b/app/views/duty_calculator/steps/annual_turnover/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @step, url: annual_turnover_path do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 
   <%= f.govuk_collection_radio_buttons :annual_turnover, @step.options, :id, :name, hint: { text: t("annual_turnover.fieldset_hint_text.#{current_route}_html", turnover_amount: ukims_annual_turnover) }, legend: { text: t('annual_turnover.fieldset_legend_text'), size: 'xl', tag: 'h1' }, include_hidden: true %>
 
@@ -12,7 +12,7 @@
 <%= render 'duty_calculator/shared/commodity_details' %>
 
 <div class="explore-topics-section">
-  <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-3"><%= t('duty_calculator.shared.explore_topic_title') %></h2>
   <%= govuk_list [
     govuk_link_to("Check if you can declare goods you bring into Northern Ireland 'not at risk' of moving to the EU", 'https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu'),
   ] %>

--- a/app/views/duty_calculator/steps/certificate_of_origin/show.html.erb
+++ b/app/views/duty_calculator/steps/certificate_of_origin/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @step, url: certificate_of_origin_path do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
   <%= f.govuk_collection_radio_buttons :certificate_of_origin, DutyCalculator::Steps::CertificateOfOrigin::OPTIONS, :id, :name, legend: { text: 'Do you have a valid proof of preferential origin?', size: 'xl', tag: 'h1' }, hint: { text: 'If you have a valid Certificate of Origin proving that your goods were materially manufactured in the UK, then you are eligible to take advantage of the 0% import duties made available under the UK / EU Trade and Cooperation Agreement.' }, include_hidden: true %>
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/duty_calculator/steps/confirmation/show.html.erb
+++ b/app/views/duty_calculator/steps/confirmation/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'duty_calculator/steps/shared/back_link' %>
 
-<span class="govuk-caption-xl">Calculate import duties</span>
+<span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 <h1 class="govuk-heading-xl">Check your answers</h1>
 <%= govuk_summary_list(rows: [
   {

--- a/app/views/duty_calculator/steps/country_of_origin/show.html.erb
+++ b/app/views/duty_calculator/steps/country_of_origin/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'duty_calculator/steps/shared/back_link' %>
 
-<span class="govuk-caption-xl">Calculate import duties</span>
+<span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 
 <% if @user_session.import_destination == 'UK' %>
   <%= render 'gb_options' %>
@@ -10,7 +10,7 @@
 
 <%= render 'duty_calculator/shared/commodity_details' %>
 <div class="explore-topics-section">
-  <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-3"><%= t('duty_calculator.shared.explore_topic_title') %></h2>
   <%= govuk_list [
     govuk_link_to('Check your goods meet the rules of origin', 'https://www.gov.uk/guidance/check-your-goods-meet-the-rules-of-origin'),
   ] %>

--- a/app/views/duty_calculator/steps/customs_value/show.html.erb
+++ b/app/views/duty_calculator/steps/customs_value/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @step, url: customs_value_path do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
   <h1 class="govuk-heading-xl">What is the customs value of this import?</h1>
   <p class="govuk-hint">
     The amount of duty you may have to pay will depend on the customs value of your goods.
@@ -24,7 +24,7 @@
 <% end %>
 <%= render 'duty_calculator/shared/commodity_details' %>
 <div class="explore-topics-section">
-  <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-3"><%= t('duty_calculator.shared.explore_topic_title') %></h2>
   <%= govuk_list [
     govuk_link_to('Valuation of imported goods for customs purposes, VAT and trade statistics', 'https://www.gov.uk/government/publications/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics'),
   ] %>

--- a/app/views/duty_calculator/steps/document_codes/show.html.erb
+++ b/app/views/duty_calculator/steps/document_codes/show.html.erb
@@ -3,7 +3,7 @@
 <%= form_for @step, url: document_codes_path do |f| %>
   <%= f.govuk_error_summary %>
 
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
   <h1 class="govuk-heading-xl">Do you have any of the following documents?</h1>
   <div class="govuk-hint govuk-!-margin-bottom-7">
     You may be able to reduce the duty applicable if you possess and can present one of the following documents.

--- a/app/views/duty_calculator/steps/duty/show.html.erb
+++ b/app/views/duty_calculator/steps/duty/show.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_back_link(href: :back) %>
 
-<span class="govuk-caption-xl">Calculate import duties</span>
+<span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 
 <% if @duty_options.nil? %>
   <fieldset class="govuk-fieldset">

--- a/app/views/duty_calculator/steps/excise/show.html.erb
+++ b/app/views/duty_calculator/steps/excise/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @step, url: excise_path do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
   <h1 class="govuk-heading-xl">Which class of excise is applicable to your trade?</h1>
 
   <%=

--- a/app/views/duty_calculator/steps/final_use/show.html.erb
+++ b/app/views/duty_calculator/steps/final_use/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @step, url: final_use_path do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 
   <%= f.govuk_collection_radio_buttons :final_use, @step.options, :id, :name, legend: { text: @step.heading, size: 'xl', tag: 'h1' }, include_hidden: true %>
 
@@ -12,7 +12,7 @@
 <%= render 'duty_calculator/shared/commodity_details' %>
 
 <div class="explore-topics-section">
-  <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-3"><%= t('duty_calculator.shared.explore_topic_title') %></h2>
   <%= govuk_list [
     govuk_link_to("Check if you can declare goods you bring into Northern Ireland 'not at risk' of moving to the EU", 'https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu'),
   ] %>

--- a/app/views/duty_calculator/steps/import_date/show.html.erb
+++ b/app/views/duty_calculator/steps/import_date/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @step, url: import_date_path, html: { novalidate: true } do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
   <%= f.govuk_date_field :import_date,
     legend: { text: 'When will the goods be imported?', size: 'xl', tag: 'h1' },
     hint: { text: 'As duties and quotas change over time, it may be important to enter the date you think your goods your goods will be imported.<br>

--- a/app/views/duty_calculator/steps/import_destination/show.html.erb
+++ b/app/views/duty_calculator/steps/import_destination/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @step, url: import_destination_path do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 
   <%= f.govuk_collection_radio_buttons :import_destination, DutyCalculator::Steps::ImportDestination::OPTIONS, :id, :name, legend: { text: 'Which part of the UK are you importing into?', size: 'xl', tag: 'h1' }, hint: { text: 'The duty you are charged may be dependent on the part of the UK to which you are importing.' }, include_hidden: true %>
 
@@ -12,7 +12,7 @@
 <%= render 'duty_calculator/shared/commodity_details' %>
 
 <div class="explore-topics-section">
-  <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-3"><%= t('duty_calculator.shared.explore_topic_title') %></h2>
   <%= govuk_list [
     govuk_link_to('Import goods into the UK: step by step', 'https://www.gov.uk/import-goods-into-uk'),
     govuk_link_to('Trading and moving goods in and out of Northern Ireland', 'https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland-from-1-january-2021'),

--- a/app/views/duty_calculator/steps/interstitial/show.html.erb
+++ b/app/views/duty_calculator/steps/interstitial/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'duty_calculator/steps/shared/back_link' %>
 
-<span class="govuk-caption-xl">Calculate import duties</span>
+<span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 
 <%= render interstitial_partial_options %>
 

--- a/app/views/duty_calculator/steps/measure_amount/show.html.erb
+++ b/app/views/duty_calculator/steps/measure_amount/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @step, url: measure_amount_path do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
     <h1 class="govuk-fieldset__heading">
@@ -28,7 +28,7 @@
 <%= render 'duty_calculator/shared/commodity_details' %>
 
 <div class="explore-topics-section">
-  <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-3"><%= t('duty_calculator.shared.explore_topic_title') %></h2>
   <%= govuk_list [
     govuk_link_to('Valuation of imported goods for customs purposes, VAT and trade statistics', 'https://www.gov.uk/government/publications/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics/notice-252-valuation-of-imported-goods-for-customs-purposes-vat-and-trade-statistics'),
   ] %>

--- a/app/views/duty_calculator/steps/meursing_additional_codes/show.html.erb
+++ b/app/views/duty_calculator/steps/meursing_additional_codes/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'duty_calculator/steps/shared/back_link' %>
 
-<span class="govuk-caption-xl">Calculate import duties</span>
+<span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 
 <%= form_for @step, url: meursing_additional_codes_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/duty_calculator/steps/planned_processing/show.html.erb
+++ b/app/views/duty_calculator/steps/planned_processing/show.html.erb
@@ -4,13 +4,19 @@
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl">Calculate import duties</span>
 
-  <%= f.govuk_radio_buttons_fieldset(:planned_processing, hint: { text: t('planned_processing.fieldset_hint_text_html') }, legend: { text: t('planned_processing.fieldset_legend_text'), size: 'xl', tag: 'h1' }) do %>
-    <br>
-    <div class='govuk-!-margin-bottom-3' >
-      <%= f.govuk_radio_button :planned_processing, 'without_any_processing', label: { text: t('planned_processing.without_any_processing.label_text_html') } %>
-    </div>
-    <%= f.govuk_radio_button :planned_processing, 'commercial_processing', label: { text: t('planned_processing.commercial_processing.label_text_html') }, hint: { text: commercial_processing_hint_text, commercial_processing_hint_text: commercial_processing_hint_text } %>
-    <%= f.govuk_radio_button :planned_processing, 'commercial_purposes', label: { text: t('planned_processing.commercial_purposes.label_text_html') } %>
+  <%= f.govuk_radio_buttons_fieldset :planned_processing,
+      legend: { text: t('planned_processing.fieldset_legend_text'), size: 'xl', tag: 'h1' },
+      hint: { text: t('planned_processing.fieldset_hint_text_html') } do %>
+    <%= f.govuk_radio_button :planned_processing,
+        'without_any_processing',
+        label: { text: t('planned_processing.without_any_processing.label_text_html') } %>
+    <%= f.govuk_radio_button :planned_processing,
+        'commercial_processing',
+        label: { text: t('planned_processing.commercial_processing.label_text_html') },
+        hint: { text: commercial_processing_hint_text } %>
+    <%= f.govuk_radio_button :planned_processing,
+        'commercial_purposes',
+        label: { text: t('planned_processing.commercial_purposes.label_text_html') } %>
   <% end %>
 
 

--- a/app/views/duty_calculator/steps/planned_processing/show.html.erb
+++ b/app/views/duty_calculator/steps/planned_processing/show.html.erb
@@ -2,14 +2,16 @@
 
 <%= form_for @step, url: planned_processing_path do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 
   <%= f.govuk_radio_buttons_fieldset :planned_processing,
       legend: { text: t('planned_processing.fieldset_legend_text'), size: 'xl', tag: 'h1' },
       hint: { text: t('planned_processing.fieldset_hint_text_html') } do %>
-    <%= f.govuk_radio_button :planned_processing,
-        'without_any_processing',
-        label: { text: t('planned_processing.without_any_processing.label_text_html') } %>
+    <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-3">
+      <%= f.govuk_radio_button :planned_processing,
+          'without_any_processing',
+          label: { text: t('planned_processing.without_any_processing.label_text_html') } %>
+    </div>
     <%= f.govuk_radio_button :planned_processing,
         'commercial_processing',
         label: { text: t('planned_processing.commercial_processing.label_text_html') },
@@ -26,7 +28,7 @@
 <%= render 'duty_calculator/shared/commodity_details' %>
 
 <div class="explore-topics-section">
-  <h2 class="govuk-heading-m govuk-!-margin-top-3">Explore the topic</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-3"><%= t('duty_calculator.shared.explore_topic_title') %></h2>
   <%= govuk_list [
     govuk_link_to('Additional requirements for when you bring goods into Northern Ireland for processing', 'https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu-from-1-january-2021#processing'),
     govuk_link_to('Apply to pay less duty on goods you import for specific uses', 'https://www.gov.uk/guidance/apply-to-pay-less-duty-on-goods-you-import-for-specific-uses'),

--- a/app/views/duty_calculator/steps/stopping/show.html.erb
+++ b/app/views/duty_calculator/steps/stopping/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'duty_calculator/steps/shared/back_link' %>
 
-<span class="govuk-caption-xl">Calculate import duties</span>
+<span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 <h1 class="govuk-heading-xl">Declared subheading not allowed</h1>
 
 <p class="govuk-body">

--- a/app/views/duty_calculator/steps/trader_scheme/show.html.erb
+++ b/app/views/duty_calculator/steps/trader_scheme/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @step, url: trader_scheme_path do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 
 
   <%= f.govuk_collection_radio_buttons :trader_scheme, @step.options, :id, :name, legend: { text: "#{trader_scheme_header}?", size: 'xl', tag: 'h1' }, hint: { text: "#{trader_scheme_body}" }, include_hidden: true %>

--- a/app/views/duty_calculator/steps/vat/show.html.erb
+++ b/app/views/duty_calculator/steps/vat/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for @step, url: vat_path do |f| %>
   <%= f.govuk_error_summary %>
-  <span class="govuk-caption-xl">Calculate import duties</span>
+  <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
 
   <%= f.govuk_collection_radio_buttons :vat, @step.vat_options, :id, :name, legend: { text: 'Which VAT rate is applicable to your trade?', size: 'xl', tag: 'h1' }, hint: { text: "There are #{applicable_vat_options.keys.count} VAT rates applicable to the trade in this commodity code. Select which rate applies to your trade. For guidance on applicable VAT rates, please see the document <a href='https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services' target='_blank' class='govuk-link'>VAT rates on different goods and services (opens in new browser window)</a>.".html_safe }, include_hidden: true %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1586,6 +1586,11 @@ en:
     duty_calculation: Import duty calculation - Online Tariff Duty calculator
     no_duty: There is no import duty to pay - Online Tariff Duty calculator
 
+  duty_calculator:
+    shared:
+      caption: Calculate import duties
+      explore_topic_title: Explore the topic
+
   duty_calculations:
     options:
       mfn:
@@ -1730,7 +1735,7 @@ en:
       How will these goods be processed after they are moved into Northern Ireland?
     without_any_processing:
       label_text_html: >
-        The goods <strong>will not be subject to processing in Northern Ireland<strong>
+        The goods <strong>will not be subject to processing in Northern Ireland</strong>
     commercial_processing:
       label_text_html: >
         The goods will undergo <strong>commercial processing</strong> for one of these purposes:


### PR DESCRIPTION
## What:
- Refactors the planned processing step template radio markup, preserving expected hint alignment and first-option spacing (`govuk-!-margin-top-6`).
- Uses shared duty calculator locale keys for the caption and "Explore the topic" heading across duty calculator step views.

## Why:
- Keeps duty calculator templates consistent and easier to maintain.
- Reduces duplicated hard-coded headings/captions across step views while keeping user-facing behaviour unchanged.

## Ticket:
- N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
This is a view/i18n refactor with no backend/API or routing changes and no intended behavioural change to journey logic. Focused planned-processing and helper specs were run during implementation.
