### PR TITLE
fix: enable Flagsmith analytics to restore flag usage metrics

### DIFF
--- a/app/services/flagsmith_client.rb
+++ b/app/services/flagsmith_client.rb
@@ -56,6 +56,7 @@ class FlagsmithClient
       environment_key: @environment_key,
       api_url: "#{@api_url}/",
       request_timeout_seconds: 1,
+      enable_analytics: true,
       logger: SdkLogger.new(Rails.logger),
       # Return a disabled default flag rather than raising for unknown features.
       default_flag_handler: ->(_name) { Flagsmith::Flags::DefaultFlag.new(enabled: false, value: nil) },


### PR DESCRIPTION
## What:
Enable analytics in the Flagsmith SDK client so that flag evaluation events are tracked and sent to Flagsmith.

## Why:
The Flagsmith Ruby SDK's `enable_analytics` option defaults to `false`. With this default, the `AnalyticsProcessor` is never instantiated and no evaluation counts are POSTed to the `analytics/flags/` endpoint — meaning the Flagsmith dashboard shows no flag usage metrics at all. Setting `enable_analytics: true` activates the processor, which batches evaluations and flushes them every 10 seconds.

## Ticket:
BAU

## Risk:

**Risk level:** 🟢

**Reason for rating:** Single additive config option on the Flagsmith SDK client. No behaviour change to flag evaluation or any user-facing journey — this only enables the analytics side-channel POST that was always intended to be active.