### PR TITLE
Allow GTM eval and GA endpoints in CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,11 +7,17 @@
 Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src :self, :https
-    policy.connect_src :self, :https, :blob
+    policy.connect_src :self, :https, :blob,
+                       'https://www.google-analytics.com',
+                       'https://analytics.google.com',
+                       'https://region1.google-analytics.com'
     policy.font_src    :self, :https, :data
-    policy.img_src     :self, :https, :data
+    policy.img_src     :self, :https, :data,
+                       'https://www.google-analytics.com',
+                       'https://www.googletagmanager.com'
     policy.object_src  :none
-    policy.script_src  :self, :https
+    # unsafe-eval is required by Google Tag Manager
+    policy.script_src  :self, :https, :unsafe_eval
     policy.style_src   :self, :https
     # Specify URI for violation reports
     policy.report_uri '/csp-violation-report'


### PR DESCRIPTION
## What:
Update the Content Security Policy to allow Google Tag Manager and Google Analytics to function correctly.

## Why:
GTM fires `eval()` at runtime to execute tags, which was being blocked by our `script-src` policy and generating a CSP violation report on every page load. GA4 also needs explicit origins in `connect-src` for beacon/hit requests and `img-src` for the measurement protocol pixel fallback.

Changes:
- Add `'unsafe-eval'` to `script-src` (required by GTM)
- Add `google-analytics.com`, `analytics.google.com`, `region1.google-analytics.com` to `connect-src`
- Add `google-analytics.com` and `googletagmanager.com` to `img-src`

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Config-only change to the CSP initializer. The policy is still in `report_only` mode so there is no enforcement risk; this purely reduces violation noise and prepares the policy for future enforcement.