### PR TITLE
Use preferred guided search experiment URL

### DIFF
--- a/config/experiment_urls.yml
+++ b/config/experiment_urls.yml
@@ -1,6 +1,6 @@
 shared:
   trusted_trader_guided_search:
-    path: /trusted-trader-guided-search
+    path: /guided-search-research
     feature: interactive_search
     starts_on: "2026-07-23"
     ends_on: "2026-07-31"

--- a/spec/requests/experiment_search_instrumentation_spec.rb
+++ b/spec/requests/experiment_search_instrumentation_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe 'Experiment search instrumentation', type: :request do
+  let(:experiment) { Rails.application.config.experiment_urls.fetch(:trusted_trader_guided_search) }
+
   let(:response_body) do
     {
       data: [],
@@ -24,7 +26,7 @@ RSpec.describe 'Experiment search instrumentation', type: :request do
       .to_return(status: 200, body: response_body, headers: { 'content-type' => 'application/json' })
 
     travel_to(Time.utc(2026, 7, 27, 12)) do
-      get '/trusted-trader-guided-search'
+      get experiment.path
       post '/search', params: { q: 'horses', interactive_search: 'true', experiment: 'spoofed' }
     end
 

--- a/spec/requests/experiment_urls_controller_spec.rb
+++ b/spec/requests/experiment_urls_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ExperimentUrlsController, type: :request do
 
   it 'enrols the active browser, redirects with its trusted label, and is not cacheable', :aggregate_failures do
     allow(FlagsmithClient.instance).to receive(:get_flags_for).and_call_original
-    travel_to(Time.utc(2026, 7, 27, 12)) { get '/trusted-trader-guided-search', params: { experiment: 'spoofed' } }
+    travel_to(Time.utc(2026, 7, 27, 12)) { get experiment.path, params: { experiment: 'spoofed' } }
     expect(session[:experiment_url_optins]).to eq([experiment.enrollment_token])
     expect(response).to redirect_to('/find_commodity?experiment=trstd-trdr')
     expect(response.headers.fetch('Cache-Control')).to include('no-store')
@@ -26,11 +26,11 @@ RSpec.describe ExperimentUrlsController, type: :request do
       expires_at => '/find_commodity',
     }
     cases.each do |time, location|
-      travel_to(time) { get '/trusted-trader-guided-search' }
+      travel_to(time) { get experiment.path }
       expect(response).to redirect_to(location)
       session.delete(:experiment_url_optins)
     end
-    travel_to(starts_at) { get '/xi/trusted-trader-guided-search' }
+    travel_to(starts_at) { get "/xi#{experiment.path}" }
     expect(response).to redirect_to('/xi/find_commodity')
   end
 
@@ -39,7 +39,7 @@ RSpec.describe ExperimentUrlsController, type: :request do
     storage = { experiment_url_optins: ['stale', experiment.enrollment_token, experiment.enrollment_token] }
     allow(described_class).to receive(:new).and_return(controller)
     allow(controller).to receive(:session).and_return(storage)
-    travel_to(Time.utc(2026, 7, 27, 12)) { 2.times { get '/trusted-trader-guided-search' } }
+    travel_to(Time.utc(2026, 7, 27, 12)) { 2.times { get experiment.path } }
     expect(storage[:experiment_url_optins]).to eq([experiment.enrollment_token])
   end
 
@@ -49,7 +49,7 @@ RSpec.describe ExperimentUrlsController, type: :request do
       storage = { experiment_url_optins: malformed }
       allow(described_class).to receive(:new).and_return(controller)
       allow(controller).to receive(:session).and_return(storage)
-      travel_to(Time.utc(2026, 7, 27, 12)) { get '/trusted-trader-guided-search' }
+      travel_to(Time.utc(2026, 7, 27, 12)) { get experiment.path }
       expect(storage[:experiment_url_optins]).to eq([experiment.enrollment_token])
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe ExperimentUrlsController, type: :request do
   it 'carries only a validated active label into guided search', :aggregate_failures do
     enable_feature(:interactive_search)
     travel_to(Time.utc(2026, 7, 27, 12)) do
-      get '/trusted-trader-guided-search'
+      get experiment.path
       follow_redirect!
     end
     expect(Capybara.string(response.body)).to have_css('input[name="experiment"][value="trstd-trdr"]', visible: :hidden)

--- a/spec/routing/experiment_urls_spec.rb
+++ b/spec/routing/experiment_urls_spec.rb
@@ -1,16 +1,18 @@
 require 'spec_helper'
 
 RSpec.describe 'Experiment URLs', type: :routing do
+  let(:experiment) { Rails.application.config.experiment_urls.fetch(:trusted_trader_guided_search) }
+
   it 'loads immutable exact routes after concrete application routes', :aggregate_failures do
     expect(Rails.application.config.experiment_urls).to be_frozen
-    expect(get: '/trusted-trader-guided-search').to route_to(controller: 'experiment_urls', action: 'show',
-                                                             experiment_key: 'trusted_trader_guided_search')
+    expect(get: experiment.path).to route_to(controller: 'experiment_urls', action: 'show',
+                                             experiment_key: 'trusted_trader_guided_search')
     expect(get: '/find_commodity').to route_to(controller: 'find_commodities', action: 'show')
     routes = Rails.application.routes.routes.to_a
     concrete = routes.index { |route| route.defaults[:controller] == 'find_commodities' }
-    experiment = routes.index { |route| route.defaults[:controller] == 'experiment_urls' }
-    expect(experiment).to be > concrete
-    %w[/trusted-trader-guided-search/extra /trusted-trader-guided-search.json].each do |path|
+    experiment_route = routes.index { |route| route.defaults[:controller] == 'experiment_urls' }
+    expect(experiment_route).to be > concrete
+    ["#{experiment.path}/extra", "#{experiment.path}.json"].each do |path|
       expect(get: path).not_to route_to(controller: 'experiment_urls', action: 'show',
                                         experiment_key: 'trusted_trader_guided_search')
     end


### PR DESCRIPTION
## What:

- [x] Change the trusted trader guided search experiment URL to `/guided-search-research`
- [x] Keep request, routing and instrumentation specs tied to the configured experiment path
- [x] Verify all experiment-related specs: 12 examples, 0 failures

## Why:

The preferred research URL replaces the original trusted trader path. The specs used the old path as a literal, so they no longer exercised the configured route after the URL changed. Reading the path from the experiment configuration keeps the route and its coverage in sync.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** A small configuration change with request and routing coverage. It does not change the experiment enrolment, instrumentation or redirect behaviour.