### PR TITLE
Fix CSP violation from inline style in small brewers relief partial

### DIFF
--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -28,12 +28,8 @@ class ClientBuilder
 
   def call
     if TradeTariffFrontend::ServiceChooser.service_choices.present?
-      ssl_cert_pem = ENV['SSL_CERT_PEM']&.gsub('\\n', "\n")
-
-      if ssl_cert_pem.present?
-        cert_path = '/tmp/backend.crt'
-        File.write(cert_path, ssl_cert_pem)
-      end
+      cert_path = '/tmp/backend.crt'
+      File.write(cert_path, ENV['SSL_CERT_PEM']&.gsub('\\n', "\n"))
 
       Faraday.new(host) do |conn|
         conn.request :url_encoded
@@ -43,7 +39,7 @@ class ClientBuilder
         conn.options.open_timeout = 5
         conn.options.timeout = 10
         conn.ssl.verify = false
-        conn.ssl.ca_file = cert_path if ssl_cert_pem.present?
+        conn.ssl.ca_file = cert_path
         conn.adapter :net_http_persistent
         conn.response :json, content_type: /\bjson$/
         conn.headers['User-Agent'] = user_agent

--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -28,8 +28,12 @@ class ClientBuilder
 
   def call
     if TradeTariffFrontend::ServiceChooser.service_choices.present?
-      cert_path = '/tmp/backend.crt'
-      File.write(cert_path, ENV['SSL_CERT_PEM']&.gsub('\\n', "\n"))
+      ssl_cert_pem = ENV['SSL_CERT_PEM']&.gsub('\\n', "\n")
+
+      if ssl_cert_pem.present?
+        cert_path = '/tmp/backend.crt'
+        File.write(cert_path, ssl_cert_pem)
+      end
 
       Faraday.new(host) do |conn|
         conn.request :url_encoded
@@ -39,7 +43,7 @@ class ClientBuilder
         conn.options.open_timeout = 5
         conn.options.timeout = 10
         conn.ssl.verify = false
-        conn.ssl.ca_file = cert_path
+        conn.ssl.ca_file = cert_path if ssl_cert_pem.present?
         conn.adapter :net_http_persistent
         conn.response :json, content_type: /\bjson$/
         conn.headers['User-Agent'] = user_agent

--- a/app/views/measures/measure_condition_replacement_modals/_small_brewers_relief_440.html
+++ b/app/views/measures/measure_condition_replacement_modals/_small_brewers_relief_440.html
@@ -3,9 +3,6 @@
 <p>Small Brewers Relief (<abbr title="Small Brewers Relief">SBR</abbr>) provides for reduced rates
 of beer duty for small brewers. <!--It was first introduced in 2002 and is sometimes referred to in the industry as
 “progressive beer duty”.//--></p>
-<style type="text/css">
-ul li b, p b {font-weight:normal}
-</style>
 
 <p><abbr title="Small Brewers Relief">SBR</abbr> is available to any brewer that produced less than 60,000 hectolitres
 (hL) in the previous calendar year and that estimates it will produce less than


### PR DESCRIPTION
## What:
Remove a bare `<style>` block from `_small_brewers_relief_440.html` that violated the `style-src-elem` CSP directive (inline styles require a nonce).

The removed rule (`ul li b, p b { font-weight: normal }`) was suppressing bold on `<b>` tags — removing it restores correct bold rendering.

## Why:
The `<style>` block was generating CSP violation reports in production.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Static asset / content change with no behaviour change.