### PR TITLE
HMRC-2405: Route ECS capacity loss alarm to production alerts

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,7 +20,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.1.0 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.0 |
 
 ## Resources
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.1.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.0"
 
   region = var.region
 


### PR DESCRIPTION
## What:

- Updated ECS service module version to v3.2.0.

## Why:

- Consume the new configurable routing capability for ECS capacity loss alarms.

## Ticket:
[HMRC-2405](https://transformuk.atlassian.net/browse/HMRC-2405)

## Risk:

**Risk level:** 🟢 

**Reason for rating:**

- Notification routing only.
- No impact on ECS services, deployments, scaling, or alarm evaluation logic.
- Existing SNS topics remain unchanged.