### PR TITLE
BAU: Grant auto-merge access to workflow runs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,7 @@ on:
 
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
## What:

- Grant the low-risk auto-merge workflow read access to GitHub Actions workflow runs.

## Why:

- trade-tariff-tools#172 made the shared workflow validate CI against the current pull request head and declare `actions: read`.
- Reusable workflows cannot elevate permissions granted by their callers, so callers without this permission fail during workflow startup.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

This is an additive, read-only permission scoped to the auto-merge workflow. It does not change application or deployment behaviour.

## Testing:

- `actionlint .github/workflows/auto-merge.yml`
