### PR TITLE
BAU Refactor cookies policy radios to GOV.UK form builder

### DIFF
--- a/app/javascript/controllers/cookie_policy_controller.js
+++ b/app/javascript/controllers/cookie_policy_controller.js
@@ -2,13 +2,12 @@ import {Controller} from '@hotwired/stimulus';
 
 import CookieManager from 'cookie-manager';
 
+const USAGE = 'cookies_policy[usage]';
+const REMEMBER_SETTINGS = 'cookies_policy[remember_settings]';
+
 export default class extends Controller {
   static targets = [
     'successMessage',
-    'usageRadioTrue',
-    'usageRadioFalse',
-    'rememberSettingsRadioTrue',
-    'rememberSettingsRadioFalse',
   ];
 
   connect() {
@@ -22,53 +21,30 @@ export default class extends Controller {
   updatePolicy(event) {
     event.preventDefault();
 
-    if (this.#pickedAllOptions()) {
-      this.cookieManager.setCookiesPolicy({
-        usage: this.#usage(),
-        remember_settings: this.#rememberSettings(),
-      });
-      this.#showSuccessMessage();
-    }
+    if (!this.#anyOptionPicked()) return;
+
+    this.cookieManager.setCookiesPolicy({
+      usage: this.#selectedBoolean(USAGE),
+      remember_settings: this.#selectedBoolean(REMEMBER_SETTINGS),
+    });
+    this.#showSuccessMessage();
   }
 
 
   #updatePolicyBasedOnCookies() {
-    if (this.#hasRadioTargets) {
-      this.#updateUsage();
-      this.#updateRememberSettings();
+    if (this.#hasRadioInputs()) {
+      this.#setRadioSelection(USAGE, this.cookieManager.usage());
+      this.#setRadioSelection(REMEMBER_SETTINGS, this.cookieManager.rememberSettings());
     }
   }
 
-  #usage() {
-    if (this.usageRadioTrueTarget.checked) {
-      return true;
-    } else if (this.usageRadioFalseTarget.checked) {
-      return false;
-    }
+  #selectedBoolean(name) {
+    return this.#selectedRadioValue(name) === 'true';
   }
 
-  #rememberSettings() {
-    if (this.rememberSettingsRadioTrueTarget.checked) {
-      return true;
-    } else if (this.rememberSettingsRadioFalseTarget.checked) {
-      return false;
-    }
-  }
-
-  #updateUsage() {
-    if (this.cookieManager.usage()) {
-      this.usageRadioTrueTarget.checked = true;
-    } else {
-      this.usageRadioFalseTarget.checked = true;
-    }
-  }
-
-  #updateRememberSettings() {
-    if (this.cookieManager.rememberSettings()) {
-      this.rememberSettingsRadioTrueTarget.checked = true;
-    } else {
-      this.rememberSettingsRadioFalseTarget.checked = true;
-    }
+  #setRadioSelection(name, checked) {
+    const value = checked === true ? 'true' : 'false';
+    this.#radioByValue(name, value).checked = true;
   }
 
   #showSuccessMessage() {
@@ -76,30 +52,22 @@ export default class extends Controller {
     this.successMessageTarget.scrollIntoView({behavior: 'smooth', block: 'center'});
   }
 
