### PR TITLE
HMRC-2418: CCWL returning users who are not logged-in being redirected to wrong page

### DIFF
--- a/app/controllers/myott/subscriptions_controller.rb
+++ b/app/controllers/myott/subscriptions_controller.rb
@@ -3,13 +3,15 @@ module Myott
     skip_before_action :authenticate, only: %i[start invalid]
 
     def start
-      @continue_url = if current_user.present?
-                        myott_path
-                      elsif safe_return_to.present?
-                        "#{identity_url}?return_to=#{CGI.escape(safe_return_to)}"
-                      else
-                        identity_url
-                      end
+      return @continue_url = myott_path if current_user.present?
+
+      redirect_url = if safe_return_to.present?
+                       "#{identity_url}?return_to=#{CGI.escape(safe_return_to)}"
+                     else
+                       identity_url
+                     end
+
+      redirect_to redirect_url, allow_other_host: true
     end
 
     def invalid
@@ -27,10 +29,6 @@ module Myott
     end
 
   private
-
-    def identity_url
-      URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s
-    end
 
     def safe_return_to
       return_to = params[:return_to].to_s

--- a/spec/controllers/myott/subscriptions_controller_spec.rb
+++ b/spec/controllers/myott/subscriptions_controller_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
         get :start, params: { return_to: '/subscriptions/mycommodities?as_of=2025-06-20' }
       end
 
-      it 'assigns @continue_url to the identity base url' do
+      it 'redirects to the identity service with the return_to parameter' do
         expected_url = "#{URI.join(TradeTariffFrontend.identity_base_url, '/myott')}?return_to=%2Fsubscriptions%2Fmycommodities%3Fas_of%3D2025-06-20"
-        expect(assigns(:continue_url)).to eq(expected_url)
+        expect(response).to redirect_to(expected_url)
       end
     end
 
@@ -42,9 +42,9 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
         get :start, params: { return_to: 'https://example.com/phishing' }
       end
 
-      it 'assigns @continue_url to the identity base url without a return URL' do
+      it 'redirects to the identity base url without a return URL' do
         expected_url = URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s
-        expect(assigns(:continue_url)).to eq(expected_url)
+        expect(response).to redirect_to(expected_url)
       end
     end
 
@@ -66,9 +66,9 @@ RSpec.describe Myott::SubscriptionsController, type: :controller do
         get :start, params: { return_to: '/subscriptions.evil/mycommodities?as_of=2025-06-20' }
       end
 
-      it 'assigns @continue_url to the identity base url without a return URL' do
+      it 'redirects to the identity base url without a return URL' do
         expected_url = URI.join(TradeTariffFrontend.identity_base_url, '/myott').to_s
-        expect(assigns(:continue_url)).to eq(expected_url)
+        expect(response).to redirect_to(expected_url)
       end
     end
   end


### PR DESCRIPTION
## What:
Users that not logged in, redirected to login page skipping the start page.

## Why:
Users that not logged in, should be e-directed to /login and then after successful auth, routed to original request page

## Ticket:
[HMRC-2418](https://transformuk.atlassian.net/browse/HMRC-2418)

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
Fixing an existing bug