### PR TITLE
HMRC-2401 Preserve MyOTT subscription return URL

### DIFF
--- a/app/controllers/myott/myott_controller.rb
+++ b/app/controllers/myott/myott_controller.rb
@@ -1,7 +1,5 @@
 module Myott
   class MyottController < ApplicationController
-    RETURN_KEY = :myott_return_url
-
     before_action :authenticate,
                   :disable_search_form,
                   :disable_switch_service_banner
@@ -12,26 +10,18 @@ module Myott
 
     def authenticate
       if current_user.nil?
-        set_return_url
-        redirect_to myott_start_path
-      elsif (path = return_url)
-        redirect_to(path)
+        redirect_to myott_start_path(return_to: request.fullpath)
       end
     end
 
     def handle_authentication_error(error)
       clear_authentication_cookies if error.should_clear_cookies?
 
-      set_return_url
-      redirect_to(URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s, allow_other_host: true)
+      redirect_to("#{identity_url}?return_to=#{CGI.escape(request.fullpath)}", allow_other_host: true)
     end
 
-    def return_url
-      session.delete(RETURN_KEY)
-    end
-
-    def set_return_url
-      session[RETURN_KEY] = request.fullpath
+    def identity_url
+      URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s
     end
 
     def clear_authentication_cookies

--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -5,8 +5,10 @@ module Myott
     def start
       @continue_url = if current_user.present?
                         myott_path
+                      elsif safe_return_to.present?
+                        "#{identity_url}?return_to=#{CGI.escape(safe_return_to)}"
                       else
-                        URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s
+                        identity_url
                       end
     end
 
@@ -15,8 +17,27 @@ module Myott
     end
 
     def index
+      if safe_return_to.present?
+        redirect_to safe_return_to, allow_other_host: false
+        return
+      end
+
       @stop_press = current_subscription('stop_press')
       @my_commodities = current_subscription('my_commodities')
+    end
+
+  private
+
+    def identity_url
+      URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s
+    end
+
+    def safe_return_to
+      return_to = params[:return_to].to_s
+      return if return_to.blank?
+      return unless return_to.start_with?('/subscriptions/') && !return_to.start_with?('//')
+
+      return_to
     end
   end
 end

--- a/spec/controllers/myott/myott_controller_spec.rb
+++ b/spec/controllers/myott/myott_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Myott::MyottController, type: :controller do
   include MyottAuthenticationHelpers
 
-  let(:return_key) { described_class::RETURN_KEY }
+  let(:return_key) { :myott_return_url }
 
   describe '#current_user' do
     let(:user) { build(:user) }
@@ -96,45 +96,39 @@ RSpec.describe Myott::MyottController, type: :controller do
     end
 
     context 'when current_user is nil' do
-      let(:request_fullpath) { '/myott/commodities/123' }
+      let(:request_fullpath) { '/subscriptions/mycommodities?as_of=2025-06-20' }
 
       before do
         allow(controller).to receive(:current_user).and_return(nil)
         allow(controller.request).to receive(:fullpath).and_return(request_fullpath)
       end
 
-      it 'stores the current path in session' do
-        controller.send(:authenticate)
-
-        expect(controller.session[return_key]).to eq(request_fullpath)
-      end
-
       it 'redirects to the start page' do
         controller.send(:authenticate)
 
-        expect(controller).to have_received(:redirect_to).with(myott_start_path)
+        expect(controller).to have_received(:redirect_to).with(myott_start_path(return_to: request_fullpath))
       end
     end
 
     context 'when current_user exists and myott_return_url is in session' do
       let(:user) { build(:user) }
-      let(:return_url) { '/myott/commodities/456' }
+      let(:return_url) { '/subscriptions/mycommodities?as_of=2025-06-20' }
 
       before do
         allow(controller).to receive(:current_user).and_return(user)
         controller.session[return_key] = return_url
       end
 
-      it 'redirects to the stored return URL' do
+      it 'does not redirect to the stored return URL' do
         controller.send(:authenticate)
 
-        expect(controller).to have_received(:redirect_to).with(return_url)
+        expect(controller).not_to have_received(:redirect_to)
       end
 
