### PR TITLE
Add Developer Portal to Privacy page

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -56,6 +56,10 @@
   'your selected preferences (e.g. tariff chapters you wish to be notified about)'
 ], type: :bullet %>
 
+<p class="govuk-body">For the Developer Portal service:</p>
+
+<%= govuk_list ['email address'], type: :bullet %>
+
 <h2 class="govuk-heading-m">The legal basis for processing your data </h2>
 
 <p>The legal basis for processing your personal data is:</p>

--- a/spec/views/pages/privacy.html.erb_spec.rb
+++ b/spec/views/pages/privacy.html.erb_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe 'pages/privacy', type: :view do
+  subject(:rendered_page) { render && rendered }
+
+  include_context 'with UK service'
+
+  it 'describes the data processed for the Developer Portal service' do
+    paragraph = Capybara.string(rendered_page).find('p', text: 'For the Developer Portal service:')
+    list = paragraph.find(:xpath, 'following-sibling::ul[1]')
+
+    expect(list).to have_css('li', text: 'email address', count: 1)
+  end
+end


### PR DESCRIPTION
## What:

Add Developer Portal to Privacy page

## Why:

We have to specify what information we are using for different services.

## Ticket:

https://transformuk.atlassian.net/jira/software/c/projects/HMRC/boards/155?selectedIssue=HMRC-2616

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Just a text change so very low risk.