### PR TITLE
Reduce ID selector usage for styling classes

### DIFF
--- a/app/assets/stylesheets/src/components/_help_popup.scss
+++ b/app/assets/stylesheets/src/components/_help_popup.scss
@@ -1,6 +1,6 @@
 @use "src/settings" as settings;
 
-#help_popup {
+.help-popup {
   background-color: settings.$tariff-body-background-colour;
   border: 1px settings.$tariff-heavy-border-colour solid;
   border-radius: 0.5em;

--- a/app/assets/stylesheets/src/journeys/tariff-custom.scss
+++ b/app/assets/stylesheets/src/journeys/tariff-custom.scss
@@ -43,25 +43,12 @@
   @include govuk.govuk-link-style-text;
 }
 
-#last-updated-at {
-  margin-top: govuk.govuk-spacing(6);
-}
-
 .pull-left {
   float: left;
 }
 
 .pull-right {
   float: right;
-}
-
-#mask {
-  position: fixed;
-  top: 0;
-  background-color: #333;
-  z-index: 5;
-  height: 100%;
-  width: 100%;
 }
 
 // terms

--- a/app/assets/stylesheets/src/overrides/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/src/overrides/_accessible-autocomplete.scss
@@ -30,7 +30,7 @@
   }
 }
 
-#q.autocomplete__input {
+.autocomplete__wrapper .autocomplete__input {
   height: 40px !important;
   line-height: 40px;
 }

--- a/app/views/commodities/_help_popup.html.erb
+++ b/app/views/commodities/_help_popup.html.erb
@@ -1,4 +1,4 @@
-<div id="help_popup">
+<div id="help_popup" class="help-popup">
   <p>
     <%= image_tag('help.png') %>
     <strong>Do you need help?</strong>

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -133,6 +133,10 @@ RSpec.describe 'Commodity page', type: :request do
       expect(page).to have_content 'Asses'
     end
 
+    it 'renders the help popup with its styling class' do
+      expect(page).to have_css '#help_popup.help-popup'
+    end
+
     it 'displays Webchat link' do
       # ENV['WEBCHAT_URL'] = 'https://webchat_url_test'
 


### PR DESCRIPTION
## What

- Moves help popup styling from `#help_popup` to `.help-popup` while preserving the ID for existing JavaScript.
- Replaces the search autocomplete `#q.autocomplete__input` override with a class-scoped selector.
- Removes orphaned `#last-updated-at` and `#mask` rules with no matching app markup.
- Adds a request spec assertion for the help popup styling class.

## Why

This reduces CSS specificity and removes unused ID selectors without changing IDs that are still used by JavaScript or generated markup.

## Ticket

BAU

## Risk

Low-risk: selectors and markup were validated before/after on the affected surfaces. The compiled CSS diff contains only the intended selector changes/removals and no print CSS changes; targeted specs passed on base and branch; Sass compilation and asset precompile passed on base and branch.