-      it 'removes the return URL from session' do
+      it 'leaves the stored return URL in session' do
         controller.send(:authenticate)
 
-        expect(controller.session[return_key]).to be_nil
+        expect(controller.session[return_key]).to eq(return_url)
       end
     end
 
@@ -156,7 +150,7 @@ RSpec.describe Myott::MyottController, type: :controller do
 
   describe '#handle_authentication_error' do
     let(:identity_base_url) { 'https://auth.example.com' }
-    let(:request_fullpath) { '/myott/commodities/123' }
+    let(:request_fullpath) { '/subscriptions/mycommodities?as_of=2025-06-20' }
     let(:error) { AuthenticationError.new('Authentication failed', reason: error_reason) }
 
     before do
@@ -175,17 +169,11 @@ RSpec.describe Myott::MyottController, type: :controller do
         expect(controller).to have_received(:clear_authentication_cookies)
       end
 
-      it 'stores the current URL in session' do
-        controller.send(:handle_authentication_error, error)
-
-        expect(controller.session[return_key]).to eq(request_fullpath)
-      end
-
-      it 'redirects to identity service' do
+      it 'redirects to identity service with the current URL as return_to' do
         controller.send(:handle_authentication_error, error)
 
         expect(controller).to have_received(:redirect_to)
-          .with('https://auth.example.com/myott', allow_other_host: true)
+          .with('https://auth.example.com/myott?return_to=%2Fsubscriptions%2Fmycommodities%3Fas_of%3D2025-06-20', allow_other_host: true)
       end
     end
 
@@ -198,17 +186,11 @@ RSpec.describe Myott::MyottController, type: :controller do
         expect(controller).not_to have_received(:clear_authentication_cookies)
       end
 
-      it 'stores the current URL in session' do
-        controller.send(:handle_authentication_error, error)
-
-        expect(controller.session[return_key]).to eq(request_fullpath)
-      end
-
-      it 'redirects to identity service' do
+      it 'redirects to identity service with the current URL as return_to' do
         controller.send(:handle_authentication_error, error)
 
         expect(controller).to have_received(:redirect_to)
-          .with('https://auth.example.com/myott', allow_other_host: true)
+          .with('https://auth.example.com/myott?return_to=%2Fsubscriptions%2Fmycommodities%3Fas_of%3D2025-06-20', allow_other_host: true)
       end
     end
   end

--- a/spec/controllers/myott/preferences_controller_spec.rb
+++ b/spec/controllers/myott/preferences_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Myott::PreferencesController, type: :controller do
         post :create, params: { preference: 'selectChapters' }
       end
 
-      it { is_expected.to redirect_to myott_start_path }
+      it { is_expected.to redirect_to myott_start_path(return_to: request.fullpath) }
     end
 
     context 'when current_user is valid' do

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -27,10 +27,46 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
     context 'when a user is not authenticated' do
       before do
         stub_unauthenticated_user
-        get :start
+        get :start, params: { return_to: '/subscriptions/mycommodities?as_of=2025-06-20' }
       end
 
       it 'assigns @continue_url to the identity base url' do
+        expected_url = "#{URI.join(TradeTariffFrontend.identity_base_url, '/myott')}?return_to=%2Fsubscriptions%2Fmycommodities%3Fas_of%3D2025-06-20"
+        expect(assigns(:continue_url)).to eq(expected_url)
+      end
+    end
+
+    context 'when a user is not authenticated and the return URL is unsafe' do
+      before do
+        stub_unauthenticated_user
+        get :start, params: { return_to: 'https://example.com/phishing' }
+      end
+
+      it 'assigns @continue_url to the identity base url without a return URL' do
+        expected_url = URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s
+        expect(assigns(:continue_url)).to eq(expected_url)
+      end
+    end
+
+    context 'when a user is not authenticated and the return URL is protocol-relative' do
+      before do
+        stub_unauthenticated_user
+        get :start, params: { return_to: '//example.com/phishing' }
+      end
+
+      it 'assigns @continue_url to the identity base url without a return URL' do
+        expected_url = URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s
+        expect(assigns(:continue_url)).to eq(expected_url)
+      end
+    end
+
+    context 'when a user is not authenticated and the return URL only has the subscriptions prefix' do
+      before do
+        stub_unauthenticated_user
+        get :start, params: { return_to: '/subscriptions.evil/mycommodities?as_of=2025-06-20' }
+      end
+
+      it 'assigns @continue_url to the identity base url without a return URL' do
         expected_url = URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s
         expect(assigns(:continue_url)).to eq(expected_url)
       end
