### PR TITLE
feat: feature flag opt-in page

### DIFF
--- a/app/controllers/concerns/flagsmith_setup.rb
+++ b/app/controllers/concerns/flagsmith_setup.rb
@@ -5,6 +5,7 @@ module FlagsmithSetup
 
   def set_current_flagsmith_identity
     Current.flagsmith_identity = current_flagsmith_identity
+    Current.flagsmith_optin_traits = session[:flagsmith_optin_traits] || {}
   end
 
   def current_flagsmith_identity

--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -1,0 +1,41 @@
+class FeatureFlagsController < ApplicationController
+  before_action :require_management_client
+
+  def index
+    flags = Current.flagsmith_flags ||= FlagsmithClient.instance.get_flags_for(Current.flagsmith_identity)
+
+    @optin_features = flags.all_flags
+      .select { |f| f.feature_name.end_with?('_optin') && f.enabled? }
+      .map { |optin_flag|
+        feature_name = optin_flag.feature_name.delete_suffix('_optin')
+        { name: feature_name, enabled: flags.get_flag(feature_name).enabled? }
+      }
+      .sort_by { |f| f[:name] }
+  rescue StandardError => e
+    Rails.logger.error("FeatureFlagsController#index: Flagsmith unavailable: #{e.class}: #{e.message}")
+    @optin_features = []
+    flash.now[:alert] = 'Feature flags could not be loaded. Flagsmith may be unavailable.'
+  end
+
+  def update
+    flag_name = params[:id]
+    enabled = params[:enabled] == 'true'
+
+    FlagsmithManagementClient.instance.set_trait(
+      Current.flagsmith_identity.identifier,
+      flag_name,
+      enabled,
+    )
+
+    redirect_to feature_flags_path, notice: "#{flag_name} #{enabled ? 'enabled' : 'disabled'}."
+  rescue StandardError => e
+    Rails.logger.error("FeatureFlagsController#update: failed to set trait #{params[:id]}: #{e.class}: #{e.message}")
+    redirect_to feature_flags_path, alert: 'Could not save your preference. Flagsmith may be unavailable.'
+  end
+
+  private
+
+  def require_management_client
+    render plain: 'Not found', status: :not_found unless FlagsmithManagementClient.configured?
+  end
+end

--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -3,7 +3,7 @@ class FeatureFlagsController < ApplicationController
   before_action :disable_search_form
 
   def index
-    flags = Current.flagsmith_flags ||= FlagsmithClient.instance.get_flags_for(Current.flagsmith_identity)
+    flags = FlagsmithManagementClient.instance.get_flags_for(Current.flagsmith_identity)
 
     @optin_features = optin_flag_names.map { |name|
       { name: name, enabled: flags.get_flag(name).enabled? }

--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -1,16 +1,13 @@
 class FeatureFlagsController < ApplicationController
   before_action :require_management_client
+  before_action :disable_search_form
 
   def index
     flags = Current.flagsmith_flags ||= FlagsmithClient.instance.get_flags_for(Current.flagsmith_identity)
 
-    @optin_features = flags.all_flags
-      .select { |f| f.feature_name.end_with?('_optin') && f.enabled? }
-      .map { |optin_flag|
-        feature_name = optin_flag.feature_name.delete_suffix('_optin')
-        { name: feature_name, enabled: flags.get_flag(feature_name).enabled? }
-      }
-      .sort_by { |f| f[:name] }
+    @optin_features = optin_flag_names.map { |name|
+      { name: name, enabled: flags.get_flag(name).enabled? }
+    }.sort_by { |f| f[:name] }
   rescue StandardError => e
     Rails.logger.error("FeatureFlagsController#index: Flagsmith unavailable: #{e.class}: #{e.message}")
     @optin_features = []
@@ -19,9 +16,8 @@ class FeatureFlagsController < ApplicationController
 
   def update
     flag_name = params[:id]
-    flags = Current.flagsmith_flags ||= FlagsmithClient.instance.get_flags_for(Current.flagsmith_identity)
 
-    unless flags.get_flag("#{flag_name}_optin").enabled?
+    unless optin_flag_names.include?(flag_name)
       return redirect_to feature_flags_path, alert: 'That feature is not available for opt-in.'
     end
 
@@ -43,5 +39,12 @@ class FeatureFlagsController < ApplicationController
 
   def require_management_client
     render plain: 'Not found', status: :not_found unless FlagsmithManagementClient.configured?
+  end
+
+  def optin_flag_names
+    TradeTariffFrontend::Config.registered_flags
+      .values
+      .select { |f| f[:optin] }
+      .map { |f| f[:name] }
   end
 end

--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -29,6 +29,9 @@ class FeatureFlagsController < ApplicationController
       enabled,
     )
 
+    session[:flagsmith_optin_traits] ||= {}
+    session[:flagsmith_optin_traits][flag_name] = enabled
+
     redirect_to feature_flags_path, notice: "#{flag_name.humanize} #{enabled ? 'enabled' : 'disabled'}."
   rescue StandardError => e
     Rails.logger.error("FeatureFlagsController#update: failed to set trait #{params[:id]}: #{e.class}: #{e.message}")

--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -19,6 +19,12 @@ class FeatureFlagsController < ApplicationController
 
   def update
     flag_name = params[:id]
+    flags = Current.flagsmith_flags ||= FlagsmithClient.instance.get_flags_for(Current.flagsmith_identity)
+
+    unless flags.get_flag("#{flag_name}_optin").enabled?
+      return redirect_to feature_flags_path, alert: 'That feature is not available for opt-in.'
+    end
+
     enabled = params[:enabled] == 'true'
 
     FlagsmithManagementClient.instance.set_trait(

--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -29,7 +29,7 @@ class FeatureFlagsController < ApplicationController
       enabled,
     )
 
-    redirect_to feature_flags_path, notice: "#{flag_name} #{enabled ? 'enabled' : 'disabled'}."
+    redirect_to feature_flags_path, notice: "#{flag_name.humanize} #{enabled ? 'enabled' : 'disabled'}."
   rescue StandardError => e
     Rails.logger.error("FeatureFlagsController#update: failed to set trait #{params[:id]}: #{e.class}: #{e.message}")
     redirect_to feature_flags_path, alert: 'Could not save your preference. Flagsmith may be unavailable.'

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -9,4 +9,8 @@ class Current < ActiveSupport::CurrentAttributes
 
   # Set when Flagsmith cannot be reached/configured during the current request.
   attribute :flagsmith_unavailable
+
+  # Opt-in trait overrides for the current request (keyed by flag name, boolean values).
+  # Loaded from session by FlagsmithSetup and passed through to Edge Proxy evaluation.
+  attribute :flagsmith_optin_traits
 end

--- a/app/services/flagsmith_client.rb
+++ b/app/services/flagsmith_client.rb
@@ -65,7 +65,7 @@ class FlagsmithClient
   # Returns a Flagsmith::Flags::Collection for the given identity.
   # Call is_feature_enabled('flag_name') or get_feature_value('flag_name') on the result.
   # Unknown flags return false (via default_flag_handler) rather than raising.
-  def get_flags_for(identity)
-    @sdk_client.get_identity_flags(identity.identifier)
+  def get_flags_for(identity, traits = {})
+    @sdk_client.get_identity_flags(identity.identifier, false, **traits.transform_keys(&:to_sym))
   end
 end

