### PR TITLE
Show duty calculator for declarable headings

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -52,7 +52,7 @@ module Declarable
   end
 
   def calculate_duties?
-    no_heading? && no_entry_price_system?
+    declarable? && no_entry_price_system?
   end
 
   def critical_footnotes
@@ -99,10 +99,6 @@ module Declarable
   end
 
   private
-
-  def no_heading?
-    !heading?
-  end
 
   def no_entry_price_system?
     !entry_price_system?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -335,13 +335,22 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe '#duty_calculator_link' do
-    subject { helper.duty_calculator_link('1704909991') }
+    subject(:link) { helper.duty_calculator_link(declarable_code) }
+
+    let(:declarable_code) { '1704909991' }
 
     context 'when the service is uk' do
       include_context 'with UK service'
 
       it { is_expected.to have_css 'a', text: 'work out the duties and taxes applicable to the import of commodity 1704 9099 91' }
       it { is_expected.to have_css 'a[href="/duty-calculator/1704909991/import-date"]' }
+
+      context 'with a heading-level code' do
+        let(:declarable_code) { '1704000000' }
+
+        it { is_expected.to have_css 'a', text: 'work out the duties and taxes applicable to the import of commodity 1704 0000 00' }
+        it { is_expected.to have_css 'a[href="/duty-calculator/1704000000/import-date"]' }
+      end
     end
 
     context 'when the service is xi' do
@@ -349,6 +358,13 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       it { is_expected.to have_css 'a', text: 'work out the duties and taxes applicable to the import of commodity 1704 9099 91' }
       it { is_expected.to have_css 'a[href="/xi/duty-calculator/1704909991/import-date"]' }
+
+      context 'with a heading-level code' do
+        let(:declarable_code) { '1704000000' }
+
+        it { is_expected.to have_css 'a', text: 'work out the duties and taxes applicable to the import of commodity 1704 0000 00' }
+        it { is_expected.to have_css 'a[href="/xi/duty-calculator/1704000000/import-date"]' }
+      end
     end
   end
 end

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -48,7 +48,26 @@ RSpec.describe Heading do
   end
 
   describe '#calculate_duties?' do
-    it { is_expected.not_to be_calculate_duties }
+    context 'when the heading is declarable' do
+      before { heading.declarable = true }
+
+      it { is_expected.to be_calculate_duties }
+    end
+
+    context 'when the heading is not declarable' do
+      before { heading.declarable = false }
+
+      it { is_expected.not_to be_calculate_duties }
+    end
+
+    context 'when the heading has measures that use the Entry Price System' do
+      before do
+        heading.declarable = true
+        heading.meta = { 'duty_calculator' => { 'entry_price_system' => true } }
+      end
+
+      it { is_expected.not_to be_calculate_duties }
+    end
   end
 
   describe '#rules' do

--- a/spec/presenters/grouped_measures_presenter_spec.rb
+++ b/spec/presenters/grouped_measures_presenter_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe GroupedMeasuresPresenter do
         %w[uk_import_controls import_duties quotas trade_remedies suspensions credibility_checks vat_excise],
       )
     end
+
+    it 'shows the duty calculator in the UK import duties section when the declarable supports it' do
+      import_duties = presenter.uk_sections.find { |section| section[:css_id] == 'import_duties' }
+
+      expect(import_duties[:show_duty_calculator]).to be true
+    end
   end
 
   describe '#xi_sections' do
@@ -70,6 +76,12 @@ RSpec.describe GroupedMeasuresPresenter do
 
     it 'sorts collections by key' do
       expect(sections.first[:collection].map(&:key)).to eq(%w[a b])
+    end
+
+    it 'shows the duty calculator in the XI import duties section when the declarable supports it' do
+      import_duties = sections.find { |section| section[:css_id] == 'import_duties' }
+
+      expect(import_duties[:show_duty_calculator]).to be true
     end
   end
 

--- a/spec/views/measures/grouped/_table.html.erb_spec.rb
+++ b/spec/views/measures/grouped/_table.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe 'measures/grouped/_table', type: :view do
+  subject(:rendered_page) { render_page && rendered }
+
+  let(:render_page) do
+    render 'measures/grouped/table',
+           caption: 'Import duties',
+           collection: [],
+           css_id: 'import_duties',
+           declarable: declarable,
+           show_duty_calculator: show_duty_calculator
+  end
+
+  let(:declarable) { instance_double(Heading, code: '1704000000') }
+  let(:show_duty_calculator) { true }
+
+  it 'renders the duty calculator link when show_duty_calculator is true' do
+    expect(rendered_page).to have_css '#duty-calculator-link[href="/duty-calculator/1704000000/import-date"]',
+                                      text: 'work out the duties and taxes applicable to the import of commodity 1704 0000 00'
+  end
+
+  context 'when show_duty_calculator is false' do
+    let(:show_duty_calculator) { false }
+
+    it 'does not render the duty calculator link' do
+      expect(rendered_page).not_to have_css '#duty-calculator-link'
+    end
+  end
+end


### PR DESCRIPTION
## What:
Show the tariff duty calculator link on eligible declarable heading pages. The frontend now treats a declarable heading as calculator-eligible when the backend marks it as `declarable` and it is not excluded by Entry Price System metadata. Added model, presenter, helper, and view coverage for heading-level calculator links and excluded cases.

## Why:
Traders can land on valid declarable heading pages that already have import duties and calculator metadata. Previously, the frontend suppressed the calculator link just because the code looked like a heading, forcing users to find an artificial commodity page before calculating duties. This change gives eligible heading pages the same calculator entry point as commodity pages.

## Ticket:
[AI-984](https://transformuk.atlassian.net/browse/AI-984)

## Risk:

**Risk level:** 🟢

**Reason for rating:**
The change is narrowly scoped to the existing `calculate_duties?` eligibility check and reuses the existing presenter, view partial, link helper, and duty calculator route.
