### PR TITLE
Instrument guided search journeys

### DIFF
--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -5,7 +5,7 @@ module InteractiveSearchable
 
   def perform_interactive_search
     if validate_interactive_search == :invalid
-      render_interactive_search_page
+      render_interactive_search_page(outcome: 'input_error')
       return
     end
 
@@ -17,7 +17,7 @@ module InteractiveSearchable
     sync_interactive_request_id
 
     if @search.errors.any?
-      render_interactive_search_page
+      render_interactive_search_page(outcome: 'backend_error')
       return
     end
 
@@ -151,6 +151,7 @@ module InteractiveSearchable
     disable_switch_service_banner
     disable_search_form
     mark_interactive_search_page
+    record_guided_search_journey(outcome: 'question')
     render :interactive_question
   end
 
@@ -158,6 +159,7 @@ module InteractiveSearchable
     disable_switch_service_banner
     disable_search_form
     mark_interactive_search_page
+    record_guided_search_journey(outcome: 'no_results')
     render :interactive_no_results
   end
 
@@ -165,6 +167,7 @@ module InteractiveSearchable
     disable_switch_service_banner
     disable_search_form
     mark_interactive_search_page
+    record_guided_search_journey(outcome: 'unknown_results')
     render :interactive_unknown_results
   end
 
@@ -172,6 +175,7 @@ module InteractiveSearchable
     disable_switch_service_banner
     disable_search_form
     mark_interactive_search_page
+    record_guided_search_journey(outcome: 'blocking_guidance')
     render :interactive_blocking
   end
 
@@ -179,17 +183,40 @@ module InteractiveSearchable
     disable_switch_service_banner
     disable_search_form
     mark_interactive_search_page
+    record_guided_search_journey(outcome: 'results')
     render :interactive_results
   end
 
-  def render_interactive_search_page
+  def render_interactive_search_page(outcome:)
     @no_shared_search = true
     @hero_story = nil
     @recent_stories = []
+    record_guided_search_journey(outcome:)
     render 'find_commodities/show_interactive'
   end
 
   def mark_interactive_search_page
     @interactive_search_page = true
+  end
+
+  def record_guided_search_journey(outcome:)
+    @guided_search_outcome = outcome
+    current_question = @results&.current_question
+
+    GuidedSearch::JourneyInstrumentation.record(
+      browser_session_id: guided_search_browser_session_id,
+      request_id: @search.request_id,
+      outcome:,
+      question_count: @results&.answered_questions&.size.to_i + (current_question.present? ? 1 : 0),
+      option_count: Array(current_question&.dig('options')).size,
+      result_count: @results&.size.to_i,
+      client_elapsed_ms: bounded_integer(params[:client_elapsed_ms], maximum: 86_400_000),
+      experiment: @search.experiment,
+    )
+  end
+
+  def guided_search_browser_session_id
+    raw_id = session[:guided_search_browser_session_id] ||= SecureRandom.uuid
+    GuidedSearch::JourneyInstrumentation.browser_session_id(raw_id)
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -122,7 +122,7 @@ class SearchController < ApplicationController
     when 'result_selected'
       goods_nomenclature_item_id = event[:goods_nomenclature_item_id].to_s[/\A\d{10}\z/]
       result_rank = bounded_integer(event[:result_rank], maximum: 100)
-      confidence = event[:confidence].to_s[/\A(strong|good|possible|unlikely|unknown)\z/]
+      confidence = event[:confidence].to_s.downcase[/\A(strong|good|possible|unlikely|unknown)\z/]
       return if [goods_nomenclature_item_id, result_rank, confidence].any?(&:nil?)
 
       {
@@ -147,7 +147,8 @@ class SearchController < ApplicationController
   end
 
   def safe_guided_search_identifier(value)
-    value.to_s.match?(/\A[a-zA-Z0-9-]{1,64}\z/) ? value : nil
+    identifier = value.to_s
+    identifier.match?(/\A[a-zA-Z0-9-]{1,64}\z/) ? identifier : nil
   end
 
   def bounded_integer(value, maximum:)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,7 +16,11 @@ class SearchController < ApplicationController
     @search.q = params[:q] if params[:q]
     @search.interactive_search = params[:interactive_search] == 'true'
     @search.answers = params[:answers] if params[:answers].present?
-    @search.request_id = params[:request_id].presence || SecureRandom.uuid
+    @search.request_id = if @search.interactive_search
+                           safe_guided_search_identifier(params[:request_id]) || SecureRandom.uuid
+                         else
+                           params[:request_id].presence || SecureRandom.uuid
+                         end
     @search.expanded_query = params[:expanded_query].presence
 
     if interactive_search?
@@ -48,6 +52,22 @@ class SearchController < ApplicationController
     render_suggestions(parsed.map { |attrs| SearchSuggestion.new(attrs) })
   end
 
+  def journey_event
+    event = guided_search_event_params
+    event_attributes = guided_search_event_attributes(event)
+    request_id = safe_guided_search_identifier(event[:request_id])
+    return head :unprocessable_content if event_attributes.nil? || request_id.nil?
+
+    GuidedSearch::JourneyInstrumentation.record(
+      browser_session_id: guided_search_browser_session_id,
+      request_id:,
+      experiment: Current.experiment,
+      **event_attributes,
+    )
+
+    head :no_content
+  end
+
   def quota_search
     if TradeTariffFrontend::ServiceChooser.xi?
       raise TradeTariffFrontend::FeatureUnavailable
@@ -71,6 +91,68 @@ class SearchController < ApplicationController
   end
 
   private
+
+  def guided_search_event_params
+    params.permit(
+      :event_type,
+      :request_id,
+      :question_number,
+      :client_elapsed_ms,
+      :goods_nomenclature_item_id,
+      :result_rank,
+      :confidence,
+      :destination,
+      :client_navigation_ms,
+    )
+  end
+
+  def guided_search_event_attributes(event)
+    case event[:event_type]
+    when 'dont_know'
+      question_count = bounded_integer(event[:question_number], maximum: 100)
+      client_elapsed_ms = bounded_integer(event[:client_elapsed_ms], maximum: 86_400_000)
+      return if question_count.nil? || client_elapsed_ms.nil?
+
+      {
+        outcome: 'dont_know',
+        used_dont_know: true,
+        question_count:,
+        client_elapsed_ms:,
+      }
+    when 'result_selected'
+      goods_nomenclature_item_id = event[:goods_nomenclature_item_id].to_s[/\A\d{10}\z/]
+      result_rank = bounded_integer(event[:result_rank], maximum: 100)
+      confidence = event[:confidence].to_s[/\A(strong|good|possible|unlikely|unknown)\z/]
+      return if [goods_nomenclature_item_id, result_rank, confidence].any?(&:nil?)
+
+      {
+        outcome: 'result_selected',
+        goods_nomenclature_item_id:,
+        result_rank:,
+        confidence:,
+      }
+    when 'page_visible'
+      destination = event[:destination].to_s[
+        /\A(question|results|no_results|unknown_results|blocking_guidance|input_error|backend_error)\z/,
+      ]
+      client_navigation_ms = bounded_integer(event[:client_navigation_ms], maximum: 86_400_000)
+      return if destination.nil? || client_navigation_ms.nil?
+
+      {
+        outcome: 'page_visible',
+        destination:,
+        client_navigation_ms:,
+      }
+    end
+  end
+
+  def safe_guided_search_identifier(value)
+    value.to_s.match?(/\A[a-zA-Z0-9-]{1,64}\z/) ? value : nil
+  end
+
+  def bounded_integer(value, maximum:)
+    Integer(value, exception: false)&.clamp(0, maximum)
+  end
 
   def render_suggestions(suggestions)
     results = suggestions.map do |s|

--- a/app/javascript/controllers/guided_search_page_controller.js
+++ b/app/javascript/controllers/guided_search_page_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static values = {
+    eventUrl: String,
+    outcome: String,
+    requestId: String,
+  }
+
+  connect() {
+    const submittedAt = Number(window.sessionStorage.getItem('guidedSearchSubmittedAt'))
+    if (!Number.isFinite(submittedAt) || submittedAt <= 0 || !this.hasEventUrlValue) return
+
+    window.sessionStorage.removeItem('guidedSearchSubmittedAt')
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+    window.fetch(this.eventUrlValue, {
+      method: 'POST',
+      keepalive: true,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken,
+      },
+      body: JSON.stringify({
+        event_type: 'page_visible',
+        request_id: this.requestIdValue,
+        destination: this.outcomeValue,
+        client_navigation_ms: Math.max(0, Math.round(Date.now() - submittedAt)),
+      }),
+    }).catch(() => {})
+  }
+}

