### PR TITLE
AI-928 Support Flagsmith-backed config flags

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
   include BasicSessionAuth
   include CacheHelper
+  include TradeTariffFrontend::Config::RegisteredFlags
 
   before_action :maintenance_mode_if_active
   before_action :set_cache
@@ -163,23 +164,6 @@ class ApplicationController < ActionController::Base
 
   def country
     params['country'].try(:upcase)
-  end
-
-  def flagsmith_feature_enabled?(flag)
-    return false if Current.flagsmith_unavailable
-
-    flags = Current.flagsmith_flags ||= FlagsmithClient.instance.get_flags_for(Current.flagsmith_identity)
-    flags.is_feature_enabled(flag.to_s)
-  rescue StandardError => e
-    Current.flagsmith_unavailable = true
-    Rails.logger.warn("Flagsmith unavailable, disabling #{flag}: #{e.class}: #{e.message}")
-    false
-  end
-
-  def interactive_search_enabled?
-    return false if TradeTariffFrontend::ServiceChooser.xi?
-
-    flagsmith_feature_enabled?(:interactive_search)
   end
 
   def set_current_flagsmith_identity

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -118,14 +118,7 @@ class Search
   private
 
   def interactive_search_enabled?
-    return false if TradeTariffFrontend::ServiceChooser.xi? || Current.flagsmith_unavailable
-
-    flags = Current.flagsmith_flags ||= FlagsmithClient.instance.get_flags_for(Current.flagsmith_identity)
-    flags.is_feature_enabled('interactive_search')
-  rescue StandardError => e
-    Current.flagsmith_unavailable = true
-    Rails.logger.warn("Flagsmith unavailable, disabling interactive search: #{e.class}: #{e.message}")
-    false
+    TradeTariffFrontend.interactive_search_enabled?
   end
 
   def perform_v2_search

--- a/lib/trade_tariff_frontend/config.rb
+++ b/lib/trade_tariff_frontend/config.rb
@@ -1,5 +1,9 @@
+require_relative 'flagsmith_backed_config'
+
 module TradeTariffFrontend
   module Config
+    prepend FlagsmithBackedConfig
+
     def production?
       environment == 'production'
     end
@@ -136,5 +140,8 @@ module TradeTariffFrontend
     def basic_session_passwords
       @basic_session_passwords ||= basic_session_password.to_s.split(',').map(&:strip).reject(&:blank?)
     end
+
+    flagsmith_flag :interactive_search_enabled?, name: :interactive_search, services: %i[uk]
+    flagsmith_flag :webchat_enabled?, name: :webchat
   end
 end

