### PR TITLE
Disable automatic commodity code links on description intercepts

### DIFF
--- a/app/helpers/intercept_guidance_helper.rb
+++ b/app/helpers/intercept_guidance_helper.rb
@@ -6,14 +6,6 @@ module InterceptGuidanceHelper
     'webchat_url' => ->(_) { TradeTariffFrontend.webchat_url },
   }.freeze
 
-  # Legacy destinations for the generic intercept "help on using the tariff" link.
-  # Prefer {{help_url}} in new template copy; keep these rewrites for already-published intercepts.
-  LEGACY_HELP_URLS = [
-    'https://www.gov.uk/guidance/classification-of-goods/',
-    'https://www.gov.uk/guidance/classification-of-goods',
-    '/help/help_find_commodity',
-  ].freeze
-
   GOVUK_MARKDOWN_CLASSES = {
     'p' => %w[govuk-body],
     'a' => %w[govuk-link],
@@ -29,13 +21,8 @@ module InterceptGuidanceHelper
 
     message.to_s.gsub(/\{\{(\w+)\}\}/) do |match|
       key = ::Regexp.last_match(1)
-      case key
-      when 'help_url'
-        help_path
-      else
-        resolver = SUPPORTED_PLACEHOLDERS[key]
-        resolver ? resolver.call(search) : match
-      end
+      resolver = SUPPORTED_PLACEHOLDERS[key]
+      resolver ? resolver.call(search) : match
     end
   end
 
@@ -53,23 +40,13 @@ private
     GOVUK_MARKDOWN_CLASSES.each do |selector, classes|
       fragment.css(selector).each { |node| append_classes(node, classes) }
     end
-    fragment.css('a').each do |node|
-      normalize_legacy_help_link(node)
-      apply_new_tab_standard(node)
-    end
+    fragment.css('a').each { |node| apply_new_tab_standard(node) }
 
     fragment.to_html.html_safe
   end
 
   def append_classes(node, classes)
     node['class'] = (node['class'].to_s.split + classes).uniq.join(' ')
-  end
-
-  def normalize_legacy_help_link(node)
-    href = node['href'].to_s
-    return unless LEGACY_HELP_URLS.include?(href) || href.end_with?('/help/help_find_commodity')
-
-    node['href'] = help_path
   end
 
   def apply_new_tab_standard(node)

--- a/app/helpers/intercept_guidance_helper.rb
+++ b/app/helpers/intercept_guidance_helper.rb
@@ -6,6 +6,14 @@ module InterceptGuidanceHelper
     'webchat_url' => ->(_) { TradeTariffFrontend.webchat_url },
   }.freeze
 
