### PR TITLE
HMRC-2398 Fix chemicals tab

### DIFF
--- a/app/views/chemicals/_chemical.html.erb
+++ b/app/views/chemicals/_chemical.html.erb
@@ -1,5 +1,0 @@
-<tr class="govuk-table__row">
-  <td class="govuk-table__cell" data-label="CAS RN"><%= chemical.cas_rn %></td>
-  <td class="govuk-table__cell" data-label="CUS number"><%= chemical.cus %></td>
-  <td class="govuk-table__cell word-breaking-cell" data-label="Name"><%= chemical.name %></td>
-</tr>

--- a/app/views/chemicals/_table.html.erb
+++ b/app/views/chemicals/_table.html.erb
@@ -11,7 +11,13 @@
     <% end %>
   <% end %>
 
-  <% table.with_body do %>
-    <%= render partial: 'chemicals/chemical', collection: chemicals %>
+  <% table.with_body do |body| %>
+    <% chemicals.each do |chemical| %>
+      <% body.with_row do |row| %>
+        <% row.with_cell(html_attributes: { data: { label: 'CAS RN' } }) { chemical.cas_rn } %>
+        <% row.with_cell(html_attributes: { data: { label: 'CUS number' } }) { chemical.cus } %>
+        <% row.with_cell(classes: 'word-breaking-cell', html_attributes: { data: { label: 'Name' } }) { chemical.name } %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/spec/views/chemicals/_table.html.erb_spec.rb
+++ b/spec/views/chemicals/_table.html.erb_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe 'chemicals/_table', type: :view do
+  subject(:rendered_page) do
+    render 'chemicals/table', chemicals: chemicals
+    rendered
+  end
+
+  let(:chemicals) { build_list :chemical_substance, 2 }
+
+  it { is_expected.to have_css 'table' }
+  it { is_expected.to have_css 'th abbr[title="Chemical Abstracts Service Registry Number"]', text: 'CAS RN' }
+  it { is_expected.to have_css 'th abbr[title="European Union unique chemical identifier"]', text: 'CUS number' }
+  it { is_expected.to have_css 'th', text: 'Name' }
+
+  it 'renders a row for each chemical' do
+    expect(rendered_page).to have_css('td', text: chemicals.first.cas_rn)
+      .and have_css('td', text: chemicals.first.cus)
+      .and have_css('td', text: chemicals.first.name)
+      .and have_css('td', text: chemicals.last.cas_rn)
+  end
+
+  it 'renders the correct number of rows' do
+    expect(rendered_page).to have_css('tbody tr', count: 2)
+  end
+
+  context 'when there are no chemicals' do
+    let(:chemicals) { [] }
+
+    it { is_expected.to have_css 'table' }
+    it { is_expected.not_to have_css 'tbody tr' }
+  end
+end


### PR DESCRIPTION
## What:
A recent change to use govuk table components caused an issue with the displaying of chemicals. Raw HTML rendered inside `with_body` is discarded so this meant the chemicals table was empty.

## Why:
Bug fix

## Ticket:
HMRC-2398

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Fixes regression and adds a test