### PR TITLE
BAU: Return 404 for invalid goods nomenclature contexts

### DIFF
--- a/app/controllers/concerns/goods_nomenclature_context.rb
+++ b/app/controllers/concerns/goods_nomenclature_context.rb
@@ -1,0 +1,29 @@
+module GoodsNomenclatureContext
+  extend ActiveSupport::Concern
+
+  VALID_CODE_PATTERN = /\A(?:\d{2}|\d{4}|\d{10}|\d{10}-\d{2})\z/
+
+  included do
+    before_action :set_goods_nomenclature_context
+  end
+
+  private
+
+  def set_goods_nomenclature_context
+    @goods_nomenclature_code = goods_nomenclature_context_param
+    return if @goods_nomenclature_code.nil? || @goods_nomenclature_code == ''
+    return if @goods_nomenclature_code.is_a?(String) && @goods_nomenclature_code.match?(VALID_CODE_PATTERN)
+
+    render 'errors/not_found', status: :not_found
+  end
+
+  def goods_nomenclature_context_param
+    params[:goods_nomenclature_code]
+  end
+
+  def nested_goods_nomenclature_context_param(key)
+    nested_params = params[key]
+
+    nested_params[:goods_nomenclature_code] if nested_params.respond_to?(:permit)
+  end
+end

--- a/app/controllers/geographical_areas_controller.rb
+++ b/app/controllers/geographical_areas_controller.rb
@@ -1,8 +1,8 @@
 class GeographicalAreasController < ApplicationController
   include GoodsNomenclatureContext
 
-  before_action :disable_search_form,
-                :disable_switch_service_banner
+  prepend_before_action :disable_search_form,
+                        :disable_switch_service_banner
 
   def show
     render 'errors/not_found', status: :not_found if params[:id] == 'countries'

--- a/app/controllers/geographical_areas_controller.rb
+++ b/app/controllers/geographical_areas_controller.rb
@@ -1,7 +1,8 @@
 class GeographicalAreasController < ApplicationController
+  include GoodsNomenclatureContext
+
   before_action :disable_search_form,
-                :disable_switch_service_banner,
-                :set_goods_nomenclature_code
+                :disable_switch_service_banner
 
   def show
     render 'errors/not_found', status: :not_found if params[:id] == 'countries'
@@ -18,9 +19,5 @@ class GeographicalAreasController < ApplicationController
     TradeTariffFrontend::ServiceChooser.with_source(:uk) do
       GeographicalArea.find(params[:id], query_params)
     end
-  end
-
-  def set_goods_nomenclature_code
-    @goods_nomenclature_code = params[:goods_nomenclature_code]
   end
 end

--- a/app/controllers/import_export_dates_controller.rb
+++ b/app/controllers/import_export_dates_controller.rb
@@ -1,9 +1,9 @@
 class ImportExportDatesController < ApplicationController
   include GoodsNomenclatureHelper
+  include GoodsNomenclatureContext
 
   before_action :disable_search_form,
-                :disable_switch_service_banner,
-                :set_goods_nomenclature_code
+                :disable_switch_service_banner
 
   def show
     @import_export_date = ImportExportDate.new(show_import_export_date_params)
@@ -62,8 +62,9 @@ class ImportExportDatesController < ApplicationController
     @today ||= Time.zone.today
   end
 
-  def set_goods_nomenclature_code
-    @goods_nomenclature_code = params[:goods_nomenclature_code] || # Set by the link to show action query param
-      params.fetch(:import_export_date, {})[:goods_nomenclature_code] # Set by the update form submission
+  def goods_nomenclature_context_param
+    params[:goods_nomenclature_code].presence || # Set by the link to show action query param
+      nested_goods_nomenclature_context_param(:import_export_date) || # Set by the update form submission
+      params[:goods_nomenclature_code]
   end
 end

--- a/app/controllers/import_export_dates_controller.rb
+++ b/app/controllers/import_export_dates_controller.rb
@@ -2,8 +2,8 @@ class ImportExportDatesController < ApplicationController
   include GoodsNomenclatureHelper
   include GoodsNomenclatureContext
 
-  before_action :disable_search_form,
-                :disable_switch_service_banner
+  prepend_before_action :disable_search_form,
+                        :disable_switch_service_banner
 
   def show
     @import_export_date = ImportExportDate.new(show_import_export_date_params)

--- a/app/controllers/measure_types/preference_codes_controller.rb
+++ b/app/controllers/measure_types/preference_codes_controller.rb
@@ -2,7 +2,7 @@ module MeasureTypes
   class PreferenceCodesController < ApplicationController
     include GoodsNomenclatureContext
 
-    before_action :disable_search_form
+    prepend_before_action :disable_search_form
 
     def show
       # pass the geographical area id to the description

