### PR TITLE
Remove unused and no-output CSS

### DIFF
--- a/app/assets/stylesheets/src/components/_cards.scss
+++ b/app/assets/stylesheets/src/components/_cards.scss
@@ -7,10 +7,6 @@
   @include govuk.govuk-responsive-margin(6, "bottom");
 }
 
-.gem-c-cards__heading--underline {
-  // Heading style used when not in column mode
-}
-
 .gem-c-cards__list {
   list-style: none;
   padding: 0;

--- a/app/assets/stylesheets/src/components/_commodity-codes.scss
+++ b/app/assets/stylesheets/src/components/_commodity-codes.scss
@@ -32,22 +32,6 @@
   height: settings.$chapter-code-height;
   margin-right: govuk.govuk-spacing(1);
 }
-.chapter-heading-code {
-  @extend .govuk-tag--grey;
-  font-weight: 400;
-  width: 2.6em;
-  padding: 0.125em 0.25em;
-  text-align: center;
-  font-size: 16px;
-}
-.chapter-chapter-code {
-  @extend .govuk-tag--grey;
-  font-weight: 400;
-  width: 1.4em;
-  padding: 0.125em 0.25em;
-  text-align: center;
-  font-size: 16px;
-}
 .commodity-code {
   width: 101px;
   height: settings.$chapter-code-height;

--- a/app/assets/stylesheets/src/components/_tariff-breadcrumbs.scss
+++ b/app/assets/stylesheets/src/components/_tariff-breadcrumbs.scss
@@ -195,7 +195,6 @@
   .heading-code {
     width: 30px;
     height: 30px;
-    //margin-right: 2px !important;
   }
 
   .commodity-code {
@@ -208,12 +207,6 @@
       display: inline-block;
       text-align: center;
       line-height: 30px;
-      //margin: 0 !important;
-
-      &:nth-child(2) {
-        //margin-left: 2px !important;
-        //margin-right: 2px !important;
-      }
     }
   }
 }

--- a/app/assets/stylesheets/src/journeys/_quota-search.scss
+++ b/app/assets/stylesheets/src/journeys/_quota-search.scss
@@ -13,11 +13,6 @@
     line-height: 2em;
   }
 
-  .multiple-choice--inline {
-    clear: none;
-    margin-right: govuk.govuk-spacing(2);
-  }
-
   input[type="submit"] {
     margin-top: 1.5em;
 

--- a/app/assets/stylesheets/src/patterns/_tables.scss
+++ b/app/assets/stylesheets/src/patterns/_tables.scss
@@ -90,10 +90,6 @@ table.small-table {
         content: "Legal base";
       }
 
-      .dates-col::before {
-        content: "Date(s)";
-      }
-
       .footnotes-col::before {
         content: "Footnotes";
       }

--- a/app/assets/stylesheets/src/print/_base.scss
+++ b/app/assets/stylesheets/src/print/_base.scss
@@ -30,19 +30,6 @@ article dd ul a {
   display: block;
 }
 
-a.print-link-without-description:after {
-  content: "";
-}
-
-.hidden-print {
-  display: none !important;
-}
-
-.visible-print {
-  display: initial !important;
-  visibility: visible !important;
-}
-
 .pull-left {
   float: left;
 }
@@ -55,27 +42,6 @@ a[href^="/"]:after,
 a[href^="http://"]:after,
 a[href^="https://"]:after {
   display: none;
-}
-
-.back-to-previous {
-  display: none;
-}
-
-.js-header-toggle.menu {
-  display: none;
-}
-
-.header-proposition {
-  display: none;
-}
-
-#proposition-name {
-  position: relative;
-  top: -0.2em;
-  font-size: 1.7em;
-  padding-left: 0.5em;
-  margin-left: 0.5em;
-  border-left: 2px solid #000;
 }
 
 #proposition-links {


### PR DESCRIPTION
## What:

- Removes unused selectors from commodity code tags, quota search, responsive table labels, tariff breadcrumbs, and print CSS.
- Removes the empty `gem-c-cards__heading--underline` SCSS block, which is still present in markup but emitted no CSS.
- Leaves generated, vendor, and dynamic hooks alone.

## Why:

Most removed selectors no longer have app markup, helper, or JavaScript references. The card heading selector is different: the class is still emitted, but the deleted SCSS block was empty and had no compiled CSS output.

## Ticket:

BAU - No Jira story.

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Low risk. This is a deletion-only Sass cleanup with no route, API, journey, legal content, auth, or infrastructure changes. Sass compilation passed for application and print CSS; the compiled CSS diff only removes selectors checked as unused or no-output.