### PR TITLE
fix(csp): allow blob: URIs in style-src to resolve style-src-elem violations

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
     policy.object_src  :none
     # unsafe-eval and strict-dynamic are required by Google Tag Manager
     policy.script_src  :self, :https, :unsafe_eval, :strict_dynamic
-    policy.style_src   :self, :https, :unsafe_inline
+    policy.style_src   :self, :https, :blob, :unsafe_inline
     # Specify URI for violation reports
     policy.report_uri '/csp-violation-report'
   end


### PR DESCRIPTION
## What:
Add `blob:` to the `style-src` CSP directive to permit blob: stylesheet URIs.

## Why:
CSP violation reports showed `style-src-elem` blocking `blob:` URIs. This is caused by Google Tag Manager injecting styles via blob: URIs. The previous fix addressed script-src violations; this covers the remaining style-src gap.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Additive CSP change (one extra source added to `style-src`) while the policy remains in report-only mode. No user journey or behaviour change.