--- a/app/services/flagsmith_management_client.rb
+++ b/app/services/flagsmith_management_client.rb
@@ -1,13 +1,36 @@
-# Thin wrapper for writing identity traits directly to the Flagsmith core API.
+# Wrapper for the Flagsmith core API — writes identity traits and reads
+# identity flags directly from the core server.
 #
-# Uses the SDK trait endpoint (POST /api/v1/traits/) with the X-Environment-Key
-# header — identical schema to the standard SDK, but sent to the Flagsmith core
-# server via Cloud Map (http://flagsmith.tariff.internal:8000) rather than the
-# Edge Proxy. The Edge Proxy is read-through and does not persist trait writes.
-#
-# Only set_trait is implemented — the read path uses the existing FlagsmithClient.
+# Both reads and writes use the SDK endpoints with the X-Environment-Key header,
+# sent to the Flagsmith core server via Cloud Map
+# (http://flagsmith.tariff.internal:8000) rather than the Edge Proxy.
+# The Edge Proxy is read-through and does not persist trait writes, so reading
+# back via the Edge Proxy after a write can show stale state.
 class FlagsmithManagementClient
   CORE_API_URL = 'http://flagsmith.tariff.internal:8000'.freeze
+
+  # Minimal flag wrapper returned by get_flags_for.
+  class Flag
+    def initialize(enabled:)
+      @enabled = enabled
+    end
+
+    def enabled?
+      @enabled
+    end
+  end
+
+  # Wraps the flags array from POST /api/v1/identities/ with a get_flag interface.
+  class Flags
+    def initialize(flags_data)
+      @by_name = flags_data.index_by { |f| f.dig('feature', 'name') }
+    end
+
+    def get_flag(name)
+      data = @by_name[name.to_s]
+      Flag.new(enabled: data ? data.fetch('enabled', false) : false)
+    end
+  end
 
   class << self
     def instance
@@ -33,6 +56,16 @@ class FlagsmithManagementClient
       f.options.timeout = 2
       f.headers['X-Environment-Key'] = environment_key
     end
+  end
+
+  # Read identity flags from core so the state is consistent with trait writes.
+  # Raises Faraday::Error on non-2xx responses.
+  def get_flags_for(identity)
+    response = @connection.post('/api/v1/identities/', {
+      identifier: identity.identifier,
+      traits: [],
+    })
+    Flags.new(response.body.fetch('flags', []))
   end
 
   # Set a trait on the given Flagsmith identity.

--- a/app/services/flagsmith_management_client.rb
+++ b/app/services/flagsmith_management_client.rb
@@ -1,20 +1,17 @@
-# Thin wrapper around the Flagsmith Management API for writing identity traits.
+# Thin wrapper for writing identity traits directly to the Flagsmith core API.
 #
-# Uses the admin identity-trait endpoint which requires:
-#   FLAGSMITH_MANAGEMENT_API_TOKEN - a personal or service API token from the
-#     Flagsmith dashboard. Distinct from the SDK environment key.
-#
-# Connects directly to the Flagsmith core API server (Cloud Map:
-# http://flagsmith.tariff.internal:8000) rather than the Edge Proxy, because
-# the Edge Proxy is read-only and does not persist trait writes.
+# Uses the SDK trait endpoint (POST /api/v1/traits/) with the X-Environment-Key
+# header — identical schema to the standard SDK, but sent to the Flagsmith core
+# server via Cloud Map (http://flagsmith.tariff.internal:8000) rather than the
+# Edge Proxy. The Edge Proxy is read-through and does not persist trait writes.
 #
 # Only set_trait is implemented — the read path uses the existing FlagsmithClient.
 class FlagsmithManagementClient
-  MANAGEMENT_API_URL = 'http://flagsmith.tariff.internal:8000'.freeze
+  CORE_API_URL = 'http://flagsmith.tariff.internal:8000'.freeze
 
   class << self
     def instance
-      @instance || raise('FlagsmithManagementClient not configured — set FLAGSMITH_MANAGEMENT_API_TOKEN')
+      @instance || raise('FlagsmithManagementClient not configured')
     end
 
     attr_writer :instance
@@ -23,19 +20,18 @@ class FlagsmithManagementClient
       @instance.present?
     end
 
-    def configure(environment_key:, api_token:)
-      @instance = new(environment_key:, api_token:)
+    def configure(environment_key:)
+      @instance = new(environment_key:)
     end
   end
 
-  def initialize(environment_key:, api_token:)
-    @environment_key = environment_key
-    @connection = Faraday.new(url: MANAGEMENT_API_URL) do |f|
+  def initialize(environment_key:)
+    @connection = Faraday.new(url: CORE_API_URL) do |f|
       f.request :json
       f.response :raise_error
       f.response :json
       f.options.timeout = 2
-      f.headers['Authorization'] = "Api-Key #{api_token}"
+      f.headers['X-Environment-Key'] = environment_key
     end
   end
 
@@ -43,7 +39,7 @@ class FlagsmithManagementClient
   # trait_value should be a boolean, string, integer, or float.
   # Raises Faraday::Error on non-2xx responses.
   def set_trait(identifier, trait_key, trait_value)