--- a/lib/trade_tariff_frontend/flagsmith_backed_config.rb
+++ b/lib/trade_tariff_frontend/flagsmith_backed_config.rb
@@ -1,0 +1,101 @@
+module TradeTariffFrontend
+  # Decorates TradeTariffFrontend::Config methods with Flagsmith-backed overrides.
+  #
+  # A config method remains the source of truth for the default value. Register it
+  # with `flagsmith_flag` to allow a configured Flagsmith value to override that
+  # default for the selected service(s):
+  #
+  #   def interactive_search_enabled?
+  #     !production? && !ServiceChooser.xi?
+  #   end
+  #
+  #   flagsmith_flag :interactive_search_enabled?,
+  #                  name: :interactive_search,
+  #                  services: %i[uk]
+  #
+  # If Flagsmith has no value, no request identity is available, or Flagsmith
+  # cannot be reached, the original config method value is returned. Registered
+  # flags are also exposed through Config::RegisteredFlags so controllers can
+  # include only the flag helpers rather than the full config module.
+  module FlagsmithBackedConfig
+    FALLBACK_EVENT = 'flagsmith.config_flag_fallback'.freeze
+
+    def self.prepended(base)
+      base.const_set(:RegisteredFlags, Module.new) unless base.const_defined?(:RegisteredFlags, false)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def registered_flags
+        @registered_flags ||= {}
+      end
+
+      def flagsmith_flag(method_name, name:, services: nil)
+        flag_name = name.to_s
+        service_names = Array(services).map(&:to_s)
+        registered_flags[method_name] = { name: flag_name, services: service_names }
+
+        TradeTariffFrontend::FlagsmithBackedConfig.define_method(method_name) do
+          default = super()
+          next default unless service_names.empty? || service_names.include?(TradeTariffFrontend::ServiceChooser.service_name)
+
+          flagsmith_config_flag(flag_name, method_name:, default:)
+        end
+
+        registered_flags_module.define_method(method_name) do
+          TradeTariffFrontend.public_send(method_name)
+        end
+        registered_flags_module.module_eval { private method_name }
+      end
+
+      private
+
+      def registered_flags_module
+        const_get(:RegisteredFlags)
+      end
+    end
+
+    private
+
+    def flagsmith_config_flag(flag_name, method_name:, default:)
+      if Current.flagsmith_unavailable
+        instrument_flagsmith_config_fallback(flag_name:, method_name:, default:, reason: :previously_unavailable)
+        return default
+      end
+
+      if Current.flagsmith_identity.blank?
+        instrument_flagsmith_config_fallback(flag_name:, method_name:, default:, reason: :missing_identity)
+        return default
+      end
+
+      flags = Current.flagsmith_flags ||= FlagsmithClient.instance.get_flags_for(Current.flagsmith_identity)
+      flag = flags.get_flag(flag_name)
+
+      if flag.is_default
+        instrument_flagsmith_config_fallback(flag_name:, method_name:, default:, reason: :missing_flag)
+        default
+      else
+        flag.enabled?
+      end
+    rescue StandardError => e
+      Current.flagsmith_unavailable = true
+      instrument_flagsmith_config_fallback(flag_name:, method_name:, default:, reason: :unavailable, error: e)
+      Rails.logger.warn("Flagsmith unavailable, using default for #{flag_name}: #{e.class}: #{e.message}")
+      default
+    end
+
+    def instrument_flagsmith_config_fallback(flag_name:, method_name:, default:, reason:, error: nil)
+      payload = {
+        flag_name:,
+        method_name:,
+        default:,
+        reason:,
+        service_name: TradeTariffFrontend::ServiceChooser.service_name,
+        environment: TradeTariffFrontend.environment,
+      }
+      payload[:error_class] = error.class.name if error
+
+      ActiveSupport::Notifications.instrument(FALLBACK_EVENT, payload)
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -65,39 +65,40 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
-  describe '#flagsmith_feature_enabled?' do
+  describe '#interactive_search_enabled?' do
     controller do
       def index
-        2.times { flagsmith_feature_enabled?(:interactive_search) }
-        render plain: 'ok'
+        render plain: interactive_search_enabled?.to_s
       end
     end
 
-    it 'does not retry Flagsmith after a failed flag fetch in the same request' do
-      allow(FlagsmithClient.instance).to receive(:get_flags_for).and_raise(Faraday::ConnectionFailed.new('timeout'))
+    before do
+      stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => 'development'))
+      allow(TradeTariffFrontend::ServiceChooser).to receive_messages(service_name: 'uk', xi?: false)
+    end
 
+    it 'uses the config default when the Flagsmith flag is not configured' do
       get :index
 
-      expect(FlagsmithClient.instance).to have_received(:get_flags_for).once
+      expect(response.body).to eq('true')
+    end
+  end
+
+  describe '#webchat_enabled?' do
+    controller do
+      def index
+        render plain: webchat_enabled?.to_s
+      end
     end
 
-    context 'when on the XI service' do
-      controller do
-        def index
-          render plain: flagsmith_feature_enabled?(:interactive_search).to_s
-        end
-      end
+    before do
+      stub_const('ENV', ENV.to_hash.merge('WEBCHAT_URL' => 'https://example.com/webchat'))
+    end
 
