### PR TITLE
HMRC-2587: Bump ECS service module to v3.2.1

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,7 +20,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.0 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
 
 ## Resources
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
 
   region = var.region
 


### PR DESCRIPTION
## What:
Updated application Terraform configurations to use aws/ecs-service-v3.2.1

## Why:
Version v3.2.1 removes CloudWatch ok_actions from the `ecs_high_cpu` alarm, reducing non-actionable recovery notifications while preserving alarm-state notifications.

## Ticket:
[HMRC-2587](https://transformuk.atlassian.net/browse/HMRC-2587)

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
- Module version update only.
- No infrastructure changes expected.
- No impact to alarm detection or alerting.
- Only recovery notifications for ECS high CPU alarms are affected.
