### PR TITLE
AI-928 Enforce frontend config ordering

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
+require:
+  - ./.rubocop/cop/trade_tariff/config_order
+
 plugins:
   - rubocop-rspec
   - rubocop-capybara
@@ -86,3 +89,6 @@ RSpec/IndexedLet:
 
 RSpec/NoExpectationExample:
   Enabled: false
+
+TradeTariff/ConfigOrder:
+  Enabled: true

--- a/.rubocop/cop/trade_tariff/config_order.rb
+++ b/.rubocop/cop/trade_tariff/config_order.rb
@@ -1,0 +1,127 @@
+module RuboCop
+  module Cop
+    module TradeTariff
+      # Enforces the grouping used by TradeTariffFrontend::Config:
+      # boolean config methods, value config methods, boolean flags, then value flags.
+      class ConfigOrder < Base
+        extend RuboCop::Cop::AutoCorrector
+
+        CONFIG_FILE = 'lib/trade_tariff_frontend/config.rb'.freeze
+        BOOLEAN_FLAG_METHODS = %i[flagsmith_flag].freeze
+        VALUE_FLAG_METHODS = %i[flagsmith_value flagsmith_config].freeze
+
+        def on_module(node)
+          return unless config_module?(node)
+
+          entries = config_entries(node)
+          return if entries.empty? || ordered?(entries)
+
+          add_offense(node.identifier.loc.expression, message: 'Config methods and flags must be grouped and sorted.') do |corrector|
+            corrector.replace(
+              replacement_range(entries),
+              ordered_source(entries),
+            )
+          end
+        end
+
+        private
+
+        def config_module?(node)
+          processed_source.file_path.end_with?(CONFIG_FILE) &&
+            node.identifier.const_name == 'Config' &&
+            node.each_ancestor(:module).any? { |ancestor| ancestor.identifier.const_name == 'TradeTariffFrontend' }
+        end
+
+        def config_entries(node)
+          body_nodes(node).filter_map do |child|
+            ConfigEntry.build(child)
+          end
+        end
+
+        def body_nodes(node)
+          body = node.body
+          return [] unless body
+          return body.children if body.begin_type?
+
+          [body]
+        end
+
+        def ordered?(entries)
+          entries.map(&:key) == entries.sort_by(&:key).map(&:key)
+        end
+
+        def replacement_range(entries)
+          first_entry = entries.min_by { |entry| entry.source_range.begin_pos }
+          last_entry = entries.max_by { |entry| entry.source_range.end_pos }
+
+          first_entry.source_range.join(last_entry.source_range)
+        end
+
+        def ordered_source(entries)
+          sorted_entries = entries.sort_by(&:key)
+
+          sorted_entries.each_with_index.map { |entry, index|
+            next entry.source if index.zero?
+
+            "#{separator_for(sorted_entries[index - 1], entry)}#{entry.source}"
+          }.join
+        end
+
+        def separator_for(previous_entry, entry)
+          previous_entry.flag? && entry.flag? && previous_entry.group == entry.group ? "\n" : "\n\n"
+        end
+
+        class ConfigEntry
+          attr_reader :node, :group, :name
+
+          def self.build(node)
+            case node.type
+            when :def
+              new(node, node.method_name.end_with?('?') ? 0 : 1, node.method_name.to_s)
+            when :send
+              flag_entry(node)
+            end
+          end
+
+          def self.flag_entry(node)
+            return unless BOOLEAN_FLAG_METHODS.include?(node.method_name) || VALUE_FLAG_METHODS.include?(node.method_name)
+
+            name = node.first_argument&.value.to_s
+            group = BOOLEAN_FLAG_METHODS.include?(node.method_name) ? 2 : 3
+
+            new(node, group, name)
+          end
+
+          def initialize(node, group, name)
+            @node = node
+            @group = group
+            @name = name
+          end
+
+          def key
+            [group, name]
+          end
+
+          def flag?
+            group >= 2
+          end
+
+          # Keep this explicit so the cop does not depend on Active Support.
+          # rubocop:disable Rails/Delegate
+          def source
+            source_range.source
+          end
+          # rubocop:enable Rails/Delegate
+
+          def source_range
+            Parser::Source::Range.new(
+              node.source_range.source_buffer,
+              node.source_range.begin_pos - node.loc.column,
+              node.source_range.end_pos,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/trade_tariff_frontend/config.rb
+++ b/lib/trade_tariff_frontend/config.rb
@@ -4,73 +4,28 @@ module TradeTariffFrontend
   module Config
     prepend FlagsmithBackedConfig
 
+    def basic_session_authentication?
+      @basic_session_authentication ||= basic_session_password.present?
+    end
+
+    def interactive_search_enabled?
+      !production? && !ServiceChooser.xi?
+    end
+
     def production?
       environment == 'production'
     end
 
-    def environment
-      ENV.fetch('ENVIRONMENT', 'production')
+    def waf_integration_enabled?
+      waf_integration_url.present?
     end
 
-    def id_token_cookie_name
-      cookie_name_for('id_token')
+    def webchat_enabled?
+      webchat_url.present?
     end
 
-    def refresh_token_cookie_name
-      cookie_name_for('refresh_token')
-    end
-
-    def cookie_name_for(base_name)
-      case environment
-      when 'production'
-        base_name
-      else
-        "#{environment}_#{base_name}"
-      end.to_sym
-    end
-
-    def redis_config
-      { url: ENV['REDIS_URL'], db: 0, id: nil }
-    end
-
-    def from_email
-      ENV['TARIFF_FROM_EMAIL']
-    end
-
-    def to_email
-      ENV['TARIFF_TO_EMAIL']
-    end
-
-    def support_email
-      ENV['TARIFF_SUPPORT_EMAIL'].presence || DEFAULT_SUPPORT_EMAIL
-    end
-
-    def enquiries_email
-      DEFAULT_ENQUIRIES_EMAIL
-    end
-
-    def host
-      ENV.fetch('FRONTEND_HOST', 'http://localhost')
-    end
-
-    def developer_portal_url
-      ENV.fetch('DEVELOPER_PORTAL_URL') { "https://hub.#{base_domain}/" }
-    end
-
-    def flagsmith_api_url
-      ENV['FLAGSMITH_API_URL'].presence || FLAGSMITH_API_URLS[environment]
-    end
-
-    def identity_base_url
-      ENV.fetch('IDENTITY_BASE_URL', 'http://localhost:3005')
-    end
-
-    def identity_cookie_domain
-      @identity_cookie_domain ||= if Rails.env.production?
-                                    ".#{base_domain}"
-                                  else
-                                    :all
-                                  end
+    def backend_base_domain
+      ENV['BACKEND_BASE_DOMAIN']
     end
 
     def base_domain
@@ -85,16 +40,97 @@ module TradeTariffFrontend
       end
     end
 
-    def backend_base_domain
-      ENV['BACKEND_BASE_DOMAIN']
+    def basic_session_password
+      @basic_session_password ||= ENV['BASIC_PASSWORD']
+    end
+
+    def basic_session_passwords
+      @basic_session_passwords ||= basic_session_password.to_s.split(',').map(&:strip).reject(&:blank?)
     end
 
     def check_duties_service_url
       ENV.fetch('CHECK_DUTIES_SERVICE_URL', 'https://www.check-duties-customs-exporting-goods.service.gov.uk')
     end
 
-    def webchat_enabled?
-      webchat_url.present?
+    def cookie_name_for(base_name)
+      case environment
+      when 'production'
+        base_name
+      else
+        "#{environment}_#{base_name}"
+      end.to_sym
+    end
+
+    def developer_portal_url
+      ENV.fetch('DEVELOPER_PORTAL_URL') { "https://hub.#{base_domain}/" }
+    end
+
+    def enquiries_email
+      DEFAULT_ENQUIRIES_EMAIL
+    end
+
+    def environment
+      ENV.fetch('ENVIRONMENT', 'production')
+    end
+
+    def flagsmith_api_url
+      ENV['FLAGSMITH_API_URL'].presence || FLAGSMITH_API_URLS[environment]
+    end
+
+    def from_email
+      ENV['TARIFF_FROM_EMAIL']
+    end
+
+    def google_tag_manager_container_id
+      ENV.fetch('GOOGLE_TAG_MANAGER_CONTAINER_ID', '')
+    end
+
+    def green_lanes_api_token
+      "Bearer #{ENV['GREEN_LANES_API_TOKEN']}"
+    end
+
+    def host
+      ENV.fetch('FRONTEND_HOST', 'http://localhost')
+    end
+
+    def id_token_cookie_name
+      cookie_name_for('id_token')
+    end
+
+    def identity_base_url
+      ENV.fetch('IDENTITY_BASE_URL', 'http://localhost:3005')
+    end
+
+    def identity_cookie_domain
+      @identity_cookie_domain ||= if Rails.env.production?
+                                    ".#{base_domain}"
+                                  else
+                                    :all
+                                  end
+    end
+
+    def legacy_results_to_show
+      ENV.fetch('LEGACY_RESULTS_TO_SHOW', '5').to_i
+    end
+
+    def redis_config
+      { url: ENV['REDIS_URL'], db: 0, id: nil }
+    end
+
+    def refresh_token_cookie_name
+      cookie_name_for('refresh_token')
+    end
+
+    def support_email
+      ENV['TARIFF_SUPPORT_EMAIL'].presence || DEFAULT_SUPPORT_EMAIL
+    end
+
+    def to_email
+      ENV['TARIFF_TO_EMAIL']
+    end
+
+    def waf_integration_url
+      ENV['WAF_INTEGRATION_URL']
     end
 
     def webchat_url
@@ -103,42 +139,6 @@ module TradeTariffFrontend
       return configured_url if configured_url.match?(%r{\Ahttps?://})
 
       URI.join(WEBCHAT_BASE_URL, configured_url).to_s
-    end
-
-    def legacy_results_to_show
-      ENV.fetch('LEGACY_RESULTS_TO_SHOW', '5').to_i
-    end
-
-    def interactive_search_enabled?
-      !production? && !ServiceChooser.xi?
-    end
-
-    def green_lanes_api_token
-      "Bearer #{ENV['GREEN_LANES_API_TOKEN']}"
-    end
-
-    def google_tag_manager_container_id
-      ENV.fetch('GOOGLE_TAG_MANAGER_CONTAINER_ID', '')
-    end
-
-    def waf_integration_url
-      ENV['WAF_INTEGRATION_URL']
-    end
-
-    def waf_integration_enabled?
-      waf_integration_url.present?
-    end
-
-    def basic_session_authentication?
-      @basic_session_authentication ||= basic_session_password.present?
-    end
-
-    def basic_session_password
-      @basic_session_password ||= ENV['BASIC_PASSWORD']
-    end
-
-    def basic_session_passwords
-      @basic_session_passwords ||= basic_session_password.to_s.split(',').map(&:strip).reject(&:blank?)
     end
 
     flagsmith_flag :interactive_search_enabled?, name: :interactive_search, services: %i[uk]


### PR DESCRIPTION
## What:

- Add a custom RuboCop cop that enforces grouped and sorted `TradeTariffFrontend::Config` methods and Flagsmith declarations.
- Autocorrect config ordering into boolean methods, value methods, boolean flags, then future value flags.
- Load the cop through `.rubocop.yml` so the existing RuboCop pre-commit hook fixes non-flake users.
- Ensure the Nix-generated RuboCop hook can load local cops via `RUBYLIB`.
- Reorder `lib/trade_tariff_frontend/config.rb` with the new autocorrect rule.

## Why:

This keeps the config file predictable as more Flagsmith-backed configuration is added, and makes the ordering rule enforceable by the existing pre-commit workflow rather than relying on review comments.

Depends on #3185.

## Ticket:

AI-928

## Risk:

**Risk level:** 🟢

**Reason for rating:**

This is a tooling/refactor change: config method bodies are unchanged, and the new RuboCop rule is covered by autocorrect specs and pre-commit verification.