### PR TITLE
Add page title assertions for duty calculator import destination

### DIFF
--- a/spec/requests/duty_calculator/steps/import_destination_spec.rb
+++ b/spec/requests/duty_calculator/steps/import_destination_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+RSpec.describe 'Duty calculator import destination step', :user_session, type: :request do
+  let(:user_session) { build(:duty_calculator_user_session, :with_commodity_information) }
+
+  describe 'GET /duty-calculator/import-destination' do
+    it 'returns success and includes the page title' do
+      get import_destination_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Which part of the UK are you importing into?')
+      expect(response.body).to include('Which part of the UK are you importing into - Online Tariff Duty calculator')
+    end
+  end
+
+  describe 'POST /duty-calculator/import-destination' do
+    let(:params) do
+      {
+        duty_calculator_steps_import_destination: {
+          import_destination: import_destination,
+        },
+      }
+    end
+
+    context 'when params are valid' do
+      let(:import_destination) { 'GB' }
+
+      it 'redirects to the next step and persists the answer' do
+        expect {
+          post import_destination_path, params:
+        }.to change(user_session, :import_destination).from(nil).to('GB')
+
+        expect(response).to redirect_to(country_of_origin_path)
+      end
+    end
+
+    context 'when params are invalid' do
+      let(:import_destination) { '' }
+
+      it 're-renders the step page and keeps the page title' do
+        post import_destination_path, params:
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('There is a problem')
+        expect(response.body).to include('Which part of the UK are you importing into - Online Tariff Duty calculator')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What:
- Adds a request spec for the duty calculator import destination step.
- Asserts the page title on the successful GET render.
- Asserts the page title is still present when POST validation fails and the page is re-rendered.

## Why:
- Page titles are part of the user-facing behaviour in this journey.
- Gives direct coverage for a core duty calculator step without expanding controller specs.

## Ticket:
- N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
This is test-only coverage and does not change production runtime behaviour.