-  #hasRadioTargets() {
-    const hasTargets = this.hasUsageRadioTrueTarget &&
-      this.hasUsageRadioFalseTarget &&
-      this.hasRememberSettingsRadioTrueTarget &&
-      this.hasRememberSettingsRadioFalseTarget;
-
-    return hasTargets;
+  #hasRadioInputs() {
+    return Boolean(this.#radioByValue(USAGE, 'true')) &&
+      Boolean(this.#radioByValue(USAGE, 'false')) &&
+      Boolean(this.#radioByValue(REMEMBER_SETTINGS, 'true')) &&
+      Boolean(this.#radioByValue(REMEMBER_SETTINGS, 'false'));
   }
 
-  #pickedAllOptions() {
-    const pickedAllOptions = this.#pickedUsageOption() && this.#pickedRememberSettingsOption;
-
-    return pickedAllOptions;
+  #anyOptionPicked() {
+    return this.#selectedRadioValue(USAGE) !== undefined || this.#selectedRadioValue(REMEMBER_SETTINGS) !== undefined;
   }
 
-  #pickedUsageOption() {
-    const pickedUsageOption = this.usageRadioTrueTarget.checked || this.usageRadioFalseTarget.checked;
-
-    return pickedUsageOption;
+  #radioByValue(name, value) {
+    return this.element.querySelector(`input[name="${name}"][value="${value}"]`);
   }
 
-  #pickedRememberSettingsOption() {
-    const pickedRememberSettingsOption = this.rememberSettingsRadioTrueTarget.checked || this.rememberSettingsRadioFalseTarget.checked;
-
-    return pickedRememberSettingsOption;
+  #selectedRadioValue(name) {
+    return this.element.querySelector(`input[name="${name}"]:checked`)?.value;
   }
 }

--- a/app/views/cookies/policies/show.html.erb
+++ b/app/views/cookies/policies/show.html.erb
@@ -8,7 +8,11 @@
 <% end %>
 
 <div data-controller="cookie-policy">
-  <form data-action="submit->cookie-policy#updatePolicy">
+  <%= form_with scope: :cookies_policy,
+                url: cookies_policy_path,
+                method: :get,
+                builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+                data: { action: 'submit->cookie-policy#updatePolicy' } do |f| %>
     <div data-cookie-policy-target="successMessage" class="govuk-grid-row" hidden="hidden">
       <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
@@ -77,28 +81,14 @@
           </tbody>
         </table>
         <br>
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset" aria-describedby="cookie-consent-usage-hint">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xs">
-              Do you consent to cookies that measure website use?
-            </legend>
-            <div id="cookie-consent-usage-hint" class="govuk-hint"></div>
-            <div class="govuk-radios govuk-radios--stacked">
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" type="radio" value="true" name="cookies_policy[usage]" id="cookies_policy_usage_true" data-cookie-policy-target="usageRadioTrue">
-                <label class="govuk-label govuk-radios__label" for="cookies_policy_usage_true">
-                  Use cookies that measure my website use
-                </label>
-              </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" type="radio" value="false" name="cookies_policy[usage]" id="cookies_policy_usage_false" data-cookie-policy-target="usageRadioFalse">
-                <label class="govuk-label govuk-radios__label" for="cookies_policy_usage_false">
-                  No, do not use cookies that measure my website use
-                </label>
-              </div>
-            </div>
-          </fieldset>
-        </div>
+        <%= f.govuk_radio_buttons_fieldset :usage,
+              legend: {
+                text: 'Do you consent to cookies that measure website use?',
+                size: 's',
+              } do %>
+          <%= f.govuk_radio_button :usage, true, label: { text: 'Use cookies that measure my website use' } %>
+          <%= f.govuk_radio_button :usage, false, label: { text: 'No, do not use cookies that measure my website use' } %>
+        <% end %>
         <h3 class="govuk-heading-s">Cookies that remember your settings</h3>
         <p>These cookies do things like remember your preferences and the choices you make, to personalise your
           experience of using the site.</p>
