### PR TITLE
HMRC-2299: ActionView::Template::Error in frontend

### DIFF
--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -14,7 +14,24 @@ module CacheHelper
     ].compact
   end
 
+  def heading_cache_key
+    [
+      'headings#show',
+      cache_key,
+      cache_params.sort.map { |_, v| v }.compact.join('/'),
+    ].compact
+  end
+
   def cache_params
     params.to_unsafe_h.except(*CACHE_EXCLUDED_PARAMS)
+  end
+
+  def resilient_cache_if(condition, key, &block)
+    cache_if(condition, key, &block)
+  rescue Zlib::DataError, Timeout::Error, Timeout::ExitException => e
+    Rails.logger.error("Cache deserialization error for key #{key}: #{e.class} - #{e.message}")
+
+    Rails.cache.delete(key)
+    capture(&block)
   end
 end

--- a/app/views/commodities/show.html.erb
+++ b/app/views/commodities/show.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 <% content_for :bodyClasses, "page--wide" %>
 
-<% cache_if(cacheable, commodity_cache_key) do %>
+<% resilient_cache_if(cacheable, commodity_cache_key) do %>
   <%= render 'commodities/header', commodity_code: declarable.code %>
 
   <% declarable.critical_footnotes.each do |footnote| %>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -6,9 +6,8 @@
   <meta name="description" content="<%= @heading %>">
 <% end %>
 
-<% heading_cache_key = ['headings#show', cache_key, cache_params.values.compact.map(&:to_s).sort.join('/')] %>
 
-<% cache_if(cacheable, heading_cache_key) do %>
+<% resilient_cache_if(cacheable, heading_cache_key) do %>
   <%= page_header do %>
     <% @heading.critical_footnotes.each do |footnote| %>
       <%= render 'footnotes/critical_warning', footnote: footnote %>

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -51,6 +51,8 @@ AuthenticationError#expired?
 BasicSession#password=
 BasicSessionsController#new
 CacheHelper#commodity_cache_key
+CacheHelper#heading_cache_key
+CacheHelper#resilient_cache_if
 Certificate#certificate_code=
 Certificate#certificate_type_code=
 Certificate#description=


### PR DESCRIPTION
## What:
Added safe cache read to fragment cache which already used in service level. It handle deserialization errors and re-render, when occured.

## Why:
Currently, error response is returned when cache deserialization errors occured

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2299

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
There is no functional changes, only handling existing error