--- a/app/controllers/measure_types/preference_codes_controller.rb
+++ b/app/controllers/measure_types/preference_codes_controller.rb
@@ -1,7 +1,8 @@
 module MeasureTypes
   class PreferenceCodesController < ApplicationController
-    before_action :disable_search_form,
-                  :set_goods_nomenclature_code
+    include GoodsNomenclatureContext
+
+    before_action :disable_search_form
 
     def show
       # pass the geographical area id to the description
@@ -9,12 +10,6 @@ module MeasureTypes
       @measure_type = MeasureType.find(params[:measure_type_id])
       @measure_type.geographical_area_id = params[:geographical_area_id]
       @preference_code = PreferenceCode.find(params[:id])
-    end
-
-    private
-
-    def set_goods_nomenclature_code
-      @goods_nomenclature_code = params[:goods_nomenclature_code]
     end
   end
 end

--- a/app/controllers/meursing_lookup/results_controller.rb
+++ b/app/controllers/meursing_lookup/results_controller.rb
@@ -1,8 +1,7 @@
 module MeursingLookup
   class ResultsController < ApplicationController
-    before_action :set_goods_nomenclature_code
-
     include GoodsNomenclatureHelper
+    include GoodsNomenclatureContext
 
     def show
       session.delete(Result::CURRENT_MEURSING_ADDITIONAL_CODE_KEY)
@@ -24,12 +23,9 @@ module MeursingLookup
       params.require(:meursing_lookup_result).permit(:meursing_additional_code_id, :goods_nomenclature_code)
     end
 
-    def set_goods_nomenclature_code
-      @goods_nomenclature_code = if params[:goods_nomenclature_code].present?
-                                   params[:goods_nomenclature_code]
-                                 elsif params[:meursing_lookup_result].present?
-                                   result_params[:goods_nomenclature_code]
-                                 end
+    def goods_nomenclature_context_param
+      params[:goods_nomenclature_code].presence ||
+        nested_goods_nomenclature_context_param(:meursing_lookup_result)
     end
   end
 end

--- a/app/controllers/meursing_lookup/steps_controller.rb
+++ b/app/controllers/meursing_lookup/steps_controller.rb
@@ -1,16 +1,16 @@
 module MeursingLookup
   class StepsController < ApplicationController
+    include GoodsNomenclatureHelper
+    include GoodsNomenclatureContext
+    include WizardSteps
+
     before_action do
       disable_search_form
       disable_switch_service_banner
 
       clear_meursing_lookup_session
       store_meursing_lookup_result_on_session
-      set_goods_nomenclature_code
     end
-
-    include GoodsNomenclatureHelper
-    include WizardSteps
 
     self.wizard_class = MeursingLookup::Wizard
 
@@ -32,9 +32,9 @@ module MeursingLookup
       session.delete(wizard_store_key) if current_step.key == MeursingLookup::Steps::Start.key
     end
 
-    def set_goods_nomenclature_code
-      @goods_nomenclature_code = params[:goods_nomenclature_code].presence ||
-        params.fetch(step_param_key, {})[:goods_nomenclature_code]
+    def goods_nomenclature_context_param
+      params[:goods_nomenclature_code].presence ||
+        nested_goods_nomenclature_context_param(step_param_key)
     end
 
     def step_param_key

--- a/app/controllers/meursing_lookup/steps_controller.rb
+++ b/app/controllers/meursing_lookup/steps_controller.rb
@@ -4,10 +4,10 @@ module MeursingLookup
     include GoodsNomenclatureContext
     include WizardSteps
 
-    before_action do
-      disable_search_form
-      disable_switch_service_banner
+    prepend_before_action :disable_search_form,
+                          :disable_switch_service_banner
 
+    before_action do
       clear_meursing_lookup_session
       store_meursing_lookup_result_on_session
     end

--- a/spec/requests/goods_nomenclature_context_spec.rb
+++ b/spec/requests/goods_nomenclature_context_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe 'Goods nomenclature context', type: :request do
         end
       end
     end
+
+    it 'hides page controls on error', :aggregate_failures do
+      get import_export_dates_path, params: { goods_nomenclature_code: '803909000' }
+
+      expect(response.body).not_to include('id="new_search"')
+      expect(response.body).not_to include('tariff-breadcrumbs clt')
+    end
   end
 
   describe 'GET /geographical_areas/:id' do
@@ -37,6 +44,13 @@ RSpec.describe 'Goods nomenclature context', type: :request do
       get geographical_area_path('1013'), params: { goods_nomenclature_code: '803909000' }
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    it 'hides page controls on error', :aggregate_failures do
+      get geographical_area_path('1013'), params: { goods_nomenclature_code: '803909000' }
+
+      expect(response.body).not_to include('id="new_search"')
+      expect(response.body).not_to include('tariff-breadcrumbs clt')
     end
   end
 
@@ -47,6 +61,13 @@ RSpec.describe 'Goods nomenclature context', type: :request do
 
       expect(response).to have_http_status(:not_found)
     end
