### PR TITLE
Establish print CSS policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,11 @@ repos:
 
   - repo: local
     hooks:
+      - id: check-sass-structure
+        name: Check Sass structure
+        entry: bin/check-sass-structure
+        language: system
+        pass_filenames: false
       - id: trufflehog
         name: TruffleHog
         description: Detect secrets in your repo

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -32,6 +32,7 @@
 @use "src/overrides/govuk-components";
 
 // Utilities.
+@use "src/utilities/floats";
 @use "src/utilities/grid_extensions";
 @use "src/utilities/images";
 @use "src/utilities/lists";

--- a/app/assets/stylesheets/print.sass.scss
+++ b/app/assets/stylesheets/print.sass.scss
@@ -6,6 +6,12 @@
 @use "src/settings";
 @use "src/tools";
 @use "src/base/legacy-grid-layout-conditionals";
+
+// Print base and shared print utilities.
 @use "src/print/base";
+
+// Component print deltas.
 @use "src/components/commodity-tree-print";
+
+// Shared print utilities.
 @use "src/print/utilities";

--- a/app/assets/stylesheets/src/components/_cards.scss
+++ b/app/assets/stylesheets/src/components/_cards.scss
@@ -7,10 +7,6 @@
   @include govuk.govuk-responsive-margin(6, "bottom");
 }
 
-.gem-c-cards__heading--underline {
-  // Heading style used when not in column mode
-}
-
 .gem-c-cards__list {
   list-style: none;
   padding: 0;

--- a/app/assets/stylesheets/src/components/_help_popup.scss
+++ b/app/assets/stylesheets/src/components/_help_popup.scss
@@ -1,6 +1,6 @@
 @use "src/settings" as settings;
 
-#help_popup {
+.help-popup {
   background-color: settings.$tariff-body-background-colour;
   border: 1px settings.$tariff-heavy-border-colour solid;
   border-radius: 0.5em;

--- a/app/assets/stylesheets/src/components/_tariff-breadcrumbs.scss
+++ b/app/assets/stylesheets/src/components/_tariff-breadcrumbs.scss
@@ -195,7 +195,6 @@
   .heading-code {
     width: 30px;
     height: 30px;
-    //margin-right: 2px !important;
   }
 
   .commodity-code {
@@ -208,12 +207,6 @@
       display: inline-block;
       text-align: center;
       line-height: 30px;
-      //margin: 0 !important;
-
-      &:nth-child(2) {
-        //margin-left: 2px !important;
-        //margin-right: 2px !important;
-      }
     }
   }
 }

--- a/app/assets/stylesheets/src/journeys/tariff-custom.scss
+++ b/app/assets/stylesheets/src/journeys/tariff-custom.scss
@@ -1,5 +1,8 @@
 @use "src/settings/govuk" as govuk;
 
+// Mixed legacy rules used across GOV.UK content pages.
+// Move rules out only when ownership is clear and cascade impact is validated.
+
 .govuk-list + .govuk-list + .govuk-list--number,
 .tariff-markdown ul + .govuk-list + .govuk-list--number,
 .tariff-markdown ol + .govuk-list + .govuk-list--number,
@@ -41,14 +44,6 @@
     text-decoration: underline;
   }
   @include govuk.govuk-link-style-text;
-}
-
-.pull-left {
-  float: left;
-}
-
-.pull-right {
-  float: right;
 }
 
 // terms

--- a/app/assets/stylesheets/src/journeys/tariff-custom.scss
+++ b/app/assets/stylesheets/src/journeys/tariff-custom.scss
@@ -43,25 +43,12 @@
   @include govuk.govuk-link-style-text;
 }
 
-#last-updated-at {
-  margin-top: govuk.govuk-spacing(6);
-}
-
 .pull-left {
   float: left;
 }
 
 .pull-right {
   float: right;
-}
-
-#mask {
-  position: fixed;
-  top: 0;
-  background-color: #333;
-  z-index: 5;
-  height: 100%;
-  width: 100%;
 }
 
 // terms

--- a/app/assets/stylesheets/src/overrides/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/src/overrides/_accessible-autocomplete.scss
@@ -30,7 +30,7 @@
   }
 }
 
-#q.autocomplete__input {
+.autocomplete__wrapper .autocomplete__input {
   height: 40px !important;
   line-height: 40px;
 }

--- a/app/assets/stylesheets/src/print/_base.scss
+++ b/app/assets/stylesheets/src/print/_base.scss
@@ -34,23 +34,6 @@ a.print-link-without-description:after {
   content: "";
 }
 
