### PR TITLE
Use GOV.UK formbuilder submits in enquiry journey

### DIFF
--- a/app/views/product_experience/enquiry_form/check_your_answers.html.erb
+++ b/app/views/product_experience/enquiry_form/check_your_answers.html.erb
@@ -6,7 +6,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Check your answers before submitting your form</h1>
-      <%= form_with url: product_experience_enquiry_form_submit_form_path, method: :post, local: true do %>
+      <%= form_with url: product_experience_enquiry_form_submit_form_path,
+                    method: :post,
+                    local: true,
+                    builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
         <%= hidden_field_tag :submission_token, session[:submission_token] %>
 
         <% rows = [
@@ -24,7 +27,7 @@
 
         <%= govuk_summary_list(rows: rows.compact) %>
 
-        <p><%= submit_tag "Submit", class: "govuk-button govuk-!-margin-top-4" %></p>
+        <%= f.govuk_submit 'Submit', class: 'govuk-!-margin-top-4' %>
       <% end %>
     </div>
   </div>

--- a/app/views/product_experience/enquiry_form/form.html.erb
+++ b/app/views/product_experience/enquiry_form/form.html.erb
@@ -7,11 +7,14 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: product_experience_enquiry_form_field_path(@field), method: :post, local: true do %>
+    <%= form_with url: product_experience_enquiry_form_field_path(@field),
+                  method: :post,
+                  local: true,
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= hidden_field_tag :submission_token, session[:submission_token] %>
       <%= hidden_field_tag :editing, params[:editing] if params[:editing].present? %>
       <%= render partial: partial_for_field(@field), locals: { field: @field } %>
-      <%= submit_tag "Continue", class: "govuk-button" %>
+      <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## What:
Use `govuk_design_system_formbuilder` submit helpers in product enquiry forms by switching submit controls in the step form and check-your-answers form to `f.govuk_submit` with GOV.UK form builder enabled.
Other parts of the journey have been left as is due to the use of a custom errors object.

## Why:
Reduce hand-rolled GOV.UK button markup in this journey while preserving existing field rendering and validation behaviour.

## Ticket:
BAU

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Small, view-only GOV.UK component usage change with no route/controller/model behaviour change.