### PR TITLE
Temporarily align staging ECS capacity settings with production

### DIFF
--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -1,9 +1,9 @@
 region        = "eu-west-2"
 environment   = "staging"
-cpu           = 1024
-memory        = 2048
-service_count = 1
-min_capacity  = 1
-max_capacity  = 8
+cpu           = 2048
+memory        = 4096
+service_count = 3
+min_capacity  = 3
+max_capacity  = 10
 
 enable_alarms = false


### PR DESCRIPTION
## What:
Temporarily update the staging ECS configuration to match production

## Why:
Ensure the staging environment reflects production capacity for more representative load testing.
Load testing will be implemented to compare the ALB algorithms, Round Robin vs LOR

## Ticket:
n/a

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
Temporary staging-only configuration change.