--- a/app/javascript/controllers/guided_search_result_controller.js
+++ b/app/javascript/controllers/guided_search_result_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
 
   select() {
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+    const confidence = this.hasConfidenceValue ? this.confidenceValue.toLowerCase() : 'unknown'
 
     window.fetch(this.eventUrlValue, {
       method: 'POST',
@@ -24,7 +25,7 @@ export default class extends Controller {
         request_id: this.requestIdValue,
         goods_nomenclature_item_id: this.goodsNomenclatureItemIdValue,
         result_rank: this.rankValue,
-        confidence: this.confidenceValue,
+        confidence,
       }),
     }).catch(() => {})
   }

--- a/app/javascript/controllers/guided_search_result_controller.js
+++ b/app/javascript/controllers/guided_search_result_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static values = {
+    confidence: String,
+    eventUrl: String,
+    goodsNomenclatureItemId: String,
+    rank: Number,
+    requestId: String,
+  }
+
+  select() {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+
+    window.fetch(this.eventUrlValue, {
+      method: 'POST',
+      keepalive: true,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken,
+      },
+      body: JSON.stringify({
+        event_type: 'result_selected',
+        request_id: this.requestIdValue,
+        goods_nomenclature_item_id: this.goodsNomenclatureItemIdValue,
+        result_rank: this.rankValue,
+        confidence: this.confidenceValue,
+      }),
+    }).catch(() => {})
+  }
+}

--- a/app/javascript/controllers/guided_search_validation_controller.js
+++ b/app/javascript/controllers/guided_search_validation_controller.js
@@ -19,6 +19,7 @@ export default class extends Controller {
     if (errors.length > 0) {
       this.#showErrors(errors)
     } else {
+      window.sessionStorage.setItem('guidedSearchSubmittedAt', Date.now().toString())
       this.#showThrobber()
       this.#submitForm(event.target.closest('form'))
     }

--- a/app/javascript/controllers/interactive_question_controller.js
+++ b/app/javascript/controllers/interactive_question_controller.js
@@ -2,14 +2,27 @@ import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
   static targets = ['pageHeader', 'header', 'form', 'dontKnow', 'thinking']
+  static values = {
+    eventUrl: String,
+    questionNumber: Number,
+    requestId: String,
+  }
+
+  connect() {
+    this.questionShownAt = performance.now()
+  }
 
   submitWithThinking(event) {
     event.preventDefault()
 
     if (this.#isUnknownAnswer(event.currentTarget)) {
+      this.#recordDontKnow()
       this.#showDontKnow()
       return
     }
+
+    this.#addElapsedTime(event.currentTarget)
+    window.sessionStorage.setItem('guidedSearchSubmittedAt', Date.now().toString())
 
     if (this.hasPageHeaderTarget) {
       this.pageHeaderTarget.classList.add('govuk-!-display-none')
@@ -63,5 +76,37 @@ export default class extends Controller {
 
   #submitForm(form) {
     window.setTimeout(() => HTMLFormElement.prototype.submit.call(form), 0)
+  }
+
+  #recordDontKnow() {
+    if (!this.hasEventUrlValue) return
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+    window.fetch(this.eventUrlValue, {
+      method: 'POST',
+      keepalive: true,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken,
+      },
+      body: JSON.stringify({
+        event_type: 'dont_know',
+        request_id: this.requestIdValue,
+        question_number: this.questionNumberValue,
+        client_elapsed_ms: this.#clientElapsedMs(),
+      }),
+    }).catch(() => {})
+  }
+
+  #addElapsedTime(form) {
+    const input = form.querySelector('input[name="client_elapsed_ms"]') || document.createElement('input')
+    input.type = 'hidden'
+    input.name = 'client_elapsed_ms'
+    input.value = this.#clientElapsedMs()
+    if (!input.parentNode) form.appendChild(input)
+  }
+
+  #clientElapsedMs() {
+    return Math.max(0, Math.round(performance.now() - this.questionShownAt))
   }
 }

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -159,7 +159,7 @@ class Search
   end
 
   def interactive_search_cache_key