@@ -122,25 +112,14 @@
           </tbody>
         </table>
         <br>
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset" aria-describedby="cookie-consent-settings-hint">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xs">
-              Do you consent to cookies that remember your settings?
-            </legend>
-            <div id="cookie-consent-settings-hint" class="govuk-hint">
-            </div>
-            <div class="govuk-radios govuk-radios--stacked">
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" type="radio" value="true" name="cookies_policy[remember_settings]" id="cookies_policy_remember_settings_true" data-cookie-policy-target="rememberSettingsRadioTrue">
-                <label class="govuk-label govuk-radios__label" for="cookies_policy_remember_settings_true">Yes, use cookies that remember my settings on the site</label>
-              </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" type="radio" value="false" name="cookies_policy[remember_settings]" id="cookies_policy_remember_settings_false" data-cookie-policy-target="rememberSettingsRadioFalse">
-                <label class="govuk-label govuk-radios__label" for="cookies_policy_remember_settings_false">No, do not use cookies that remember my settings on the site</label>
-              </div>
-            </div>
-          </fieldset>
-        </div>
+        <%= f.govuk_radio_buttons_fieldset :remember_settings,
+              legend: {
+                text: 'Do you consent to cookies that remember your settings?',
+                size: 's',
+              } do %>
+          <%= f.govuk_radio_button :remember_settings, true, label: { text: 'Yes, use cookies that remember my settings on the site' } %>
+          <%= f.govuk_radio_button :remember_settings, false, label: { text: 'No, do not use cookies that remember my settings on the site' } %>
+        <% end %>
         <h3 class="govuk-heading-s">Strictly necessary cookies</h3>
         <p>These essential cookies do things like remember your progress through the application.
           They always need to be on, or the service will not function.
@@ -186,10 +165,10 @@
           </tbody>
         </table>
 
-        <input type="submit" name="commit" value="Save Changes" class="govuk-button cookies_save_changes">
+        <%= f.govuk_submit 'Save Changes', class: 'cookies_save_changes' %>
         <p>Last updated 16 Mar 2021</p>
       </div>
       <div class="govuk-grid-column-two-thirds"></div>
     </div>
-  </form>
+  <% end %>
 </div>

--- a/app/views/cookies/policies/show.html.erb
+++ b/app/views/cookies/policies/show.html.erb
@@ -22,7 +22,7 @@
         </div>
         <div class="govuk-notification-banner__content">
           <h3 class="govuk-notification-banner__heading">
-            Your cookie settings were saved
+            <%= t('.saved_heading') %>
           </h3>
           <p>You can update these settings at any time.</p>
         </div>
@@ -83,11 +83,11 @@
         <br>
         <%= f.govuk_radio_buttons_fieldset :usage,
               legend: {
-                text: 'Do you consent to cookies that measure website use?',
+                text: t('.usage.legend'),
                 size: 's',
               } do %>
-          <%= f.govuk_radio_button :usage, true, label: { text: 'Use cookies that measure my website use' } %>
-          <%= f.govuk_radio_button :usage, false, label: { text: 'No, do not use cookies that measure my website use' } %>
+          <%= f.govuk_radio_button :usage, true, label: { text: t('.usage.yes_label') } %>
+          <%= f.govuk_radio_button :usage, false, label: { text: t('.usage.no_label') } %>
         <% end %>
         <h3 class="govuk-heading-s">Cookies that remember your settings</h3>
         <p>These cookies do things like remember your preferences and the choices you make, to personalise your
@@ -114,11 +114,11 @@
         <br>
         <%= f.govuk_radio_buttons_fieldset :remember_settings,
               legend: {
-                text: 'Do you consent to cookies that remember your settings?',
+                text: t('.remember_settings.legend'),
                 size: 's',
               } do %>
-          <%= f.govuk_radio_button :remember_settings, true, label: { text: 'Yes, use cookies that remember my settings on the site' } %>
-          <%= f.govuk_radio_button :remember_settings, false, label: { text: 'No, do not use cookies that remember my settings on the site' } %>
+          <%= f.govuk_radio_button :remember_settings, true, label: { text: t('.remember_settings.yes_label') } %>
+          <%= f.govuk_radio_button :remember_settings, false, label: { text: t('.remember_settings.no_label') } %>
         <% end %>
         <h3 class="govuk-heading-s">Strictly necessary cookies</h3>
         <p>These essential cookies do things like remember your progress through the application.
@@ -165,7 +165,7 @@
           </tbody>
         </table>
 
