### PR TITLE
fix(accessibility): remove combobox role from autocomplete fallback

### DIFF
--- a/app/views/shared/search/_autocomplete.html.erb
+++ b/app/views/shared/search/_autocomplete.html.erb
@@ -42,14 +42,14 @@
         });
       } catch(e) {
         var node = document.getElementById('autocomplete');
-        node.innerHTML = '<div class="autocomplete__wrapper"><input autocomplete="off" class="autocomplete__input autocomplete__input--default" id="<%= input_id %>" name="<%= input_name %>" placeholder="Enter the name of the goods or commodity code" type="text" role="combobox" required=""></div>'
+        node.innerHTML = '<div class="autocomplete__wrapper"><input autocomplete="off" class="autocomplete__input autocomplete__input--default" id="<%= input_id %>" name="<%= input_name %>" placeholder="Enter the name of the goods or commodity code" type="text" required=""></div>'
       }
     })
   <% end %>
 
   <noscript>
     <div class="autocomplete__wrapper">
-      <input autocomplete="off" class="autocomplete__input autocomplete__input--default" id="<%= input_id %>" name="<%= input_name %>" placeholder="Enter the name of the goods or commodity code" type="text" role="combobox" required="">
+      <input autocomplete="off" class="autocomplete__input autocomplete__input--default" id="<%= input_id %>" name="<%= input_name %>" placeholder="Enter the name of the goods or commodity code" type="text" required="">
     </div>
   </noscript>
 </div>

--- a/spec/views/shared/search/_search_form.html.erb_spec.rb
+++ b/spec/views/shared/search/_search_form.html.erb_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe 'shared/search/_search_form', type: :view do
     expect(rendered_form).not_to have_css('button[formnovalidate]')
   end
 
+  it 'renders the noscript autocomplete fallback as a plain text input' do
+    expect(rendered_form).to have_css('noscript input#search-q-field[type="text"]:not([role])', visible: :all)
+  end
+
+  it 'does not render fallback combobox roles outside the enhanced autocomplete' do
+    expect(rendered_form).not_to include('role="combobox"')
+  end
+
   context 'when shared search button text is not used' do
     before do
       assign(:no_shared_search, true)


### PR DESCRIPTION
## What:
Remove `role="combobox"` from the shared search autocomplete fallback and noscript input. The enhanced `accessible-autocomplete` path still provides the combobox/listbox semantics; the fallback is a plain text input and should not advertise combobox semantics.

## Why:
The post-merge accessibility workflow for PR #3213 failed on Browse Tariff because axe reported 2 violations while the page threshold allows 1. Brave/axe before validation on `https://dev.trade-tariff.service.gov.uk/browse` showed the extra violation was `aria-required-attr` on `#search-q-field` in fallback markup: `role="combobox"` without `aria-expanded` and `aria-controls`. Removing the incorrect fallback role leaves only the existing `region` violation, within the current threshold.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Low-risk accessibility markup fix with before/after validation. The enhanced autocomplete path was proven still to render a valid combobox/listbox, and the changed fallback paths are covered as plain text inputs.


## Accessibility impact:
Improves fallback semantics by avoiding an invalid combobox role when the autocomplete widget is not active. The enhanced JavaScript autocomplete continues to expose combobox/listbox semantics through the library-generated markup.

## Backend/API/environment/deployment implications:
None. No backend calls, environment variables, or deployment order changes.
