### PR TITLE
Document CSS ownership rules

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory is the starting point for understanding the Trade Tariff Frontend
 - [Duty calculator architecture](architecture/duty-calculator.md) maps the import duty calculation journey, option construction, and high-risk decision points.
 - [Development and delivery](development-and-delivery.md) summarises local setup, checks, PR, and deployment conventions.
 - [Style guide](style-guide.md) covers Ruby/Rails, tests, GOV.UK Frontend components, and PR review expectations.
+- [CSS and Sass architecture](css-architecture.md) defines stylesheet ownership, layers, selector policy, and print CSS expectations.
 - [Code Wiki guide](code-wiki.md) explains how to use generated repository documentation safely.
 - Existing domain notes: [Rules of Origin](../doc/rules_of_origin.md).
 

--- a/docs/css-architecture.md
+++ b/docs/css-architecture.md
@@ -6,23 +6,65 @@ Use this file when changing Sass structure, selectors, print CSS, or stylesheet 
 
 `app/assets/stylesheets/application.sass.scss` imports Sass by ownership layer. Keep new partials in the matching directory:
 
-- `settings/`: design tokens, variables, shared colours, breakpoints, and values that other layers read.
-- `tools/`: Sass functions and mixins that emit no CSS by themselves.
+- `settings/`: design tokens, variables, shared colours, breakpoints, and values that other layers read, such as `settings/_colors.scss`.
+- `tools/`: Sass functions and mixins that emit no CSS by themselves, such as `tools/_functions.scss`.
 - `base/`: global element defaults, GOV.UK extension points, and legacy app-wide fixes.
-- `overrides/`: deliberate GOV.UK or third-party component overrides.
-- `utilities/`: narrow reusable utility classes.
+- `overrides/`: deliberate GOV.UK or third-party component overrides, kept narrow and named for the thing being overridden.
+- `utilities/`: tiny reusable utility classes with intentionally global behaviour.
 - `patterns/`: reusable multi-component patterns such as common table treatments.
 - `components/`: reusable app components that can appear on more than one journey.
 - `journeys/`: page or journey-specific layout and presentation.
-- `vendor/`: copied or adapted third-party styles.
+- `print/`: print-only base rules and print deltas over screen components.
+- `vendor/`: copied or adapted third-party styles. Avoid local edits where possible.
+
+Keep the entrypoint order deliberate: settings and tools first, then base, overrides, utilities, patterns, components, and journeys. Do not make one component depend on another component's import order; move shared prerequisites into `settings/`, `tools/`, `base/`, or `patterns/`.
+
+## Component CSS
+
+Use `components/` when the CSS owns one reusable UI concept that can appear on more than one page or journey, for example cards, related navigation, feature panels, or downloadable documents.
+
+Component CSS should:
+
+- target app-owned classes rather than IDs;
+- stay close to the component markup or helper that emits those classes;
+- avoid depending on page-specific parent selectors;
+- expose variants through explicit modifier classes instead of new one-off descendants.
+
+## Journey CSS
+
+Use `journeys/` when the styles are specific to one route, feature area, or user journey. Examples include search, Rules of Origin, exchange rates, and MyOTT.
+
+Journey CSS should be scoped to a route or journey parent class where practical. If a rule becomes useful outside that journey, move it to `components/`, `patterns/`, or `utilities/` rather than importing journey CSS elsewhere.
+
+## Base, Utilities, And Patterns
+
+Use `base/` only for global HTML defaults, GOV.UK extension points, and compatibility fixes that genuinely apply across the service. Broad element selectors belong here or should not be added.
+
+Use `utilities/` for tiny, explicit classes that are intentionally global. A utility should do one thing and should not encode journey-specific layout.
+
+Use `patterns/` for reusable compositions that are broader than a single component but narrower than base CSS, such as common table treatments.
 
 ## Change Rules
 
 - Prefer moving shared prerequisites into `settings/`, `tools/`, or `base/` rather than making one component depend on another component's import order.
 - Keep component CSS with reusable components and journey CSS with the journey that owns the markup.
 - Avoid styling through IDs or broad global selectors. If app-owned markup needs styling, add or use a class while preserving IDs required for labels, anchors, JavaScript, or accessibility.
+- Avoid new `!important` declarations. If one is unavoidable, keep it local, explain the competing rule, and cover the affected rendering in validation.
 - Keep GOV.UK overrides explicit and narrow. Use GOV.UK Sass variables, mixins, spacing, and typography before adding custom values.
 - Treat `print.sass.scss` as print overrides over the screen component model, not a second fork of component CSS.
+
+## GOV.UK And Vendor Policy
+
+Prefer GOV.UK Frontend, `govuk-components`, GOV.UK Sass helpers, and GOV.UK utility classes before custom CSS. Do not approximate GOV.UK component markup or override broad GOV.UK classes by default.
+
+When a GOV.UK or vendor override is necessary:
+
+- put it in `overrides/` unless it belongs to a local component wrapper;
+- keep the selector as narrow as possible;
+- call out the reason and validation in the PR;
+- include representative page coverage when the override affects high-risk pages.
+
+Copied or adapted third-party CSS belongs in `vendor/`. Local service behaviour should usually live outside `vendor/` so future upstream updates are easier to review.
 
 ## Verification
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -43,6 +43,7 @@ Use `BAU` as the ticket when there is no Jira story.
 
 - Use GOV.UK Sass variables, mixins, spacing, typography, and colour helpers before custom values.
 - Keep Sass scoped to a component, journey, or existing module under `app/assets/stylesheets/src/`.
+- Use [CSS and Sass architecture](css-architecture.md) when deciding stylesheet ownership, selector scope, print CSS structure, or GOV.UK override placement.
 - Do not use colour alone to convey meaning.
 - Check small screens, print styles where relevant, and long tariff descriptions or commodity codes.
 - Avoid broad overrides of GOV.UK classes unless the change is intentional, tested, and called out in the PR.


### PR DESCRIPTION
## What:

Expand `docs/css-architecture.md` with concrete ownership guidance for Sass layers, component CSS, journey CSS, base rules, utilities, patterns, GOV.UK overrides, vendor CSS, and print CSS.

Link the guide from `docs/README.md` and `docs/style-guide.md` so contributors can find it before changing stylesheets.

## Why:

The Sass layer structure gives the codebase a place for each kind of stylesheet, but contributors still need a short local decision guide for where new CSS belongs and how reviewers should evaluate selectors, overrides, and print rules.

## Ticket:

BAU

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Docs-only change. Before/after validation confirmed this PR changes 0 app view surfaces and 0 stylesheet files; markdownlint and whitespace checks pass on the stacked base and this branch.