### PR TITLE
Add duty calculator import destination feature coverage

### DIFF
--- a/spec/features/duty_calculator_import_destination_spec.rb
+++ b/spec/features/duty_calculator_import_destination_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe 'Duty calculator import destination', :js, type: :feature do
+  let(:user_session) { build(:duty_calculator_user_session, :with_commodity_information) }
+
+  before do
+    allow(DutyCalculator::UserSession).to receive_messages(build: user_session, build_from_params: user_session, get: user_session)
+  end
+
+  it 'shows the expected page title and form copy on the step page' do
+    visit import_destination_path
+
+    expect(page).to have_css('h1', text: 'Which part of the UK are you importing into?')
+    expect(page).to have_title('Which part of the UK are you importing into - Online Tariff Duty calculator')
+    expect(page).to have_css('.govuk-hint', text: 'The duty you are charged may be dependent on the part of the UK to which you are importing.')
+    expect(page).to have_field('England, Scotland or Wales (GB)')
+    expect(page).to have_field('Northern Ireland')
+  end
+
+  it 'shows an error summary when the form is submitted without a choice' do
+    visit import_destination_path
+    click_button 'Continue'
+
+    expect(page).to have_css('.govuk-error-summary')
+    expect(page).to have_css('.govuk-error-summary__list', text: "can't be blank")
+    expect(page).to have_title('Which part of the UK are you importing into - Online Tariff Duty calculator')
+  end
+end


### PR DESCRIPTION
## What:
- Adds a feature spec for the duty calculator import destination page.
- Asserts the page title, heading, hint text, and radio labels on the step page.
- Asserts the error summary appears after submitting the step without selecting an option.

## Why:
- Gives direct coverage for the user-visible accessibility and validation behaviour on a core duty calculator step.
- Complements the controller/request coverage by exercising the page in the browser.

## Ticket:
- N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
This is test-only coverage and does not change production runtime behaviour.
