### PR TITLE
Fix CSP violations: nonce es-module-shims and allow blob img-src

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
 
   <%= yield :head %>
 
-  <script async src="/javascripts/es-module-shims.js?v=<%= CURRENT_REVISION %>"></script>
+  <script async src="/javascripts/es-module-shims.js?v=<%= CURRENT_REVISION %>" nonce="<%= content_security_policy_nonce %>"></script>
   <script type="esms-options" nonce="<%= content_security_policy_nonce %>">
     {
       "noLoadEventRetriggers": true

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
                        'https://analytics.google.com',
                        'https://region1.google-analytics.com'
     policy.font_src    :self, :https, :data
-    policy.img_src     :self, :https, :data,
+    policy.img_src     :self, :https, :data, :blob,
                        'https://www.google-analytics.com',
                        'https://www.googletagmanager.com'
     policy.object_src  :none


### PR DESCRIPTION
## What:
- Add `nonce` attribute to the `es-module-shims.js` script tag in the application layout
- Add `blob:` to `img-src` in the CSP initializer

## Why:
Two new classes of violation appearing since `'strict-dynamic'` was added to `script-src`:

**`script-src-elem` blocking `es-module-shims.js`**
`'strict-dynamic'` explicitly ignores `'self'` and `https:` allowlists for scripts. This means every parser-inserted `<script src="...">` tag in the HTML must carry a nonce to be trusted. The `es-module-shims.js` tag already had its sibling `<script type="esms-options" nonce="...">` nonced, but the shims loader itself was missing one.

**`img-src` blocking `blob:` URIs**
GTM and browser APIs (canvas-to-blob, object URLs) produce `blob:` image URLs. `blob:` was already in `connect-src` but not in `img-src`.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Config-only and a single attribute addition to the layout. Policy remains in `report_only` mode — no user journeys can break. The nonce addition is purely additive; the blob allowance is a narrow, well-scoped source type.