### PR TITLE
[HMRC-2300] Raise a 404 instead on page not found in glossary

### DIFF
--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -1,5 +1,6 @@
 ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   'Faraday::ResourceNotFound' => :not_found,
+  'Pages::Glossary::UnknownPage' => :not_found,
   'WizardSteps::UnknownStep' => :not_found,
   'ActionView::MissingTemplate' => :not_found,
   'ActionController::UnknownFormat' => :not_found,

--- a/spec/requests/pages/glossary_controller_spec.rb
+++ b/spec/requests/pages/glossary_controller_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Pages::GlossaryController, type: :request do
         get glossary_term_path('unknown_page')
       end
 
-      it { expect(response).to have_http_status(:internal_server_error) }
+      it { expect(response).to have_http_status(:not_found) }
+      it { expect(response.body).to include('Page not found') }
     end
   end
 end


### PR DESCRIPTION
## What:
Rescues `Pages::Glossary::UnknownPage` and maps it to a 404 not found response

## Why:
Unknown pages on the glossary were raising 500 errors. These should raise a 404 instead.

## Ticket:
[HMRC-2300](https://transformuk.atlassian.net/browse/HMRC-2300)

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
Only changes http status code on low impact page