### PR TITLE
[HMRC-2644] -  Fix a 404 when clicking rules of origin proof document link

### DIFF
--- a/app/controllers/rules_of_origin/proofs_controller.rb
+++ b/app/controllers/rules_of_origin/proofs_controller.rb
@@ -3,7 +3,7 @@ module RulesOfOrigin
     before_action :disable_switch_service_banner, :disable_search_form
 
     def index
-      @schemes = RulesOfOrigin::Scheme.all(include: 'proofs')
+      @schemes = RulesOfOrigin::Scheme.all(include: 'proofs,origin_reference_document')
     end
   end
 end

--- a/spec/requests/rules_of_origin/proofs_controller_spec.rb
+++ b/spec/requests/rules_of_origin/proofs_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RulesOfOrigin::ProofsController, type: :request do
 
   describe 'GET #index' do
     before do
-      allow(RulesOfOrigin::Scheme).to receive(:all).with(include: 'proofs')
+      allow(RulesOfOrigin::Scheme).to receive(:all).with(include: 'proofs,origin_reference_document')
                                                    .and_return(schemes)
 
       get rules_of_origin_proofs_path
@@ -15,5 +15,31 @@ RSpec.describe RulesOfOrigin::ProofsController, type: :request do
 
     it { is_expected.to have_http_status :ok }
     it { is_expected.to have_attributes content_type: %r{text/html} }
+
+    it 'requests schemes with the origin reference document included so proof content can resolve {ord_url} links' do
+      expect(RulesOfOrigin::Scheme).to have_received(:all).with(include: 'proofs,origin_reference_document')
+    end
+  end
+
+  describe 'origin reference document links in proof content' do
+    let(:scheme) do
+      build(:rules_of_origin_scheme,
+            proofs: [attributes_for(:rules_of_origin_proof,
+                                    content: 'See the full text. <a href="{ord_url}">Origin Reference Document</a>')])
+    end
+
+    before do
+      allow(RulesOfOrigin::Scheme).to receive(:all).and_return([scheme])
+
+      get rules_of_origin_proofs_path
+    end
+
+    it 'renders a working link to the origin reference document, not a 404' do
+      href = Capybara.string(response.body).find_link('Origin Reference Document')[:href]
+
+      get href
+
+      expect(response).to have_http_status :ok
+    end
   end
 end

--- a/spec/views/rules_of_origin/proofs/index.html.erb_spec.rb
+++ b/spec/views/rules_of_origin/proofs/index.html.erb_spec.rb
@@ -27,4 +27,14 @@ RSpec.describe 'rules_of_origin/proofs/index', type: :view do
     it { is_expected.to have_css 'details summary', text: schemes.first.proofs.first.summary }
     it { is_expected.to have_css 'details .govuk-details__text *' }
   end
+
+  describe 'origin reference document link within proof content' do
+    let(:schemes) do
+      build_list :rules_of_origin_scheme, 1,
+                 proofs: [attributes_for(:rules_of_origin_proof,
+                                         content: 'See the full text. <a href="{ord_url}">Origin Reference Document</a>')]
+    end
+
+    it { is_expected.to have_link 'Origin Reference Document', href: '/roo_origin_reference_documents/211203_ORD_Japan_V1.1.odt' }
+  end
 end


### PR DESCRIPTION
## What:

Fix a 404 when clicking a rules of origin proof document link, and add regression tests for it.        

 
## Why:
`RulesOfOrigin::ProofsController#index` requested schemes without including the `origin_reference_document` relation. Proof content can embed a literal `<a href="{ord_url}">...</a>` placeholder that only resolves to the real asset path when that relation is present. With it missing,  the raw `{ord_url}` string was left in the rendered link's `href`, so clicking it 404'd.

Added:                                                                                                 
  - A request spec asserting the controller requests `include: 'proofs,origin_reference_document'`, so this can't silently regress.                                                                           
  - An end-to-end request spec that renders a proof containing the real `{ord_url}` pattern, follows the rendered link, and asserts it resolves (200) rather than 404.                                          
  - A view spec asserting the `origin_reference_document.document_path` link resolves correctly.

## Ticket:

https://transformuk.atlassian.net/jira/software/c/projects/HMRC/boards/155?selectedIssue=HMRC-2644

## Risk:

**Risk level:** 🟢  

**Reason for rating:**

Additive change to an existing API call (adds one relation to an already-used `include` param) plus new test coverage; no behaviour change to any other journey.