### PR TITLE
fix: remove html entities from exchange rate views

### DIFF
--- a/app/views/exchange_rates/_download_files.html.erb
+++ b/app/views/exchange_rates/_download_files.html.erb
@@ -1,6 +1,6 @@
 <dt class="gem-c-metadata__term">From:</dt>
 <dd class="gem-c-metadata__definition">
-  <strong><%= govuk_link_to('HM Revenue &amp; Customs', 'https://www.gov.uk/government/organisations/hm-revenue-customs') %></strong>
+  <strong><%= govuk_link_to('HM Revenue & Customs', 'https://www.gov.uk/government/organisations/hm-revenue-customs') %></strong>
 </dd>
 <dt class="gem-c-metadata__term">Published:</dt>
 <dd class="gem-c-metadata__definition"><%= @exchange_rate_collection.published_date %></dd>

--- a/app/views/exchange_rates/index.html.erb
+++ b/app/views/exchange_rates/index.html.erb
@@ -60,7 +60,7 @@
     <dt class="gem-c-metadata__term">From:</dt>
     <dd class="gem-c-metadata__definition">
       <strong>
-        <%= govuk_link_to('HM Revenue &amp; Customs', 'https://www.gov.uk/government/organisations/hm-revenue-customs') %>
+        <%= govuk_link_to('HM Revenue & Customs', 'https://www.gov.uk/government/organisations/hm-revenue-customs') %>
       </strong>
     </dd>
 


### PR DESCRIPTION
## What:
- Replace HTML ampersand (&) entities with unicode text. 

## Why:
- These are not escaped and just show the raw entity `&amp;` in live pages.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

- Fixes body copy.