-        <%= f.govuk_submit 'Save Changes', class: 'cookies_save_changes' %>
+        <%= f.govuk_submit t('.submit'), class: 'cookies_save_changes' %>
         <p>Last updated 16 Mar 2021</p>
       </div>
       <div class="govuk-grid-column-two-thirds"></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,6 +175,20 @@ en:
     uk: "UK Integrated Online Tariff"
     xi: "Northern Ireland Online Tariff"
 
+  cookies:
+    policies:
+      show:
+        saved_heading: "Your cookie settings were saved"
+        submit: "Save Changes"
+        usage:
+          legend: "Do you consent to cookies that measure website use?"
+          yes_label: "Use cookies that measure my website use"
+          no_label: "No, do not use cookies that measure my website use"
+        remember_settings:
+          legend: "Do you consent to cookies that remember your settings?"
+          yes_label: "Yes, use cookies that remember my settings on the site"
+          no_label: "No, do not use cookies that remember my settings on the site"
+
   tabs:
     footnote:
       heading: Notes for %{declarable_type} %{goods_nomenclature_item_id}

--- a/spec/features/cookies_spec.rb
+++ b/spec/features/cookies_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'Cookies management', :js do
     expect(cookie_for('cookies_policy')).to eq('remember_settings' => true, 'usage' => true)
     expect(cookie_for('cookies_preferences_set')).to be_nil
     expect(page).to have_css '.govuk-notification-banner h3', text: 'Your cookie settings were saved'
-    expect(page).to have_css '#cookies_accepted'
+    expect(page).to have_css '#cookies_accepted', text: 'You have accepted additional cookies.'
 
     visit cookies_path
     find(:button, 'Hide this message', visible: true).click

