### PR TITLE
Suppress Flagsmith SDK request logs

### DIFF
--- a/app/services/flagsmith_client.rb
+++ b/app/services/flagsmith_client.rb
@@ -7,6 +7,28 @@
 # double (see spec/support/flagsmith.rb). Use FlagsmithClient.instance= to
 # inject any replacement.
 class FlagsmithClient
+  class SdkLogger
+    def initialize(logger)
+      @logger = logger
+    end
+
+    def debug(*) = nil
+
+    def info(*) = nil
+
+    def warn(message = nil, &block)
+      @logger.warn(message || block&.call)
+    end
+
+    def error(message = nil, &block)
+      @logger.error(message || block&.call)
+    end
+
+    def fatal(message = nil, &block)
+      @logger.fatal(message || block&.call)
+    end
+  end
+
   class << self
     def instance
       @instance || raise('FlagsmithClient not configured - call FlagsmithClient.configure first or set instance= in tests')
@@ -26,6 +48,7 @@ class FlagsmithClient
       environment_key: @environment_key,
       api_url: "#{@api_url}/",
       request_timeout_seconds: 1,
+      logger: SdkLogger.new(Rails.logger),
       # Return a disabled default flag rather than raising for unknown features.
       default_flag_handler: ->(_name) { Flagsmith::Flags::DefaultFlag.new(enabled: false, value: nil) },
     )

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -332,6 +332,7 @@ Feedback#telephone=
 FeedbackController#new
 FeedbackController#thanks
 FindCommoditiesController#show
+FlagsmithClient::SdkLogger#debug
 FlagsmithClient#configure
 FlagsmithClient#instance=
 Footnote#code=

--- a/spec/services/flagsmith_client_spec.rb
+++ b/spec/services/flagsmith_client_spec.rb
@@ -52,6 +52,49 @@ RSpec.describe FlagsmithClient do
         hash_including(request_timeout_seconds: 1),
       )
     end
+
+    it 'configures the SDK with a quiet logger for request noise' do
+      allow(Flagsmith::Client).to receive(:new).and_call_original
+
+      described_class.new(
+        environment_key: 'test-env-key',
+        api_url: 'https://flags-edge.example.com/api/v1/',
+      )
+
+      expect(Flagsmith::Client).to have_received(:new).with(
+        hash_including(logger: an_instance_of(described_class::SdkLogger)),
+      )
+    end
+  end
+
+  describe 'SDK logging' do
+    subject(:logger) { described_class::SdkLogger.new(rails_logger) }
+
+    let(:rails_logger) { instance_spy(ActiveSupport::Logger) }
+
+    it 'suppresses debug request logs' do
+      logger.debug('debug details')
+
+      expect(rails_logger).not_to have_received(:debug)
+    end
+
+    it 'suppresses info request logs' do
+      logger.info { 'request: POST https://flags-edge.example.com/api/v1/identities/' }
+
+      expect(rails_logger).not_to have_received(:info)
+    end
+
+    it 'forwards warnings to the Rails logger' do
+      logger.warn('Flagsmith warning')
+
+      expect(rails_logger).to have_received(:warn).with('Flagsmith warning')
+    end
+
+    it 'forwards errors to the Rails logger' do
+      logger.error { 'Flagsmith error' }
+
+      expect(rails_logger).to have_received(:error).with('Flagsmith error')
+    end
   end
 
   describe '#get_flags_for' do


### PR DESCRIPTION
## What:
Adds a small logger adapter for the Flagsmith SDK so debug and info request noise is suppressed while warnings, errors, and fatal messages continue to be forwarded to the Rails logger.

This also keeps non-suppressed SDK log output on the application’s Rails logger path, so it follows the same configured logger handling as other app-level log messages instead of using the SDK’s own logger output.

Also adds service specs for the logger configuration and forwarding behaviour, plus a Debride whitelist entry for the SDK logger interface method that is called externally.

## Why:
The Flagsmith SDK can emit noisy request logs at lower log levels. This keeps production logs focused while preserving higher-severity SDK logging and avoids SDK-generated log output bypassing the application logger conventions.

## Ticket:
BAU

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Low-risk observability/logging change. It does not change user-facing journeys, tariff presentation, backend API calls, auth/session handling, or deployment configuration.

## Validation:
- `bundle exec rspec spec/services/flagsmith_client_spec.rb` - 12 examples, 0 failures
- `pre-commit run --hook-stage pre-push --all-files` - Debride and TruffleHog passed
- Push hooks - Debride and TruffleHog passed

## Manual evidence:
Not applicable; this is a logging-only service change.

## Accessibility impact:
No user-facing UI or content changes.