### PR TITLE
fix(csp): remove style-src from nonce directives to restore unsafe-inline

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
 
   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
   config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
-  config.content_security_policy_nonce_directives = %w[script-src style-src]
+  config.content_security_policy_nonce_directives = %w[script-src]
 
   # Report violations without enforcing the policy.
   config.content_security_policy_report_only = true


### PR DESCRIPTION
## What:
Remove `style-src` from `content_security_policy_nonce_directives`.

## Why:
CSP3 specifies that when a nonce is present in a directive, `'unsafe-inline'` is ignored by the browser. By including `style-src` in nonce directives, Rails was generating a per-request style nonce on every response — which silently disabled `'unsafe-inline'` and caused all GTM-injected `<style>` elements and the noscript `<iframe style="...">` to be blocked.

No `<style nonce=...>` tags are generated anywhere in the application (`stylesheet_link_tag` produces `<link>` elements covered by `'self' https:`), so the nonce on `style-src` was doing nothing useful while actively breaking things.

Removing it restores `'unsafe-inline'` so GTM tags can inject styles normally and the noscript iframe's inline style attribute is allowed.

`script-src` keeps its nonce — it is genuinely used by the `esms-options` script block and `javascript_tag nonce: true`.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Config-only change to the report-only CSP policy. Restores intended behaviour (unsafe-inline for styles) with no change to application code or user-facing functionality.