### PR TITLE
Exclude packs-test assets from trufflehog

### DIFF
--- a/.trufflehog-exclude-paths.txt
+++ b/.trufflehog-exclude-paths.txt
@@ -1,5 +1,6 @@
 (^|/)node_modules/
 (^|/)public/packs/
+(^|/)public/packs-test/
 (^|/)terraform/\.terraform/
 (^|/)vendor/bundle/
 (^|/)tmp/


### PR DESCRIPTION
## What:
Add `public/packs-test/` to the TruffleHog exclude paths so generated test bundle artifacts are skipped during repository secret scans.

## Why:
The pre-commit TruffleHog hook scans the whole repository filesystem and was failing on false positives in compiled assets under `public/packs-test`, even though those files are gitignored.

## Ticket:
BAU

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Small configuration-only change that narrows secret scanning away from generated test assets and does not affect application runtime behaviour.