+
+    it 'hides the search form on error' do
+      get measure_type_preference_code_path(measure_type_id: '103', id: '100'),
+          params: { goods_nomenclature_code: '803909000' }
+
+      expect(response.body).not_to include('id="new_search"')
+    end
   end
 
   describe 'GET /meursing_lookup/steps/:id' do
@@ -54,6 +75,13 @@ RSpec.describe 'Goods nomenclature context', type: :request do
       get meursing_lookup_step_path(:start), params: { goods_nomenclature_code: '803909000' }
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    it 'hides page controls on error', :aggregate_failures do
+      get meursing_lookup_step_path(:start), params: { goods_nomenclature_code: '803909000' }
+
+      expect(response.body).not_to include('id="new_search"')
+      expect(response.body).not_to include('tariff-breadcrumbs clt')
     end
   end
 

--- a/spec/requests/goods_nomenclature_context_spec.rb
+++ b/spec/requests/goods_nomenclature_context_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+RSpec.describe 'Goods nomenclature context', type: :request do
+  describe 'GET /import_export_dates' do
+    [
+      '1x',
+      '19x1',
+      '803909000',
+      '190120000x',
+      '1901200000-1x',
+      'invalid-id',
+      %w[1901200000],
+      { code: '1901200000' },
+    ].each do |goods_nomenclature_code|
+      context "with #{goods_nomenclature_code.inspect}" do
+        it 'returns not found' do
+          get import_export_dates_path, params: { goods_nomenclature_code: }
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    [nil, '', '19', '1901', '1901200000', '1901200000-10'].each do |goods_nomenclature_code|
+      context "with #{goods_nomenclature_code.inspect}" do
+        it 'preserves valid contexts' do
+          get import_export_dates_path, params: { goods_nomenclature_code: }
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe 'GET /geographical_areas/:id' do
+    it 'rejects before loading the area' do
+      get geographical_area_path('1013'), params: { goods_nomenclature_code: '803909000' }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'GET /measure_types/:id/preference_codes/:id' do
+    it 'rejects before loading preference data' do
+      get measure_type_preference_code_path(measure_type_id: '103', id: '100'),
+          params: { goods_nomenclature_code: '803909000' }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'GET /meursing_lookup/steps/:id' do
+    it 'rejects invalid context' do
+      get meursing_lookup_step_path(:start), params: { goods_nomenclature_code: '803909000' }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'GET /meursing_lookup/result' do
+    it 'rejects invalid context' do
+      get meursing_lookup_result_path, params: { goods_nomenclature_code: '803909000' }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'POST /meursing_lookup/result' do
+    it 'rejects invalid nested context' do
+      post meursing_lookup_result_path,
+           params: {
+             meursing_lookup_result: {
+               goods_nomenclature_code: '803909000',
+               meursing_additional_code_id: '707',
+             },
+           }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'PATCH /import_export_dates' do
+    it 'rejects invalid nested context' do
+      patch import_export_dates_path,
+            params: {
+              import_export_date: {
+                'import_date(1i)': '2026',
+                'import_date(2i)': '7',
+                'import_date(3i)': '29',
+                goods_nomenclature_code: '803909000',
+              },
+            }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'does not mask invalid nested context' do
+      patch import_export_dates_path,
+            params: {
+              goods_nomenclature_code: '',
+              import_export_date: {
+                'import_date(1i)': '2026',
+                'import_date(2i)': '7',
+                'import_date(3i)': '29',
+                goods_nomenclature_code: '803909000',
+              },
+            }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## What:

- Validate optional goods nomenclature context parameters at the controller boundary.
- Return the existing 404 page for malformed strings and structured parameter values.
- Apply the shared handling to geographical areas, import/export dates, preference codes, and Meursing entry points.
- Cover valid code boundaries, malformed 9-digit codes, nested form submissions, and conflicting top-level/nested values.

## Why:

Production traffic supplied 9-digit `goods_nomenclature_code` values to geographical-area and import/export-date pages. Those views attempted to generate `/commodities/:id` back links, but commodity routes require exactly 10 digits, so Rails raised `ActionController::UrlGenerationError` and returned 500.

Rejecting malformed optional context before controller/API work gives the request the correct 404 response and prevents it being recorded as an application error. Valid chapter, heading, commodity, and subheading contexts are unchanged.

Verification:

- Full RSpec suite: 5,894 examples, 0 failures, 4 existing pending.
- Focused request spec: 21 examples, 0 failures.
- Brakeman: 0 security warnings.
- Pre-commit and pre-push hooks: passed.
- Asset precompilation: passed.

## Ticket:

BAU

## Risk:

**Risk level:** 🟢

**Reason for rating:** The change is limited to malformed optional navigation context, reuses the existing 404 template, adds no API calls or dependencies, and preserves all valid code formats with request and full-suite coverage.