### PR TITLE
Extend guided search experiment cutoff to 12 August 2026

### DIFF
--- a/config/experiment_urls.yml
+++ b/config/experiment_urls.yml
@@ -3,7 +3,7 @@ shared:
     path: /guided-search-research
     feature: interactive_search
     starts_on: "2026-07-23"
-    ends_on: "2026-08-07"
+    ends_on: "2026-08-12"
     timezone: Europe/London
     redirect: /find_commodity
     service: uk


### PR DESCRIPTION
## What:
Extends the `ends_on` date for the `trusted_trader_guided_search` experiment entry in `config/experiment_urls.yml` from `2026-08-07` to `2026-08-12`.

## Why:
The experiment's configured end date had already passed, so visitors to `/guided-search-research` were no longer being enrolled in the guided search (AI-assisted commodity search) opt-in. The team wants the trusted-trader research window kept open a bit longer. This supersedes #3271 (merged), which extended the same window to 7 August.

## Ticket:
[AI-1137](https://transformuk.atlassian.net/browse/AI-1137)

## Risk:

**Risk level:** 🟢

**Reason for rating:** This is a pure date-range extension on an experiment window that is already live and already agreed with the team (no new flag, no behaviour change, no new user segment) — consistent with the team's low-risk call on the equivalent #3271 change. The change itself is a single date value with existing config validation (`ExperimentUrls`) enforcing `ends_on >= starts_on` and ISO8601 format.

## Test plan
- [ ] Confirm `bundle exec rspec spec/lib/trade_tariff_frontend/experiment_urls_spec.rb spec/requests/experiment_urls_controller_spec.rb` passes (fixtures use their own dates, unaffected by this config change)
- [ ] After deploy, visit `https://staging.trade-tariff.service.gov.uk/guided-search-research` and confirm it redirects to `/find_commodity?experiment=trstd-trdr` rather than a bare redirect
- [ ] Note: this is a `config_for`-loaded boot-time setting — merging this PR alone does not take effect, it requires a deploy