### PR TITLE
HMRC-2468: Fix accessible autocomplete after debounce@3 upgrade

### DIFF
--- a/app/views/shared/search/_autocomplete.html.erb
+++ b/app/views/shared/search/_autocomplete.html.erb
@@ -28,7 +28,7 @@
             tempQuery = query;
             const searchSuggestionsPath = document.querySelector('.path_info').dataset.searchSuggestionsPath;
             window.GOVUK.Utility.fetchCommoditySearchSuggestions(query, searchSuggestionsPath, [], populateResults);
-          }, 200, false),
+          }, 200, { immediate: false }),
           onConfirm: (suggestion) => {
             if (suggestion) {
               document.querySelector('#<%= input_id %>').value = suggestion

--- a/spec/views/shared/search/_search_form.html.erb_spec.rb
+++ b/spec/views/shared/search/_search_form.html.erb_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe 'shared/search/_search_form', type: :view do
     expect(rendered_form).not_to include('role="combobox"')
   end
 
+  it 'configures debounce with an options object for debounce@3 compatibility' do
+    # debounce@3 throws if the third argument is a boolean, which caused the
+    # accessible autocomplete init try/catch to fall back to a plain input.
+    expect(rendered_form).to include('}, 200, { immediate: false })')
+  end
+
   context 'when shared search button text is not used' do
     before do
       assign(:no_shared_search, true)


### PR DESCRIPTION
### What?

<img width="1072" height="646" alt="image" src="https://github.com/user-attachments/assets/ac5b0aae-074d-4295-af04-5415d52ed557" />


- [x] Pass `{ immediate: false }` to `debounce` instead of boolean `false` in commodity search autocomplete
- [x] Add a view regression check that the rendered init script uses the debounce@3 options object shape

### Why?

PR #3200 upgraded vendored `debounce` from 2.2.0 to 3.0.0. debounce@3 rejects a boolean third argument and throws:

```text
TypeError: The `options` parameter must be an object, not a boolean. Use `{immediate: true}` instead.
```

That exception is swallowed by the autocomplete `try/catch` in `_autocomplete.html.erb`, so init falls back to a plain text input with no suggestions dropdown. Confirmed on `dev.trade-tariff.service.gov.uk/find_commodity`.

Backend search suggestions are healthy; the failure is frontend init only.

### Ticket

N/A

### Risk

**Risk level:** 🟢

**Reason for rating:** One-line JS options-shape fix restoring previous autocomplete behaviour, plus a targeted view regression. No backend, routing, or data changes.