### PR TITLE
refactor: derive navigation items from sections in GroupedMeasuresPresenter

### DIFF
--- a/app/presenters/grouped_measures_presenter.rb
+++ b/app/presenters/grouped_measures_presenter.rb
@@ -176,29 +176,11 @@ class GroupedMeasuresPresenter
   end
 
   def uk_navigation_items
-    return [] if uk_import_measures.blank?
-
-    items = []
-    items << { text: 'Import controls', anchor: '#uk_import_controls' } if uk_import_measures.import_controls.present?
-    items << { text: 'Import duties', anchor: '#import_duties' } if uk_import_measures.customs_duties.present?
-    items << { text: 'Quotas', anchor: '#quotas' } if uk_import_measures.quotas.present?
-    items << { text: 'Trade remedies, safeguards and retaliatory duties', anchor: '#trade_remedies' } if uk_import_measures.trade_remedies.present?
-    items << { text: 'Suspensions', anchor: '#suspensions' } if uk_import_measures.suspensions.present?
-    items << { text: 'Credibility checks', anchor: '#credibility_checks' } if uk_import_measures.credibility_checks.present?
-    items << { text: 'Import VAT and excise', anchor: '#vat_excise' } if uk_import_measures.vat_excise.present?
-    items
+    uk_sections.map { |section| { text: section[:caption], anchor: "##{section[:css_id]}" } }
   end
 
   def xi_navigation_items
-    items = []
-    items << { text: 'Import duties', anchor: '#import_duties' } if xi_import_measures.customs_duties.present?
-    items << { text: 'Trade remedies, safeguards and retaliatory duties', anchor: '#trade_remedies' } if xi_import_measures.trade_remedies.present?
-    items << { text: 'Suspensions', anchor: '#suspensions' } if xi_import_measures.suspensions.present?
-    items << { text: 'Credibility checks', anchor: '#credibility_checks' } if xi_import_measures.credibility_checks.present?
-    items << { text: 'Import VAT and excise', anchor: '#vat_excise' } if uk_import_measures&.vat_excise.present?
-    items << { text: 'EU import controls', anchor: '#xi_import_controls' } if xi_import_measures.import_controls.present?
-    items << { text: 'UK import controls', anchor: '#uk_import_controls' } if uk_import_measures&.import_controls.present?
-    items
+    xi_sections.map { |section| { text: section[:caption], anchor: "##{section[:css_id]}" } }
   end
 
   def show_meursing_form?


### PR DESCRIPTION
## What:
Replace the manually-maintained `uk_navigation_items` and `xi_navigation_items` methods with derivations from `uk_sections` and `xi_sections` using `map`.

## Why:
The four methods (`uk_sections`, `xi_sections`, `uk_navigation_items`, `xi_navigation_items`) shared duplicated knowledge about which sections exist and their captions/CSS IDs. Adding or renaming a section required touching all four methods. Now the section arrays are the single source of truth — navigation items are derived directly from them.

## Ticket:
BAU

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Pure refactor with no behaviour change. The nav items produced are identical to before because `uk_sections`/`xi_sections` already gate each entry on the same `present?` checks. All 9 presenter specs pass unchanged.