### PR TITLE
Fix basic session password show/hide button label

### DIFF
--- a/app/views/basic_sessions/new.html.erb
+++ b/app/views/basic_sessions/new.html.erb
@@ -24,7 +24,9 @@
 
           <%= form.govuk_password_field :password,
                                         label: { text: 'Password' },
-                                        class: 'govuk-input--width-10' %>
+                                        class: 'govuk-input--width-10',
+                                        show_password_text: 'Show',
+                                        hide_password_text: 'Hide' %>
 
 
 	  <%= form.hidden_field :return_url, value: @basic_session.return_url %>

--- a/spec/views/basic_sessions/new.html.erb_spec.rb
+++ b/spec/views/basic_sessions/new.html.erb_spec.rb
@@ -18,15 +18,21 @@ RSpec.describe 'basic_sessions/new', type: :view do
   # show_password_text is passed. Without it the GOV.UK JS unhides an empty
   # secondary button (thin grey bar) because setType early-returns when the
   # input is already type=password.
+  # visible: :all / :hidden — the toggle is server-rendered with [hidden]
+  # until GOV.UK Frontend JS runs.
   it 'renders the show password toggle with visible label text' do
-    expect(rendered_page).to match(
-      %r{<button[^>]*class="[^"]*govuk-password-input__toggle[^"]*"[^>]*>\s*Show\s*</button>}m,
+    expect(rendered_page).to have_css(
+      'button.govuk-password-input__toggle',
+      text: 'Show',
+      visible: :all,
     )
   end
 
   it 'keeps the show password toggle hidden until JS initialises' do
-    expect(rendered_page).to match(
-      %r{<button[^>]*hidden="hidden"[^>]*class="[^"]*govuk-password-input__toggle[^"]*"[^>]*>\s*Show\s*</button>}m,
+    expect(rendered_page).to have_css(
+      'button.govuk-password-input__toggle[hidden]',
+      text: 'Show',
+      visible: :hidden,
     )
   end
 end

--- a/spec/views/basic_sessions/new.html.erb_spec.rb
+++ b/spec/views/basic_sessions/new.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe 'basic_sessions/new', type: :view do
+  subject(:rendered_page) { render && rendered }
+
+  before do
+    # Route is only drawn when BASIC_PASSWORD is present at boot (not in test).
+    without_partial_double_verification do
+      allow(view).to receive(:basic_sessions_path).and_return('/basic_sessions')
+    end
+
+    assign :basic_session, BasicSession.new(return_url: '/')
+  end
+
+  it { is_expected.to have_css 'h1', text: /non-production Online Trade Tariff/ }
+
+  # govuk_design_system_formbuilder only puts label text on the button when
+  # show_password_text is passed. Without it the GOV.UK JS unhides an empty
+  # secondary button (thin grey bar) because setType early-returns when the
+  # input is already type=password.
+  it 'renders the show password toggle with visible label text' do
+    expect(rendered_page).to match(
+      %r{<button[^>]*class="[^"]*govuk-password-input__toggle[^"]*"[^>]*>\s*Show\s*</button>}m,
+    )
+  end
+
+  it 'keeps the show password toggle hidden until JS initialises' do
+    expect(rendered_page).to match(
+      %r{<button[^>]*hidden="hidden"[^>]*class="[^"]*govuk-password-input__toggle[^"]*"[^>]*>\s*Show\s*</button>}m,
+    )
+  end
+end


### PR DESCRIPTION
### Jira link

<img width="1000" height="1100" alt="dev-still-broken" src="https://github.com/user-attachments/assets/3294e5d2-f381-468a-a4d2-44e1f9044cc1" />
<img width="1000" height="1100" alt="screenshot-after-local-fixed" src="https://github.com/user-attachments/assets/74925e0e-4bca-44f0-9fe4-cc514b114b84" />
N/A


### What?

- [x] Pass explicit `show_password_text` / `hide_password_text` on the non-production basic session password field
- [x] Add view coverage asserting the toggle button is rendered with `Show` text (and remains `hidden` until JS runs)

### Why?

On non-production environments the basic session login page showed a thin grey bar beside the password field instead of a **Show** button.

`govuk_password_field` was rendered without button label text. The form builder leaves the toggle button content empty when those args are omitted (the documented "Show" default is only applied to optional `data-i18n` attributes). GOV.UK Frontend JS then removes `hidden` on init, but does not set the button label when the input is already `type="password"` (early return in `setType`). Result: an empty secondary button — the thin grey strip.

### Risk

**Risk level:** 🟢

**Reason for rating:** Copy-only fix on the non-production login gate plus a view spec. No trader-facing production journey, no API or auth behaviour change beyond restoring the intended Show/Hide control label.