### PR TITLE
Revert "Revert "HMRC-2451: Route exchange rate file downloads through frontend paths""

### DIFF
--- a/app/controllers/exchange_rates_controller.rb
+++ b/app/controllers/exchange_rates_controller.rb
@@ -12,7 +12,7 @@ class ExchangeRatesController < ApplicationController
   end
 
   def files
-    redirect_to "/uk/api/exchange_rates/files/#{params[:id]}.#{params[:format]}" and return true
+    redirect_to "/uk/api/exchange_rates/files/#{params[:id]}/redirect.#{params[:format]}", allow_other_host: true and return true
   end
 
   def show

--- a/app/models/exchange_rates/file.rb
+++ b/app/models/exchange_rates/file.rb
@@ -8,6 +8,10 @@ class ExchangeRates::File
 
   delegate :year, :month, to: :publication_date, allow_nil: true
 
+  def filename
+    File.basename(file_path)
+  end
+
   def adjusted_file_path
     url = TradeTariffFrontend.backend_base_domain
 

--- a/app/views/exchange_rates/_document_detail.html.erb
+++ b/app/views/exchange_rates/_document_detail.html.erb
@@ -19,7 +19,7 @@
 
         <% if period.files.any? %>
           <% period.files.each do |file| %>
-            <a title="Download <%= period.month%> <%= period.year %> monthly exchange rates in <%= file.format.upcase %> format" href="<%= exchange_rate_file_path(URI(file.adjusted_file_path).path.split('/').last) %>">
+            <a title="Download <%= period.month%> <%= period.year %> monthly exchange rates in <%= file.format.upcase %> format" href="<%= exchange_rate_file_path(file.filename) %>">
               <strong><%= file.format.upcase %></strong> <%= file.file_size_in_kb %> KB
             </a>
           <% end %>

--- a/app/views/exchange_rates/_download_files.html.erb
+++ b/app/views/exchange_rates/_download_files.html.erb
@@ -8,7 +8,7 @@
 <dt class="gem-c-metadata__term">Download:</dt>
 <dd class="gem-c-metadata__definition">
   <% files.each_with_index do |file, index| %>
-    <%= govuk_link_to file.file_size_label, file.adjusted_file_path %>
+    <%= govuk_link_to file.file_size_label, exchange_rate_file_path(file.filename) %>
     <% unless index + 1 == files.length %>
       |
     <% end %>

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -315,6 +315,7 @@ ExchangeRates::ExchangeRate#validity_end_date=
 ExchangeRates::ExchangeRate#validity_start_date=
 ExchangeRates::ExchangeRate#year=
 ExchangeRates::File#adjusted_file_path
+ExchangeRates::File#filename
 ExchangeRates::File#file_path
 ExchangeRates::File#file_path=
 ExchangeRates::File#file_size=

--- a/spec/models/exchange_rates/file_spec.rb
+++ b/spec/models/exchange_rates/file_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe ExchangeRates::File do
     it { expect(file.file_size_label).to eq 'CSV file (2.0 KB)' }
   end
 
+  describe '#filename' do
+    it 'returns just the filename portion of the file path' do
+      expect(file.filename).to eq 'exrates-monthly-0623.csv'
+    end
+  end
+
   describe '#adjusted_file_path' do
     before do
       allow(TradeTariffFrontend).to receive(:backend_base_domain).and_return(backend_base_domain)

--- a/spec/requests/exchange_rates_controller_spec.rb
+++ b/spec/requests/exchange_rates_controller_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe ExchangeRatesController, type: :request, vcr: { cassette_name: 'e
     end
   end
 
+  describe 'GET #files' do
+    before { get '/exchange_rates/view/files/monthly_csv_2022-1.csv' }
+
+    it { is_expected.to redirect_to('/uk/api/exchange_rates/files/monthly_csv_2022-1/redirect.csv') }
+    it { is_expected.to have_http_status :found }
+  end
+
   describe 'GET #show' do
     context 'when exchange rate type is "monthly"' do
       before { get '/exchange_rates/view/2022-1?type=monthly' }

--- a/spec/views/exchange_rates/_download_files.html.erb_spec.rb
+++ b/spec/views/exchange_rates/_download_files.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe 'exchange_rates/_download_files', type: :view do
+  let(:file) { build(:exchange_rate_file) }
+  let(:exchange_rate_collection) { build(:exchange_rate_collection) }
+
+  before do
+    assign :exchange_rate_collection, exchange_rate_collection
+    allow(view).to receive(:files) { [file] }
+  end
+
+  it 'renders a download link through the frontend exchange rate file path, not a backend URL' do
+    render
+    expect(rendered).to have_link('CSV file (2.0 KB)', href: '/exchange_rates/view/files/exrates-monthly-0623.csv')
+  end
+end


### PR DESCRIPTION
## What:
Routes all exchange rate file download links through frontend `exchange_rate_file_path` helper rather than exposing backend/API file paths directly. The frontend `files` action now redirects to the new backend presigned-redirect endpoint.

- `_download_files.html.erb`: replace `file.adjusted_file_path` with `exchange_rate_file_path(file.filename)`
- `_document_detail.html.erb`: simplify existing URI-parsing one-liner to `file.filename`
- `ExchangeRates::File#filename`: new method returning `File.basename(file_path)`, shared by both partials
- `ExchangeRatesController#files`: redirects to `/uk/api/exchange_rates/files/:id/redirect.:format` (new backend presigned endpoint) instead of the old proxy

Depends on: trade-tariff/trade-tariff-backend#HMRC-2451-exchange-rate-file-presigned-redirect

## Why:
Collection-page download links were rendering backend API URLs directly, contrary to the goal of keeping all download links behind frontend routes. Additionally, the old backend proxy held a Puma worker for the full duration of each file download from S3; the new presigned redirect frees the worker immediately.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2451

## Risk:

**Risk level:** 🟢

**Reason for rating:** Modifies how exchange rate file download links are rendered and where the frontend redirects for file downloads — a new backend endpoint is required before this can be merged to production.