### PR TITLE
AI-1071: Align guided search tips content

### DIFF
--- a/app/views/shared/search/_interactive_search_form.html.erb
+++ b/app/views/shared/search/_interactive_search_form.html.erb
@@ -42,8 +42,19 @@
 
       <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-guided" hidden data-interactive-search-radio-target="guidedSection">
         <%= govuk_details(summary_text: 'Tips for using guided search', classes: 'govuk-!-margin-bottom-4') do %>
-          <p>Guided search asks you questions about your product to narrow down the commodity code.</p>
-          <p>Answer each question as specifically as you can. If you are unsure, select "I don't know" and the system will show you the best results based on what you have provided.</p>
+          <p>To find a commodity code, you must specify what the item is. If the item is a gift, you must still specify the product.</p>
+          <p>Expect technical language. Commodity code descriptions can be quite formal. For example, a laptop might be described as a “Portable automatic data-processing machines, weighing not more than 10 kg, consisting of at least a central processing unit, a keyboard and a display.”</p>
+          <p>Use plain English and avoid using foreign words or special characters. The search is also unable to pick up on any spelling mistakes.</p>
+          <p>Do not enter any personal or sensitive information in your search queries.</p>
+          <p>Make sure you’re using the correct country’s classification. Commodity codes can vary between countries. Make sure you’re using the right code for the country you’re importing to or from.</p>
+          <p>If you are struggling to understand the duty you may need to pay then this guidance may help you: <%= govuk_link_to "Tax and customs for goods sent from abroad: Tax and duty - GOV.UK", "https://www.gov.uk/goods-sent-from-abroad/tax-and-duty" %></p>
+
+          <h3 class="govuk-heading-s">Steps for using guided search</h3>
+          <ol class="special-numbered-list govuk-!-margin-bottom-0">
+            <li>Give as much detail as possible about the product you’re searching for. The more detail you give, the better the search results.</li>
+            <li>To improve the search results, you might be asked some questions about the product. If you don’t want to answer these further questions, you can skip and go straight to the results.</li>
+            <li>You will be shown the best matches for your product based on the level of confidence this is what you were searching for.</li>
+          </ol>
         <% end %>
 
         <%= f.govuk_text_area :q,

--- a/spec/views/find_commodities/show_interactive.html.erb_spec.rb
+++ b/spec/views/find_commodities/show_interactive.html.erb_spec.rb
@@ -39,6 +39,21 @@ RSpec.describe 'find_commodities/show_interactive', type: :view do
     it { is_expected.to have_text('Steps for searching the tariff') }
   end
 
+  describe 'guided search tips content' do
+    it 'renders the approved guidance and steps', :aggregate_failures do
+      render
+      guided_tips = Capybara.string(rendered).find('#conditional-guided', visible: :all)
+
+      expect(guided_tips).to have_css('h3', text: 'Steps for using guided search')
+      expect(guided_tips).to have_css('.special-numbered-list li', count: 3)
+      expect(guided_tips).to have_text('Do not enter any personal or sensitive information in your search queries.')
+      expect(guided_tips).to have_link(
+        'Tax and customs for goods sent from abroad: Tax and duty - GOV.UK',
+        href: 'https://www.gov.uk/goods-sent-from-abroad/tax-and-duty',
+      )
+    end
+  end
+
   describe 'hero spimm banner' do
     it { is_expected.to have_css('.govuk-notification-banner', text: /Importing goods into Northern Ireland/) }
     it { is_expected.to have_link('Check eligibility') }


### PR DESCRIPTION
## What:

- [x] Replace the guided-search tips copy with the approved content
- [x] Add the three-step numbered guidance and GOV.UK tax-and-duty link
- [x] Add focused view coverage for the rendered guidance and structure
- [x] Verify the existing guided-search feature journey remains unchanged

Verification completed:

- `bundle exec rspec spec/views/find_commodities/show_interactive.html.erb_spec.rb spec/features/search_spec.rb` — 56 examples, 0 failures
- `pre-commit run --files app/views/shared/search/_interactive_search_form.html.erb spec/views/find_commodities/show_interactive.html.erb_spec.rb` — all applicable hooks passed
- Desktop browser evidence captured with the disclosure expanded

## Why:

The current guided-search details component contains only two short paragraphs and does not match the agreed content reference. This update gives users clearer product-description guidance, warns against entering personal or sensitive information, and explains the optional follow-up questions and confidence-ranked results.

The change preserves the existing GOV.UK details disclosure, semantic heading and ordered-list structure, radio selection, conditional reveal, validation, and submission behaviour. No backend API, environment, deployment, or JavaScript changes are required.

## Ticket:

[AI-1071](https://transformuk.atlassian.net/browse/AI-1071)

## Risk:

**Risk level:** 🟢

**Reason for rating:** This is an isolated copy and content-structure update inside an existing GOV.UK details component. It does not change search behaviour, tariff presentation, API calls, navigation, or application styling, and the relevant view and feature coverage passes.