### PR TITLE
Normalize TariffDate input key handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,11 +90,7 @@ class ApplicationController < ActionController::Base
   end
 
   def extract_search_date_parts(source = search_attribute_params)
-    {
-      day: source[:day].presence || source['as_of(day)'].presence || source['as_of(3i)'].presence,
-      month: source[:month].presence || source['as_of(month)'].presence || source['as_of(2i)'].presence,
-      year: source[:year].presence || source['as_of(year)'].presence || source['as_of(1i)'].presence,
-    }.compact
+    TariffDate.normalized_date_attributes(source)
   end
 
   def search_date_query_params

--- a/app/models/tariff_date.rb
+++ b/app/models/tariff_date.rb
@@ -31,10 +31,20 @@ class TariffDate < SimpleDelegator
                      date_attributes.to_h
                    end
 
+      lookup = lambda do |*keys|
+        keys.filter_map { |key| attributes[key].presence }.first
+      end
+
       {
-        'year' => attributes['year'] || attributes[:year] || attributes['as_of(year)'] || attributes[:'as_of(year)'] || attributes['as_of(1i)'] || attributes[:'as_of(1i)'],
-        'month' => attributes['month'] || attributes[:month] || attributes['as_of(month)'] || attributes[:'as_of(month)'] || attributes['as_of(2i)'] || attributes[:'as_of(2i)'],
-        'day' => attributes['day'] || attributes[:day] || attributes['as_of(day)'] || attributes[:'as_of(day)'] || attributes['as_of(3i)'] || attributes[:'as_of(3i)'],
+        'year' => lookup.call(
+          'year', :year, 'as_of(year)', :'as_of(year)', 'as_of(1i)', :'as_of(1i)'
+        ),
+        'month' => lookup.call(
+          'month', :month, 'as_of(month)', :'as_of(month)', 'as_of(2i)', :'as_of(2i)'
+        ),
+        'day' => lookup.call(
+          'day', :day, 'as_of(day)', :'as_of(day)', 'as_of(3i)', :'as_of(3i)'
+        ),
       }
     end
 

--- a/app/models/tariff_date.rb
+++ b/app/models/tariff_date.rb
@@ -3,10 +3,12 @@ class TariffDate < SimpleDelegator
 
   class << self
     def build(date_attributes)
-      date = if complete_date_attributes?(date_attributes)
-               raise Date::Error unless valid_date_attributes?(date_attributes)
+      normalized_attributes = normalize_date_attributes(date_attributes)
 
-               Date.new(*date_attributes.slice(*DATE_KEYS).values.map(&:to_i))
+      date = if complete_date_attributes?(normalized_attributes)
+               raise Date::Error unless valid_date_attributes?(normalized_attributes)
+
+               Date.new(*normalized_attributes.slice(*DATE_KEYS).values.map(&:to_i))
              else
                Time.zone.today
              end
@@ -15,6 +17,18 @@ class TariffDate < SimpleDelegator
     end
 
     private
+
+    def normalize_date_attributes(date_attributes)
+      return {} unless date_attributes.respond_to?(:to_h)
+
+      attributes = date_attributes.to_h
+
+      {
+        'year' => attributes['year'] || attributes[:year] || attributes['as_of(year)'] || attributes[:'as_of(year)'] || attributes['as_of(1i)'] || attributes[:'as_of(1i)'],
+        'month' => attributes['month'] || attributes[:month] || attributes['as_of(month)'] || attributes[:'as_of(month)'] || attributes['as_of(2i)'] || attributes[:'as_of(2i)'],
+        'day' => attributes['day'] || attributes[:day] || attributes['as_of(day)'] || attributes[:'as_of(day)'] || attributes['as_of(3i)'] || attributes[:'as_of(3i)'],
+      }
+    end
 
     def complete_date_attributes?(date_param)
       date_param.present? && date_param.is_a?(Hash) &&

--- a/app/models/tariff_date.rb
+++ b/app/models/tariff_date.rb
@@ -2,6 +2,10 @@ class TariffDate < SimpleDelegator
   DATE_KEYS = %w[year month day].freeze
 
   class << self
+    def normalized_date_attributes(date_attributes)
+      normalize_date_attributes(date_attributes).compact
+    end
+
     def build(date_attributes)
       normalized_attributes = normalize_date_attributes(date_attributes)
 
@@ -21,7 +25,11 @@ class TariffDate < SimpleDelegator
     def normalize_date_attributes(date_attributes)
       return {} unless date_attributes.respond_to?(:to_h)
 
-      attributes = date_attributes.to_h
+      attributes = if date_attributes.respond_to?(:to_unsafe_h)
+                     date_attributes.to_unsafe_h
+                   else
+                     date_attributes.to_h
+                   end
 
       {
         'year' => attributes['year'] || attributes[:year] || attributes['as_of(year)'] || attributes[:'as_of(year)'] || attributes['as_of(1i)'] || attributes[:'as_of(1i)'],

--- a/spec/models/tariff_date_spec.rb
+++ b/spec/models/tariff_date_spec.rb
@@ -1,4 +1,32 @@
 RSpec.describe TariffDate do
+  describe '.normalized_date_attributes' do
+    subject(:normalized_date_attributes) { described_class.normalized_date_attributes(date_attributes) }
+
+    context 'when passing string date keys' do
+      let(:date_attributes) do
+        {
+          'year' => '2021',
+          'month' => '01',
+          'day' => '02',
+        }
+      end
+
+      it { is_expected.to eq('year' => '2021', 'month' => '01', 'day' => '02') }
+    end
+
+    context 'when passing date picker keys' do
+      let(:date_attributes) do
+        {
+          'as_of(1i)' => '2021',
+          'as_of(2i)' => '01',
+          'as_of(3i)' => '02',
+        }
+      end
+
+      it { is_expected.to eq('year' => '2021', 'month' => '01', 'day' => '02') }
+    end
+  end
+
   describe '.build' do
     subject(:tariff_date) { described_class.build(date_attributes) }
 

--- a/spec/models/tariff_date_spec.rb
+++ b/spec/models/tariff_date_spec.rb
@@ -14,9 +14,36 @@ RSpec.describe TariffDate do
       it { is_expected.to eq('year' => '2021', 'month' => '01', 'day' => '02') }
     end
 
+    context 'when passing symbol date keys' do
+      let(:date_attributes) do
+        {
+          year: '2021',
+          month: '01',
+          day: '02',
+        }
+      end
+
+      it { is_expected.to eq('year' => '2021', 'month' => '01', 'day' => '02') }
+    end
+
     context 'when passing date picker keys' do
       let(:date_attributes) do
         {
+          'as_of(1i)' => '2021',
+          'as_of(2i)' => '01',
+          'as_of(3i)' => '02',
+        }
+      end
+
+      it { is_expected.to eq('year' => '2021', 'month' => '01', 'day' => '02') }
+    end
+
+    context 'when string keys are blank but date picker keys are present' do
+      let(:date_attributes) do
+        {
+          'year' => '',
+          'month' => '',
+          'day' => '',
           'as_of(1i)' => '2021',
           'as_of(2i)' => '01',
           'as_of(3i)' => '02',


### PR DESCRIPTION
## What:
Normalize date input key handling inside TariffDate.build so it accepts common key formats and converts them to canonical year/month/day before validation.

## Why:
Date callers pass different key styles (string keys, symbol keys, multipart as_of(...) keys). This centralizes normalization in one place and removes per-caller conversion burden.

## Ticket:
N/A (BAU)

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Small, isolated model-layer normalization change with no route/view flow changes. Change is backward-compatible for existing key formats.