-    digest = Digest::SHA256.hexdigest(MultiJson.dump({ q:, answers:, as_of: date.to_fs(:db), expanded_query:, experiment: }))
+    digest = Digest::SHA256.hexdigest(MultiJson.dump({ q:, answers:, as_of: date.to_fs(:db), expanded_query:, experiment:, request_id: }))
     "interactive_search/#{digest}"
   end
 end

--- a/app/services/guided_search/journey_instrumentation.rb
+++ b/app/services/guided_search/journey_instrumentation.rb
@@ -1,0 +1,20 @@
+module GuidedSearch
+  class JourneyInstrumentation
+    EVENT_NAME = 'guided_search.journey'.freeze
+    SCHEMA_VERSION = 1
+
+    class << self
+      def record(**attributes)
+        payload = { schema_version: SCHEMA_VERSION, **attributes }.compact
+
+        ActiveSupport::Notifications.instrument(EVENT_NAME, payload)
+        Rails.logger.info({ event: EVENT_NAME, **payload }.to_json)
+      end
+
+      def browser_session_id(raw_id)
+        digest = OpenSSL::HMAC.hexdigest('SHA256', Rails.application.secret_key_base, raw_id)
+        "v1:#{digest}"
+      end
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -80,6 +80,7 @@
 
     <main id="content" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing govuk-!-padding-top-7" role="main">
       <%= render 'shared/flashes' %>
+      <%= render 'search/interactive_page_tracking' if @guided_search_outcome.present? %>
       <%= yield :before_main_content %>
 
       <%= render 'shared/search/search_form' unless @no_shared_search %>

--- a/app/views/search/_interactive_page_tracking.html.erb
+++ b/app/views/search/_interactive_page_tracking.html.erb
@@ -1,0 +1,4 @@
+<div data-controller="guided-search-page"
+     data-guided-search-page-event-url-value="<%= guided_search_event_path(day: nil, month: nil, year: nil) %>"
+     data-guided-search-page-request-id-value="<%= @search.request_id %>"
+     data-guided-search-page-outcome-value="<%= @guided_search_outcome %>"></div>

--- a/app/views/search/_interactive_result.html.erb
+++ b/app/views/search/_interactive_result.html.erb
@@ -8,6 +8,15 @@
     </p>
     <%= govuk_link_to "View this commodity code",
         commodity_path(result.goods_nomenclature_item_id, request_id: @search.request_id),
+        data: {
+          controller: 'guided-search-result',
+          action: 'click->guided-search-result#select',
+          guided_search_result_event_url_value: guided_search_event_path(day: nil, month: nil, year: nil),
+          guided_search_result_request_id_value: @search.request_id,
+          guided_search_result_goods_nomenclature_item_id_value: result.goods_nomenclature_item_id,
+          guided_search_result_rank_value: rank,
+          guided_search_result_confidence_value: result.try(:confidence),
+        },
         new_tab: true %>
   </div>
   <div class="interactive-result__confidence">

--- a/app/views/search/_interactive_result.html.erb
+++ b/app/views/search/_interactive_result.html.erb
@@ -15,7 +15,7 @@
           guided_search_result_request_id_value: @search.request_id,
           guided_search_result_goods_nomenclature_item_id_value: result.goods_nomenclature_item_id,
           guided_search_result_rank_value: rank,
-          guided_search_result_confidence_value: result.try(:confidence),
+          guided_search_result_confidence_value: result.try(:confidence).to_s.downcase.presence || 'unknown',
         },
         new_tab: true %>
   </div>

--- a/app/views/search/_interactive_results_content.html.erb
+++ b/app/views/search/_interactive_results_content.html.erb
@@ -38,7 +38,7 @@
 
     <div class="interactive-results">
       <% strong_results.each do |result| %>
-        <%= render 'search/interactive_result', result: result %>
+        <%= render 'search/interactive_result', result: result, rank: display_results.index(result) + 1 %>
       <% end %>
 
       <% if strong_results.any? && other_results.any? %>
@@ -46,7 +46,7 @@
       <% end %>
 
       <% other_results.each do |result| %>
-        <%= render 'search/interactive_result', result: result %>
+        <%= render 'search/interactive_result', result: result, rank: display_results.index(result) + 1 %>
       <% end %>
     </div>
 

--- a/app/views/search/_interactive_results_content.html.erb
+++ b/app/views/search/_interactive_results_content.html.erb
@@ -33,12 +33,13 @@
     <% display_results = @results.result_limit.zero? ? @results.all : @results.all.first(@results.result_limit) %>
     <% strong_results, other_results = display_results.partition { |result| result.try(:confidence).to_s.casecmp('strong').zero? } %>
     <% top_result_count = strong_results.any? ? strong_results.size : display_results.size %>
+    <% result_ranks = display_results.each_with_index.to_h { |result, index| [result.object_id, index + 1] } %>
 
     <h2 class="interactive-results__section-heading govuk-heading-m">Top search <%= 'result'.pluralize(top_result_count) %></h2>
 
     <div class="interactive-results">
       <% strong_results.each do |result| %>
-        <%= render 'search/interactive_result', result: result, rank: display_results.index(result) + 1 %>
+        <%= render 'search/interactive_result', result: result, rank: result_ranks.fetch(result.object_id) %>
       <% end %>
 
       <% if strong_results.any? && other_results.any? %>
@@ -46,7 +47,7 @@
       <% end %>
 
       <% other_results.each do |result| %>
-        <%= render 'search/interactive_result', result: result, rank: display_results.index(result) + 1 %>
+        <%= render 'search/interactive_result', result: result, rank: result_ranks.fetch(result.object_id) %>
       <% end %>
     </div>
 

--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -2,7 +2,10 @@
   <%= generate_breadcrumbs "Search", [["Home", home_path]] %>
 <% end %>
 
