### PR TITLE
fix: add Secure flag to Google Analytics cookies (HMRC-1996)

### DIFF
--- a/app/views/shared/_gtm.html.erb
+++ b/app/views/shared/_gtm.html.erb
@@ -1,6 +1,9 @@
 <% if part == 'head' %>
   <!-- Google Tag Manager -->
   <%= javascript_tag(nonce: true) do %>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('set', 'cookie_flags', 'Secure');
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=


### PR DESCRIPTION
## What:
Sets the `Secure` flag on Google Analytics cookies (`_ga`, `_ga_*`) by calling `gtag('set', 'cookie_flags', 'Secure')` before the GTM snippet initialises. This ensures GA cookies are only transmitted over HTTPS.

## Why:
Pen test finding HMRC-1996 identified that the three GA cookies lacked the `Secure` flag, which means they could theoretically be transmitted in cleartext over HTTP. Since this service is HTTPS-only in all environments, always marking these cookies as `Secure` is safe and addresses the finding.

Note: the pen test also flags `HttpOnly` as missing, but that flag cannot be set on cookies created by client-side JavaScript (which is how GA sets them). The pen test itself assesses the likelihood of a successful attack as minimal.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-1996

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Additive change to the GTM snippet only. Adds three lines of JS before the GTM init that configure GA4 to use the `Secure` cookie flag. No changes to Ruby code, routing, or data handling. No user-facing impact.