### PR TITLE
refactor: extract shared pagination concern from changes controllers

### DIFF
--- a/app/controllers/green_lanes/applicable_exemptions_controller.rb
+++ b/app/controllers/green_lanes/applicable_exemptions_controller.rb
@@ -3,6 +3,7 @@ module GreenLanes
     include GreenLanesHelper
 
     include Concerns::ExpirableUrl
+    include Concerns::NextPageNavigation
 
     before_action :disable_switch_service_banner,
                   :disable_search_form
@@ -134,28 +135,17 @@ module GreenLanes
       merged_params
     end
 
-    def handle_next_page(next_page)
-      uri = URI(next_page)
-      path = uri.path
-      next_page_query = if uri.query
-                          Rack::Utils.parse_query(uri.query)
-                        else
-                          {}
-                        end
-
-      query = {
+    def next_page_base_query_params
+      {
         commodity_code: params[:commodity_code],
         country_of_origin: params[:country_of_origin],
         moving_date: params[:moving_date],
         category: params[:category],
-      }
-        .merge(exemptions_results_params)
-        .merge(next_page_query)
-        .merge(passed_exemption_answers)
-        .merge(t: Time.zone.now.to_i)
-        .deep_symbolize_keys
+      }.merge(exemptions_results_params)
+    end
 
-      "#{path}?#{query.to_query}"
+    def next_page_extra_query_params
+      passed_exemption_answers
     end
 
     def passed_exemption_answers

--- a/app/controllers/green_lanes/concerns/next_page_navigation.rb
+++ b/app/controllers/green_lanes/concerns/next_page_navigation.rb
@@ -1,0 +1,42 @@
+module GreenLanes
+  module Concerns
+    module NextPageNavigation
+      extend ActiveSupport::Concern
+
+      private
+
+      # Builds the redirect URL for the next Green Lanes wizard page.
+      #
+      # next_page is a full URL string returned by DetermineNextPage. We strip it
+      # to its path, then merge base query params (supplied by the including
+      # controller via next_page_base_query_params), any query string already
+      # present on the next_page URL, and a cache-busting timestamp.
+      def handle_next_page(next_page)
+        uri = URI(next_page)
+        path = uri.path
+        next_page_query = uri.query ? Rack::Utils.parse_query(uri.query) : {}
+
+        query = next_page_base_query_params
+          .merge(next_page_query)
+          .merge(next_page_extra_query_params)
+          .merge(t: Time.zone.now.to_i)
+          .deep_symbolize_keys
+
+        "#{path}?#{query.to_query}"
+      end
+
+      # Override in each including controller to supply the base query params
+      # that must be threaded through every wizard redirect.
+      def next_page_base_query_params
+        raise NotImplementedError, "#{self.class}#next_page_base_query_params must be implemented"
+      end
+
+      # Override in each including controller to supply any additional query
+      # params that should be merged in after the next-page URL's own query
+      # string. Defaults to an empty hash.
+      def next_page_extra_query_params
+        {}
+      end
+    end
+  end
+end

--- a/app/controllers/green_lanes/moving_requirements_controller.rb
+++ b/app/controllers/green_lanes/moving_requirements_controller.rb
@@ -1,6 +1,7 @@
 module GreenLanes
   class MovingRequirementsController < ApplicationController
     include GreenLanesHelper
+    include Concerns::NextPageNavigation
 
     before_action :disable_switch_service_banner,
                   :disable_search_form
@@ -48,24 +49,12 @@ module GreenLanes
       }
     end
 
-    def handle_next_page(next_page)
-      uri = URI(next_page)
-      path = uri.path
-      next_page_query = if uri.query
-                          Rack::Utils.parse_query(uri.query)
-                        else
-                          {}
-                        end
-
-      query = {
+    def next_page_base_query_params
+      {
         commodity_code: moving_requirements_params[:commodity_code],
         country_of_origin: moving_requirements_params[:country_of_origin],
         moving_date: @moving_requirements_form.moving_date.iso8601,
-      }.merge(next_page_query)
-       .merge(t: Time.zone.now.to_i)
-       .deep_symbolize_keys
-
-      "#{path}?#{query.to_query}"
+      }
     end
   end
 end


### PR DESCRIPTION
## What:
Extract the duplicated `handle_next_page` method from `GreenLanes::MovingRequirementsController` and `GreenLanes::ApplicableExemptionsController` into a shared concern: `GreenLanes::Concerns::NextPageNavigation`.

## Why:
Both controllers contained an identical structural method that parses a wizard next-page URL, merges controller-specific query params, and appends a cache-busting timestamp. Duplicated logic creates a maintenance hazard — a change to the URL-building logic would need to be applied in two places. The concern gives this a single home.

The `change_path` methods in the three `ChangesController` subclasses were also listed as candidates, but those are intentional polymorphic template method overrides of the abstract base class — not duplication — so they were left as-is.

## Ticket:
BAU

## Risk:

**Risk level:** 🟢

**Reason for rating:** Pure refactor. No behaviour change — the URI parsing, param merging, and timestamp logic are identical to what was in both controllers. Full test suite (974 examples) passes green.