-<div data-controller="interactive-question">
+<div data-controller="interactive-question"
+     data-interactive-question-event-url-value="<%= guided_search_event_path(day: nil, month: nil, year: nil) %>"
+     data-interactive-question-request-id-value="<%= @search.request_id %>"
+     data-interactive-question-question-number-value="<%= @results.answered_questions.size + 1 %>">
   <div data-interactive-question-target="pageHeader">
     <%= page_header %>
   </div>

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -842,6 +842,7 @@ Search::Outcome#reference_match=
 Search::Outcome#type=
 SearchController#chemical_search
 SearchController#interactive_suggestions
+SearchController#journey_event
 SearchReference#id=
 SearchReference#productline_suffix
 SearchReference#productline_suffix=

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,7 @@ Rails.application.routes.draw do
   end
 
   match '/search', as: :perform_search, via: %i[get post], to: 'search#search'
+  post '/search/guided-search-event', to: 'search#journey_event', as: :guided_search_event
 
   scope constraints: ->(_req) { TradeTariffFrontend::ServiceChooser.uk? } do
     get 'exchange_rates(/:type)', to: 'exchange_rates#index', as: 'exchange_rates'

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -352,9 +352,7 @@ RSpec.describe SearchController, type: :controller do
         before { do_response }
 
         it 'records the input page as an error outcome' do
-          expect(journey_events).to contain_exactly(
-            hash_including(outcome: 'input_error', request_id: 'invalid-input-journey', result_count: 0),
-          )
+          expect(journey_events).to contain_exactly(hash_including(outcome: 'input_error', request_id: 'invalid-input-journey', result_count: 0))
         end
       end
 
@@ -457,9 +455,7 @@ RSpec.describe SearchController, type: :controller do
         it { expect(assigns(:results).all).to contain_exactly(an_object_having_attributes(goods_nomenclature_item_id: '0101210000')) }
 
         it 'records the results page as a frontend journey outcome' do
-          expect(journey_events).to contain_exactly(
-            hash_including(outcome: 'results', request_id: 'abc-123', result_count: 1),
-          )
+          expect(journey_events).to contain_exactly(hash_including(outcome: 'results', request_id: 'abc-123', result_count: 1))
         end
       end
 
@@ -506,11 +502,7 @@ RSpec.describe SearchController, type: :controller do
 
         it 'records how long the presented question was visible before submission' do
           expect(journey_events).to contain_exactly(
-            hash_including(
-              outcome: 'results',
-              request_id: 'abc-123',
-              client_elapsed_ms: 3210,
-            ),
+            hash_including(outcome: 'results', request_id: 'abc-123', client_elapsed_ms: 3210),
           )
         end
 
@@ -601,9 +593,7 @@ RSpec.describe SearchController, type: :controller do
         it { expect(response.body).to include('Search cannot suggest a code') }
 
         it 'records the unknown-results page as a frontend journey outcome' do
-          expect(journey_events).to contain_exactly(
-            hash_including(outcome: 'unknown_results', request_id: 'abc-123', result_count: 1),
-          )
+          expect(journey_events).to contain_exactly(hash_including(outcome: 'unknown_results', request_id: 'abc-123', result_count: 1))
         end
       end
 
@@ -694,9 +684,7 @@ RSpec.describe SearchController, type: :controller do
         it { expect(response.body).not_to include('app-section-break--thick') }
 
         it 'records the blocking-guidance page as a frontend journey outcome' do
-          expect(journey_events).to contain_exactly(
-            hash_including(outcome: 'blocking_guidance', request_id: 'stable-request-id', result_count: 0),
-          )
+          expect(journey_events).to contain_exactly(hash_including(outcome: 'blocking_guidance', request_id: 'stable-request-id', result_count: 0))
         end
       end
 
@@ -728,9 +716,7 @@ RSpec.describe SearchController, type: :controller do
         it { expect(response.body).to include('No search results could be found') }
 
         it 'records the no-results page as a frontend journey outcome' do
-          expect(journey_events).to contain_exactly(
-            hash_including(outcome: 'no_results', request_id: 'abc-123', result_count: 0),
-          )
+          expect(journey_events).to contain_exactly(hash_including(outcome: 'no_results', request_id: 'abc-123', result_count: 0))
         end
       end
     end

--- a/spec/controllers/search_controller_search_spec.rb
+++ b/spec/controllers/search_controller_search_spec.rb
@@ -315,6 +315,7 @@ RSpec.describe SearchController, type: :controller do
     context 'with internal interactive search via POST' do
       subject(:do_response) { post :search, params: }
 
+      let(:journey_events) { [] }
       let(:commodity_data) do
         {
           'id' => '123',
@@ -332,8 +333,45 @@ RSpec.describe SearchController, type: :controller do
         }
       end
 
+      around do |example|
+        subscriber = ActiveSupport::Notifications.subscribe('guided_search.journey') do |*args|
+          journey_events << ActiveSupport::Notifications::Event.new(*args).payload
+        end
+        example.run
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
       before do
         enable_feature(:interactive_search)
+      end
+
+      context 'when the guided search input is invalid' do
+        let(:params) { { q: '', interactive_search: 'true', request_id: 'invalid-input-journey' } }
+
+        before { do_response }
+
+        it 'records the input page as an error outcome' do
+          expect(journey_events).to contain_exactly(
+            hash_including(outcome: 'input_error', request_id: 'invalid-input-journey', result_count: 0),
+          )
+        end
+      end
+
+      context 'when the guided search journey identifier is invalid' do
+        let(:params) { { q: '', interactive_search: 'true', request_id: 'raw private text!' } }
+
+        before { do_response }
+
+        it 'replaces it before recording frontend telemetry', :aggregate_failures do
+          expect(journey_events).to contain_exactly(
+            hash_including(
+              outcome: 'input_error',
+              request_id: a_string_matching(/\A[0-9a-f-]{36}\z/),
+            ),
+          )
+          expect(journey_events.to_json).not_to include('raw private text')
+        end
       end
 
       context 'when backend returns a pending question' do
