### PR TITLE
Fix InvalidAuthenticityToken on SearchController#search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,6 +5,8 @@ class SearchController < ApplicationController
   include ClassicSearchable
   include InteractiveSearchable
 
+  skip_before_action :verify_authenticity_token, only: [:search]
+
   before_action :disable_switch_service_banner, only: [:quota_search]
   before_action :disable_search_form, except: [:search]
 


### PR DESCRIPTION
## What:
Skip CSRF token verification for `SearchController#search`.

## Why:
Users were hitting `InvalidAuthenticityToken` errors when submitting the search form via POST. The most likely cause is a shared/proxy cache serving a page with a stale embedded CSRF token (or an expired session), so the token no longer matches when the form is submitted.

The `search` action is read-only — it reads params and returns results, never writing state — so CSRF protection is not needed here. Skipping `verify_authenticity_token` only for this action is the appropriate fix.

## Ticket:
N/A

## Risk:

**Risk level:** 🟠

**Reason for rating:**
Modifies CSRF protection behaviour on the primary search action. The change is safe (the action is read-only), but it touches security configuration on a high-traffic, user-facing endpoint.