### PR TITLE
chore: disable Copilot review gate for auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,5 +22,6 @@ jobs:
     with:
       label: low-risk
       merge-method: merge
+      copilot-review-required: false
     secrets:
       github-token: ${{ secrets.PULL_REQUEST_PAT }}


### PR DESCRIPTION
## Summary

- Passes `copilot-review-required: false` to the shared auto-merge workflow, since Copilot code review is not configured for this repo.
- Without this, the auto-merge check was failing with a jq crash (`test("copilot"; "i") cannot be applied to: null`) and then blocking all low-risk PR merges indefinitely.

## Depends on

Requires [trade-tariff/trade-tariff-tools#160](https://github.com/trade-tariff/trade-tariff-tools/pull/160) to be merged first — that PR adds the `copilot-review-required` input to the reusable workflow.

## Risk

- **Low** — CI/CD change only, no application code touched. The `copilot-review-required: false` default in trade-tariff-tools means this flag is redundant once that PR lands, but makes the intent explicit for this repo.

## Test plan

- [ ] Merge trade-tariff-tools#160
- [ ] Verify the next low-risk PR auto-merges without the Copilot gate blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)