-.hidden-print {
-  display: none !important;
-}
-
-.visible-print {
-  display: initial !important;
-  visibility: visible !important;
-}
-
-.pull-left {
-  float: left;
-}
-
-.pull-right {
-  float: right;
-}
-
 a[href^="/"]:after,
 a[href^="http://"]:after,
 a[href^="https://"]:after {

--- a/app/assets/stylesheets/src/print/_utilities.scss
+++ b/app/assets/stylesheets/src/print/_utilities.scss
@@ -4,6 +4,23 @@
   display: none;
 }
 
+.hidden-print {
+  display: none !important;
+}
+
+.visible-print {
+  display: initial !important;
+  visibility: visible !important;
+}
+
+.pull-left {
+  float: left;
+}
+
+.pull-right {
+  float: right;
+}
+
 .tariff-print-grid-column-full-width {
   @extend .govuk-grid-column-full;
 }

--- a/app/assets/stylesheets/src/utilities/_floats.scss
+++ b/app/assets/stylesheets/src/utilities/_floats.scss
@@ -1,0 +1,7 @@
+.pull-left {
+  float: left;
+}
+
+.pull-right {
+  float: right;
+}

--- a/app/views/commodities/_help_popup.html.erb
+++ b/app/views/commodities/_help_popup.html.erb
@@ -1,4 +1,4 @@
-<div id="help_popup">
+<div id="help_popup" class="help-popup">
   <p>
     <%= image_tag('help.png') %>
     <strong>Do you need help?</strong>

