### PR TITLE
Restore GOV.UK document frame on attachment thumbs

### DIFF
--- a/app/assets/stylesheets/src/journeys/_help.scss
+++ b/app/assets/stylesheets/src/journeys/_help.scss
@@ -18,15 +18,30 @@
     margin-bottom: 3em;
   }
 
+  // Match GOV.UK attachment thumbnail framing so pale spreadsheet icons
+  // read as paper documents (edge + depth), not flat blocks on white.
+  // See govuk_publishing_components govspeak/_attachment.scss
   .attachment-thumb {
-    img {
-      border: 5px solid settings.$tariff-white;
+    img,
+    svg {
+      display: block;
       max-width: 99px;
       width: 100%;
+      height: auto;
+      background: settings.$tariff-white-colour;
+      border: 0;
+      box-shadow:
+        0 2px 2px rgba(settings.$tariff-shadow-colour, 0.4),
+        0 0 0 5px rgba(settings.$tariff-shadow-colour, 0.1);
 
       @include govuk.govuk-media-query($until: tablet) {
         max-width: 50px;
       }
+    }
+
+    svg {
+      fill: govuk.govuk-colour("black", $variant: "tint-80");
+      stroke: govuk.govuk-colour("black", $variant: "tint-80");
     }
   }
 }

--- a/spec/views/exchange_rates/_document_detail.html.erb_spec.rb
+++ b/spec/views/exchange_rates/_document_detail.html.erb_spec.rb
@@ -16,11 +16,7 @@ RSpec.describe 'exchange_rates/_document_detail', type: :view do
 
   it { is_expected.to have_link('View online', href: "/exchange_rates/view/#{period.year}-#{period.month}?type=spot") }
 
-  it 'renders the shared downloads attachment-thumb with the spreadsheet icon asset' do
-    render
-
-    expect(rendered).to have_css '.downloads .attachment-thumb img[src*="spreadsheet"]'
-  end
+  it { is_expected.to have_css '.downloads .attachment-thumb img[src*="spreadsheet"]' }
 
   it { is_expected.to have_css 'p', text: 'This file may not be suitable for users of assistive technology' }
 

--- a/spec/views/exchange_rates/_document_detail.html.erb_spec.rb
+++ b/spec/views/exchange_rates/_document_detail.html.erb_spec.rb
@@ -15,4 +15,14 @@ RSpec.describe 'exchange_rates/_document_detail', type: :view do
   it { is_expected.to have_link('CSV', href: '/exchange_rates/view/files/exrates-monthly-0623.csv', count: 2) }
 
   it { is_expected.to have_link('View online', href: "/exchange_rates/view/#{period.year}-#{period.month}?type=spot") }
+
+  it 'renders the shared downloads attachment-thumb with the spreadsheet icon asset' do
+    render
+
+    expect(rendered).to have_css '.downloads .attachment-thumb img[src*="spreadsheet"]'
+  end
+
+  it { is_expected.to have_css 'p', text: 'This file may not be suitable for users of assistive technology' }
+
+  it { is_expected.to have_css 'details', text: 'Request an accessible format.' }
 end


### PR DESCRIPTION
## What:
- [x] Replace pale `#f0f0f0` border on `.downloads .attachment-thumb` with GOV.UK-style document framing (white background, drop shadow, 5px outline)
- [x] Apply framing to both `img` and `svg` so exchange rates and help download surfaces stay consistent
- [x] Cover attachment-thumb + spreadsheet icon rendering in the exchange rates document detail view spec

## Why:
Spreadsheet/file icons on the monthly exchange rates listing (and other `.downloads .attachment-thumb` pages) looked like flat washed-out grey blocks. They used to read as proper paper documents. The old `border: 5px solid #f0f0f0` provided almost no edge against a white page; GOV.UK attachment thumbnails use a light outline plus shadow for document depth.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Static stylesheet presentation change for existing attachment thumbnails only. No layout/navigation redesign, no backend or API changes, no journey behaviour change. Shared CSS path covers all current `.downloads .attachment-thumb` surfaces consistently. Focused view specs green.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.