### PR TITLE
AI-888: Increase frontend search timeout

### DIFF
--- a/lib/trade_tariff_frontend/service_timeout.rb
+++ b/lib/trade_tariff_frontend/service_timeout.rb
@@ -1,7 +1,7 @@
 module TradeTariffFrontend
   class ServiceTimeout
     DEFAULT_TIMEOUT = 15
-    DEFAULT_PATH_OVERRIDES = '/uk/search:50,/xi/search:50,/search:50,/internal/search:50'.freeze
+    DEFAULT_PATH_OVERRIDES = '/uk/search:100,/xi/search:100,/search:100,/internal/search:100'.freeze
 
     class << self
       def timeout_for(path)

--- a/spec/lib/trade_tariff_frontend/service_timeout_spec.rb
+++ b/spec/lib/trade_tariff_frontend/service_timeout_spec.rb
@@ -25,24 +25,24 @@ RSpec.describe TradeTariffFrontend::ServiceTimeout do
         ENV.delete('RACK_TIMEOUT_PATH_OVERRIDES')
       end
 
-      it 'applies 50s timeout to /uk/search' do
+      it 'applies 100s timeout to /uk/search' do
         middleware.call('PATH_INFO' => '/uk/search')
-        expect(Timeout).to have_received(:timeout).with(50)
+        expect(Timeout).to have_received(:timeout).with(100)
       end
 
-      it 'applies 50s timeout to /xi/search' do
+      it 'applies 100s timeout to /xi/search' do
         middleware.call('PATH_INFO' => '/xi/search')
-        expect(Timeout).to have_received(:timeout).with(50)
+        expect(Timeout).to have_received(:timeout).with(100)
       end
 
-      it 'applies 50s timeout to /search' do
+      it 'applies 100s timeout to /search' do
         middleware.call('PATH_INFO' => '/search')
-        expect(Timeout).to have_received(:timeout).with(50)
+        expect(Timeout).to have_received(:timeout).with(100)
       end
 
-      it 'applies 50s timeout to /internal/search' do
+      it 'applies 100s timeout to /internal/search' do
         middleware.call('PATH_INFO' => '/internal/search')
-        expect(Timeout).to have_received(:timeout).with(50)
+        expect(Timeout).to have_received(:timeout).with(100)
       end
 
       it 'applies default timeout to non-search paths' do

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Search do
 
         perform_search
 
-        expect(captured_env.request.timeout).to eq(50)
+        expect(captured_env.request.timeout).to eq(100)
       end
 
       it 'sends the cached expanded query to internal search when present' do


### PR DESCRIPTION
## What:

- [x] Increased default rack-timeout overrides for frontend search paths from 50s to 100s.
- [x] Updated ServiceTimeout specs for /uk/search, /xi/search, /search and /internal/search.

## Why:

Assisted search requests can take longer than the previous frontend middleware timeout. The search path timeout now matches the CDN timeout window so the frontend does not stop the request before the gateway can return a longer-running response.

## Ticket:

[AI-888](https://transformuk.atlassian.net/browse/AI-888)

## Risk:

**Risk level:** 🟠

**Reason for rating:** This changes timeout behaviour for search paths used by traders. The change is small and covered by focused specs, but it affects a live journey.