-      before do
-        allow(TradeTariffFrontend::ServiceChooser).to receive(:xi?).and_return(true)
-        enable_feature(:interactive_search)
-      end
+    it 'uses the config default when the Flagsmith flag is not configured' do
+      get :index
 
-      it 'returns the raw Flagsmith flag value' do
-        get :index
-
-        expect(response.body).to eq('true')
-      end
+      expect(response.body).to eq('true')
     end
   end
 

--- a/spec/lib/trade_tariff_frontend_spec.rb
+++ b/spec/lib/trade_tariff_frontend_spec.rb
@@ -5,6 +5,19 @@ RSpec.describe TradeTariffFrontend do
     expect(described_class.singleton_class.ancestors).to include(described_class::Config)
   end
 
+  it 'registers config-backed feature flags' do
+    expect(described_class::Config.registered_flags).to include(
+      interactive_search_enabled?: {
+        name: 'interactive_search',
+        services: %w[uk],
+      },
+      webchat_enabled?: {
+        name: 'webchat',
+        services: [],
+      },
+    )
+  end
+
   describe '.enquiries_email' do
     it 'returns the default classification enquiries email' do
       expect(described_class.enquiries_email).to eq('classification.enquiries@hmrc.gov.uk')
@@ -53,6 +66,55 @@ RSpec.describe TradeTariffFrontend do
         expect(described_class.webchat_url).to eq(
           'https://www.tax.service.gov.uk/ask-hmrc/chat/test-online-services-helpdesk',
         )
+      end
+    end
+  end
+
+  describe '.webchat_enabled?' do
+    before do
+      Current.flagsmith_identity = Flagsmith::AnonymousIdentity.new('anon-123')
+    end
+
+    context 'when the Flagsmith flag is not configured' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('WEBCHAT_URL' => 'https://example.com/webchat'))
+      end
+
+      it 'uses the configured default' do
+        expect(described_class.webchat_enabled?).to be(true)
+      end
+    end
+
+    context 'when the Flagsmith flag is configured as disabled' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('WEBCHAT_URL' => 'https://example.com/webchat'))
+        disable_feature(:webchat)
+      end
+
+      it 'overrides the configured default' do
+        expect(described_class.webchat_enabled?).to be(false)
+      end
+    end
+
+    context 'when the Flagsmith flag is configured as enabled' do
+      before do
+        stub_const('ENV', ENV.to_hash.except('WEBCHAT_URL'))
+        enable_feature(:webchat)
+      end
+
+      it 'overrides the configured default' do
+        expect(described_class.webchat_enabled?).to be(true)
+      end
+    end
+
+    context 'when Flagsmith is unavailable' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('WEBCHAT_URL' => 'https://example.com/webchat'))
+        allow(FlagsmithClient.instance).to receive(:get_flags_for).and_raise(Faraday::ConnectionFailed.new('timeout'))
+      end
+
+      it 'uses the configured default' do
+        expect(described_class.webchat_enabled?).to be(true)
       end
     end
   end
@@ -123,6 +185,155 @@ RSpec.describe TradeTariffFrontend do
 
         it 'does not return a Flagsmith Edge URL' do
           expect(described_class.flagsmith_api_url).to be_nil
