### PR TITLE
Fix for search form labels

### DIFF
--- a/app/views/search/chemicals/_form.html.erb
+++ b/app/views/search/chemicals/_form.html.erb
@@ -12,13 +12,13 @@
                          width: 'one-quarter',
                          id: 'cas',
                          name: 'cas',
-                         label: { text: t('chemical_search.form.cas_label') } %>
+                         label: { text: t('chemical_search.form.cas_label'), for: 'cas' } %>
 
   <%= f.govuk_text_field :name,
                          width: 'one-half',
                          id: 'name',
                          name: 'name',
-                         label: { text: t('chemical_search.form.name_label') } %>
+                         label: { text: t('chemical_search.form.name_label'), for: 'name' } %>
 
   <%= f.govuk_submit t('chemical_search.form.submit'),
                      name: 'new_search',

--- a/app/views/search/quotas/_form.html.erb
+++ b/app/views/search/quotas/_form.html.erb
@@ -19,7 +19,7 @@
                          id: 'order_number',
                          name: 'order_number',
                          maxlength: 6,
-                         label: { text: t('quota_search.form.order_number_label') },
+                         label: { text: t('quota_search.form.order_number_label'), for: 'order_number' },
                          form_group: { class: 'govuk-!-margin-top-6' } %>
 
   <%= f.govuk_text_field :goods_nomenclature_item_id,
@@ -27,7 +27,7 @@
                          id: 'goods_nomenclature_item_id',
                          name: 'goods_nomenclature_item_id',
                          maxlength: 10,
-                         label: { text: t('quota_search.form.goods_nomenclature_item_id_label') },
+                         label: { text: t('quota_search.form.goods_nomenclature_item_id_label'), for: 'goods_nomenclature_item_id' },
                          form_group: { class: 'govuk-!-margin-top-6' } %>
 
   <div class="js-quota-country-picker">
@@ -36,7 +36,7 @@
                                   :id,
                                   :long_description,
                                   options: { include_blank: t('quota_search.form.geographical_area_id_blank') },
-                                  label: { text: t('quota_search.form.geographical_area_id_label') },
+                                  label: { text: t('quota_search.form.geographical_area_id_label'), for: 'geographical_area_id' },
                                   form_group: { class: 'govuk-!-margin-top-6' },
                                   id: 'geographical_area_id',
                                   name: 'geographical_area_id',
@@ -53,7 +53,7 @@
   <%= f.govuk_select :critical,
                      QuotaSearchForm::CRITICAL_VALUES,
                      options: { include_blank: true },
-                     label: { text: t('quota_search.form.critical_label') },
+                     label: { text: t('quota_search.form.critical_label'), for: 'critical' },
                      form_group: { class: 'govuk-!-margin-top-6' },
                      id: 'critical',
                      name: 'critical',
@@ -62,7 +62,7 @@
   <%= f.govuk_select :status,
                      QuotaSearchForm::STATUS_VALUES,
                      options: { include_blank: true },
-                     label: { text: t('quota_search.form.status_label') },
+                     label: { text: t('quota_search.form.status_label'), for: 'status' },
                      form_group: { class: 'govuk-!-margin-top-6' },
                      id: 'status',
                      name: 'status',

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -85,6 +85,7 @@ Chemical#id=
 Chemical#name=
 ChemicalSearchForm#cas=
 ChemicalSearchForm#name=
+ChemicalSearchForm#persisted?
 ChemicalSubstance#cas_rn
 ChemicalSubstance#cas_rn=
 ChemicalSubstance#cus
@@ -699,6 +700,8 @@ QuotaSearchForm#goods_nomenclature_item_id=
 QuotaSearchForm#large_result?
 QuotaSearchForm#month=
 QuotaSearchForm#page=
+QuotaSearchForm#persisted?
+QuotaSearchForm#read_attribute_for_validation
 QuotaSearchForm#status=
 QuotaSearchForm#year=
 QuotaSearchHelper#quota_search_today_params

--- a/spec/views/search/chemicals/_form.html.erb_spec.rb
+++ b/spec/views/search/chemicals/_form.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe 'search/chemicals/_form', type: :view do
+  subject(:rendered_page) do
+    render partial: 'search/chemicals/form', locals: { search_form: ChemicalSearchForm.new({}), section_css: '' }
+    rendered
+  end
+
+  it 'keeps flat parameter names and matching label targets', :aggregate_failures do
+    expect(rendered_page).to have_css('label[for="cas"]', text: 'CAS number')
+    expect(rendered_page).to have_css('input#cas[name="cas"]')
+    expect(rendered_page).to have_css('label[for="name"]', text: 'Chemical name')
+    expect(rendered_page).to have_css('input#name[name="name"]')
+  end
+end

--- a/spec/views/search/quotas/_form.html.erb_spec.rb
+++ b/spec/views/search/quotas/_form.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe 'search/quotas/_form', type: :view do
+  subject(:rendered_page) do
+    render partial: 'search/quotas/form', locals: { search_form:, section_css: '' }
+    rendered
+  end
+
+  let(:search_form) { QuotaSearchForm.new({}) }
+
+  before do
+    allow(search_form).to receive(:geographical_areas).and_return([])
+  end
+
+  it 'keeps flat parameter names and matching label targets', :aggregate_failures do
+    expect(rendered_page).to have_css('label[for="order_number"]', text: /quota order number/i)
+    expect(rendered_page).to have_css('input#order_number[name="order_number"]')
+    expect(rendered_page).to have_css('label[for="goods_nomenclature_item_id"]', text: /commodity code/i)
+    expect(rendered_page).to have_css('input#goods_nomenclature_item_id[name="goods_nomenclature_item_id"]')
+    expect(rendered_page).to have_css('label[for="geographical_area_id"]', text: /country to which the quota applies/i)
+    expect(rendered_page).to have_css('select#geographical_area_id[name="geographical_area_id"]')
+    expect(rendered_page).to have_css('label[for="critical"]', text: /critical state/i)
+    expect(rendered_page).to have_css('select#critical[name="critical"]')
+    expect(rendered_page).to have_css('label[for="status"]', text: 'Status')
+    expect(rendered_page).to have_css('select#status[name="status"]')
+  end
+end


### PR DESCRIPTION
## What:
Updates `for` values for labels in search form. 
The labels are not linking to the input, and this is also causing e2e tests to fail.

## Why:
These inputs have custom names, so the labels also need to match to have the correct content.

## Ticket:
https://transformuk.atlassian.net/browse/OTTIMP-654

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
Fixes regression
