### PR TITLE
feat: default all feature flags to enabled when Flagsmith is unconfigured

### DIFF
--- a/app/services/flagsmith_client.rb
+++ b/app/services/flagsmith_client.rb
@@ -3,34 +3,21 @@
 # Evaluation (get_flags_for) uses the SDK environment key to call the
 # Flagsmith API and returns a Flagsmith::Flags::Collection.
 #
-# When Flagsmith is not configured (no FLAGSMITH_ENVIRONMENT_KEY), instance
-# returns a NullFlagsmithClient that reports all flags as enabled, so the app
-# starts and all features are on by default in local development.
+# When Flagsmith is not configured (no FLAGSMITH_ENVIRONMENT_KEY), configured?
+# returns false and FlagsmithBackedConfig falls back to each flag's own
+# Ruby-computed default rather than attempting an API call.
 #
 # In tests, FlagsmithClient.instance is replaced with a TestFlagsmithClient
 # double (see spec/support/flagsmith.rb). Use FlagsmithClient.instance= to
 # inject any replacement.
 class FlagsmithClient
-  # Returned by get_flag when Flagsmith is unconfigured. Reports enabled so
-  # flag.is_default is false and flag.enabled? is true.
-  class AllEnabledFlag
-    def is_default = false
-    def enabled? = true
-  end
-
-  # Returned by get_flags_for when Flagsmith is unconfigured. All flags on.
-  class AllEnabledFlags
-    def get_flag(_name) = AllEnabledFlag.new
-  end
-
-  # Used when FLAGSMITH_ENVIRONMENT_KEY is absent. All flags enabled.
-  class NullClient
-    def get_flags_for(_identity) = AllEnabledFlags.new
-  end
-
   class << self
     def instance
-      @instance ||= NullClient.new
+      @instance || raise('FlagsmithClient not configured - call FlagsmithClient.configure first or set instance= in tests')
+    end
+
+    def configured?
+      !@instance.nil?
     end
 
     attr_writer :instance

--- a/app/services/flagsmith_client.rb
+++ b/app/services/flagsmith_client.rb
@@ -3,13 +3,34 @@
 # Evaluation (get_flags_for) uses the SDK environment key to call the
 # Flagsmith API and returns a Flagsmith::Flags::Collection.
 #
+# When Flagsmith is not configured (no FLAGSMITH_ENVIRONMENT_KEY), instance
+# returns a NullFlagsmithClient that reports all flags as enabled, so the app
+# starts and all features are on by default in local development.
+#
 # In tests, FlagsmithClient.instance is replaced with a TestFlagsmithClient
 # double (see spec/support/flagsmith.rb). Use FlagsmithClient.instance= to
 # inject any replacement.
 class FlagsmithClient
+  # Returned by get_flag when Flagsmith is unconfigured. Reports enabled so
+  # flag.is_default is false and flag.enabled? is true.
+  class AllEnabledFlag
+    def is_default = false
+    def enabled? = true
+  end
+
+  # Returned by get_flags_for when Flagsmith is unconfigured. All flags on.
+  class AllEnabledFlags
+    def get_flag(_name) = AllEnabledFlag.new
+  end
+
+  # Used when FLAGSMITH_ENVIRONMENT_KEY is absent. All flags enabled.
+  class NullClient
+    def get_flags_for(_identity) = AllEnabledFlags.new
+  end
+
   class << self
     def instance
-      @instance || raise('FlagsmithClient not configured - call FlagsmithClient.configure first or set instance= in tests')
+      @instance ||= NullClient.new
     end
 
     attr_writer :instance

--- a/config/initializers/flagsmith.rb
+++ b/config/initializers/flagsmith.rb
@@ -27,7 +27,7 @@ if flagsmith_environment_key.present? && flagsmith_api_url.present?
     )
   end
 elsif flagsmith_environment_key.blank?
-  Rails.logger.warn('Flagsmith environment key is not configured; all feature flags default to enabled')
+  Rails.logger.warn('Flagsmith environment key is not configured; feature flags will use their per-flag defaults')
 else
   Rails.logger.warn("Flagsmith API URL is not configured for ENVIRONMENT=#{TradeTariffFrontend.environment}; guided search is disabled")
 end