-    @connection.post("/api/v1/environments/#{@environment_key}/traits/", {
+    @connection.post('/api/v1/traits/', {
       identity: { identifier: identifier },
       trait_key: trait_key.to_s,
       trait_value: trait_value,

--- a/app/services/flagsmith_management_client.rb
+++ b/app/services/flagsmith_management_client.rb
@@ -1,10 +1,17 @@
 # Thin wrapper around the Flagsmith Management API for writing identity traits.
 #
-# The Management API requires a separate token (FLAGSMITH_MANAGEMENT_API_TOKEN)
-# distinct from the environment SDK key used by FlagsmithClient.
+# Uses the admin identity-trait endpoint which requires:
+#   FLAGSMITH_MANAGEMENT_API_TOKEN - a personal or service API token from the
+#     Flagsmith dashboard. Distinct from the SDK environment key.
+#
+# Connects directly to the Flagsmith core API server (Cloud Map:
+# http://flagsmith.tariff.internal:8000) rather than the Edge Proxy, because
+# the Edge Proxy is read-only and does not persist trait writes.
 #
 # Only set_trait is implemented — the read path uses the existing FlagsmithClient.
 class FlagsmithManagementClient
+  MANAGEMENT_API_URL = 'http://flagsmith.tariff.internal:8000'.freeze
+
   class << self
     def instance
       @instance || raise('FlagsmithManagementClient not configured — set FLAGSMITH_MANAGEMENT_API_TOKEN')
@@ -16,13 +23,14 @@ class FlagsmithManagementClient
       @instance.present?
     end
 
-    def configure(api_url:, api_token:)
-      @instance = new(api_url:, api_token:)
+    def configure(environment_key:, api_token:)
+      @instance = new(environment_key:, api_token:)
     end
   end
 
-  def initialize(api_url:, api_token:)
-    @connection = Faraday.new(url: api_url.to_s.delete_suffix('/')) do |f|
+  def initialize(environment_key:, api_token:)
+    @environment_key = environment_key
+    @connection = Faraday.new(url: MANAGEMENT_API_URL) do |f|
       f.request :json
       f.response :raise_error
       f.response :json
@@ -35,7 +43,7 @@ class FlagsmithManagementClient
   # trait_value should be a boolean, string, integer, or float.
   # Raises Faraday::Error on non-2xx responses.
   def set_trait(identifier, trait_key, trait_value)
-    @connection.post('/api/v1/traits/', {
+    @connection.post("/api/v1/environments/#{@environment_key}/traits/", {
       identity: { identifier: identifier },
       trait_key: trait_key.to_s,
       trait_value: trait_value,

--- a/app/services/flagsmith_management_client.rb
+++ b/app/services/flagsmith_management_client.rb
@@ -24,14 +24,16 @@ class FlagsmithManagementClient
   def initialize(api_url:, api_token:)
     @connection = Faraday.new(url: api_url.to_s.delete_suffix('/')) do |f|
       f.request :json
+      f.response :raise_error
       f.response :json
       f.options.timeout = 2
-      f.headers['Authorization'] = "Token #{api_token}"
+      f.headers['Authorization'] = "Api-Key #{api_token}"
     end
   end
 
   # Set a trait on the given Flagsmith identity.
   # trait_value should be a boolean, string, integer, or float.
+  # Raises Faraday::Error on non-2xx responses.
   def set_trait(identifier, trait_key, trait_value)
     @connection.post('/api/v1/traits/', {
       identity: { identifier: identifier },

--- a/app/services/flagsmith_management_client.rb
+++ b/app/services/flagsmith_management_client.rb
@@ -1,0 +1,42 @@
+# Thin wrapper around the Flagsmith Management API for writing identity traits.
+#
+# The Management API requires a separate token (FLAGSMITH_MANAGEMENT_API_TOKEN)
+# distinct from the environment SDK key used by FlagsmithClient.
+#
+# Only set_trait is implemented — the read path uses the existing FlagsmithClient.
+class FlagsmithManagementClient
+  class << self
+    def instance
+      @instance || raise('FlagsmithManagementClient not configured — set FLAGSMITH_MANAGEMENT_API_TOKEN')
+    end
+
+    attr_writer :instance
+
+    def configured?
+      @instance.present?
+    end
+
+    def configure(api_url:, api_token:)
+      @instance = new(api_url:, api_token:)
+    end
+  end
+
+  def initialize(api_url:, api_token:)
+    @connection = Faraday.new(url: api_url.to_s.delete_suffix('/')) do |f|
+      f.request :json
+      f.response :json
+      f.options.timeout = 2
+      f.headers['Authorization'] = "Token #{api_token}"
+    end
+  end
+
+  # Set a trait on the given Flagsmith identity.
+  # trait_value should be a boolean, string, integer, or float.
+  def set_trait(identifier, trait_key, trait_value)
+    @connection.post('/api/v1/traits/', {
+      identity: { identifier: identifier },
+      trait_key: trait_key.to_s,
+      trait_value: trait_value,
+    })
+  end
+end

--- a/app/views/feature_flags/index.html.erb
+++ b/app/views/feature_flags/index.html.erb
@@ -1,66 +1,41 @@
 <% content_for :title, "Feature flags | #{default_title}" %>
 
 <div class="govuk-width-container">
-  <main class="govuk-main-wrapper" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Feature flags</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Feature flags</h1>
 
-        <p class="govuk-body">
-          Opt into experimental features for your current browser session.
-          These features are under development and may change or be removed.
-        </p>
+      <p class="govuk-body">
+        Opt into experimental features for your current browser session.
+        These features are under development and may change or be removed.
+      </p>
 
-        <% if flash[:notice] %>
-          <div class="govuk-notification-banner govuk-notification-banner--success" role="alert"
-               aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-            <div class="govuk-notification-banner__header">
-              <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Success</h2>
+      <% if @optin_features.any? %>
+        <dl class="govuk-summary-list">
+          <% @optin_features.each do |feature| %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                <%= feature[:name].tr('_', ' ').capitalize %>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <strong class="govuk-tag <%= feature[:enabled] ? 'govuk-tag--green' : 'govuk-tag--grey' %>">
+                  <%= feature[:enabled] ? 'Enabled' : 'Disabled' %>
+                </strong>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <%= button_to feature_flag_path(feature[:name]),
+                              method: :patch,
+                              params: { enabled: (!feature[:enabled]).to_s },
+                              class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0' do %>
+                  <%= feature[:enabled] ? 'Disable' : 'Enable' %>
+                <% end %>
+              </dd>
             </div>
-            <div class="govuk-notification-banner__content">
-              <p class="govuk-body"><%= flash[:notice] %></p>
-            </div>
-          </div>
-        <% end %>
-
-        <% if flash[:alert] %>
-          <div class="govuk-error-summary" data-module="govuk-error-summary">
-            <div role="alert">
-              <h2 class="govuk-error-summary__title">There was a problem</h2>
-              <div class="govuk-error-summary__body">
-                <p class="govuk-body"><%= flash[:alert] %></p>
-              </div>
-            </div>
-          </div>
-        <% end %>
-
-        <% if @optin_features.any? %>
-          <dl class="govuk-summary-list">
-            <% @optin_features.each do |feature| %>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  <%= feature[:name].tr('_', ' ').capitalize %>
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  <strong class="govuk-tag <%= feature[:enabled] ? 'govuk-tag--green' : 'govuk-tag--grey' %>">
-                    <%= feature[:enabled] ? 'Enabled' : 'Disabled' %>
-                  </strong>
-                </dd>
-                <dd class="govuk-summary-list__actions">
-                  <%= button_to feature_flag_path(feature[:name]),
-                                method: :patch,
-                                params: { enabled: (!feature[:enabled]).to_s },
-                                class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0' do %>
-                    <%= feature[:enabled] ? 'Disable' : 'Enable' %>
-                  <% end %>
-                </dd>
-              </div>
-            <% end %>
-          </dl>
-        <% else %>
-          <p class="govuk-body">No features are currently available for opt-in.</p>
-        <% end %>
-      </div>
+          <% end %>
+        </dl>
+      <% else %>
+        <p class="govuk-body">No features are currently available for opt-in.</p>
+      <% end %>
     </div>
-  </main>
+  </div>
 </div>

--- a/app/views/feature_flags/index.html.erb
+++ b/app/views/feature_flags/index.html.erb
@@ -1,0 +1,66 @@
+<% content_for :title, "Feature flags | #{default_title}" %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Feature flags</h1>
+
+        <p class="govuk-body">
+          Opt into experimental features for your current browser session.
+          These features are under development and may change or be removed.
+        </p>
+
+        <% if flash[:notice] %>
+          <div class="govuk-notification-banner govuk-notification-banner--success" role="alert"
+               aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+              <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Success</h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+              <p class="govuk-body"><%= flash[:notice] %></p>
+            </div>
+          </div>
+        <% end %>
+
+        <% if flash[:alert] %>
+          <div class="govuk-error-summary" data-module="govuk-error-summary">
+            <div role="alert">
+              <h2 class="govuk-error-summary__title">There was a problem</h2>
+              <div class="govuk-error-summary__body">
+                <p class="govuk-body"><%= flash[:alert] %></p>
+              </div>
+            </div>
+          </div>
+        <% end %>
+
+        <% if @optin_features.any? %>
+          <dl class="govuk-summary-list">
+            <% @optin_features.each do |feature| %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  <%= feature[:name].tr('_', ' ').capitalize %>
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  <strong class="govuk-tag <%= feature[:enabled] ? 'govuk-tag--green' : 'govuk-tag--grey' %>">
+                    <%= feature[:enabled] ? 'Enabled' : 'Disabled' %>
+                  </strong>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                  <%= button_to feature_flag_path(feature[:name]),
+                                method: :patch,
+                                params: { enabled: (!feature[:enabled]).to_s },
+                                class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0' do %>
+                    <%= feature[:enabled] ? 'Disable' : 'Enable' %>
+                  <% end %>
+                </dd>
+              </div>
+            <% end %>
+          </dl>
+        <% else %>
+          <p class="govuk-body">No features are currently available for opt-in.</p>
+        <% end %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -335,6 +335,7 @@ FindCommoditiesController#show
 FlagsmithClient#configure
 FlagsmithClient#instance=
 FlagsmithManagementClient#configure
+FlagsmithManagementClient#instance=
 Footnote#code=
 Footnote#description=
 Footnote#footnote_id

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -334,6 +334,7 @@ FeedbackController#thanks
 FindCommoditiesController#show
 FlagsmithClient#configure
 FlagsmithClient#instance=
+FlagsmithManagementClient#configure
 Footnote#code=
 Footnote#description=
 Footnote#footnote_id

--- a/config/initializers/flagsmith.rb
+++ b/config/initializers/flagsmith.rb
@@ -2,14 +2,11 @@
 #
 # FLAGSMITH_ENVIRONMENT_KEY - SDK key for the self-hosted environment.
 #   Used by the flagsmith gem to evaluate flags and read identity flags.
+#   Also used by FlagsmithManagementClient to write identity traits via
+#   the Flagsmith core API (Cloud Map internal URL, not Edge Proxy).
 # FLAGSMITH_API_URL - optional override for the self-hosted FlagSmith
 #   instance. Defaults to the Flagsmith Edge URL for
 #   TradeTariffFrontend.environment.
-# FLAGSMITH_MANAGEMENT_API_TOKEN - personal or service API token for the
-#   Flagsmith Management API. Used by FlagsmithManagementClient to write
-#   identity traits (e.g. for user opt-in to feature flags). The management
-#   client connects directly to the core API (Cloud Map internal URL) — not
-#   the Edge Proxy, which is read-only.
 #
 # In the test environment the singletons are replaced by test doubles
 # (see spec/support/flagsmith.rb) so these env vars are not required there.
@@ -23,7 +20,6 @@
 # the top level here raises NameError during asset precompilation.
 flagsmith_environment_key = ENV['FLAGSMITH_ENVIRONMENT_KEY']
 flagsmith_api_url = TradeTariffFrontend.flagsmith_api_url
-flagsmith_management_api_token = ENV['FLAGSMITH_MANAGEMENT_API_TOKEN']
 
 if flagsmith_environment_key.present? && flagsmith_api_url.present?
   Rails.application.config.to_prepare do
@@ -32,12 +28,9 @@ if flagsmith_environment_key.present? && flagsmith_api_url.present?
       api_url: flagsmith_api_url,
     )
 
-    if flagsmith_management_api_token.present?
-      FlagsmithManagementClient.configure(
-        environment_key: flagsmith_environment_key,
-        api_token: flagsmith_management_api_token,
-      )
-    end
+    FlagsmithManagementClient.configure(
+      environment_key: flagsmith_environment_key,
+    )
   end
 elsif flagsmith_environment_key.blank?
   Rails.logger.warn('Flagsmith environment key is not configured; guided search is disabled')

--- a/config/initializers/flagsmith.rb
+++ b/config/initializers/flagsmith.rb
@@ -5,6 +5,9 @@
 # FLAGSMITH_API_URL - optional override for the self-hosted FlagSmith
 #   instance. Defaults to the Flagsmith Edge URL for
 #   TradeTariffFrontend.environment.
+# FLAGSMITH_MANAGEMENT_API_URL - base URL for the Flagsmith Management API
+#   (the core API server, not the Edge Proxy). Required for trait writes.
+#   The Edge Proxy does not persist traits.
 # FLAGSMITH_MANAGEMENT_API_TOKEN - personal or service API token for the
 #   Flagsmith Management API. Used by FlagsmithManagementClient to write
 #   identity traits (e.g. for user opt-in to feature flags).
@@ -21,6 +24,7 @@
 # the top level here raises NameError during asset precompilation.
 flagsmith_environment_key = ENV['FLAGSMITH_ENVIRONMENT_KEY']
 flagsmith_api_url = TradeTariffFrontend.flagsmith_api_url
+flagsmith_management_api_url = ENV['FLAGSMITH_MANAGEMENT_API_URL']
 flagsmith_management_api_token = ENV['FLAGSMITH_MANAGEMENT_API_TOKEN']
 
 if flagsmith_environment_key.present? && flagsmith_api_url.present?
@@ -30,9 +34,9 @@ if flagsmith_environment_key.present? && flagsmith_api_url.present?
       api_url: flagsmith_api_url,
     )
 
-    if flagsmith_management_api_token.present?
+    if flagsmith_management_api_url.present? && flagsmith_management_api_token.present?
       FlagsmithManagementClient.configure(
-        api_url: flagsmith_api_url,
+        api_url: flagsmith_management_api_url,
         api_token: flagsmith_management_api_token,
       )
     end

--- a/config/initializers/flagsmith.rb
+++ b/config/initializers/flagsmith.rb
@@ -1,23 +1,27 @@
-# Configure FlagsmithClient with credentials from environment variables.
+# Configure Flagsmith clients with credentials from environment variables.
 #
 # FLAGSMITH_ENVIRONMENT_KEY - SDK key for the self-hosted environment.
 #   Used by the flagsmith gem to evaluate flags and read identity flags.
 # FLAGSMITH_API_URL - optional override for the self-hosted FlagSmith
 #   instance. Defaults to the Flagsmith Edge URL for
 #   TradeTariffFrontend.environment.
+# FLAGSMITH_MANAGEMENT_API_TOKEN - personal or service API token for the
+#   Flagsmith Management API. Used by FlagsmithManagementClient to write
+#   identity traits (e.g. for user opt-in to feature flags).
 #
-# In the test environment the singleton is replaced by a TestFlagsmithClient
-# double (see spec/support/flagsmith.rb) so these env vars are not required there.
+# In the test environment the singletons are replaced by test doubles
+# (see spec/support/flagsmith.rb) so these env vars are not required there.
 #
 # Guarded on FLAGSMITH_ENVIRONMENT_KEY and api_url so environments without
 # credentials (CI asset precompilation, test, ad-hoc review apps) boot cleanly
 # with guided search disabled.
 #
-# Wrapped in to_prepare so the autoloaded FlagsmithClient constant resolves
-# correctly: initializers run before eager loading, and referencing an app/
-# constant at the top level here raises NameError during asset precompilation.
+# Wrapped in to_prepare so the autoloaded constants resolve correctly:
+# initializers run before eager loading, and referencing an app/ constant at
+# the top level here raises NameError during asset precompilation.
 flagsmith_environment_key = ENV['FLAGSMITH_ENVIRONMENT_KEY']
 flagsmith_api_url = TradeTariffFrontend.flagsmith_api_url
+flagsmith_management_api_token = ENV['FLAGSMITH_MANAGEMENT_API_TOKEN']
 
 if flagsmith_environment_key.present? && flagsmith_api_url.present?
   Rails.application.config.to_prepare do
@@ -25,6 +29,13 @@ if flagsmith_environment_key.present? && flagsmith_api_url.present?
       environment_key: flagsmith_environment_key,
       api_url: flagsmith_api_url,
     )
+
+    if flagsmith_management_api_token.present?
+      FlagsmithManagementClient.configure(
+        api_url: flagsmith_api_url,
+        api_token: flagsmith_management_api_token,
+      )
+    end
   end
 elsif flagsmith_environment_key.blank?
   Rails.logger.warn('Flagsmith environment key is not configured; guided search is disabled')

--- a/config/initializers/flagsmith.rb
+++ b/config/initializers/flagsmith.rb
@@ -5,12 +5,11 @@
 # FLAGSMITH_API_URL - optional override for the self-hosted FlagSmith
 #   instance. Defaults to the Flagsmith Edge URL for
 #   TradeTariffFrontend.environment.
-# FLAGSMITH_MANAGEMENT_API_URL - base URL for the Flagsmith Management API
-#   (the core API server, not the Edge Proxy). Required for trait writes.
-#   The Edge Proxy does not persist traits.
 # FLAGSMITH_MANAGEMENT_API_TOKEN - personal or service API token for the
 #   Flagsmith Management API. Used by FlagsmithManagementClient to write
-#   identity traits (e.g. for user opt-in to feature flags).
+#   identity traits (e.g. for user opt-in to feature flags). The management
+#   client connects directly to the core API (Cloud Map internal URL) — not
+#   the Edge Proxy, which is read-only.
 #
 # In the test environment the singletons are replaced by test doubles
 # (see spec/support/flagsmith.rb) so these env vars are not required there.
@@ -24,7 +23,6 @@
 # the top level here raises NameError during asset precompilation.
 flagsmith_environment_key = ENV['FLAGSMITH_ENVIRONMENT_KEY']
 flagsmith_api_url = TradeTariffFrontend.flagsmith_api_url
-flagsmith_management_api_url = ENV['FLAGSMITH_MANAGEMENT_API_URL']
 flagsmith_management_api_token = ENV['FLAGSMITH_MANAGEMENT_API_TOKEN']
 
 if flagsmith_environment_key.present? && flagsmith_api_url.present?
@@ -34,9 +32,9 @@ if flagsmith_environment_key.present? && flagsmith_api_url.present?
       api_url: flagsmith_api_url,
     )
 
-    if flagsmith_management_api_url.present? && flagsmith_management_api_token.present?
+    if flagsmith_management_api_token.present?
       FlagsmithManagementClient.configure(
-        api_url: flagsmith_management_api_url,
+        environment_key: flagsmith_environment_key,
         api_token: flagsmith_management_api_token,
       )
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   get 'healthcheck', to: 'healthcheck#check'
   get 'healthcheckz', to: 'healthcheck#checkz'
 
+  resources :feature_flags, only: %i[index update], path: 'feature-flags'
+
   get 'help', to: 'pages#help', as: 'help'
   get 'help/cn2021_cn2022', to: 'pages#cn2021_cn2022', as: 'cn2021_cn2022'
   get 'help/changes_999l', to: 'pages#changes_999l', as: 'help_changes_999l'

--- a/lib/trade_tariff_frontend/config.rb
+++ b/lib/trade_tariff_frontend/config.rb
@@ -4,73 +4,28 @@ module TradeTariffFrontend
   module Config
     prepend FlagsmithBackedConfig
 
+    def basic_session_authentication?
+      @basic_session_authentication ||= basic_session_password.present?
+    end
+
+    def interactive_search_enabled?
+      !production? && !ServiceChooser.xi?
+    end
+
     def production?
       environment == 'production'
     end
 
-    def environment
-      ENV.fetch('ENVIRONMENT', 'production')
+    def waf_integration_enabled?
+      waf_integration_url.present?
     end
 
-    def id_token_cookie_name
-      cookie_name_for('id_token')
+    def webchat_enabled?
+      webchat_url.present?
     end
 
-    def refresh_token_cookie_name
-      cookie_name_for('refresh_token')
-    end
-
-    def cookie_name_for(base_name)
-      case environment
-      when 'production'
-        base_name
-      else
-        "#{environment}_#{base_name}"
-      end.to_sym
-    end
-
-    def redis_config
-      { url: ENV['REDIS_URL'], db: 0, id: nil }
-    end
-
-    def from_email
-      ENV['TARIFF_FROM_EMAIL']
-    end
-
-    def to_email
-      ENV['TARIFF_TO_EMAIL']
-    end
-
-    def support_email
-      ENV['TARIFF_SUPPORT_EMAIL'].presence || DEFAULT_SUPPORT_EMAIL
-    end
-
-    def enquiries_email
-      DEFAULT_ENQUIRIES_EMAIL
-    end
-
-    def host
-      ENV.fetch('FRONTEND_HOST', 'http://localhost')
-    end
-
-    def developer_portal_url
-      ENV.fetch('DEVELOPER_PORTAL_URL') { "https://hub.#{base_domain}/" }
-    end
-
-    def flagsmith_api_url
-      ENV['FLAGSMITH_API_URL'].presence || FLAGSMITH_API_URLS[environment]
-    end
-
-    def identity_base_url
-      ENV.fetch('IDENTITY_BASE_URL', 'http://localhost:3005')
-    end
-
-    def identity_cookie_domain
-      @identity_cookie_domain ||= if Rails.env.production?
-                                    ".#{base_domain}"
-                                  else
-                                    :all
-                                  end
+    def backend_base_domain
+      ENV['BACKEND_BASE_DOMAIN']
     end
 
     def base_domain
@@ -85,16 +40,97 @@ module TradeTariffFrontend
       end
     end
 
-    def backend_base_domain
-      ENV['BACKEND_BASE_DOMAIN']
+    def basic_session_password
+      @basic_session_password ||= ENV['BASIC_PASSWORD']
+    end
+
+    def basic_session_passwords
+      @basic_session_passwords ||= basic_session_password.to_s.split(',').map(&:strip).reject(&:blank?)
     end
 
     def check_duties_service_url
       ENV.fetch('CHECK_DUTIES_SERVICE_URL', 'https://www.check-duties-customs-exporting-goods.service.gov.uk')
     end
 
-    def webchat_enabled?
-      webchat_url.present?
+    def cookie_name_for(base_name)
+      case environment
+      when 'production'
+        base_name
+      else
+        "#{environment}_#{base_name}"
+      end.to_sym
+    end
+
+    def developer_portal_url
+      ENV.fetch('DEVELOPER_PORTAL_URL') { "https://hub.#{base_domain}/" }
+    end
+
+    def enquiries_email
+      DEFAULT_ENQUIRIES_EMAIL
+    end
+
+    def environment
+      ENV.fetch('ENVIRONMENT', 'production')
+    end
+
+    def flagsmith_api_url
+      ENV['FLAGSMITH_API_URL'].presence || FLAGSMITH_API_URLS[environment]
+    end
+
+    def from_email
+      ENV['TARIFF_FROM_EMAIL']
+    end
+
+    def google_tag_manager_container_id
+      ENV.fetch('GOOGLE_TAG_MANAGER_CONTAINER_ID', '')
+    end
+
+    def green_lanes_api_token
+      "Bearer #{ENV['GREEN_LANES_API_TOKEN']}"
+    end
+
+    def host
+      ENV.fetch('FRONTEND_HOST', 'http://localhost')
+    end
+
+    def id_token_cookie_name
+      cookie_name_for('id_token')
+    end
+
+    def identity_base_url
+      ENV.fetch('IDENTITY_BASE_URL', 'http://localhost:3005')
+    end
+
+    def identity_cookie_domain
+      @identity_cookie_domain ||= if Rails.env.production?
+                                    ".#{base_domain}"
+                                  else
+                                    :all
+                                  end
+    end
+
+    def legacy_results_to_show
+      ENV.fetch('LEGACY_RESULTS_TO_SHOW', '5').to_i
+    end
+
+    def redis_config
+      { url: ENV['REDIS_URL'], db: 0, id: nil }
+    end
+
+    def refresh_token_cookie_name
+      cookie_name_for('refresh_token')
+    end
+
+    def support_email
+      ENV['TARIFF_SUPPORT_EMAIL'].presence || DEFAULT_SUPPORT_EMAIL
+    end
+
+    def to_email
+      ENV['TARIFF_TO_EMAIL']
+    end
+
+    def waf_integration_url
+      ENV['WAF_INTEGRATION_URL']
     end
 
     def webchat_url
@@ -105,43 +141,7 @@ module TradeTariffFrontend
       URI.join(WEBCHAT_BASE_URL, configured_url).to_s
     end
 
-    def legacy_results_to_show
-      ENV.fetch('LEGACY_RESULTS_TO_SHOW', '5').to_i
-    end
-
-    def interactive_search_enabled?
-      !production? && !ServiceChooser.xi?
-    end
-
-    def green_lanes_api_token
-      "Bearer #{ENV['GREEN_LANES_API_TOKEN']}"
-    end
-
-    def google_tag_manager_container_id
-      ENV.fetch('GOOGLE_TAG_MANAGER_CONTAINER_ID', '')
-    end
-
-    def waf_integration_url
-      ENV['WAF_INTEGRATION_URL']
-    end
-
-    def waf_integration_enabled?
-      waf_integration_url.present?
-    end
-
-    def basic_session_authentication?
-      @basic_session_authentication ||= basic_session_password.present?
-    end
-
-    def basic_session_password
-      @basic_session_password ||= ENV['BASIC_PASSWORD']
-    end
-
-    def basic_session_passwords
-      @basic_session_passwords ||= basic_session_password.to_s.split(',').map(&:strip).reject(&:blank?)
-    end
-
-    flagsmith_flag :interactive_search_enabled?, name: :interactive_search, services: %i[uk]
+    flagsmith_flag :interactive_search_enabled?, name: :interactive_search, services: %i[uk], optin: true
     flagsmith_flag :webchat_enabled?, name: :webchat
   end
 end

--- a/lib/trade_tariff_frontend/flagsmith_backed_config.rb
+++ b/lib/trade_tariff_frontend/flagsmith_backed_config.rb
@@ -73,7 +73,7 @@ module TradeTariffFrontend
         return default
       end
 
-      flags = Current.flagsmith_flags ||= FlagsmithClient.instance.get_flags_for(Current.flagsmith_identity)
+      flags = Current.flagsmith_flags ||= FlagsmithClient.instance.get_flags_for(Current.flagsmith_identity, Current.flagsmith_optin_traits || {})
       flag = flags.get_flag(flag_name)
 
       if flag.is_default

--- a/lib/trade_tariff_frontend/flagsmith_backed_config.rb
+++ b/lib/trade_tariff_frontend/flagsmith_backed_config.rb
@@ -30,10 +30,10 @@ module TradeTariffFrontend
         @registered_flags ||= {}
       end
 
-      def flagsmith_flag(method_name, name:, services: nil)
+      def flagsmith_flag(method_name, name:, services: nil, optin: false)
         flag_name = name.to_s
         service_names = Array(services).map(&:to_s)
-        registered_flags[method_name] = { name: flag_name, services: service_names }
+        registered_flags[method_name] = { name: flag_name, services: service_names, optin: optin }
 
         TradeTariffFrontend::FlagsmithBackedConfig.define_method(method_name) do
           default = super()

--- a/spec/lib/trade_tariff_frontend_spec.rb
+++ b/spec/lib/trade_tariff_frontend_spec.rb
@@ -10,10 +10,12 @@ RSpec.describe TradeTariffFrontend do
       interactive_search_enabled?: {
         name: 'interactive_search',
         services: %w[uk],
+        optin: true,
       },
       webchat_enabled?: {
         name: 'webchat',
         services: [],
+        optin: false,
       },
     )
   end

--- a/spec/requests/feature_flags_controller_spec.rb
+++ b/spec/requests/feature_flags_controller_spec.rb
@@ -76,6 +76,18 @@ RSpec.describe FeatureFlagsController, type: :request do
         )
       end
 
+      it 'stores the enabled trait in the session' do
+        patch feature_flag_path('interactive_search'), params: { enabled: 'true' }
+
+        expect(session[:flagsmith_optin_traits]).to include('interactive_search' => true)
+      end
+
+      it 'stores the disabled trait in the session' do
+        patch feature_flag_path('interactive_search'), params: { enabled: 'false' }
+
+        expect(session[:flagsmith_optin_traits]).to include('interactive_search' => false)
+      end
+
       it 'redirects when the flag is not a registered optin flag' do
         patch feature_flag_path('unknown_flag'), params: { enabled: 'true' }
 

--- a/spec/requests/feature_flags_controller_spec.rb
+++ b/spec/requests/feature_flags_controller_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe FeatureFlagsController, type: :request do
     end
 
     describe 'PATCH /feature-flags/:id' do
+      before { enable_feature('interactive_search_optin') }
+
       it 'redirects back to the feature flags page' do
         patch feature_flag_path('interactive_search'), params: { enabled: 'true' }
 
@@ -86,6 +88,13 @@ RSpec.describe FeatureFlagsController, type: :request do
         expect(TEST_FLAGSMITH_MANAGEMENT_CLIENT.recorded_traits).to include(
           hash_including(trait_key: 'interactive_search', trait_value: false),
         )
+      end
+
+      it 'rejects a flag not in the optin allowlist' do
+        patch feature_flag_path('unknown_flag'), params: { enabled: 'true' }
+
+        expect(response).to redirect_to(feature_flags_path)
+        expect(TEST_FLAGSMITH_MANAGEMENT_CLIENT.recorded_traits).to be_empty
       end
     end
   end

--- a/spec/requests/feature_flags_controller_spec.rb
+++ b/spec/requests/feature_flags_controller_spec.rb
@@ -66,10 +66,15 @@ RSpec.describe FeatureFlagsController, type: :request do
     end
 
     describe 'PATCH /feature-flags/:id' do
-      it 'sets the trait on the management client and redirects' do
+      it 'redirects back to the feature flags page' do
         patch feature_flag_path('interactive_search'), params: { enabled: 'true' }
 
         expect(response).to redirect_to(feature_flags_path)
+      end
+
+      it 'writes the trait to the management client' do
+        patch feature_flag_path('interactive_search'), params: { enabled: 'true' }
+
         expect(TEST_FLAGSMITH_MANAGEMENT_CLIENT.recorded_traits).to include(
           hash_including(trait_key: 'interactive_search', trait_value: true),
         )

--- a/spec/requests/feature_flags_controller_spec.rb
+++ b/spec/requests/feature_flags_controller_spec.rb
@@ -90,10 +90,15 @@ RSpec.describe FeatureFlagsController, type: :request do
         )
       end
 
-      it 'rejects a flag not in the optin allowlist' do
+      it 'redirects when the flag is not in the optin allowlist' do
         patch feature_flag_path('unknown_flag'), params: { enabled: 'true' }
 
         expect(response).to redirect_to(feature_flags_path)
+      end
+
+      it 'does not write a trait when the flag is not in the optin allowlist' do
+        patch feature_flag_path('unknown_flag'), params: { enabled: 'true' }
+
         expect(TEST_FLAGSMITH_MANAGEMENT_CLIENT.recorded_traits).to be_empty
       end
     end

--- a/spec/requests/feature_flags_controller_spec.rb
+++ b/spec/requests/feature_flags_controller_spec.rb
@@ -25,9 +25,8 @@ RSpec.describe FeatureFlagsController, type: :request do
     describe 'GET /feature-flags' do
       subject(:perform_request) { get feature_flags_path }
 
-      context 'when optin flags are enabled' do
+      context 'when a registered optin feature is enabled' do
         before do
-          enable_feature('interactive_search_optin')
           enable_feature('interactive_search')
           perform_request
         end
@@ -36,7 +35,7 @@ RSpec.describe FeatureFlagsController, type: :request do
           expect(response).to have_http_status(:ok)
         end
 
-        it 'shows the available opt-in feature' do
+        it 'shows the registered optin feature' do
           expect(response.body).to include('Interactive search')
         end
 
@@ -45,19 +44,8 @@ RSpec.describe FeatureFlagsController, type: :request do
         end
       end
 
-      context 'when no optin flags are enabled' do
+      context 'when a registered optin feature is not yet enabled by the user' do
         before { perform_request }
-
-        it 'shows the empty state message' do
-          expect(response.body).to include('No features are currently available for opt-in')
-        end
-      end
-
-      context 'when a feature is available but disabled' do
-        before do
-          enable_feature('interactive_search_optin')
-          perform_request
-        end
 
         it 'shows the feature as disabled' do
           expect(response.body).to include('Disabled')
@@ -66,8 +54,6 @@ RSpec.describe FeatureFlagsController, type: :request do
     end
 
     describe 'PATCH /feature-flags/:id' do
-      before { enable_feature('interactive_search_optin') }
-
       it 'redirects back to the feature flags page' do
         patch feature_flag_path('interactive_search'), params: { enabled: 'true' }
 
@@ -90,13 +76,13 @@ RSpec.describe FeatureFlagsController, type: :request do
         )
       end
 
-      it 'redirects when the flag is not in the optin allowlist' do
+      it 'redirects when the flag is not a registered optin flag' do
         patch feature_flag_path('unknown_flag'), params: { enabled: 'true' }
 
         expect(response).to redirect_to(feature_flags_path)
       end
 
-      it 'does not write a trait when the flag is not in the optin allowlist' do
+      it 'does not write a trait when the flag is not a registered optin flag' do
         patch feature_flag_path('unknown_flag'), params: { enabled: 'true' }
 
         expect(TEST_FLAGSMITH_MANAGEMENT_CLIENT.recorded_traits).to be_empty

--- a/spec/requests/feature_flags_controller_spec.rb
+++ b/spec/requests/feature_flags_controller_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+RSpec.describe FeatureFlagsController, type: :request do
+  context 'when the management client is not configured' do
+    before do
+      FlagsmithManagementClient.instance = nil
+    end
+
+    after do
+      FlagsmithManagementClient.instance = TEST_FLAGSMITH_MANAGEMENT_CLIENT
+    end
+
+    it 'returns 404 for GET /feature-flags' do
+      get feature_flags_path
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns 404 for PATCH /feature-flags/:id' do
+      patch feature_flag_path('interactive_search'), params: { enabled: 'true' }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'when the management client is configured' do
+    describe 'GET /feature-flags' do
+      subject(:perform_request) { get feature_flags_path }
+
+      context 'when optin flags are enabled' do
+        before do
+          enable_feature('interactive_search_optin')
+          enable_feature('interactive_search')
+          perform_request
+        end
+
+        it 'returns 200' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'shows the available opt-in feature' do
+          expect(response.body).to include('Interactive search')
+        end
+
+        it 'shows the enabled state' do
+          expect(response.body).to include('Enabled')
+        end
+      end
+
+      context 'when no optin flags are enabled' do
+        before { perform_request }
+
+        it 'shows the empty state message' do
+          expect(response.body).to include('No features are currently available for opt-in')
+        end
+      end
+
+      context 'when a feature is available but disabled' do
+        before do
+          enable_feature('interactive_search_optin')
+          perform_request
+        end
+
+        it 'shows the feature as disabled' do
+          expect(response.body).to include('Disabled')
+        end
+      end
+    end
+
+    describe 'PATCH /feature-flags/:id' do
+      it 'sets the trait on the management client and redirects' do
+        patch feature_flag_path('interactive_search'), params: { enabled: 'true' }
+
+        expect(response).to redirect_to(feature_flags_path)
+        expect(TEST_FLAGSMITH_MANAGEMENT_CLIENT.recorded_traits).to include(
+          hash_including(trait_key: 'interactive_search', trait_value: true),
+        )
+      end
+
+      it 'disables the trait when enabled is false' do
+        patch feature_flag_path('interactive_search'), params: { enabled: 'false' }
+
+        expect(TEST_FLAGSMITH_MANAGEMENT_CLIENT.recorded_traits).to include(
+          hash_including(trait_key: 'interactive_search', trait_value: false),
+        )
+      end
+    end
+  end
+end

--- a/spec/services/flagsmith_management_client_spec.rb
+++ b/spec/services/flagsmith_management_client_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe FlagsmithManagementClient do
+  describe '.instance' do
+    it 'raises if not configured' do
+      original = described_class.instance
+      described_class.instance = nil
+      expect { described_class.instance }.to raise_error(RuntimeError, /not configured/)
+    ensure
+      described_class.instance = original
+    end
+  end
+
+  describe '.configured?' do
+    it 'returns false when instance is nil' do
+      original = described_class.instance
+      described_class.instance = nil
+      expect(described_class.configured?).to be false
+    ensure
+      described_class.instance = original
+    end
+
+    it 'returns true when instance is set' do
+      expect(described_class.configured?).to be true
+    end
+  end
+
+  describe '#set_trait' do
+    subject(:client) do
+      described_class.new(
+        api_url: 'https://flagsmith.example.com',
+        api_token: 'test-token',
+      )
+    end
+
+    before do
+      stub_request(:post, 'https://flagsmith.example.com/api/v1/traits/')
+        .with(
+          headers: { 'Authorization' => 'Token test-token' },
+          body: {
+            identity: { identifier: 'Anonymous:abc123' },
+            trait_key: 'interactive_search',
+            trait_value: true,
+          },
+        )
+        .to_return(
+          status: 200,
+          body: { trait_key: 'interactive_search', trait_value: true }.to_json,
+          headers: { 'Content-Type' => 'application/json' },
+        )
+    end
+
+    it 'POSTs the trait to the management API' do
+      client.set_trait('Anonymous:abc123', 'interactive_search', true)
+
+      expect(WebMock).to have_requested(:post, 'https://flagsmith.example.com/api/v1/traits/')
+        .with(body: hash_including(trait_key: 'interactive_search', trait_value: true))
+    end
+  end
+end

--- a/spec/services/flagsmith_management_client_spec.rb
+++ b/spec/services/flagsmith_management_client_spec.rb
@@ -24,17 +24,12 @@ RSpec.describe FlagsmithManagementClient do
   end
 
   describe '#set_trait' do
-    subject(:client) do
-      described_class.new(
-        environment_key: 'test-env-key',
-        api_token: 'test-token',
-      )
-    end
+    subject(:client) { described_class.new(environment_key: 'test-env-key') }
 
     before do
-      stub_request(:post, "#{described_class::MANAGEMENT_API_URL}/api/v1/environments/test-env-key/traits/")
+      stub_request(:post, "#{described_class::CORE_API_URL}/api/v1/traits/")
         .with(
-          headers: { 'Authorization' => 'Api-Key test-token' },
+          headers: { 'X-Environment-Key' => 'test-env-key' },
           body: {
             identity: { identifier: 'Anonymous:abc123' },
             trait_key: 'interactive_search',
@@ -48,10 +43,10 @@ RSpec.describe FlagsmithManagementClient do
         )
     end
 
-    it 'POSTs the trait to the admin identity-trait endpoint' do
+    it 'POSTs the trait to the core API using the SDK trait endpoint' do
       client.set_trait('Anonymous:abc123', 'interactive_search', true)
 
-      expect(WebMock).to have_requested(:post, "#{described_class::MANAGEMENT_API_URL}/api/v1/environments/test-env-key/traits/")
+      expect(WebMock).to have_requested(:post, "#{described_class::CORE_API_URL}/api/v1/traits/")
         .with(body: hash_including(trait_key: 'interactive_search', trait_value: true))
     end
   end

--- a/spec/services/flagsmith_management_client_spec.rb
+++ b/spec/services/flagsmith_management_client_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe FlagsmithManagementClient do
   describe '#set_trait' do
     subject(:client) do
       described_class.new(
-        api_url: 'https://flagsmith.example.com',
+        environment_key: 'test-env-key',
         api_token: 'test-token',
       )
     end
 
     before do
-      stub_request(:post, 'https://flagsmith.example.com/api/v1/traits/')
+      stub_request(:post, "#{described_class::MANAGEMENT_API_URL}/api/v1/environments/test-env-key/traits/")
         .with(
           headers: { 'Authorization' => 'Api-Key test-token' },
           body: {
@@ -48,10 +48,10 @@ RSpec.describe FlagsmithManagementClient do
         )
     end
 
-    it 'POSTs the trait to the management API' do
+    it 'POSTs the trait to the admin identity-trait endpoint' do
       client.set_trait('Anonymous:abc123', 'interactive_search', true)
 
-      expect(WebMock).to have_requested(:post, 'https://flagsmith.example.com/api/v1/traits/')
+      expect(WebMock).to have_requested(:post, "#{described_class::MANAGEMENT_API_URL}/api/v1/environments/test-env-key/traits/")
         .with(body: hash_including(trait_key: 'interactive_search', trait_value: true))
     end
   end

--- a/spec/services/flagsmith_management_client_spec.rb
+++ b/spec/services/flagsmith_management_client_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe FlagsmithManagementClient do
     before do
       stub_request(:post, 'https://flagsmith.example.com/api/v1/traits/')
         .with(
-          headers: { 'Authorization' => 'Token test-token' },
+          headers: { 'Authorization' => 'Api-Key test-token' },
           body: {
             identity: { identifier: 'Anonymous:abc123' },
             trait_key: 'interactive_search',

--- a/spec/support/flagsmith.rb
+++ b/spec/support/flagsmith.rb
@@ -72,6 +72,10 @@ class TestFlagsmithManagementClient
     @recorded_traits = []
   end
 
+  def get_flags_for(identity) # rubocop:disable Rails/Delegate
+    TEST_FLAGSMITH_CLIENT.get_flags_for(identity)
+  end
+
   def set_trait(identifier, trait_key, trait_value)
     @recorded_traits << { identifier:, trait_key:, trait_value: }
   end

--- a/spec/support/flagsmith.rb
+++ b/spec/support/flagsmith.rb
@@ -72,7 +72,7 @@ class TestFlagsmithManagementClient
     @recorded_traits = []
   end
 
-  def get_flags_for(identity, traits = {}) # rubocop:disable Rails/Delegate
+  def get_flags_for(identity, traits = {})
     TEST_FLAGSMITH_CLIENT.get_flags_for(identity, traits)
   end
 

--- a/spec/support/flagsmith.rb
+++ b/spec/support/flagsmith.rb
@@ -4,9 +4,10 @@
 # threads in JS tests see the same state as the test thread.
 class TestFlagsmithClient
   class TestFlag
-    attr_reader :enabled, :default
+    attr_reader :enabled, :default, :feature_name
 
-    def initialize(enabled:, default:)
+    def initialize(feature_name:, enabled:, default:)
+      @feature_name = feature_name
       @enabled = enabled
       @default = default
     end
@@ -31,10 +32,14 @@ class TestFlagsmithClient
       flag_name = flag_name.to_s
 
       if @flags.key?(flag_name)
-        TestFlag.new(enabled: @flags.fetch(flag_name), default: false)
+        TestFlag.new(feature_name: flag_name, enabled: @flags.fetch(flag_name), default: false)
       else
-        TestFlag.new(enabled: false, default: true)
+        TestFlag.new(feature_name: flag_name, enabled: false, default: true)
       end
+    end
+
+    def all_flags
+      @flags.map { |name, enabled| TestFlag.new(feature_name: name, enabled: enabled, default: false) }
     end
   end
 
@@ -56,17 +61,34 @@ class TestFlagsmithClient
   end
 end
 
+class TestFlagsmithManagementClient
+  attr_reader :recorded_traits
+
+  def initialize
+    @recorded_traits = []
+  end
+
+  def reset!
+    @recorded_traits = []
+  end
+
+  def set_trait(identifier, trait_key, trait_value)
+    @recorded_traits << { identifier:, trait_key:, trait_value: }
+  end
+end
+
 TEST_FLAGSMITH_CLIENT = TestFlagsmithClient.new
+TEST_FLAGSMITH_MANAGEMENT_CLIENT = TestFlagsmithManagementClient.new
 
 RSpec.configure do |config|
   config.before(:suite) do
-    next unless defined?(FlagsmithClient)
-
-    FlagsmithClient.instance = TEST_FLAGSMITH_CLIENT
+    FlagsmithClient.instance = TEST_FLAGSMITH_CLIENT if defined?(FlagsmithClient)
+    FlagsmithManagementClient.instance = TEST_FLAGSMITH_MANAGEMENT_CLIENT if defined?(FlagsmithManagementClient)
   end
 
   config.before do
     TEST_FLAGSMITH_CLIENT.reset!
+    TEST_FLAGSMITH_MANAGEMENT_CLIENT.reset!
     Current.reset
   end
 end

--- a/spec/support/flagsmith.rb
+++ b/spec/support/flagsmith.rb
@@ -56,7 +56,7 @@ class TestFlagsmithClient
   end
 
   # FlagsmithClient interface - evaluation
-  def get_flags_for(_identity)
+  def get_flags_for(_identity, _traits = {})
     TestFlags.new(@flags)
   end
 end
@@ -72,8 +72,8 @@ class TestFlagsmithManagementClient
     @recorded_traits = []
   end
 
-  def get_flags_for(identity) # rubocop:disable Rails/Delegate
-    TEST_FLAGSMITH_CLIENT.get_flags_for(identity)
+  def get_flags_for(identity, traits = {}) # rubocop:disable Rails/Delegate
+    TEST_FLAGSMITH_CLIENT.get_flags_for(identity, traits)
   end
 
   def set_trait(identifier, trait_key, trait_value)


### PR DESCRIPTION
## What:
Adds a hidden feature flag opt-in page at `/feature-flags` where internal users can enable experimental features for their browser session.

## Why:
Allows the team to test Flagsmith-backed features in deployed environments without manually editing identity overrides. Users visit the page, see the features registered as opt-in capable in frontend config, and toggle them on/off.

Opting in writes a trait to the current anonymous Flagsmith identity. The page reads and writes through the Flagsmith core API (`http://flagsmith.tariff.internal:8000`) using the existing `FLAGSMITH_ENVIRONMENT_KEY`, so it does not need a separate management token.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Purely additive — new route, controller, service, and view. No changes to any existing flag evaluation path or user-facing journey. The page is effectively hidden unless Flagsmith is configured for the environment.