--- a/bin/check-sass-structure
+++ b/bin/check-sass-structure
@@ -1,0 +1,176 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "pathname"
+require "set"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+STYLESHEET_ROOT = ROOT.join("app/assets/stylesheets")
+LOCAL_SOURCE_ROOT = STYLESHEET_ROOT.join("src")
+VENDOR_SOURCE_ROOT = LOCAL_SOURCE_ROOT.join("vendor")
+ENTRYPOINTS = %w[
+  app/assets/stylesheets/application.sass.scss
+  app/assets/stylesheets/print.sass.scss
+].freeze
+
+Finding = Data.define(:path, :line, :message) do
+  def to_s
+    "#{path}:#{line}: #{message}"
+  end
+end
+
+def relative_path(path)
+  Pathname.new(path).relative_path_from(ROOT).to_s
+end
+
+def stylesheet_partials
+  LOCAL_SOURCE_ROOT.glob("**/*.{scss,sass}").reject do |path|
+    path.to_s.start_with?("#{VENDOR_SOURCE_ROOT}/")
+  end
+end
+
+def duplicate_import_findings(path)
+  seen = {}
+  findings = []
+
+  path.each_line.with_index(1) do |line, line_number|
+    next unless line =~ /^\s*@(use|import)\s+(?:url\()?["']([^"']+)["']/
+
+    directive = Regexp.last_match(1)
+    imported_path = Regexp.last_match(2)
+    key = [directive, imported_path]
+
+    if seen.key?(key)
+      findings << Finding.new(
+        path: relative_path(path),
+        line: line_number,
+        message: "duplicate @#{directive} of #{imported_path.inspect} first used on line #{seen[key]}",
+      )
+    else
+      seen[key] = line_number
+    end
+  end
+
+  findings
+end
+
+def selector_block_start?(line)
+  stripped = line.strip
+
+  return false if stripped.start_with?("@", "//", "/*", "*")
+  return false unless stripped.end_with?("{")
+
+  selector = stripped.delete_suffix("{").strip
+
+  selector.include?(".") || selector.include?("#")
+end
+
+def ignorable_empty_block_line?(line)
+  stripped = line.strip
+
+  stripped.empty? ||
+    stripped.start_with?("//") ||
+    stripped.start_with?("/*") ||
+    stripped.start_with?("*") ||
+    stripped.end_with?("*/")
+end
+
+def empty_selector_block_findings(path)
+  lines = path.readlines
+  findings = []
+  index = 0
+
+  while index < lines.length
+    line = lines[index]
+
+    if line.match?(/^\s*[.#][^{]+\{\s*\}\s*(?:\/\/.*)?$/)
+      findings << Finding.new(
+        path: relative_path(path),
+        line: index + 1,
+        message: "empty selector block",
+      )
+      index += 1
+      next
+    end
+
+    unless selector_block_start?(line)
+      index += 1
+      next
+    end
+
+    body_index = index + 1
+    body_empty = true
+
+    while body_index < lines.length
+      body_line = lines[body_index]
+      break if body_line.strip == "}"
+
+      unless ignorable_empty_block_line?(body_line)
+        body_empty = false
+        break
+      end
+
+      body_index += 1
+    end
+
+    if body_empty && body_index < lines.length && lines[body_index].strip == "}"
+      findings << Finding.new(
+        path: relative_path(path),
+        line: index + 1,
+        message: "empty selector block",
+      )
+      index = body_index + 1
+    else
+      index += 1
+    end
+  end
+
+  findings
+end
+
+def commented_out_declaration_findings(path)
+  findings = []
+  content = path.read
+
+  path.each_line.with_index(1) do |line, line_number|
+    next unless line =~ %r{^\s*// ?([a-z-]+)\s*:}
+    next if Regexp.last_match(1).match?(/\Ahttps?\z/)
+
+    findings << Finding.new(
+      path: relative_path(path),
+      line: line_number,
+      message: "commented-out declaration",
+    )
+  end
+
+  content.to_enum(:scan, %r{/\*.*?\*/}m).each do
+    comment = Regexp.last_match(0)
+    next unless comment.match?(/^\s*\/\*+\s*[a-z-]+\s*:/) ||
+                comment.match?(/^\s*\*+\s*[a-z-]+\s*:/)
+
+    line_number = content[0...Regexp.last_match.begin(0)].count("\n") + 1
+    findings << Finding.new(
+      path: relative_path(path),
+      line: line_number,
+      message: "commented-out declaration",
+    )
+  end
+
+  findings
+end
+
+findings = []
+
+ENTRYPOINTS.each do |entrypoint|
+  findings.concat(duplicate_import_findings(ROOT.join(entrypoint)))
+end
+
+stylesheet_partials.each do |path|
+  findings.concat(empty_selector_block_findings(path))
+  findings.concat(commented_out_declaration_findings(path))
+end
+
+if findings.any?
+  warn findings.map(&:to_s).join("\n")
+  exit 1
+end

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory is the starting point for understanding the Trade Tariff Frontend
 - [Duty calculator architecture](architecture/duty-calculator.md) maps the import duty calculation journey, option construction, and high-risk decision points.
 - [Development and delivery](development-and-delivery.md) summarises local setup, checks, PR, and deployment conventions.
 - [Style guide](style-guide.md) covers Ruby/Rails, tests, GOV.UK Frontend components, and PR review expectations.
+- [CSS and Sass architecture](css-architecture.md) defines stylesheet ownership, layers, selector policy, and print CSS expectations.
 - [Code Wiki guide](code-wiki.md) explains how to use generated repository documentation safely.
 - Existing domain notes: [Rules of Origin](../doc/rules_of_origin.md).
 

--- a/docs/css-architecture.md
+++ b/docs/css-architecture.md
@@ -44,6 +44,16 @@ Use `utilities/` for tiny, explicit classes that are intentionally global. A uti
 
 Use `patterns/` for reusable compositions that are broader than a single component but narrower than base CSS, such as common table treatments.
 
+## Print CSS
+
+Keep `print.sass.scss` as the print entrypoint. It should import print base rules, print-only utilities, and component print partials rather than carrying full component implementations inline.
+
+Print partials should contain deltas over the screen component model. Shared component structure belongs with the screen component, and print partials should only describe what changes for printed output.
+
+Prefer GOV.UK print utilities in markup for simple show/hide behaviour, for example `govuk-!-display-none-print`. Use custom print CSS when the rule is reusable, structural, or cannot be expressed with a GOV.UK utility.
+
+Avoid duplicating complete screen components in print stylesheets. Extract shared Sass mixins or component structure first, then layer print deltas over the shared component.
+
 ## Change Rules
 
 - Prefer moving shared prerequisites into `settings/`, `tools/`, or `base/` rather than making one component depend on another component's import order.

--- a/docs/css-architecture.md
+++ b/docs/css-architecture.md
@@ -6,23 +6,65 @@ Use this file when changing Sass structure, selectors, print CSS, or stylesheet 
 
 `app/assets/stylesheets/application.sass.scss` imports Sass by ownership layer. Keep new partials in the matching directory:
 
-- `settings/`: design tokens, variables, shared colours, breakpoints, and values that other layers read.
-- `tools/`: Sass functions and mixins that emit no CSS by themselves.
+- `settings/`: design tokens, variables, shared colours, breakpoints, and values that other layers read, such as `settings/_colors.scss`.
+- `tools/`: Sass functions and mixins that emit no CSS by themselves, such as `tools/_functions.scss`.
 - `base/`: global element defaults, GOV.UK extension points, and legacy app-wide fixes.
-- `overrides/`: deliberate GOV.UK or third-party component overrides.
-- `utilities/`: narrow reusable utility classes.
+- `overrides/`: deliberate GOV.UK or third-party component overrides, kept narrow and named for the thing being overridden.
+- `utilities/`: tiny reusable utility classes with intentionally global behaviour.
 - `patterns/`: reusable multi-component patterns such as common table treatments.
 - `components/`: reusable app components that can appear on more than one journey.
 - `journeys/`: page or journey-specific layout and presentation.
-- `vendor/`: copied or adapted third-party styles.
+- `print/`: print-only base rules and print deltas over screen components.
+- `vendor/`: copied or adapted third-party styles. Avoid local edits where possible.
+
+Keep the entrypoint order deliberate: settings and tools first, then base, overrides, utilities, patterns, components, and journeys. Do not make one component depend on another component's import order; move shared prerequisites into `settings/`, `tools/`, `base/`, or `patterns/`.
+
+## Component CSS
+
+Use `components/` when the CSS owns one reusable UI concept that can appear on more than one page or journey, for example cards, related navigation, feature panels, or downloadable documents.
+
+Component CSS should:
+
+- target app-owned classes rather than IDs;
+- stay close to the component markup or helper that emits those classes;
+- avoid depending on page-specific parent selectors;
+- expose variants through explicit modifier classes instead of new one-off descendants.
+
+## Journey CSS
+
+Use `journeys/` when the styles are specific to one route, feature area, or user journey. Examples include search, Rules of Origin, exchange rates, and MyOTT.
+
+Journey CSS should be scoped to a route or journey parent class where practical. If a rule becomes useful outside that journey, move it to `components/`, `patterns/`, or `utilities/` rather than importing journey CSS elsewhere.
+
+## Base, Utilities, And Patterns
+
+Use `base/` only for global HTML defaults, GOV.UK extension points, and compatibility fixes that genuinely apply across the service. Broad element selectors belong here or should not be added.
+
+Use `utilities/` for tiny, explicit classes that are intentionally global. A utility should do one thing and should not encode journey-specific layout.
+
+Use `patterns/` for reusable compositions that are broader than a single component but narrower than base CSS, such as common table treatments.
 
 ## Change Rules
 
 - Prefer moving shared prerequisites into `settings/`, `tools/`, or `base/` rather than making one component depend on another component's import order.
 - Keep component CSS with reusable components and journey CSS with the journey that owns the markup.
 - Avoid styling through IDs or broad global selectors. If app-owned markup needs styling, add or use a class while preserving IDs required for labels, anchors, JavaScript, or accessibility.
+- Avoid new `!important` declarations. If one is unavoidable, keep it local, explain the competing rule, and cover the affected rendering in validation.
 - Keep GOV.UK overrides explicit and narrow. Use GOV.UK Sass variables, mixins, spacing, and typography before adding custom values.
 - Treat `print.sass.scss` as print overrides over the screen component model, not a second fork of component CSS.
+
+## GOV.UK And Vendor Policy
+
+Prefer GOV.UK Frontend, `govuk-components`, GOV.UK Sass helpers, and GOV.UK utility classes before custom CSS. Do not approximate GOV.UK component markup or override broad GOV.UK classes by default.
+
+When a GOV.UK or vendor override is necessary:
+
+- put it in `overrides/` unless it belongs to a local component wrapper;
+- keep the selector as narrow as possible;
+- call out the reason and validation in the PR;
+- include representative page coverage when the override affects high-risk pages.
+
+Copied or adapted third-party CSS belongs in `vendor/`. Local service behaviour should usually live outside `vendor/` so future upstream updates are easier to review.
 
 ## Verification
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -43,6 +43,7 @@ Use `BAU` as the ticket when there is no Jira story.
 
 - Use GOV.UK Sass variables, mixins, spacing, typography, and colour helpers before custom values.
 - Keep Sass scoped to a component, journey, or existing module under `app/assets/stylesheets/src/`.
+- Use [CSS and Sass architecture](css-architecture.md) when deciding stylesheet ownership, selector scope, print CSS structure, or GOV.UK override placement.
 - Do not use colour alone to convey meaning.
 - Check small screens, print styles where relevant, and long tariff descriptions or commodity codes.
 - Avoid broad overrides of GOV.UK classes unless the change is intentional, tested, and called out in the PR.

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -133,6 +133,10 @@ RSpec.describe 'Commodity page', type: :request do
       expect(page).to have_content 'Asses'
     end
 
+    it 'renders the help popup with its styling class' do
+      expect(page).to have_css '#help_popup.help-popup'
+    end
+
     it 'displays Webchat link' do
       # ENV['WEBCHAT_URL'] = 'https://webchat_url_test'
 


### PR DESCRIPTION
## What

- Documents the print CSS policy in `docs/css-architecture.md`.
- Adds layer comments to the print entrypoint.
- Moves print-only utility selectors from `src/print/_base.scss` into `src/print/_utilities.scss`.

## Why

Print CSS should be treated as deltas over the screen component model, not as a place for duplicated component implementations or mixed utility rules.

## Ticket

BAU

## Risk

Medium-risk: this changes the order of a small print utility block in the compiled print stylesheet. Before/after validation passed: base and branch Sass compilation passed; base and branch `bin/rails assets:precompile` passed; targeted view specs passed with 30 examples; application CSS is unchanged; print CSS diff only moves `.hidden-print`, `.visible-print`, `.pull-left`, and `.pull-right`; changed app views: 0.