### PR TITLE
AI-588: Add request ID to guided search details

### DIFF
--- a/app/views/search/_interactive_results_content.html.erb
+++ b/app/views/search/_interactive_results_content.html.erb
@@ -9,6 +9,9 @@
     <div data-controller="copy-search-details">
       <%= govuk_details(summary_text: 'View search details') do %>
         <p class="govuk-body-s"><strong>Search term:</strong> <%= @search.q %></p>
+        <% if @search.request_id.present? %>
+          <p class="govuk-body-s"><strong>Request ID:</strong> <%= @search.request_id %></p>
+        <% end %>
         <% if @results.answered_questions.any? %>
           <% @results.answered_questions.each do |qa| %>
             <p class="govuk-body-s govuk-!-margin-bottom-1">

--- a/app/views/search/_interactive_unknown_results_content.html.erb
+++ b/app/views/search/_interactive_unknown_results_content.html.erb
@@ -9,6 +9,13 @@
           <%= @search.q %>
         <% end %>
 
+        <% if @search.request_id.present? %>
+          <%= tag.p(class: 'govuk-body') do %>
+            <%= tag.strong('Request ID') %><br>
+            <%= @search.request_id %>
+          <% end %>
+        <% end %>
+
         <% @results.answered_questions.each do |qa| %>
           <%= tag.p(class: 'govuk-body govuk-!-margin-bottom-3') do %>
             <%= tag.strong(qa['question']) %><br>

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
     it { is_expected.to have_text('citrus jam') }
     it { is_expected.to have_text('What type of fruit?') }
     it { is_expected.to have_text('Citrus') }
+    it { is_expected.to have_text('Request ID: test-uuid-123') }
     it { is_expected.to have_css('button', text: 'Copy search details') }
   end
 

--- a/spec/views/search/_interactive_unknown_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_unknown_results_content.html.erb_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'search/_interactive_unknown_results_content', type: :view do
     it { is_expected.to have_css('.govuk-inset-text', text: 'These are the details you supplied:') }
     it { is_expected.to have_css('.govuk-inset-text', text: 'Initial search term') }
     it { is_expected.to have_css('.govuk-inset-text', text: 'flimflammagoo') }
+    it { is_expected.to have_css('.govuk-inset-text', text: 'Request ID') }
+    it { is_expected.to have_css('.govuk-inset-text', text: 'test-uuid-123') }
     it { is_expected.to have_css('.govuk-inset-text', text: 'Which of these best describes the product?') }
     it { is_expected.to have_css('.govuk-inset-text', text: 'Standard jam / jelly / marmalade / fruit spread for general consumption') }
     it { is_expected.to have_css('button', text: 'Copy results to clipboard') }


### PR DESCRIPTION
### Jira link

[AI-588](https://transformuk.atlassian.net/browse/AI-588)

<img width="725" height="746" alt="image" src="https://github.com/user-attachments/assets/fb8a6728-b610-4edb-9f70-cb46e7069f3b" />

### What?

- [x] Add the guided search request ID to the copyable successful results details
- [x] Add the guided search request ID to the copyable unable-to-suggest details
- [x] Cover both terminal guided search states in view specs

### Why?

Support need enough context to investigate guided search requests from a single paste. The copied details already include the user's search term and guided answers, but they did not include the request ID that ties the journey back to backend/search logs.

### Risk

**Risk level:** 🟢

**Reason for rating:** Small content addition to existing guided search details. No search classification logic, routing, API calls, or clipboard JavaScript behaviour changes.
