### PR TITLE
Add AWS WAF JS Integration SDK

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,6 +36,10 @@
   </script>
 
   <%= javascript_importmap_tags %>
+
+  <% if TradeTariffFrontend.waf_integration_enabled? %>
+    <script src="<%= TradeTariffFrontend.waf_integration_url %>/challenge.js" defer></script>
+  <% end %>
 </head>
 
 <body class="govuk-template__body <%= service_choice || service_default %>-service">

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -935,6 +935,7 @@ TradeTariffFrontend#google_tag_manager_container_id
 TradeTariffFrontend#redis_config
 TradeTariffFrontend#roo_wizard?
 TradeTariffFrontend#single_trade_window_linking_enabled?
+TradeTariffFrontend#waf_integration_enabled?
 TradeTariffFrontend#webchat_enabled?
 TradeTariffFrontend#welsh?
 TradeTariffFrontend::ServiceChooser#currency

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -154,6 +154,14 @@ module TradeTariffFrontend
     ENV.fetch('GOOGLE_TAG_MANAGER_CONTAINER_ID', '')
   end
 
+  def waf_integration_url
+    ENV['WAF_INTEGRATION_URL']
+  end
+
+  def waf_integration_enabled?
+    waf_integration_url.present?
+  end
+
   def basic_session_authentication?
     @basic_session_authentication ||= basic_session_password.present?
   end


### PR DESCRIPTION
## What:
Adds the AWS WAF Application Integration SDK script to the frontend layout, enabling the challenge token mechanism required by Bot Control Targeted rules.

The script is loaded conditionally via a `WAF_INTEGRATION_URL` env var — it is a no-op when the var is unset, so local dev, test, and staging are unaffected until explicitly configured.

## Why:
The companion terraform PR ([trade-tariff-platform-aws-terraform#639](https://github.com/trade-tariff/trade-tariff-platform-aws-terraform/pull/639)) upgrades Bot Control to Targeted inspection level with ML. The `TGT_*` rules that detect session anomalies and automated browsers (`TGT_VolumetricSession`, `TGT_SignalAutomatedBrowser`, `TGT_SignalBrowserInconsistency`, `TGT_ML_CoordinatedActivity*`) all require a valid challenge token on incoming requests — without one, WAF cannot track client sessions and these rules are dormant.

The SDK runs a silent background JavaScript challenge on page load and attaches the resulting token as a cookie. Real users see nothing; bots that fail the challenge or lack a valid token are caught by the `TGT_*` rules on the WAF side.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
The script only loads when `WAF_INTEGRATION_URL` is explicitly set, so there is zero change in behaviour until that env var is configured. When enabled, `defer` ensures it does not block page render. The CSP `script_src` already permits `:https` so no policy changes are needed.