### PR TITLE
fix: guided search back button freezes on 'Collecting information' throbber

### DIFF
--- a/app/javascript/controllers/guided_search_validation_controller.js
+++ b/app/javascript/controllers/guided_search_validation_controller.js
@@ -6,6 +6,15 @@ const MIN_QUERY_LENGTH = 2
 export default class extends Controller {
   static targets = ['hiddenField', 'textarea', 'formGroup', 'formContent']
 
+  connect() {
+    this.boundRestoreFromBfcache = this.#restoreFromBfcache.bind(this)
+    window.addEventListener('pageshow', this.boundRestoreFromBfcache)
+  }
+
+  disconnect() {
+    window.removeEventListener('pageshow', this.boundRestoreFromBfcache)
+  }
+
   async validateAndSubmit(event) {
     if (this.hiddenFieldTarget.value !== 'true') return
 
@@ -103,5 +112,16 @@ export default class extends Controller {
 
   #submitForm(form) {
     window.setTimeout(() => HTMLFormElement.prototype.submit.call(form), 0)
+  }
+
+  #restoreFromBfcache(event) {
+    if (!event.persisted) return
+
+    const pageContent = document.querySelector('[data-guided-search-validation-page-content]')
+    const loadingPage = document.querySelector('[data-guided-search-validation-loading-page]')
+
+    if (pageContent) pageContent.classList.remove('govuk-!-display-none')
+    if (loadingPage) loadingPage.classList.add('govuk-!-display-none')
+    if (this.hasFormContentTarget) this.formContentTarget.classList.remove('govuk-!-display-none')
   }
 }

--- a/app/javascript/controllers/interactive_question_controller.js
+++ b/app/javascript/controllers/interactive_question_controller.js
@@ -10,6 +10,12 @@ export default class extends Controller {
 
   connect() {
     this.questionShownAt = performance.now()
+    this.boundRestoreFromBfcache = this.#restoreFromBfcache.bind(this)
+    window.addEventListener('pageshow', this.boundRestoreFromBfcache)
+  }
+
+  disconnect() {
+    window.removeEventListener('pageshow', this.boundRestoreFromBfcache)
   }
 
   submitWithThinking(event) {
@@ -108,5 +114,27 @@ export default class extends Controller {
 
   #clientElapsedMs() {
     return Math.max(0, Math.round(performance.now() - this.questionShownAt))
+  }
+
+  #restoreFromBfcache(event) {
+    if (!event.persisted) return
+
+    this.questionShownAt = performance.now()
+
+    if (this.hasPageHeaderTarget) {
+      this.pageHeaderTarget.classList.remove('govuk-!-display-none')
+    }
+    if (this.hasHeaderTarget) {
+      this.headerTarget.classList.remove('govuk-!-display-none')
+    }
+    if (this.hasFormTarget) {
+      this.formTarget.classList.remove('govuk-!-display-none')
+    }
+    if (this.hasThinkingTarget) {
+      this.thinkingTarget.classList.add('govuk-!-display-none')
+    }
+    if (this.hasDontKnowTarget) {
+      this.dontKnowTarget.classList.add('govuk-!-display-none')
+    }
   }
 }

--- a/spec/javascript/controllers/guided_search_validation_controller_spec.js
+++ b/spec/javascript/controllers/guided_search_validation_controller_spec.js
@@ -322,4 +322,35 @@ describe('GuidedSearchValidationController', () => {
       expect(document.querySelector('[data-guided-search-validation-loading-page]').classList.contains('govuk-!-display-none')).toBe(false);
     });
   });
+
+  describe('bfcache restore', () => {
+    it('restores the page content and hides the loading page when the page is restored from bfcache', async () => {
+      await setup({textareaValue: 'televisions'});
+      submitForm();
+
+      const pageContent = document.querySelector('[data-guided-search-validation-page-content]');
+      const loadingPage = document.querySelector('[data-guided-search-validation-loading-page]');
+
+      expect(pageContent.classList.contains('govuk-!-display-none')).toBe(true);
+      expect(loadingPage.classList.contains('govuk-!-display-none')).toBe(false);
+
+      window.dispatchEvent(new PageTransitionEvent('pageshow', {persisted: true}));
+
+      expect(pageContent.classList.contains('govuk-!-display-none')).toBe(false);
+      expect(loadingPage.classList.contains('govuk-!-display-none')).toBe(true);
+    });
+
+    it('does nothing on a normal (non-bfcache) pageshow', async () => {
+      await setup({textareaValue: 'televisions'});
+      submitForm();
+
+      const pageContent = document.querySelector('[data-guided-search-validation-page-content]');
+      const loadingPage = document.querySelector('[data-guided-search-validation-loading-page]');
+
+      window.dispatchEvent(new PageTransitionEvent('pageshow', {persisted: false}));
+
+      expect(pageContent.classList.contains('govuk-!-display-none')).toBe(true);
+      expect(loadingPage.classList.contains('govuk-!-display-none')).toBe(false);
+    });
+  });
 });

