### PR TITLE
AI-887: Linkify promoted tariff notes conditionally

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,13 @@ module ApplicationHelper
     Govspeak::Document.new(text, sanitize: true).to_html.html_safe
   end
 
+  def govspeak_note(text)
+    html = govspeak(text)
+    html = GoodsNomenclatureCodeLinkifier.new(html).render unless TradeTariffFrontend.production?
+
+    insert_service_links(html).html_safe
+  end
+
   def a_z_index(letter = 'a')
     ('a'..'z').map { |index_letter|
       tag.li(class: ('active' if index_letter == letter).to_s) do

--- a/app/models/goods_nomenclature_code_linkifier.rb
+++ b/app/models/goods_nomenclature_code_linkifier.rb
@@ -1,21 +1,27 @@
 class GoodsNomenclatureCodeLinkifier
   Pattern = Data.define(:regexp, :code_from_match)
 
-  SPACED_TERMINATORS = /(?=\s|;|,|$|\.|\)|\z)/
-  PUNCTUATION_TERMINATORS = /(?=;|,|$|\)|\z|<br>|<\/br>)/
-  COMBINED_TERMINATORS = /(?=\s|;|,|$|\.|\)|\z|<br>|<\/br>)/
+  CODE_SPACE = /(?:\s|\u00A0)/
+  SPACED_TERMINATORS = /(?=#{CODE_SPACE}|;|,|:|$|\.|\)|\z)/
+  COMBINED_TERMINATORS = /(?=#{CODE_SPACE}|;|,|:|$|\.|\)|\z|<br>|<\/br>)/
   CODE_BOUNDARY_START = /(?<![A-Za-z0-9.\/-])/
   CODE_BOUNDARY_END = /(?![A-Za-z0-9.\/-])/
   HEADING_CODE = /(?:0[1-9]|[1-9]\d)(?:0[1-9]|[1-9]\d)/
+  CHAPTER_CONTINUATION = Pattern.new(/#{CODE_BOUNDARY_START}(\d{1,2})#{SPACED_TERMINATORS}/, ->(match) { match[1].rjust(2, '0') })
 
   PATTERNS = [
-    Pattern.new(/chapter\s+(\d{2})#{SPACED_TERMINATORS}/i, ->(match) { match[1] }),
+    Pattern.new(/(?<=\bchapter )(\d{1,2})#{SPACED_TERMINATORS}/i, ->(match) { match[1].rjust(2, '0') }),
+    Pattern.new(/(?<=\bchapter\u00A0)(\d{1,2})#{SPACED_TERMINATORS}/i, ->(match) { match[1].rjust(2, '0') }),
+    Pattern.new(/(?<=\bchapters )(\d{1,2})#{SPACED_TERMINATORS}/i, ->(match) { match[1].rjust(2, '0') }),
+    Pattern.new(/(?<=\bchapters\u00A0)(\d{1,2})#{SPACED_TERMINATORS}/i, ->(match) { match[1].rjust(2, '0') }),
     Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})\.(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}" }),
-    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})\s(\d{2})\s(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}#{match[3]}" }),
-    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})\s(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}" }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})#{CODE_SPACE}(\d{4})#{CODE_SPACE}(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}#{match[3]}" }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})#{CODE_SPACE}(\d{2})#{CODE_SPACE}(\d{2})#{CODE_SPACE}(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}#{match[3]}#{match[4]}" }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})#{CODE_SPACE}(\d{4})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}" }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})#{CODE_SPACE}(\d{2})#{CODE_SPACE}(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}#{match[3]}" }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})#{CODE_SPACE}(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}" }),
     Pattern.new(/#{CODE_BOUNDARY_START}(\d{10}|\d{8}|\d{6})#{COMBINED_TERMINATORS}/, ->(match) { match[1] }),
-    Pattern.new(/#{CODE_BOUNDARY_START}(\d{10}|\d{8}|\d{6}|\d{2})#{CODE_BOUNDARY_END}/, ->(match) { match[1] }),
-    Pattern.new(/#{CODE_BOUNDARY_START}(\d{2})(?=\.\s|\.\z)/, ->(match) { match[1] }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{10}|\d{8}|\d{6})#{CODE_BOUNDARY_END}/, ->(match) { match[1] }),
     Pattern.new(/\A(#{HEADING_CODE})#{SPACED_TERMINATORS}/, ->(match) { match[1] }),
     Pattern.new(/#{CODE_BOUNDARY_START}(#{HEADING_CODE})#{COMBINED_TERMINATORS}/, ->(match) { match[1] }),
   ].freeze
@@ -63,15 +69,63 @@ private
   end
 
   def next_match(text, position)
-    PATTERNS.each_with_object([nil, nil]) do |pattern, best|
+    best = PATTERNS.each_with_object([nil, nil]) do |pattern, candidate|
       match = pattern.regexp.match(text, position)
       next unless match
+      next unless linkifiable_match?(text, match, pattern)
 
-      if best[1].nil? || match.begin(0) < best[1].begin(0)
-        best[0] = pattern
-        best[1] = match
+      if candidate[1].nil? || match.begin(0) < candidate[1].begin(0)
+        candidate[0] = pattern
+        candidate[1] = match
       end
     end
+
+    chapter_continuation = next_chapter_continuation_match(text, position)
+    if chapter_continuation && (best[1].nil? || chapter_continuation.begin(0) < best[1].begin(0))
+      best = [CHAPTER_CONTINUATION, chapter_continuation]
+    end
+
+    best
+  end
+
+  def next_chapter_continuation_match(text, position)
+    offset = position
+
+    while (match = CHAPTER_CONTINUATION.regexp.match(text, offset))
+      return match if chapter_continuation?(text, match.begin(0))
+
+      offset = match.end(0)
+    end
+  end
+
+  def chapter_continuation?(text, position)
+    context = text[[position - 120, 0].max...position].to_s
+    context = context.split(/[.;:()\n]/).last.to_s
+
+    context.match?(/\bchapters?\s+\d{1,2}(?:\s*(?:,|to|or|and)\s*\d{1,2})*\s*(?:,|to|or|and)\s*\z/i)
+  end
+
+  def linkifiable_match?(text, match, pattern)
+    code = pattern.code_from_match.call(match)
+    return true unless code.match?(/\A\d{4}\z/)
+
+    before = text[[match.begin(0) - 60, 0].max...match.begin(0)].to_s
+    after = text[match.end(0), 40].to_s
+
+    return false if standard_reference_context?(before)
+    return false if code.match?(/\A(?:19|20)\d{2}\z/) && !explicit_code_context?(before)
+    return false if before.end_with?(':') && text[[match.begin(0) - 20, 0].max...match.begin(0)].to_s.match?(/\bISO\s+\d{4}:\z/i)
+    return false if after.match?(/\A\s*(?:method|methods)\b/i) && before.match?(/\b(?:ISO|EN ISO|ASTM D|Standard)\s*\z/i)
+
+    true
+  end
+
+  def standard_reference_context?(before)
+    before.match?(/\b(?:ISO|EN ISO|ASTM D|Standard)\s*\z/i)
+  end
+
+  def explicit_code_context?(before)
+    before.match?(/\b(?:heading|headings|subheading|subheadings|code|codes)\s+(?:\d{4}(?:\s+\d{2,4})*(?:\s*(?:,|to|or|and)\s*)?)*\z/i)
   end
 
   def link_for(text, code)

--- a/app/views/shared/_notes.html.erb
+++ b/app/views/shared/_notes.html.erb
@@ -6,18 +6,18 @@ chapter_note ||= false %>
 <article id="notes" class="tariff-markdown govuk-!-margin-top-8">
   <% if section_note && chapter_note %>
     <h3 class="govuk-heading-s">Chapter notes</h3>
-    <%= insert_service_links(govspeak(chapter_note)) %>
+    <%= govspeak_note(chapter_note) %>
 
     <h3 class="govuk-heading-s">Section notes</h3>
-    <%= insert_service_links(govspeak(section_note)) %>
+    <%= govspeak_note(section_note) %>
 
   <% elsif chapter_note %>
     <h2 class="govuk-heading-s">Chapter notes</h2>
-    <%= insert_service_links(govspeak(chapter_note)) %>
+    <%= govspeak_note(chapter_note) %>
 
   <% elsif section_note %>
     <h2 class="govuk-heading-s">There are important section notes for this part of the tariff:</h2>
-    <%= insert_service_links(govspeak(section_note)) %>
+    <%= govspeak_note(section_note) %>
   <% end %>
 
   <%= render 'shared/general_rules_for_interpretation' %>

--- a/spec/helpers/intercept_guidance_helper_spec.rb
+++ b/spec/helpers/intercept_guidance_helper_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe InterceptGuidanceHelper do
       msg = 'Review Chapter 71, headings 3207 to 3210, subheading 8703.10 and commodity 0101210000.'
       html = render_intercept_message(msg, search:)
 
-      expect(html).to have_css('a.govuk-link[href="/search?q=71"][target="_blank"][rel="noopener noreferrer"]', text: 'Chapter 71')
+      expect(html).to have_css('a.govuk-link[href="/search?q=71"][target="_blank"][rel="noopener noreferrer"]', text: '71')
       expect(html).to have_css('a.govuk-link[href="/search?q=3207"]', text: '3207')
       expect(html).to have_css('a.govuk-link[href="/search?q=3210"]', text: '3210')
       expect(html).to have_css('a.govuk-link[href="/search?q=870310"]', text: '8703.10')
@@ -91,7 +91,7 @@ RSpec.describe InterceptGuidanceHelper do
       html = render_intercept_message('[Read about 0101](https://example.com/existing) and Chapter 71', search:)
 
       expect(html).to have_css('a.govuk-link[href="https://example.com/existing"]', text: 'Read about 0101')
-      expect(html).to have_css('a.govuk-link[href="/search?q=71"]', text: 'Chapter 71')
+      expect(html).to have_css('a.govuk-link[href="/search?q=71"]', text: '71')
       expect(html).not_to have_css('a[href="https://example.com/existing"] a')
     end
   end

--- a/spec/models/goods_nomenclature_code_linkifier_spec.rb
+++ b/spec/models/goods_nomenclature_code_linkifier_spec.rb
@@ -9,9 +9,27 @@ RSpec.describe GoodsNomenclatureCodeLinkifier do
     Capybara.string(render(html, service_path:))
   end
 
+  def link_texts(rendered)
+    rendered.all('a').map { |link| link.text.gsub(/ \(opens in new tab\)\z/, '') }
+  end
+
+  def linked_code_only?(rendered, phrase, code, href)
+    rendered.has_text?(phrase) &&
+      rendered.has_link?(code, href:) &&
+      link_texts(rendered).exclude?(phrase)
+  end
+
   describe '#render' do
     it 'linkifies a chapter keyword reference' do
-      expect(page('<p>goods of Chapter 71</p>')).to have_link('Chapter 71', href: '/search?q=71')
+      rendered = page('<p>goods of Chapter 71</p>')
+
+      expect(linked_code_only?(rendered, 'Chapter 71', '71', '/search?q=71')).to be(true)
+    end
+
+    it 'linkifies single-digit chapters' do
+      rendered = page('<p>Heading 1005 does not cover sweetcorn (Chapter 7)</p>')
+
+      expect(linked_code_only?(rendered, 'Chapter 7', '7', '/search?q=07')).to be(true)
     end
 
     it 'linkifies heading codes using mixed separators', :aggregate_failures do
@@ -28,8 +46,83 @@ RSpec.describe GoodsNomenclatureCodeLinkifier do
       expect(page('<p>commodity 0101210000.</p>')).to have_link('0101210000', href: '/search?q=0101210000')
     end
 
+    it 'linkifies codes followed by a colon' do
+      rendered = page('<p>for the purposes of code 0202 20 10: forequarters</p>')
+
+      expect(rendered).to have_link('0202 20 10', href: '/search?q=02022010')
+        .and have_no_link(href: '/search?q=10')
+    end
+
+    it 'linkifies ten-digit codes with compact middle spacing' do
+      rendered = page('<p>Code 2404 1200 90 applies.</p>')
+
+      expect(rendered).to have_link('2404 1200 90', href: '/search?q=2404120090')
+        .and have_no_link(href: '/search?q=1200')
+    end
+
+    it 'linkifies eight-digit codes with compact middle spacing' do
+      rendered = page('<p>codes 2710 2011 to 2710 2090</p>')
+
+      expect(rendered).to have_link('2710 2011', href: '/search?q=27102011')
+        .and have_link('2710 2090', href: '/search?q=27102090')
+        .and have_no_link(href: '/search?q=2011')
+    end
+
+    it 'supports non-breaking spaces around codes' do
+      rendered = page("<p>For subheadings 8549 11\u00A0to 8549 19\u00A0, spent cells are covered.</p>")
+
+      expect(rendered).to have_link('8549 11', href: '/search?q=854911')
+        .and have_link('8549 19', href: '/search?q=854919')
+        .and have_no_link(href: '/search?q=11')
+        .and have_no_link(href: '/search?q=19')
+    end
+
+    it 'linkifies continuation chapters in lists' do
+      rendered = page('<p>goods of Chapter 39, 40 or 63.</p>')
+
+      expect(link_texts(rendered)).to eq(%w[39 40 63])
+    end
+
     it 'does not linkify decimal numbers' do
       expect(page('<p>width exceeds 10.5mm</p>')).not_to have_link('10')
+    end
+
+    it 'does not linkify percentages' do
+      rendered = page('<p>not more than 10 % of chromium and 30% of manganese</p>')
+
+      expect(rendered).to have_no_link('10')
+        .and have_no_link('30')
+    end
+
+    it 'does not linkify quantities' do
+      rendered = page('<p>at least 10 times the thickness, exceeds 15 mm but not 52 mm, under a current of 50 Hz.</p>')
+
+      expect(rendered).to have_no_link('10')
+        .and have_no_link('15')
+        .and have_no_link('52')
+        .and have_no_link('50')
+    end
+
+    it 'does not linkify legal references' do
+      rendered = page('<p>Article 45 of Regulation (EU) 33/2019.</p>')
+
+      expect(rendered).to have_no_link('45')
+        .and have_no_link('33')
+    end
+
+    it 'does not linkify standard references' do
+      rendered = page('<p>ISO 8069:2005 method and EN ISO 3104 method.</p>')
+
+      expect(rendered).to have_no_link('8069')
+        .and have_no_link('2005')
+        .and have_no_link('3104')
+    end
+
+    it 'does not linkify years' do
+      rendered = page('<p>The Seed Potatoes Regulations 1991 and Cereal Seeds Regulation 1974 apply.</p>')
+
+      expect(rendered).to have_no_link('1991')
+        .and have_no_link('1974')
     end
 
     it 'does not double-linkify existing links', :aggregate_failures do
@@ -37,12 +130,12 @@ RSpec.describe GoodsNomenclatureCodeLinkifier do
       rendered = page(html)
 
       expect(rendered).to have_link('3606', href: '/foo')
-      expect(rendered).to have_link('chapter 71', href: '/search?q=71')
+      expect(rendered).to have_link('71', href: '/search?q=71')
       expect(rendered).not_to have_css('a a')
     end
 
     it 'adds the xi service path when rendering in xi context' do
-      expect(page('<p>Chapter 71</p>', service_path: '/xi')).to have_link('Chapter 71', href: '/xi/search?q=71')
+      expect(page('<p>Chapter 71</p>', service_path: '/xi')).to have_link('71', href: '/xi/search?q=71')
     end
 
     it 'marks generated links as new-tab GOV.UK links', :aggregate_failures do

--- a/spec/views/shared/_notes.html.erb_spec.rb
+++ b/spec/views/shared/_notes.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'shared/_notes.html.erb' do
+  subject(:rendered_page) do
+    render partial: 'shared/notes', locals: { chapter_note:, section_note: }
+    Capybara.string(rendered)
+  end
+
+  let(:chapter_note) { 'Goods of Chapter 7 and heading 1005.' }
+  let(:section_note) { nil }
+
+  before do
+    allow(TradeTariffFrontend::ServiceChooser).to receive(:xi?).and_return(false)
+  end
+
+  context 'when the frontend is not production' do
+    before do
+      allow(TradeTariffFrontend).to receive(:production?).and_return(false)
+    end
+
+    it 'linkifies goods code references' do
+      expect(rendered_page).to have_link('7', href: '/search?q=07')
+        .and have_link('1005', href: '/search?q=1005')
+    end
+  end
+
+  context 'when the frontend is production' do
+    before do
+      allow(TradeTariffFrontend).to receive(:production?).and_return(true)
+    end
+
+    it 'does not linkify goods code references' do
+      expect(rendered_page).to have_no_link('7', href: '/search?q=07')
+        .and have_no_link('1005', href: '/search?q=1005')
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
## What:

- [x] Render chapter and section notes through a shared note markdown helper.
- [x] Linkify goods nomenclature code references in notes only outside production.
- [x] Align the frontend goods code linkifier with the admin preview behaviour for promoted tariff notes.
- [x] Add regression coverage for conditional note linkification and the admin linkifier edge cases.

## Why:

Promoted customs tariff notes can contain plain-text chapter, heading, subheading and commodity references. In non-production environments those references should be linked for validation, while production should continue to render note content without this extra linkification layer.

## Ticket:

[AI-887](https://transformuk.atlassian.net/browse/AI-887)

## Risk:

**Risk level:** 🟢

**Reason for rating:** The user-visible linkification is gated to non-production environments, and production note rendering remains un-linkified. The change is covered by focused model, helper and view specs.