### PR TITLE
Add stylesheet rule to support CSP-safe GTM anti-flickering

### DIFF
--- a/app/assets/stylesheets/src/_fixes.scss
+++ b/app/assets/stylesheets/src/_fixes.scss
@@ -7,3 +7,9 @@
 form fieldset div.govuk-hint p {
   @extend .govuk-hint;
 }
+
+// Applied by the GTM anti-flickering tag while the page loads.
+// Using a class avoids injecting a <style> element, which would violate style-src-elem CSP.
+html.abhide {
+  opacity: 0;
+}


### PR DESCRIPTION
## What:
Adds an `html.abhide { opacity: 0 }` rule to `_fixes.scss` to support a CSP-safe version of the GTM anti-flickering tag.

## Why:
The current GTM anti-flickering tag injects a `<style>` element dynamically:

```js
var n = h.createElement("style");
n.innerHTML = "body{opacity:0}";
h.head.appendChild(n);
```

This is blocked by the `style-src-elem` CSP directive and generates violation reports on every page.

With this stylesheet rule in place, the GTM tag can be updated to use a class instead — **deploy this PR first, then update the GTM tag**.

## GTM tag update

Replace the current anti-flickering tag content with:

```html
<!-- Anti-flickering script -->
<script>
var timeout = 3000;
document.documentElement.classList.add('abhide');
window.rmfk = function() {
  document.documentElement.classList.remove('abhide');
};
setTimeout(window.rmfk, timeout);
</script>
```

`window.rmfk` is preserved so the Mida A/B testing script can call it directly when it finishes loading, un-hiding the page early rather than waiting the full 3 second timeout.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Additive stylesheet change only. The new rule has no effect until the GTM tag is updated to use the class.