### PR TITLE
Extract shared search form error helper methods

### DIFF
--- a/app/helpers/search_results_helper.rb
+++ b/app/helpers/search_results_helper.rb
@@ -1,4 +1,43 @@
 module SearchResultsHelper
+  def search_error_messages(search)
+    search.errors.map(&:message)
+  end
+
+  def search_error_summary(search, anchor:)
+    return unless search.errors.any?
+
+    content_tag(:div, class: 'govuk-error-summary', data: { module: 'govuk-error-summary' }) do
+      content_tag(:div, role: 'alert') do
+        safe_join([
+                    content_tag(:h2, 'There is a problem', class: 'govuk-error-summary__title'),
+                    content_tag(:div, class: 'govuk-error-summary__body') do
+                      error_items = search_error_messages(search).map { |message| govuk_link_to(message, "##{anchor}") }
+                      govuk_list(error_items, classes: 'govuk-error-summary__list')
+                    end,
+                  ])
+      end
+    end
+  end
+
+  def search_field_error_class(search)
+    ' govuk-form-group--error' if search.errors.any?
+  end
+
+  def search_textarea_error_class(search)
+    ' govuk-textarea--error' if search.errors.any?
+  end
+
+  def search_inline_error(search, id:)
+    return unless search.errors.any?
+
+    content_tag(:p, class: 'govuk-error-message', id:) do
+      safe_join([
+                  content_tag(:span, 'Error:', class: 'govuk-visually-hidden'),
+                  " #{search_error_messages(search).join('. ')}",
+                ])
+    end
+  end
+endmodule SearchResultsHelper
   CONFIDENCE_LEVELS = {
     'Strong' => {
       label: 'Strong result',

--- a/app/views/shared/search/_interactive_search_form.html.erb
+++ b/app/views/shared/search/_interactive_search_form.html.erb
@@ -6,18 +6,7 @@
 
 <%= render 'shared/invalid_date_error_summary' if params[:invalid_date].present? %>
 
-<% if @search.errors.any? %>
-<div class="govuk-error-summary" data-module="govuk-error-summary">
-  <div role="alert">
-    <h2 class="govuk-error-summary__title">There is a problem</h2>
-    <div class="govuk-error-summary__body">
-      <% error_items = @search.errors.map { |error| govuk_link_to(error.message, '#guided_q') } %>
-      <%= govuk_list error_items, classes: 'govuk-error-summary__list' %>
-    </div>
-  </div>
-</div>
-
-<% end %>
+<%= search_error_summary(@search, anchor: 'guided_q') %>
 
 <% if @search.day_month_and_year_set? %>
 <%= hidden_field_tag :year, @search.year %>
@@ -52,7 +41,7 @@
           <p>Answer each question as specifically as you can. If you are unsure, select "I don't know" and the system will show you the best results based on what you have provided.</p>
         <% end %>
 
-        <div class="govuk-form-group<%= ' govuk-form-group--error' if @search.errors.any? %>"
+        <div class="govuk-form-group<%= search_field_error_class(@search) %>"
              data-guided-search-validation-target="formGroup">
           <label class="govuk-label" for="guided_q">
             Describe the products you are trading
@@ -60,12 +49,8 @@
           <div class="govuk-hint" id="guided-q-hint">
             For example, 55" 4K Ultra HD OLED Smart TV
           </div>
-          <% if @search.errors.any? %>
-            <p class="govuk-error-message" id="guided-q-error">
-              <span class="govuk-visually-hidden">Error:</span> <%= @search.errors.map(&:message).join('. ') %>
-            </p>
-          <% end %>
-          <textarea class="govuk-textarea<%= ' govuk-textarea--error' if @search.errors.any? %>" id="guided_q" name="q" rows="5"
+          <%= search_inline_error(@search, id: 'guided-q-error') %>
+          <textarea class="govuk-textarea<%= search_textarea_error_class(@search) %>" id="guided_q" name="q" rows="5"
                     aria-describedby="guided-q-hint<%= ' guided-q-error' if @search.errors.any? %>"
                     data-interactive-search-radio-target="guidedInput"
                     data-guided-search-validation-target="textarea"><%= @search.q %></textarea>

--- a/app/views/shared/search/_search_form.html.erb
+++ b/app/views/shared/search/_search_form.html.erb
@@ -4,17 +4,7 @@
   <%= render 'shared/invalid_date_error_summary' %>
 <% end %>
 
-<% if @search.errors.any? %>
-<div class="govuk-error-summary" data-module="govuk-error-summary">
-  <div role="alert">
-    <h2 class="govuk-error-summary__title">There is a problem</h2>
-    <div class="govuk-error-summary__body">
-      <% error_items = @search.errors.map { |error| govuk_link_to(error.message, '#q') } %>
-      <%= govuk_list error_items, classes: 'govuk-error-summary__list' %>
-    </div>
-  </div>
-</div>
-<% end %>
+<%= search_error_summary(@search, anchor: 'q') %>
 
 <% if @search.day_month_and_year_set? %>
 <%= hidden_field_tag :year, @search.year %>
@@ -23,13 +13,9 @@
 <% end %>
 
 
-<div class="govuk-form-group<%= ' govuk-form-group--error' if @search.errors.any? %>">
+<div class="govuk-form-group<%= search_field_error_class(@search) %>">
   <%= label_tag :q, search_label_text, class: 'govuk-label' %>
-  <% if @search.errors.any? %>
-    <p class="govuk-error-message" id="q-error">
-      <span class="govuk-visually-hidden">Error:</span> <%= @search.errors.map(&:message).join('. ') %>
-    </p>
-  <% end %>
+  <%= search_inline_error(@search, id: 'q-error') %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters column-three-quarters-mobile-only">
       <%= render 'shared/search/autocomplete' %>


### PR DESCRIPTION
## What:
- Extracts reusable search form error helper methods in app/helpers/search_results_helper.rb.
- Replaces duplicated error summary and inline error markup in app/views/shared/search/_search_form.html.erb.
- Replaces duplicated error summary and inline error markup in app/views/shared/search/_interactive_search_form.html.erb.

## Why:
- Reduces repeated error-rendering logic and centralises accessibility-related error output.
- Makes search form error behaviour easier to keep consistent.

## Ticket:
- N/A

## Risk:

**Risk level:** 🟠

**Reason for rating:**
This changes user-facing search form validation markup in core journeys. Intended behaviour is unchanged, but search UI behaviour should be socialised before merge.
