### PR TITLE
HMRC-2430: Harden live issue commodity links

### DIFF
--- a/app/helpers/live_issue_helper.rb
+++ b/app/helpers/live_issue_helper.rb
@@ -1,4 +1,6 @@
 module LiveIssueHelper
+  COMMODITY_CODE_WITH_OPTIONAL_TRAILING_COMMA = /\A\s*(\d{10}),?\s*\z/
+
   SORT_LABELS = {
     'updated_desc' => 'live_issues.sort.updated_desc',
     'updated_asc' => 'live_issues.sort.updated_asc',
@@ -22,6 +24,13 @@ module LiveIssueHelper
     return t('live_issues.card.none') if live_issue.suggested_action.blank?
 
     markdown_field(live_issue.suggested_action)
+  end
+
+  def live_issue_commodity_link(commodity_code)
+    normalized_commodity_code = commodity_code.to_s.match(COMMODITY_CODE_WITH_OPTIONAL_TRAILING_COMMA)&.[](1)
+    return commodity_code.to_s if normalized_commodity_code.blank?
+
+    govuk_link_to(normalized_commodity_code, commodity_path(normalized_commodity_code))
   end
 
   def live_issue_from_to_date(live_issue)

--- a/app/views/live_issues/_commodities.html.erb
+++ b/app/views/live_issues/_commodities.html.erb
@@ -1,19 +1,21 @@
-<% if live_issue.commodities.empty? %>
+<% commodities = Array(live_issue.commodities).filter_map { |commodity| commodity.to_s.presence } %>
+
+<% if commodities.empty? %>
   <p class="govuk-body">
     <%= t('live_issues.commodities.none') %>
   </p>
-<% elsif live_issue.commodities.size > 1 %>
-  <%= govuk_details(summary_text: t('live_issues.commodities.count', count: live_issue.commodities.count)) do %>
+<% elsif commodities.size > 1 %>
+  <%= govuk_details(summary_text: t('live_issues.commodities.count', count: commodities.count)) do %>
     <ul class="govuk-list govuk-!-margin-bottom-0 live-issues__commodity-list">
-      <% live_issue.commodities.each do |commodity_code| %>
+      <% commodities.each do |commodity_code| %>
         <li>
-          <%= govuk_link_to(commodity_code, commodity_path(commodity_code)) %>
+          <%= live_issue_commodity_link(commodity_code) %>
         </li>
       <% end %>
     </ul>
   <% end %>
 <% else %>
   <p class="govuk-body">
-    <%= govuk_link_to(live_issue.commodities.first, commodity_path(live_issue.commodities.first)) %>
+    <%= live_issue_commodity_link(commodities.first) %>
   </p>
 <% end %>

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -497,6 +497,7 @@ LiveIssue#status=
 LiveIssue#suggested_action=
 LiveIssue#title=
 LiveIssue#updated_at=
+LiveIssueHelper#live_issue_commodity_link
 LiveIssueHelper#live_issue_from_to_date
 LiveIssueHelper#live_issue_recommendation
 LiveIssueHelper#live_issue_selected_filters

--- a/spec/features/live_issues_spec.rb
+++ b/spec/features/live_issues_spec.rb
@@ -34,4 +34,37 @@ RSpec.describe 'Live issues log', :js, type: :feature do
     expect(page).to have_css('.govuk-summary-card:first-of-type', text: 'Issue 2')
     expect(page).to have_no_content('Issue 1')
   end
+
+  it 'renders live issue commodity links when a commodity code includes non-digit characters' do
+    allow(LiveIssue).to receive(:all).and_return([
+      build(:live_issue, commodities: ['3402420090,', '7222190000']),
+    ])
+
+    visit live_issues_path
+
+    expect(page).to have_link('3402420090', href: commodity_path('3402420090'))
+    expect(page).to have_link('7222190000', href: commodity_path('7222190000'))
+  end
+
+  it 'renders invalid live issue commodity values as text' do
+    allow(LiveIssue).to receive(:all).and_return([
+      build(:live_issue, commodities: %w[BAD]),
+    ])
+
+    visit live_issues_path
+
+    expect(page).to have_content('BAD')
+    expect(page).to have_no_link('BAD')
+  end
+
+  it 'renders none when live issue commodities are nil or blank' do
+    allow(LiveIssue).to receive(:all).and_return([
+      build(:live_issue, commodities: nil),
+      build(:live_issue, commodities: [nil, '', ' ']),
+    ])
+
+    visit live_issues_path
+
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Commodities affected None', count: 2)
+  end
 end

--- a/spec/helpers/live_issue_helper_spec.rb
+++ b/spec/helpers/live_issue_helper_spec.rb
@@ -8,6 +8,28 @@ RSpec.describe LiveIssueHelper, type: :helper do
     it { is_expected.to eq(expected_html) }
   end
 
+  describe '#live_issue_commodity_link' do
+    subject(:live_issue_commodity_link) { helper.live_issue_commodity_link(commodity_code) }
+
+    context 'when a commodity code contains non-digit characters' do
+      let(:commodity_code) { '3402420090,' }
+
+      it { is_expected.to have_link('3402420090', href: commodity_path('3402420090')) }
+    end
+
+    context 'when a commodity code cannot be normalized to ten digits' do
+      let(:commodity_code) { 'BAD' }
+
+      it { is_expected.to eq('BAD') }
+    end
+
+    context 'when a commodity code contains unexpected characters around ten digits' do
+      let(:commodity_code) { '<script>3402420090</script>' }
+
+      it { is_expected.to eq('<script>3402420090</script>') }
+    end
+  end
+
   describe '#live_issue_from_to_date' do
     subject(:live_issue_from_to_date) { helper.live_issue_from_to_date(live_issue) }
 


### PR DESCRIPTION
## What:
- [x] Normalize live issue commodity link targets to digits before generating commodity URLs.
- [x] Render malformed commodity values as plain text if they cannot become a 10 digit commodity code.
- [x] Treat nil live issue commodity arrays as empty in the commodity partial.
- [x] Add feature and helper coverage for a trailing-comma commodity code.

## Why:
A malformed commodity code value in live issue data caused the public Live Issues page to fail while generating commodity links. The frontend should continue rendering the page even if upstream live issue data contains punctuation or an invalid commodity entry.

## Ticket:
[HMRC-2430](https://transformuk.atlassian.net/browse/HMRC-2430)

## Risk:
**Risk level:** 🟢

**Reason for rating:** Narrow defensive defect fix with focused feature and helper coverage. Valid commodity links are preserved while malformed values no longer break the page.