@@ -71,6 +107,38 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
     context 'when current_user is valid' do
       before do
         stub_authenticated_user(user)
+      end
+
+      context 'when return_to is a safe subscriptions path' do
+        before do
+          get :index, params: { return_to: '/subscriptions/mycommodities?as_of=2025-06-20' }
+        end
+
+        it { is_expected.to redirect_to('/subscriptions/mycommodities?as_of=2025-06-20') }
+      end
+
+      context 'when return_to is an unsafe absolute URL' do
+        before do
+          get :index, params: { return_to: 'https://example.com/phishing' }
+        end
+
+        it { is_expected.to respond_with(:success) }
+      end
+
+      context 'when return_to is a protocol-relative URL' do
+        before do
+          get :index, params: { return_to: '//example.com/phishing' }
+        end
+
+        it { is_expected.to respond_with(:success) }
+      end
+
+      context 'when return_to is the subscriptions index path' do
+        before do
+          get :index, params: { return_to: '/subscriptions' }
+        end
+
+        it { is_expected.to respond_with(:success) }
       end
 
       context 'when my_commodities is enabled' do

--- a/spec/support/shared_examples/a_protected_myott_page.rb
+++ b/spec/support/shared_examples/a_protected_myott_page.rb
@@ -5,6 +5,6 @@ RSpec.shared_examples 'a protected myott page' do |action|
       get action
     end
 
-    it { is_expected.to redirect_to myott_start_path }
+    it { is_expected.to redirect_to myott_start_path(return_to: request.fullpath) }
   end
 end


### PR DESCRIPTION
## What:
Preserve the original MyOTT subscription URL after a user signs in through Identity.

The fix carries a validated, relative `return_to` through the frontend-to-Identity handoff. When a user opens a dated CCWL link while logged out, the journey now keeps that original destination explicit all the way through login.

## Why:
CCWL email links include the effective date in the URL, for example `/subscriptions/mycommodities?as_of=YYYY-MM-DD`. On `main`, this can work via the frontend Rails session, but the flow is indirect: after login the user returns to the generic `/subscriptions` endpoint, where frontend has to recover the stored destination and redirect again.

This change makes the intent part of the login handoff instead. After successful authentication, the user is returned directly to the URL they originally clicked, rather than landing on generic `/subscriptions` and relying on a secondary session lookup to replay the destination.

The final redirect remains owned by frontend. Frontend only consumes nested `/subscriptions/...` paths and rejects external or malformed destinations.

## Sequence diagram:

```mermaid
sequenceDiagram
  autonumber
  actor User

  box rgb(24, 82, 74) Frontend owns route validation
    participant Frontend as trade-tariff-frontend
  end

  box rgb(57, 65, 121) Identity owns login
    participant Identity as identity
  end

  User->>Frontend: Open CCWL dated MyOTT URL
  Frontend->>Frontend: Create relative return_to
  Note over Frontend: Only nested /subscriptions paths are consumed

  Frontend->>Identity: Send return_to via /myott
  Note over Identity: Preserve the relative path without route-level validation

  alt Magic-link login needed
    Identity-->>User: Send magic link
    User->>Identity: Open callback
  else Existing Identity session
    Identity->>Identity: Reuse valid session
  end

  Identity-->>Frontend: Success callback with return_to
  Frontend->>Frontend: Validate nested subscriptions path
  Frontend-->>User: Redirect to original dated MyOTT URL
```

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2401

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Low risk bug fix. The change is constrained to preserving the intended MyOTT return path for subscription pages, with allowlisting for nested `/subscriptions/...` paths and rejection of absolute or prefix-trap URLs.