+        end
+      end
+    end
+  end
+
+  describe '.interactive_search_enabled?' do
+    before do
+      Current.flagsmith_identity = Flagsmith::AnonymousIdentity.new('anon-123')
+      allow(described_class::ServiceChooser).to receive_messages(service_name: 'uk', xi?: false)
+    end
+
+    def capture_flagsmith_fallback_events
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe('flagsmith.config_flag_fallback') do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      yield events
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    context 'when the Flagsmith flag is not configured' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => 'development'))
+      end
+
+      it 'uses the configured default' do
+        expect(described_class.interactive_search_enabled?).to be(true)
+      end
+    end
+
+    context 'when the Flagsmith flag is not configured in production' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => 'production'))
+      end
+
+      it 'uses the configured default' do
+        expect(described_class.interactive_search_enabled?).to be(false)
+      end
+
+      it 'instruments the fallback reason' do
+        capture_flagsmith_fallback_events do |events|
+          described_class.interactive_search_enabled?
+
+          expect(events.map(&:payload)).to include(
+            a_hash_including(
+              flag_name: 'interactive_search',
+              method_name: :interactive_search_enabled?,
+              reason: :missing_flag,
+              service_name: 'uk',
+              default: false,
+            ),
+          )
+        end
+      end
+    end
+
+    context 'without a Flagsmith identity' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => 'development'))
+        Current.flagsmith_identity = nil
+        allow(FlagsmithClient.instance).to receive(:get_flags_for).and_call_original
+      end
+
+      it 'uses the configured default without fetching Flagsmith flags', :aggregate_failures do
+        expect(described_class.interactive_search_enabled?).to be(true)
+        expect(FlagsmithClient.instance).not_to have_received(:get_flags_for)
+      end
+
+      it 'instruments the fallback reason' do
+        capture_flagsmith_fallback_events do |events|
+          described_class.interactive_search_enabled?
+
+          expect(events.map(&:payload)).to include(
+            a_hash_including(
+              flag_name: 'interactive_search',
+              method_name: :interactive_search_enabled?,
+              reason: :missing_identity,
+              service_name: 'uk',
+              default: true,
+            ),
+          )
+        end
+      end
+    end
+
+    context 'when the Flagsmith flag is configured as disabled' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => 'development'))
+        disable_feature(:interactive_search)
+      end
+
+      it 'overrides the configured default' do
+        expect(described_class.interactive_search_enabled?).to be(false)
+      end
+    end
+
+    context 'when the Flagsmith flag is configured as enabled' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => 'production'))
+        enable_feature(:interactive_search)
+      end
+
+      it 'overrides the configured default' do
+        expect(described_class.interactive_search_enabled?).to be(true)
+      end
+    end
+
+    context 'when the flag does not apply to the current service' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => 'development'))
+        allow(described_class::ServiceChooser).to receive_messages(service_name: 'xi', xi?: true)
+        enable_feature(:interactive_search)
+      end
+
+      it 'uses the configured default' do
+        expect(described_class.interactive_search_enabled?).to be(false)
+      end
+    end
+
+    context 'when Flagsmith is unavailable' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => 'development'))
+        allow(FlagsmithClient.instance).to receive(:get_flags_for).and_raise(Faraday::ConnectionFailed.new('timeout'))
+      end
+
+      it 'uses the configured default and does not retry during the request', :aggregate_failures do
+        2.times do
+          expect(described_class.interactive_search_enabled?).to be(true)
+        end
+
+        expect(FlagsmithClient.instance).to have_received(:get_flags_for).once
+      end
+
+      it 'instruments the fallback reason' do
+        capture_flagsmith_fallback_events do |events|
+          described_class.interactive_search_enabled?
+
+          expect(events.map(&:payload)).to include(
+            a_hash_including(
+              flag_name: 'interactive_search',
+              method_name: :interactive_search_enabled?,
+              reason: :unavailable,
+              service_name: 'uk',
+              default: true,
+              error_class: 'Faraday::ConnectionFailed',
+            ),
+          )
         end
       end
     end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -233,6 +233,10 @@ RSpec.describe Search do
   end
 
   describe '#perform' do
+    before do
+      Current.flagsmith_identity = Flagsmith::AnonymousIdentity.new('anon-123')
+    end
+
     context 'when interactive_search is true and interactive search is enabled' do
       subject(:perform_search) do
         search = described_class.new(q: 'horses')
@@ -334,6 +338,28 @@ RSpec.describe Search do
       end
     end
 
