### PR TITLE
Fix CSP violations from GTM inline script and style injection

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,9 +16,9 @@ Rails.application.configure do
                        'https://www.google-analytics.com',
                        'https://www.googletagmanager.com'
     policy.object_src  :none
-    # unsafe-eval is required by Google Tag Manager
-    policy.script_src  :self, :https, :unsafe_eval
-    policy.style_src   :self, :https
+    # unsafe-eval and strict-dynamic are required by Google Tag Manager
+    policy.script_src  :self, :https, :unsafe_eval, :strict_dynamic
+    policy.style_src   :self, :https, :unsafe_inline
     # Specify URI for violation reports
     policy.report_uri '/csp-violation-report'
   end


### PR DESCRIPTION
## What:
Add `'strict-dynamic'` to `script-src` and `'unsafe-inline'` to `style-src` in the Content Security Policy initializer.

## Why:
We are seeing a steady stream of CSP violation reports from Google Tag Manager injecting inline scripts and styles that lack nonces:

- **`script-src-elem` violations** originate from `gtm.js` line 818 — GTM's runtime injects inline `<script>` blocks dynamically. The GTM init snippet itself carries a nonce (via `javascript_tag(nonce: true)`), but the inline scripts GTM subsequently spawns do not. `'strict-dynamic'` fixes this by granting transitive trust to scripts created by a nonce-bearing script, so GTM's child injections are permitted without needing individual nonces.

- **`style-src-elem` violations** come from GTM tag templates and Consent Mode injecting bare `<style>` blocks. Since GTM controls that injection we cannot nonce them from our side, so `'unsafe-inline'` on `style-src` is the pragmatic fix. (Unlike `script-src`, `'unsafe-inline'` on `style-src` is not silently overridden by nonces — it actively permits the un-nonced styles.)

The policy remains in `report_only` mode, so this can be verified against live reports before enforcement is considered.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Config-only change to a report-only CSP policy — no production code paths or user journeys are affected. The policy is not enforced, so there is no risk of breaking anything. The changes relax two CSP directives in line with the threat model for GTM-based analytics.