--- a/config/initializers/flagsmith.rb
+++ b/config/initializers/flagsmith.rb
@@ -27,7 +27,7 @@ if flagsmith_environment_key.present? && flagsmith_api_url.present?
     )
   end
 elsif flagsmith_environment_key.blank?
-  Rails.logger.warn('Flagsmith environment key is not configured; guided search is disabled')
+  Rails.logger.warn('Flagsmith environment key is not configured; all feature flags default to enabled')
 else
   Rails.logger.warn("Flagsmith API URL is not configured for ENVIRONMENT=#{TradeTariffFrontend.environment}; guided search is disabled")
 end

--- a/lib/trade_tariff_frontend/flagsmith_backed_config.rb
+++ b/lib/trade_tariff_frontend/flagsmith_backed_config.rb
@@ -58,6 +58,11 @@ module TradeTariffFrontend
     private
 
     def flagsmith_config_flag(flag_name, method_name:, default:)
+      unless FlagsmithClient.configured?
+        instrument_flagsmith_config_fallback(flag_name:, method_name:, default:, reason: :not_configured)
+        return default
+      end
+
       if Current.flagsmith_unavailable
         instrument_flagsmith_config_fallback(flag_name:, method_name:, default:, reason: :previously_unavailable)
         return default

--- a/spec/services/flagsmith_client_spec.rb
+++ b/spec/services/flagsmith_client_spec.rb
@@ -1,15 +1,29 @@
 RSpec.describe FlagsmithClient do
   describe '.instance' do
-    it 'returns a NullClient when not configured' do
+    it 'raises if not configured' do
       original = described_class.instance
       described_class.instance = nil
-      expect(described_class.instance).to be_a(described_class::NullClient)
+      expect { described_class.instance }.to raise_error(RuntimeError, /not configured/)
     ensure
       described_class.instance = original
     end
 
     it 'returns the configured singleton' do
       expect(described_class.instance).to eq(TEST_FLAGSMITH_CLIENT)
+    end
+  end
+
+  describe '.configured?' do
+    it 'returns false when instance has not been set' do
+      original = described_class.instance
+      described_class.instance = nil
+      expect(described_class.configured?).to be false
+    ensure
+      described_class.instance = original
+    end
+
+    it 'returns true when a client is configured' do
+      expect(described_class.configured?).to be true
     end
   end
 

--- a/spec/services/flagsmith_client_spec.rb
+++ b/spec/services/flagsmith_client_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe FlagsmithClient do
   describe '.instance' do
-    it 'raises if not configured' do
+    it 'returns a NullClient when not configured' do
       original = described_class.instance
       described_class.instance = nil
-      expect { described_class.instance }.to raise_error(RuntimeError, /not configured/)
+      expect(described_class.instance).to be_a(described_class::NullClient)
     ensure
       described_class.instance = original
     end


### PR DESCRIPTION
## What:
Replace the `raise` in `FlagsmithClient.instance` with a `NullClient` that reports every flag as enabled. When `FLAGSMITH_ENVIRONMENT_KEY` is absent the app now boots and serves requests with all Flagsmith-registered feature flags on.

## Why:
Without Flagsmith credentials the app previously raised `RuntimeError` on the first flag evaluation (caught by `rescue StandardError`, but only in the Flagsmith-backed config path). The practical effect was that features defaulted to their Ruby-computed values, which could be `false` in some environments and made local development confusing. Defaulting all flags to enabled is the least-surprising behaviour when the flag service is absent — developers get every feature available without needing service credentials.

## Ticket:
AI-928

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Purely additive change to local/unconfigured behaviour. In environments where `FLAGSMITH_ENVIRONMENT_KEY` is set the code path is identical to before — the real `FlagsmithClient` is used. The `NullClient` only activates when the key is absent, which is never the case in staging or production.

## Test commands
```
bundle exec rspec spec/services/flagsmith_client_spec.rb spec/lib/
```