+  # Legacy destinations for the generic intercept "help on using the tariff" link.
+  # Prefer {{help_url}} in new template copy; keep these rewrites for already-published intercepts.
+  LEGACY_HELP_URLS = [
+    'https://www.gov.uk/guidance/classification-of-goods/',
+    'https://www.gov.uk/guidance/classification-of-goods',
+    '/help/help_find_commodity',
+  ].freeze
+
   GOVUK_MARKDOWN_CLASSES = {
     'p' => %w[govuk-body],
     'a' => %w[govuk-link],
@@ -21,21 +29,22 @@ module InterceptGuidanceHelper
 
     message.to_s.gsub(/\{\{(\w+)\}\}/) do |match|
       key = ::Regexp.last_match(1)
-      resolver = SUPPORTED_PLACEHOLDERS[key]
-      resolver ? resolver.call(search) : match
+      case key
+      when 'help_url'
+        help_path
+      else
+        resolver = SUPPORTED_PLACEHOLDERS[key]
+        resolver ? resolver.call(search) : match
+      end
     end
   end
 
   def render_intercept_message(message, search:)
     resolved = resolve_intercept_placeholders(message, search:)
-    govuk_markdown(linkified_code_references(govspeak(resolved)))
+    govuk_markdown(govspeak(resolved))
   end
 
 private
-
-  def linkified_code_references(html)
-    GoodsNomenclatureCodeLinkifier.new(html).render
-  end
 
   def govuk_markdown(html)
     fragment = Nokogiri::HTML::DocumentFragment.parse(html.to_s)
@@ -44,13 +53,23 @@ private
     GOVUK_MARKDOWN_CLASSES.each do |selector, classes|
       fragment.css(selector).each { |node| append_classes(node, classes) }
     end
-    fragment.css('a').each { |node| apply_new_tab_standard(node) }
+    fragment.css('a').each do |node|
+      normalize_legacy_help_link(node)
+      apply_new_tab_standard(node)
+    end
 
     fragment.to_html.html_safe
   end
 
   def append_classes(node, classes)
     node['class'] = (node['class'].to_s.split + classes).uniq.join(' ')
+  end
+
+  def normalize_legacy_help_link(node)
+    href = node['href'].to_s
+    return unless LEGACY_HELP_URLS.include?(href) || href.end_with?('/help/help_find_commodity')
+
+    node['href'] = help_path
   end
 
   def apply_new_tab_standard(node)

--- a/spec/helpers/intercept_guidance_helper_spec.rb
+++ b/spec/helpers/intercept_guidance_helper_spec.rb
@@ -32,13 +32,6 @@ RSpec.describe InterceptGuidanceHelper do
       expect(resolve_intercept_placeholders(msg, search:)).to eq('[Ask HMRC online](https://example.com/webchat)')
     end
 
-    it 'replaces {{help_url}} with the general help path' do
-      msg = 'See [help on using the tariff (opens in new tab)]({{help_url}})'
-      expect(resolve_intercept_placeholders(msg, search:)).to eq(
-        'See [help on using the tariff (opens in new tab)](/help)',
-      )
-    end
-
     it 'leaves unknown placeholders untouched' do
       msg = 'Contact {{unknown_email}} for help.'
       expect(resolve_intercept_placeholders(msg, search:)).to eq('Contact {{unknown_email}} for help.')
@@ -106,36 +99,6 @@ RSpec.describe InterceptGuidanceHelper do
       expect(html).to include('Chapter 71')
       expect(html).not_to have_css('a[href="/search?q=71"]')
       expect(html).not_to have_css('a[href="https://example.com/existing"] a')
-    end
-
-    it 'resolves {{help_url}} to the general help page', :aggregate_failures do
-      html = render_intercept_message(
-        'Guidance is in [help on using the tariff (opens in new tab)]({{help_url}}).',
-        search:,
-      )
-
-      expect(html).to have_css(
-        'a.govuk-link[href="/help"][target="_blank"][rel~="noopener"][rel~="noreferrer"]',
-        text: 'help on using the tariff (opens in new tab)',
-      )
-      expect(html).not_to have_css('a[href="/help/help_find_commodity"]')
-    end
-
-    it 'rewrites legacy generic-help destinations to the general help page', :aggregate_failures do
-      legacy_urls = [
-        'https://www.gov.uk/guidance/classification-of-goods/',
-        '/help/help_find_commodity',
-      ]
-
-      legacy_urls.each do |legacy_url|
-        html = render_intercept_message(
-          "Guidance is in [help on using the tariff (opens in new tab)](#{legacy_url}).",
-          search:,
-        )
-
-        expect(html).to have_css('a.govuk-link[href="/help"]', text: 'help on using the tariff (opens in new tab)')
-        expect(html).not_to have_css(%(a[href="#{legacy_url}"]))
-      end
     end
   end
 end

--- a/spec/helpers/intercept_guidance_helper_spec.rb
+++ b/spec/helpers/intercept_guidance_helper_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe InterceptGuidanceHelper do
       expect(resolve_intercept_placeholders(msg, search:)).to eq('[Ask HMRC online](https://example.com/webchat)')
     end
 
+    it 'replaces {{help_url}} with the general help path' do
+      msg = 'See [help on using the tariff (opens in new tab)]({{help_url}})'
+      expect(resolve_intercept_placeholders(msg, search:)).to eq(
+        'See [help on using the tariff (opens in new tab)](/help)',
+      )
+    end
+
     it 'leaves unknown placeholders untouched' do
       msg = 'Contact {{unknown_email}} for help.'
       expect(resolve_intercept_placeholders(msg, search:)).to eq('Contact {{unknown_email}} for help.')
@@ -75,24 +82,60 @@ RSpec.describe InterceptGuidanceHelper do
       expect(html).not_to have_css('a .govuk-visually-hidden', text: '(opens in new tab)')
     end
 
-    it 'linkifies goods nomenclature code references like the admin preview', :aggregate_failures do
+    it 'does not linkify goods nomenclature code references', :aggregate_failures do
       msg = 'Review Chapter 71, headings 3207 to 3210, subheading 8703.10 and commodity 0101210000.'
       html = render_intercept_message(msg, search:)
 
-      expect(html).to have_css('a.govuk-link[href="/search?q=71"][target="_blank"][rel="noopener noreferrer"]', text: '71')
-      expect(html).to have_css('a.govuk-link[href="/search?q=3207"]', text: '3207')
-      expect(html).to have_css('a.govuk-link[href="/search?q=3210"]', text: '3210')
-      expect(html).to have_css('a.govuk-link[href="/search?q=870310"]', text: '8703.10')
-      expect(html).to have_css('a.govuk-link[href="/search?q=0101210000"]', text: '0101210000')
-      expect(html).to have_css('a .govuk-visually-hidden', text: '(opens in new tab)', count: 5)
+      expect(html).to include('Chapter 71')
+      expect(html).to include('3207')
+      expect(html).to include('3210')
+      expect(html).to include('8703.10')
+      expect(html).to include('0101210000')
+      expect(html).not_to have_css('a[href="/search?q=71"]')
+      expect(html).not_to have_css('a[href="/search?q=3207"]')
+      expect(html).not_to have_css('a[href="/search?q=3210"]')
+      expect(html).not_to have_css('a[href="/search?q=870310"]')
+      expect(html).not_to have_css('a[href="/search?q=0101210000"]')
+      expect(html).not_to have_css('a .govuk-visually-hidden', text: '(opens in new tab)')
     end
 
-    it 'does not linkify code references inside existing markdown links', :aggregate_failures do
+    it 'still renders explicit markdown links without auto-linking surrounding codes', :aggregate_failures do
       html = render_intercept_message('[Read about 0101](https://example.com/existing) and Chapter 71', search:)
 
       expect(html).to have_css('a.govuk-link[href="https://example.com/existing"]', text: 'Read about 0101')
-      expect(html).to have_css('a.govuk-link[href="/search?q=71"]', text: '71')
+      expect(html).to include('Chapter 71')
+      expect(html).not_to have_css('a[href="/search?q=71"]')
       expect(html).not_to have_css('a[href="https://example.com/existing"] a')
+    end
+
+    it 'resolves {{help_url}} to the general help page', :aggregate_failures do
+      html = render_intercept_message(
+        'Guidance is in [help on using the tariff (opens in new tab)]({{help_url}}).',
+        search:,
+      )
+
+      expect(html).to have_css(
+        'a.govuk-link[href="/help"][target="_blank"][rel~="noopener"][rel~="noreferrer"]',
+        text: 'help on using the tariff (opens in new tab)',
+      )
+      expect(html).not_to have_css('a[href="/help/help_find_commodity"]')
+    end
+
+    it 'rewrites legacy generic-help destinations to the general help page', :aggregate_failures do
+      legacy_urls = [
+        'https://www.gov.uk/guidance/classification-of-goods/',
+        '/help/help_find_commodity',
+      ]
+
+      legacy_urls.each do |legacy_url|
+        html = render_intercept_message(
+          "Guidance is in [help on using the tariff (opens in new tab)](#{legacy_url}).",
+          search:,
+        )
+
+        expect(html).to have_css('a.govuk-link[href="/help"]', text: 'help on using the tariff (opens in new tab)')
+        expect(html).not_to have_css(%(a[href="#{legacy_url}"]))
+      end
     end
   end
 end


### PR DESCRIPTION
## What:
- [x] Stop automatically linkifying commodity codes in description intercept guidance messages
- [x] Keep explicit markdown links and existing placeholder resolution unchanged
- [x] Update helper specs for the no-autolink behaviour

## Why:
Description intercept guidance should not invent commodity code links. Editors can still add explicit markdown links when a code should be clickable.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Display-only rendering change for description intercept guidance. Explicit markdown links still work, and helper coverage checks that bare codes are no longer auto-linked.