+    context 'when the interactive search flag is not configured but the config default is enabled' do
+      subject(:perform_search) do
+        search = described_class.new(q: 'horses')
+        search.interactive_search = true
+        search.perform
+      end
+
+      before do
+        stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => 'development'))
+        Current.flagsmith_identity = Flagsmith::AnonymousIdentity.new('anon-123')
+        allow(TradeTariffFrontend::ServiceChooser).to receive_messages(service_name: 'uk', xi?: false)
+        stub_api_request('search', :post, internal: true)
+          .to_return(status: 200,
+                     body: { 'data' => [] }.to_json,
+                     headers: { 'content-type' => 'application/json; charset=utf-8' })
+      end
+
+      it 'returns an InternalSearchResult' do
+        expect(perform_search).to be_a(Search::InternalSearchResult)
+      end
+    end
+
     context 'when interactive_search is false even though interactive search is enabled' do
       subject(:perform_search) { described_class.new(q: 'horses').perform }
 
@@ -422,6 +448,7 @@ RSpec.describe Search do
       end
 
       before do
+        stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => 'production'))
         allow(FlagsmithClient.instance).to receive(:get_flags_for).and_raise(Faraday::ConnectionFailed.new('timeout'))
         stub_api_request('search', :post).to_return(
           jsonapi_response(:search, {
@@ -434,6 +461,12 @@ RSpec.describe Search do
 
       it 'returns a Search::Outcome' do
         expect(perform_search).to be_a(Search::Outcome)
+      end
+
+      it 'attempts to fetch Flagsmith flags before falling back' do
+        perform_search
+
+        expect(FlagsmithClient.instance).to have_received(:get_flags_for).once
       end
     end
   end

--- a/spec/support/flagsmith.rb
+++ b/spec/support/flagsmith.rb
@@ -3,13 +3,38 @@
 # Shared across threads (it is a constant, not thread-local), so Puma server
 # threads in JS tests see the same state as the test thread.
 class TestFlagsmithClient
+  class TestFlag
+    attr_reader :enabled, :default
+
+    def initialize(enabled:, default:)
+      @enabled = enabled
+      @default = default
+    end
+
+    def enabled?
+      enabled
+    end
+
+    alias_method :is_default, :default
+  end
+
   class TestFlags
     def initialize(flags)
       @flags = flags
     end
 
     def is_feature_enabled(flag_name)
-      @flags.fetch(flag_name.to_s, false)
+      get_flag(flag_name).enabled?
+    end
+
+    def get_flag(flag_name)
+      flag_name = flag_name.to_s
+
+      if @flags.key?(flag_name)
+        TestFlag.new(enabled: @flags.fetch(flag_name), default: false)
+      else
+        TestFlag.new(enabled: false, default: true)
+      end
     end
   end
 


### PR DESCRIPTION
## What:

- Add a small `TradeTariffFrontend::FlagsmithBackedConfig` decorator for explicitly registered config flags.
- Register `interactive_search_enabled?` as a UK-only Flagsmith-backed config flag using the existing `interactive_search` flag name.
- Accumulate registered flag metadata on `TradeTariffFrontend::Config.registered_flags`.
- Expose only registered flag methods to controllers via `TradeTariffFrontend::Config::RegisteredFlags`, rather than including the full config module.
- Move controller and `Search` interactive-search checks onto `TradeTariffFrontend.interactive_search_enabled?`.
- Instrument config flag fallbacks for missing identity, missing Flagsmith flag, and Flagsmith client unavailability.

## Why:

This keeps current config defaults as the fallback when Flagsmith has no value, is unavailable, or has no current request identity, while allowing configured Flagsmith values to override registered config flags. It also keeps service scoping explicit so a UK-only flag cannot enable the XI journey.

Depends on #3184.

## Ticket:

AI-928

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Defaults are preserved when Flagsmith has no configuration, no request identity, or is unavailable. The interactive search flag remains off in production by default and behaves as it does today unless a service-scoped Flagsmith value is configured.