--- a/spec/javascript/controllers/cookie_policy_controller_spec.js
+++ b/spec/javascript/controllers/cookie_policy_controller_spec.js
@@ -34,19 +34,19 @@ describe('CookiePolicyController', () => {
 
         <div class="govuk-radios govuk-radios--stacked">
           <div class="govuk-radios__item">
-            <input type="radio" value="true" name="cookies_policy[usage]" data-cookie-policy-target="usageRadioTrue">
+            <input id="cookies_policy_usage_true" type="radio" value="true" name="cookies_policy[usage]">
           </div>
           <div class="govuk-radios__item">
-            <input type="radio" value="false" name="cookies_policy[usage]" data-cookie-policy-target="usageRadioFalse">
+            <input id="cookies_policy_usage_false" type="radio" value="false" name="cookies_policy[usage]">
           </div>
         </div>
 
         <div class="govuk-radios govuk-radios--stacked">
           <div class="govuk-radios__item">
-            <input type="radio" value="true" data-cookie-policy-target="rememberSettingsRadioTrue">
+            <input id="cookies_policy_remember_settings_true" type="radio" value="true" name="cookies_policy[remember_settings]">
           </div>
           <div class="govuk-radios__item">
-            <input type="radio" value="false" data-cookie-policy-target="rememberSettingsRadioFalse">
+            <input id="cookies_policy_remember_settings_false" type="radio" value="false" name="cookies_policy[remember_settings]">
           </div>
         </div>
 
@@ -70,11 +70,29 @@ describe('CookiePolicyController', () => {
     it('should set the all options to unchecked by default', () => {
       application.start();
       controllerInstance = application.getControllerForElementAndIdentifier(element, 'cookie-policy');
+      const usageRadioTrue = element.querySelector('#cookies_policy_usage_true');
+      const usageRadioFalse = element.querySelector('#cookies_policy_usage_false');
+      const rememberSettingsRadioTrue = element.querySelector('#cookies_policy_remember_settings_true');
+      const rememberSettingsRadioFalse = element.querySelector('#cookies_policy_remember_settings_false');
 
-      expect(controllerInstance.usageRadioTrueTarget.checked).toEqual(false);
-      expect(controllerInstance.usageRadioFalseTarget.checked).toEqual(false);
-      expect(controllerInstance.rememberSettingsRadioTrueTarget.checked).toEqual(false);
-      expect(controllerInstance.rememberSettingsRadioFalseTarget.checked).toEqual(false);
+      expect(controllerInstance).toBeDefined();
+      expect(usageRadioTrue.checked).toEqual(false);
+      expect(usageRadioFalse.checked).toEqual(false);
+      expect(rememberSettingsRadioTrue.checked).toEqual(false);
+      expect(rememberSettingsRadioFalse.checked).toEqual(false);
+    });
+
+    it('should restore checked options from an existing cookies policy', () => {
+      cookieManager.setCookiesPolicy({usage: false, remember_settings: true});
+
+      controllerInstance = application.getControllerForElementAndIdentifier(element, 'cookie-policy');
+      controllerInstance.connect();
+      const usageRadioFalse = element.querySelector('#cookies_policy_usage_false');
+      const rememberSettingsRadioTrue = element.querySelector('#cookies_policy_remember_settings_true');
+
+      expect(controllerInstance).toBeDefined();
+      expect(usageRadioFalse.checked).toEqual(true);
+      expect(rememberSettingsRadioTrue.checked).toEqual(true);
     });
   });
 
@@ -90,12 +108,30 @@ describe('CookiePolicyController', () => {
       expect(cookieManager.getCookiesPolicy()).toEqual(null);
     });
 
+    it('should set the cookies policy when only one option group is selected and default the other to false', () => {
+      application.start();
+      controllerInstance = application.getControllerForElementAndIdentifier(element, 'cookie-policy');
+      const usageRadioTrue = element.querySelector('#cookies_policy_usage_true');
+      const successMessage = element.querySelector('[data-cookie-policy-target="successMessage"]');
+
+      usageRadioTrue.checked = true;
+
+      const form = element.querySelector('form');
+      const submitEvent = new Event('submit', {bubbles: true, cancelable: true});
+      form.dispatchEvent(submitEvent);
+
+      expect(cookieManager.getCookiesPolicy()).toEqual({usage: true, remember_settings: false});
+      expect(successMessage.hidden).toEqual(false);
+    });
+
     it('should set the cookies policy when we submit the form and the options are picked', () => {
       application.start();
       controllerInstance = application.getControllerForElementAndIdentifier(element, 'cookie-policy');
+      const usageRadioTrue = element.querySelector('#cookies_policy_usage_true');
+      const rememberSettingsRadioTrue = element.querySelector('#cookies_policy_remember_settings_true');
 
-      controllerInstance.usageRadioTrueTarget.checked = true;
-      controllerInstance.rememberSettingsRadioTrueTarget.checked = true;
+      usageRadioTrue.checked = true;
+      rememberSettingsRadioTrue.checked = true;
 
       const form = element.querySelector('form');
       const submitEvent = new Event('submit', {bubbles: true, cancelable: true});


### PR DESCRIPTION
## What:
- Refactors the cookies settings form to use GOVUKDesignSystemFormBuilder radio helpers instead of hand-rolled radio markup.
- Updates the cookies policy Stimulus controller to read, validate, and restore radio selections by name/value selectors rather than Stimulus radio targets.
- Updates the related JavaScript and feature specs to match and verify the save flow behaviour.
- Moves cookies policy form copy into scoped locale keys in config/locales/en.yml and updates the template to use scoped translations.

## Why:
- Aligns with repository guidance to prefer GOV.UK components over custom markup.
- Reduces accessibility and consistency risk from manually maintained radio HTML.
- Keeps controller logic aligned to stable input name/value contracts from formbuilder output instead of coupling to specific target wiring.
- Makes the save flow more robust while keeping user-visible behaviour unchanged.
- Keeps reusable copy in locale files rather than hardcoding it in the template.

## Ticket:
- N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
This is a focused refactor to GOV.UK component usage and locale extraction with equivalent behaviour and matching test updates. No route or API changes are introduced.
