### PR TITLE
Split float utilities from legacy CSS bucket

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -32,6 +32,7 @@
 @use "src/overrides/govuk-components";
 
 // Utilities.
+@use "src/utilities/floats";
 @use "src/utilities/grid_extensions";
 @use "src/utilities/images";
 @use "src/utilities/lists";

--- a/app/assets/stylesheets/src/journeys/tariff-custom.scss
+++ b/app/assets/stylesheets/src/journeys/tariff-custom.scss
@@ -1,5 +1,8 @@
 @use "src/settings/govuk" as govuk;
 
+// Mixed legacy rules used across GOV.UK content pages.
+// Move rules out only when ownership is clear and cascade impact is validated.
+
 .govuk-list + .govuk-list + .govuk-list--number,
 .tariff-markdown ul + .govuk-list + .govuk-list--number,
 .tariff-markdown ol + .govuk-list + .govuk-list--number,
@@ -41,14 +44,6 @@
     text-decoration: underline;
   }
   @include govuk.govuk-link-style-text;
-}
-
-.pull-left {
-  float: left;
-}
-
-.pull-right {
-  float: right;
 }
 
 // terms

--- a/app/assets/stylesheets/src/utilities/_floats.scss
+++ b/app/assets/stylesheets/src/utilities/_floats.scss
@@ -1,0 +1,7 @@
+.pull-left {
+  float: left;
+}
+
+.pull-right {
+  float: right;
+}


### PR DESCRIPTION
## What

- Moves `.pull-left` and `.pull-right` from the mixed `tariff-custom` journey bucket to `src/utilities/_floats.scss`.
- Imports the new utility partial from the utilities section.
- Adds a short header to `tariff-custom.scss` explaining why the remaining mixed rules are deferred.

## Why

This reduces the size of a legacy mixed bucket while keeping the change reviewable and preserving the declarations exactly.

## Ticket

BAU

## Risk

Low-risk: this was validated before/after as a declaration-preserving move. Sass compilation and asset precompile passed on base and branch; compiled CSS only moves `.pull-left` and `.pull-right`; print CSS is unchanged; no app views changed.