@@ -362,6 +400,20 @@ RSpec.describe SearchController, type: :controller do
 
         it { is_expected.to have_http_status(:ok) }
         it { is_expected.to render_template(:interactive_question) }
+
+        it 'records the question page as a frontend journey outcome' do
+          expect(journey_events).to contain_exactly(
+            hash_including(
+              schema_version: 1,
+              outcome: 'question',
+              request_id: 'abc-123',
+              browser_session_id: a_string_starting_with('v1:'),
+              question_count: 1,
+              option_count: 2,
+              result_count: 1,
+            ),
+          )
+        end
       end
 
       context 'when backend returns a single exact match' do
@@ -403,15 +455,24 @@ RSpec.describe SearchController, type: :controller do
         it { is_expected.to have_http_status(:ok) }
         it { is_expected.to render_template(:interactive_results) }
         it { expect(assigns(:results).all).to contain_exactly(an_object_having_attributes(goods_nomenclature_item_id: '0101210000')) }
+
+        it 'records the results page as a frontend journey outcome' do
+          expect(journey_events).to contain_exactly(
+            hash_including(outcome: 'results', request_id: 'abc-123', result_count: 1),
+          )
+        end
       end
 
       context 'when all questions are answered' do
+        render_views
+
         let(:params) do
           {
             q: 'horses',
             expanded_query: 'pure-bred breeding horses',
             interactive_search: 'true',
             request_id: 'abc-123',
+            client_elapsed_ms: '3210',
             answers: [
               { question: 'What type of horse?', options: %w[Racing Breeding], answer: 'Breeding' },
             ],
@@ -442,6 +503,25 @@ RSpec.describe SearchController, type: :controller do
         it { is_expected.to have_http_status(:ok) }
         it { is_expected.to render_template(:interactive_results) }
         it { expect(assigns(:search).expanded_query).to eq('pure-bred breeding horses') }
+
+        it 'records how long the presented question was visible before submission' do
+          expect(journey_events).to contain_exactly(
+            hash_including(
+              outcome: 'results',
+              request_id: 'abc-123',
+              client_elapsed_ms: 3210,
+            ),
+          )
+        end
+
+        it 'adds journey, rank, and confidence metadata to the displayed result link', :aggregate_failures do
+          link = Capybara.string(response.body).find_link('View this commodity code')
+
+          expect(link['data-controller']).to eq('guided-search-result')
+          expect(link['data-guided-search-result-request-id-value']).to eq('abc-123')
+          expect(link['data-guided-search-result-rank-value']).to eq('1')
+          expect(link['data-guided-search-result-confidence-value']).to eq('strong')
+        end
       end
 
       context 'when answer validation fails after query expansion' do
@@ -519,6 +599,12 @@ RSpec.describe SearchController, type: :controller do
         it { is_expected.to have_http_status(:ok) }
         it { is_expected.to render_template(:interactive_unknown_results) }
         it { expect(response.body).to include('Search cannot suggest a code') }
+
+        it 'records the unknown-results page as a frontend journey outcome' do
+          expect(journey_events).to contain_exactly(
+            hash_including(outcome: 'unknown_results', request_id: 'abc-123', result_count: 1),
+          )
+        end
       end
 
       context 'when backend returns a blocking description intercept' do
@@ -592,7 +678,13 @@ RSpec.describe SearchController, type: :controller do
         it { expect(response.body).to include('Example guidance header') }
         it { expect(response.body).to include('Example guidance message body') }
         it { expect(response.body).to include('<strong>stable-request-id</strong>') }
-        it { expect(response.body).not_to include('generated-request-id') }
+
+        it do
+          message = Capybara.string(response.body).find('p.govuk-body', text: 'Example guidance message body')
+
+          expect(message).not_to have_text('generated-request-id')
+        end
+
         it { expect(response.body).to include('classification.enquiries@hmrc.gov.uk') }
         it { expect(response.body).to include('href="https://example.com/webchat"') }
         it { expect(response.body).to include('exampleterm') }
@@ -600,6 +692,12 @@ RSpec.describe SearchController, type: :controller do
         it { expect(Capybara.string(response.body).find('.govuk-inset-text')).not_to have_text('canonical intercept term') }
         it { expect(response.body).not_to include('style=') }
         it { expect(response.body).not_to include('app-section-break--thick') }
+
+        it 'records the blocking-guidance page as a frontend journey outcome' do
+          expect(journey_events).to contain_exactly(
+            hash_including(outcome: 'blocking_guidance', request_id: 'stable-request-id', result_count: 0),
+          )
+        end
       end
 
       context 'when backend returns no results' do
@@ -628,6 +726,12 @@ RSpec.describe SearchController, type: :controller do
         it { is_expected.to have_http_status(:ok) }
         it { is_expected.to render_template(:interactive_no_results) }
         it { expect(response.body).to include('No search results could be found') }
+
+        it 'records the no-results page as a frontend journey outcome' do
+          expect(journey_events).to contain_exactly(
+            hash_including(outcome: 'no_results', request_id: 'abc-123', result_count: 0),
+          )
+        end
       end
     end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -206,6 +206,13 @@ RSpec.describe 'Search', :js do
 
         expect(page).to have_css('h1', text: 'Search for a commodity')
         expect(page).to have_content('What type of fish?')
+        journey = page.find('[data-controller="interactive-question"]')
+        expect(journey['data-interactive-question-event-url-value']).to eq(guided_search_event_path)
+        expect(journey['data-interactive-question-request-id-value']).to eq('guided-request-123')
+        expect(journey['data-interactive-question-question-number-value']).to eq('1')
+        page_tracker = page.find('[data-controller="guided-search-page"]')
+        expect(page_tracker['data-guided-search-page-request-id-value']).to eq('guided-request-123')
+        expect(page_tracker['data-guided-search-page-outcome-value']).to eq('question')
 
         choose 'Haddock'
         click_button 'Submit'

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -206,13 +206,8 @@ RSpec.describe 'Search', :js do
 
         expect(page).to have_css('h1', text: 'Search for a commodity')
         expect(page).to have_content('What type of fish?')
-        journey = page.find('[data-controller="interactive-question"]')
-        expect(journey['data-interactive-question-event-url-value']).to eq(guided_search_event_path)
-        expect(journey['data-interactive-question-request-id-value']).to eq('guided-request-123')
-        expect(journey['data-interactive-question-question-number-value']).to eq('1')
-        page_tracker = page.find('[data-controller="guided-search-page"]')
-        expect(page_tracker['data-guided-search-page-request-id-value']).to eq('guided-request-123')
-        expect(page_tracker['data-guided-search-page-outcome-value']).to eq('question')
+        expect(page).to have_css('[data-controller="interactive-question"][data-interactive-question-request-id-value="guided-request-123"]')
+        expect(page).to have_css('[data-controller="guided-search-page"][data-guided-search-page-outcome-value="question"]')
 
         choose 'Haddock'
         click_button 'Submit'

--- a/spec/javascript/controllers/guided_search_page_controller_spec.js
+++ b/spec/javascript/controllers/guided_search_page_controller_spec.js
@@ -1,0 +1,47 @@
+import {Application} from '@hotwired/stimulus';
+import GuidedSearchPageController from '../../../app/javascript/controllers/guided_search_page_controller';
+
+describe('GuidedSearchPageController', () => {
+  let application;
+
+  beforeEach(() => {
+    document.head.innerHTML = '<meta name="csrf-token" content="csrf-token-123">';
+    document.body.innerHTML = `
+      <div data-controller="guided-search-page"
+           data-guided-search-page-event-url-value="/search/guided-search-event"
+           data-guided-search-page-request-id-value="request-123"
+           data-guided-search-page-outcome-value="question"></div>
+    `;
+    window.fetch = jest.fn().mockResolvedValue({ok: true});
+    window.sessionStorage.setItem('guidedSearchSubmittedAt', '3766');
+    jest.spyOn(Date, 'now').mockReturnValue(5000);
+  });
+
+  afterEach(() => {
+    if (application) application.stop();
+    window.sessionStorage.clear();
+    delete window.fetch;
+    jest.restoreAllMocks();
+  });
+
+  it('records submit-to-visible timing once the destination page connects', async () => {
+    application = Application.start();
+    application.register('guided-search-page', GuidedSearchPageController);
+    await Promise.resolve();
+
+    expect(window.fetch).toHaveBeenCalledWith(
+      '/search/guided-search-event',
+      expect.objectContaining({
+        method: 'POST',
+        keepalive: true,
+        body: JSON.stringify({
+          event_type: 'page_visible',
+          request_id: 'request-123',
+          destination: 'question',
+          client_navigation_ms: 1234,
+        }),
+      }),
+    );
+    expect(window.sessionStorage.getItem('guidedSearchSubmittedAt')).toBeNull();
+  });
+});

--- a/spec/javascript/controllers/guided_search_result_controller_spec.js
+++ b/spec/javascript/controllers/guided_search_result_controller_spec.js
@@ -14,7 +14,7 @@ describe('GuidedSearchResultController', () => {
          data-guided-search-result-request-id-value="request-123"
          data-guided-search-result-goods-nomenclature-item-id-value="2007919930"
          data-guided-search-result-rank-value="2"
-         data-guided-search-result-confidence-value="good">
+         data-guided-search-result-confidence-value="Good">
         View this commodity code
       </a>
     `;

--- a/spec/javascript/controllers/guided_search_result_controller_spec.js
+++ b/spec/javascript/controllers/guided_search_result_controller_spec.js
@@ -1,0 +1,54 @@
+import {Application} from '@hotwired/stimulus';
+import GuidedSearchResultController from '../../../app/javascript/controllers/guided_search_result_controller';
+
+describe('GuidedSearchResultController', () => {
+  let application;
+
+  beforeEach(() => {
+    document.head.innerHTML = '<meta name="csrf-token" content="csrf-token-123">';
+    document.body.innerHTML = `
+      <a href="/commodities/2007919930?request_id=request-123"
+         data-controller="guided-search-result"
+         data-action="click->guided-search-result#select"
+         data-guided-search-result-event-url-value="/search/guided-search-event"
+         data-guided-search-result-request-id-value="request-123"
+         data-guided-search-result-goods-nomenclature-item-id-value="2007919930"
+         data-guided-search-result-rank-value="2"
+         data-guided-search-result-confidence-value="good">
+        View this commodity code
+      </a>
+    `;
+    window.fetch = jest.fn().mockResolvedValue({ok: true});
+
+    application = Application.start();
+    application.register('guided-search-result', GuidedSearchResultController);
+  });
+
+  afterEach(() => {
+    application.stop();
+    delete window.fetch;
+  });
+
+  it('records rank and confidence without preventing navigation', () => {
+    const link = document.querySelector('a');
+    const event = new MouseEvent('click', {bubbles: true, cancelable: true});
+
+    link.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(window.fetch).toHaveBeenCalledWith(
+      '/search/guided-search-event',
+      expect.objectContaining({
+        method: 'POST',
+        keepalive: true,
+        body: JSON.stringify({
+          event_type: 'result_selected',
+          request_id: 'request-123',
+          goods_nomenclature_item_id: '2007919930',
+          result_rank: 2,
+          confidence: 'good',
+        }),
+      }),
+    );
+  });
+});

--- a/spec/javascript/controllers/guided_search_validation_controller_spec.js
+++ b/spec/javascript/controllers/guided_search_validation_controller_spec.js
@@ -88,6 +88,7 @@ describe('GuidedSearchValidationController', () => {
   }
 
   beforeEach(() => {
+    window.sessionStorage.clear();
     submitSpy = jest.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation(() => {});
     setTimeoutSpy = jest.spyOn(window, 'setTimeout').mockImplementation(() => {});
     scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
@@ -306,6 +307,7 @@ describe('GuidedSearchValidationController', () => {
       await setup({textareaValue: 'televisions'});
       const form = submitForm();
 
+      expect(Number(window.sessionStorage.getItem('guidedSearchSubmittedAt'))).toBeGreaterThan(0);
       window.setTimeout.mock.calls[0][0]();
 
       expect(submitSpy).toHaveBeenCalledWith();

--- a/spec/javascript/controllers/interactive_question_controller_spec.js
+++ b/spec/javascript/controllers/interactive_question_controller_spec.js
@@ -5,9 +5,15 @@ describe('InteractiveQuestionController', () => {
   let application;
 
   beforeEach(() => {
+    window.sessionStorage.clear();
+    document.head.innerHTML = '<meta name="csrf-token" content="csrf-token-123">';
+    window.fetch = jest.fn().mockResolvedValue({ok: true});
     document.body.innerHTML = `
       <main id="content">
-      <div data-controller="interactive-question">
+      <div data-controller="interactive-question"
+           data-interactive-question-event-url-value="/search/guided-search-event"
+           data-interactive-question-request-id-value="request-123"
+           data-interactive-question-question-number-value="2">
         <div data-interactive-question-target="pageHeader" id="page-header">
           <span>UK Integrated Online Tariff</span>
         </div>
@@ -42,6 +48,8 @@ describe('InteractiveQuestionController', () => {
   afterEach(() => {
     application.stop();
     jest.useRealTimers();
+    jest.restoreAllMocks();
+    delete window.fetch;
   });
 
   describe('selecting the unknown option', () => {
@@ -136,13 +144,16 @@ describe('InteractiveQuestionController', () => {
       formEl.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
 
       expect(submitSpy).not.toHaveBeenCalled();
+      expect(formEl.querySelector('input[name="client_elapsed_ms"]').value).toMatch(/^\d+$/);
+      expect(Number(window.sessionStorage.getItem('guidedSearchSubmittedAt'))).toBeGreaterThan(0);
 
       jest.runOnlyPendingTimers();
 
       expect(submitSpy).toHaveBeenCalledWith();
     });
 
-    it('shows the dont know page after the unknown answer is submitted without fetching', () => {
+    it('records the unknown answer before showing the dont know page', () => {
+      const fetchSpy = window.fetch.mockResolvedValue({ok: true});
       const header = document.querySelector('#header');
       const form = document.querySelector('#form');
       const thinking = document.querySelector('#thinking');
@@ -158,6 +169,24 @@ describe('InteractiveQuestionController', () => {
       expect(thinking.classList.contains('govuk-!-display-none')).toBe(true);
       expect(dontKnow.classList.contains('govuk-!-display-none')).toBe(false);
       expect(submitSpy).not.toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/search/guided-search-event',
+        expect.objectContaining({
+          method: 'POST',
+          keepalive: true,
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': 'csrf-token-123',
+          },
+          body: expect.any(String),
+        }),
+      );
+      expect(JSON.parse(fetchSpy.mock.calls[0][1].body)).toEqual({
+        event_type: 'dont_know',
+        request_id: 'request-123',
+        question_number: 2,
+        client_elapsed_ms: expect.any(Number),
+      });
     });
   });
 });

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -353,6 +353,22 @@ RSpec.describe Search do
 
         expect(stub).to have_been_requested.twice
       end
+
+      it 'isolates cached results by guided search journey' do
+        allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+        stub = stub_api_request('search', :post, internal: true)
+          .to_return(status: 200,
+                     body: internal_response_body.to_json,
+                     headers: { 'content-type' => 'application/json; charset=utf-8' })
+
+        %w[first-journey first-journey second-journey].each do |request_id|
+          search = described_class.new(q: 'cache isolation query', request_id:)
+          search.interactive_search = true
+          search.perform
+        end
+
+        expect(stub).to have_been_requested.twice
+      end
     end
 
     context 'when interactive_search is true and response is empty' do

--- a/spec/requests/guided_search_journey_events_spec.rb
+++ b/spec/requests/guided_search_journey_events_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'Guided search journey events', type: :request do
+RSpec.describe 'Guided search journey events', :aggregate_failures, type: :request do
   let(:journey_events) { [] }
 
   around do |example|
@@ -12,83 +12,46 @@ RSpec.describe 'Guided search journey events', type: :request do
     ActiveSupport::Notifications.unsubscribe(subscriber)
   end
 
-  it 'records when a user selects the unknown answer', :aggregate_failures do
-    post '/search/guided-search-event',
-         params: {
-           event_type: 'dont_know',
-           request_id: 'request-123',
-           question_number: 2,
-           client_elapsed_ms: 4_321,
-         },
-         as: :json
+  it 'records each supported browser event' do
+    cases = [
+      [
+        { event_type: 'dont_know', request_id: 123, question_number: 2, client_elapsed_ms: 4_321 },
+        { outcome: 'dont_know', used_dont_know: true, request_id: '123', question_count: 2, client_elapsed_ms: 4_321 },
+      ],
+      [
+        {
+          event_type: 'result_selected',
+          request_id: 'request-123',
+          goods_nomenclature_item_id: '2007919930',
+          result_rank: 2,
+          confidence: 'Good',
+        },
+        {
+          outcome: 'result_selected',
+          request_id: 'request-123',
+          goods_nomenclature_item_id: '2007919930',
+          result_rank: 2,
+          confidence: 'good',
+        },
+      ],
+      [
+        { event_type: 'page_visible', request_id: 'request-123', destination: 'question', client_navigation_ms: 1_234 },
+        { outcome: 'page_visible', request_id: 'request-123', destination: 'question', client_navigation_ms: 1_234 },
+      ],
+    ]
 
-    expect(response).to have_http_status(:no_content)
-    expect(journey_events).to contain_exactly(
-      hash_including(
-        outcome: 'dont_know',
-        used_dont_know: true,
-        request_id: 'request-123',
-        question_count: 2,
-        client_elapsed_ms: 4_321,
-        browser_session_id: a_string_starting_with('v1:'),
-      ),
-    )
-  end
+    cases.each do |params, expected|
+      post guided_search_event_path, params:, as: :json
 
-  it 'records the displayed result selected by the user', :aggregate_failures do
-    post '/search/guided-search-event',
-         params: {
-           event_type: 'result_selected',
-           request_id: 'request-123',
-           goods_nomenclature_item_id: '2007919930',
-           result_rank: 2,
-           confidence: 'good',
-         },
-         as: :json
-
-    expect(response).to have_http_status(:no_content)
-    expect(journey_events).to contain_exactly(
-      hash_including(
-        outcome: 'result_selected',
-        request_id: 'request-123',
-        goods_nomenclature_item_id: '2007919930',
-        result_rank: 2,
-        confidence: 'good',
-        browser_session_id: a_string_starting_with('v1:'),
-      ),
-    )
-  end
-
-  it 'records the destination and browser-visible navigation time', :aggregate_failures do
-    post '/search/guided-search-event',
-         params: {
-           event_type: 'page_visible',
-           request_id: 'request-123',
-           destination: 'question',
-           client_navigation_ms: 1_234,
-         },
-         as: :json
-
-    expect(response).to have_http_status(:no_content)
-    expect(journey_events).to contain_exactly(
-      hash_including(
-        outcome: 'page_visible',
-        destination: 'question',
-        request_id: 'request-123',
-        client_navigation_ms: 1_234,
-      ),
-    )
+      expect(response).to have_http_status(:no_content)
+      expect(journey_events.shift).to include(expected)
+    end
   end
 
   it 'uses one pseudonymous identifier for the browser session' do
     2.times do |index|
-      post '/search/guided-search-event',
-           params: {
-             event_type: 'dont_know',
-             request_id: "request-#{index}",
-             question_number: 1,
-             client_elapsed_ms: 100,
-           },
+      post guided_search_event_path,
+           params: { event_type: 'dont_know', request_id: "request-#{index}", question_number: 1, client_elapsed_ms: 100 },
            as: :json
     end
 
@@ -97,13 +60,9 @@ RSpec.describe 'Guided search journey events', type: :request do
     )
   end
 
-  it 'rejects incomplete events without recording them', :aggregate_failures do
-    post '/search/guided-search-event',
-         params: {
-           event_type: 'page_visible',
-           request_id: 'request-123',
-           destination: 'invented',
-         },
+  it 'rejects incomplete events without recording them' do
+    post guided_search_event_path,
+         params: { event_type: 'page_visible', request_id: 'request-123', destination: 'invented' },
          as: :json
 
     expect(response).to have_http_status(:unprocessable_content)

--- a/spec/requests/guided_search_journey_events_spec.rb
+++ b/spec/requests/guided_search_journey_events_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+RSpec.describe 'Guided search journey events', type: :request do
+  let(:journey_events) { [] }
+
+  around do |example|
+    subscriber = ActiveSupport::Notifications.subscribe('guided_search.journey') do |*args|
+      journey_events << ActiveSupport::Notifications::Event.new(*args).payload
+    end
+    example.run
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+
+  it 'records when a user selects the unknown answer', :aggregate_failures do
+    post '/search/guided-search-event',
+         params: {
+           event_type: 'dont_know',
+           request_id: 'request-123',
+           question_number: 2,
+           client_elapsed_ms: 4_321,
+         },
+         as: :json
+
+    expect(response).to have_http_status(:no_content)
+    expect(journey_events).to contain_exactly(
+      hash_including(
+        outcome: 'dont_know',
+        used_dont_know: true,
+        request_id: 'request-123',
+        question_count: 2,
+        client_elapsed_ms: 4_321,
+        browser_session_id: a_string_starting_with('v1:'),
+      ),
+    )
+  end
+
+  it 'records the displayed result selected by the user', :aggregate_failures do
+    post '/search/guided-search-event',
+         params: {
+           event_type: 'result_selected',
+           request_id: 'request-123',
+           goods_nomenclature_item_id: '2007919930',
+           result_rank: 2,
+           confidence: 'good',
+         },
+         as: :json
+
+    expect(response).to have_http_status(:no_content)
+    expect(journey_events).to contain_exactly(
+      hash_including(
+        outcome: 'result_selected',
+        request_id: 'request-123',
+        goods_nomenclature_item_id: '2007919930',
+        result_rank: 2,
+        confidence: 'good',
+        browser_session_id: a_string_starting_with('v1:'),
+      ),
+    )
+  end
+
+  it 'records the destination and browser-visible navigation time', :aggregate_failures do
+    post '/search/guided-search-event',
+         params: {
+           event_type: 'page_visible',
+           request_id: 'request-123',
+           destination: 'question',
+           client_navigation_ms: 1_234,
+         },
+         as: :json
+
+    expect(response).to have_http_status(:no_content)
+    expect(journey_events).to contain_exactly(
+      hash_including(
+        outcome: 'page_visible',
+        destination: 'question',
+        request_id: 'request-123',
+        client_navigation_ms: 1_234,
+      ),
+    )
+  end
+
+  it 'uses one pseudonymous identifier for the browser session' do
+    2.times do |index|
+      post '/search/guided-search-event',
+           params: {
+             event_type: 'dont_know',
+             request_id: "request-#{index}",
+             question_number: 1,
+             client_elapsed_ms: 100,
+           },
+           as: :json
+    end
+
+    expect(journey_events.pluck(:browser_session_id).uniq).to contain_exactly(
+      a_string_matching(/\Av1:[0-9a-f]{64}\z/),
+    )
+  end
+
+  it 'rejects incomplete events without recording them', :aggregate_failures do
+    post '/search/guided-search-event',
+         params: {
+           event_type: 'page_visible',
+           request_id: 'request-123',
+           destination: 'invented',
+         },
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(journey_events).to be_empty
+  end
+end


### PR DESCRIPTION
## What:

- [x] Record the guided-search page shown for every frontend outcome
- [x] Correlate events with the existing search `request_id` and a pseudonymous `browser_session_id`
- [x] Record question timing, “I do not know” selections, browser-visible navigation time and displayed-result selections
- [x] Validate client event payloads and keep raw search, question and answer text out of the new telemetry
- [x] Isolate guided-search cache entries by request ID to prevent cross-journey correlation
- [x] Add controller, request, model, feature and JavaScript coverage
- [x] Verify 5,873 Rails examples, 114 JavaScript tests, RuboCop and Zeitwerk

## Why:

Backend request instrumentation cannot tell which page the trader actually saw, when they selected “I do not know”, how long the browser journey took, or which displayed result they selected. These frontend events fill those gaps using low-cardinality metadata while leaving the guided-search UI and fallback behaviour unchanged.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Additive, fail-open observability only. It does not change visible content, search decisions or tariff data, and the full Rails and JavaScript suites pass.