--- a/spec/javascript/controllers/interactive_question_controller_spec.js
+++ b/spec/javascript/controllers/interactive_question_controller_spec.js
@@ -189,4 +189,63 @@ describe('InteractiveQuestionController', () => {
       });
     });
   });
+
+  describe('bfcache restore', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    it('restores the header and form and hides the thinking screen when the page is restored from bfcache', () => {
+      const pageHeader = document.querySelector('#page-header');
+      const header = document.querySelector('#header');
+      const form = document.querySelector('#form');
+      const thinking = document.querySelector('#thinking');
+      const formEl = document.querySelector('form');
+
+      formEl.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
+
+      expect(thinking.classList.contains('govuk-!-display-none')).toBe(false);
+
+      window.dispatchEvent(new PageTransitionEvent('pageshow', {persisted: true}));
+
+      expect(pageHeader.classList.contains('govuk-!-display-none')).toBe(false);
+      expect(header.classList.contains('govuk-!-display-none')).toBe(false);
+      expect(form.classList.contains('govuk-!-display-none')).toBe(false);
+      expect(thinking.classList.contains('govuk-!-display-none')).toBe(true);
+    });
+
+    it('restores the header and form and hides the dont know screen when the page is restored from bfcache', () => {
+      const pageHeader = document.querySelector('#page-header');
+      const header = document.querySelector('#header');
+      const form = document.querySelector('#form');
+      const dontKnow = document.querySelector('#dont-know');
+      const radio = document.querySelector('#unknown');
+      const formEl = document.querySelector('form');
+
+      radio.checked = true;
+      formEl.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
+
+      expect(dontKnow.classList.contains('govuk-!-display-none')).toBe(false);
+
+      window.dispatchEvent(new PageTransitionEvent('pageshow', {persisted: true}));
+
+      expect(pageHeader.classList.contains('govuk-!-display-none')).toBe(false);
+      expect(header.classList.contains('govuk-!-display-none')).toBe(false);
+      expect(form.classList.contains('govuk-!-display-none')).toBe(false);
+      expect(dontKnow.classList.contains('govuk-!-display-none')).toBe(true);
+    });
+
+    it('does nothing on a normal (non-bfcache) pageshow', () => {
+      const header = document.querySelector('#header');
+      const thinking = document.querySelector('#thinking');
+      const formEl = document.querySelector('form');
+
+      formEl.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
+
+      window.dispatchEvent(new PageTransitionEvent('pageshow', {persisted: false}));
+
+      expect(header.classList.contains('govuk-!-display-none')).toBe(true);
+      expect(thinking.classList.contains('govuk-!-display-none')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## What:
Adds a bfcache (browser back-forward cache) restore handler to both `guided_search_validation_controller.js` (the initial search form) and `interactive_question_controller.js` (each guided search question). When the browser restores a page from bfcache after Back is pressed, the handler puts the visible form/header back and hides the "Collecting information..." throbber.

## Why:
Answering a guided search question hides the question form and shows a "Collecting information..." throbber client-side (via JS classes), then submits a real form POST to move to the next question. That means the page the browser freezes into its back-forward cache — the snapshot it restores when you press Back — is frozen mid-throbber, not showing the form.

Browsers normally skip re-running page JS (`connect()` etc.) on a bfcache restore, since nothing actually reloads — it's the exact same in-memory DOM being shown again. So without a handler for this specific case, that frozen throbber state was permanent: pressing Back left the user stuck with no way to answer the question or go back further, matching the ticket's report of a second Back press skipping past `/find-commodity` entirely.

The fix listens for the browser's `pageshow` event and checks `event.persisted` (true only on a bfcache restore, not a normal page load) to reset the DOM back to the form-visible state whenever this happens. This mirrors an existing pattern already used for the same class of problem in `search-autocomplete.js`.

## Ticket:
[AI-1150](https://transformuk.atlassian.net/browse/AI-1150)

## Risk:

**Risk level:** 🟠

**Reason for rating:** This changes browser back/forward navigation behaviour within the guided search journey (Search UI change, per the Amber criteria in the PR template). It's additive — a new `pageshow` listener plus DOM class toggles that only run on a bfcache restore — and doesn't touch the form submission or search request logic itself, but navigation behaviour changes are easy to get subtly wrong across browsers, so it's worth a second pair of eyes before merging.

## Test plan
- [ ] `yarn jest spec/javascript/controllers/guided_search_validation_controller_spec.js spec/javascript/controllers/interactive_question_controller_spec.js` — 30/30 passing, including new bfcache-restore cases and a case confirming a normal (non-bfcache) `pageshow` is a no-op
- [ ] Manually confirmed on a local dev server (`bin/dev`): start a guided search, answer at least one question, then press browser Back — lands back on the previous question/search page with the form visible, not the throbber. Forward navigation also confirmed working.
- [ ] Accessibility impact: none expected — no new interactive elements, only visibility toggles on existing GOV.UK components using the same `govuk-!-display-none` convention already used elsewhere on these pages