### PR TITLE
AI-906: Fix guided search result page UX

### DIFF
--- a/app/assets/stylesheets/src/journeys/_interactive-search.scss
+++ b/app/assets/stylesheets/src/journeys/_interactive-search.scss
@@ -29,11 +29,6 @@
   min-width: 120px;
 }
 
-.interactive-results__other-heading {
-  border-top: 1px solid settings.$tariff-subtle-border-colour;
-  padding-top: govuk.govuk-spacing(4);
-}
-
 .confidence-indicator {
   display: flex;
   flex-direction: column;

--- a/app/assets/stylesheets/src/journeys/_interactive-search.scss
+++ b/app/assets/stylesheets/src/journeys/_interactive-search.scss
@@ -19,6 +19,11 @@
   margin-bottom: govuk.govuk-spacing(4);
 }
 
+.interactive-results__section-heading {
+  border-bottom: 1px solid settings.$tariff-subtle-border-colour;
+  padding-bottom: govuk.govuk-spacing(4);
+}
+
 .interactive-result__content {
   flex: 1;
 }

--- a/app/javascript/controllers/guided_search_validation_controller.js
+++ b/app/javascript/controllers/guided_search_validation_controller.js
@@ -90,6 +90,8 @@ export default class extends Controller {
     const pageContent = document.querySelector('[data-guided-search-validation-page-content]')
     const loadingPage = document.querySelector('[data-guided-search-validation-loading-page]')
 
+    window.scrollTo({ top: 0, left: 0 })
+
     this.formContentTarget.classList.add('govuk-!-display-none')
 
     if (pageContent && loadingPage) {

--- a/app/views/search/_interactive_results_content.html.erb
+++ b/app/views/search/_interactive_results_content.html.erb
@@ -34,7 +34,7 @@
     <% strong_results, other_results = display_results.partition { |result| result.try(:confidence).to_s.casecmp('strong').zero? } %>
     <% top_result_count = strong_results.any? ? strong_results.size : display_results.size %>
 
-    <h2 class="govuk-heading-m">Top search <%= 'result'.pluralize(top_result_count) %></h2>
+    <h2 class="interactive-results__section-heading govuk-heading-m">Top search <%= 'result'.pluralize(top_result_count) %></h2>
 
     <div class="interactive-results">
       <% strong_results.each do |result| %>
@@ -42,7 +42,7 @@
       <% end %>
 
       <% if strong_results.any? && other_results.any? %>
-        <h2 class="govuk-heading-m">Other search results</h2>
+        <h2 class="interactive-results__section-heading govuk-heading-m">Other search results</h2>
       <% end %>
 
       <% other_results.each do |result| %>

--- a/app/views/search/_interactive_results_content.html.erb
+++ b/app/views/search/_interactive_results_content.html.erb
@@ -32,8 +32,9 @@
 
     <% display_results = @results.result_limit.zero? ? @results.all : @results.all.first(@results.result_limit) %>
     <% strong_results, other_results = display_results.partition { |result| result.try(:confidence).to_s.casecmp('strong').zero? } %>
+    <% top_result_count = strong_results.any? ? strong_results.size : display_results.size %>
 
-    <h2 class="govuk-heading-m">Top search results</h2>
+    <h2 class="govuk-heading-m">Top search <%= 'result'.pluralize(top_result_count) %></h2>
 
     <div class="interactive-results">
       <% strong_results.each do |result| %>
@@ -41,7 +42,7 @@
       <% end %>
 
       <% if strong_results.any? && other_results.any? %>
-        <h3 class="interactive-results__other-heading govuk-heading-m">Other search results</h3>
+        <h2 class="govuk-heading-m">Other search results</h2>
       <% end %>
 
       <% other_results.each do |result| %>

--- a/spec/javascript/controllers/guided_search_validation_controller_spec.js
+++ b/spec/javascript/controllers/guided_search_validation_controller_spec.js
@@ -70,6 +70,7 @@ describe('GuidedSearchValidationController', () => {
   let submitSpy;
   let fetchSpy;
   let setTimeoutSpy;
+  let scrollToSpy;
 
   async function setup(options) {
     document.body.innerHTML = buildHTML(options);
@@ -89,6 +90,7 @@ describe('GuidedSearchValidationController', () => {
   beforeEach(() => {
     submitSpy = jest.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation(() => {});
     setTimeoutSpy = jest.spyOn(window, 'setTimeout').mockImplementation(() => {});
+    scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
     global.fetch = jest.fn();
     fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
       redirected: false,
@@ -100,6 +102,7 @@ describe('GuidedSearchValidationController', () => {
     if (application) application.stop();
     submitSpy.mockRestore();
     setTimeoutSpy.mockRestore();
+    scrollToSpy.mockRestore();
     fetchSpy.mockRestore();
     delete global.fetch;
   });
@@ -276,6 +279,16 @@ describe('GuidedSearchValidationController', () => {
       submitForm();
 
       expect(document.querySelector('[data-guided-search-validation-page-content]').classList.contains('govuk-!-display-none')).toBe(true);
+    });
+
+    it('scrolls to the top before showing the loading page', async () => {
+      await setup({textareaValue: 'televisions'});
+      submitForm();
+
+      expect(scrollToSpy).toHaveBeenCalledWith({top: 0, left: 0});
+      expect(scrollToSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        setTimeoutSpy.mock.invocationCallOrder[0],
+      );
     });
 
     it('does not show throbber when validation fails', async () => {

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -68,7 +68,25 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
   end
 
   describe 'results subheading' do
-    it { is_expected.to have_css('h2', text: 'Top search results') }
+    it { is_expected.to have_css('h2', text: 'Top search result') }
+
+    context 'when there is more than one strong result' do
+      let(:results) do
+        Search::InternalSearchResult.new(
+          [
+            result_attrs,
+            result_attrs.merge(
+              'goods_nomenclature_item_id' => '2007919940',
+              'classification_description' => 'Other citrus fruit jam',
+              'confidence' => 'strong',
+            ),
+          ],
+          meta,
+        )
+      end
+
+      it { is_expected.to have_css('h2', text: 'Top search results') }
+    end
   end
 
   describe 'result descriptions' do
@@ -148,10 +166,11 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
         )
       end
 
-      it 'separates the remaining results with an Other search results heading', :aggregate_failures do
+      it 'separates the remaining results with an Other search results heading and a single result boundary', :aggregate_failures do
         render partial: 'search/interactive_results_content'
 
-        expect(rendered).to have_css('.interactive-results__other-heading', text: 'Other search results')
+        expect(rendered).to have_css('h2.govuk-heading-m', text: 'Other search results')
+        expect(rendered).not_to have_css('.interactive-results__other-heading')
         expect(rendered.index('Citrus fruit jam')).to be < rendered.index('Other search results')
         expect(rendered.index('Other search results')).to be < rendered.index('Other citrus fruit jam')
       end
@@ -161,7 +180,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
       it 'does not render the divider' do
         render partial: 'search/interactive_results_content'
 
-        expect(rendered).not_to have_css('.interactive-results__other-heading')
+        expect(rendered).not_to have_css('h2', text: 'Other search results')
       end
     end
   end

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
   end
 
   describe 'results subheading' do
-    it { is_expected.to have_css('h2', text: 'Top search result') }
+    it { is_expected.to have_css('h2.interactive-results__section-heading', text: 'Top search result') }
 
     context 'when there is more than one strong result' do
       let(:results) do
@@ -85,7 +85,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
         )
       end
 
-      it { is_expected.to have_css('h2', text: 'Top search results') }
+      it { is_expected.to have_css('h2.interactive-results__section-heading', text: 'Top search results') }
     end
   end
 
@@ -169,7 +169,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
       it 'separates the remaining results with an Other search results heading and a single result boundary', :aggregate_failures do
         render partial: 'search/interactive_results_content'
 
-        expect(rendered).to have_css('h2.govuk-heading-m', text: 'Other search results')
+        expect(rendered).to have_css('h2.interactive-results__section-heading.govuk-heading-m', text: 'Other search results')
         expect(rendered).not_to have_css('.interactive-results__other-heading')
         expect(rendered.index('Citrus fruit jam')).to be < rendered.index('Other search results')
         expect(rendered.index('Other search results')).to be < rendered.index('Other citrus fruit jam')


### PR DESCRIPTION
## What:
- Singularise the guided search top-results heading when there is only one top result.
- Remove the duplicate boundary before the other-results section by using the section heading as the divider point.
- Scroll to the top before showing the guided search loading page.
- Add focused view and JavaScript coverage for the changed behaviour.

## Why:
Follow-up from the guided search UX review against the prototype.

## Ticket:
https://transformuk.atlassian.net/browse/AI-906

## Risk:

**Risk level:** 🟢

**Reason for rating:**
This is limited to the non-production AI guided search experience and has focused view, JavaScript, CSS build, and browser validation evidence.
