### PR TITLE
[HMRC-2652] - Fix cookie overflows on feedback page

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -3,22 +3,21 @@ class FeedbackController < ApplicationController
                 :disable_switch_service_banner
 
   def new
-    session[:feedback_referrer] = feedback_url
-    session[:feedback_query] = feedback_query
-    session[:feedback_request_id] = feedback_request_id
-    session[:feedback_date] = feedback_date
-
     @feedback = Feedback.new
     @feedback.page_useful = params[:page_useful]
+    @feedback.referrer = feedback_url
+    @feedback.query = feedback_query
+    @feedback.request_id = feedback_request_id
+    @feedback.date = feedback_date
   end
 
   def create
     @feedback = Feedback.new(feedback_params)
     @feedback.authenticity_token = params[:authenticity_token]
-    @feedback.referrer = session[:feedback_referrer]
-    @feedback.query = session[:feedback_query]
-    @feedback.request_id = session[:feedback_request_id]
-    @feedback.date = session[:feedback_date]
+    @feedback.referrer = params[:feedback_url]
+    @feedback.query = params[:feedback_query]
+    @feedback.request_id = params[:feedback_request_id]
+    @feedback.date = params[:feedback_date]
 
     return redirect_to(find_commodity_path) unless @feedback.valid_page_useful_options?
 
@@ -27,17 +26,14 @@ class FeedbackController < ApplicationController
       FrontendMailer.new_feedback(@feedback).deliver_now unless @feedback.silently_fail?
       @feedback.record_delivery!
 
-      redirect_to feedback_thanks_path
+      redirect_to feedback_thanks_path(feedback_url: @feedback.referrer)
     else
       render :new
     end
   end
 
   def thanks
-    @referrer = session.delete(:feedback_referrer)
-    session.delete(:feedback_query)
-    session.delete(:feedback_request_id)
-    session.delete(:feedback_date)
+    @referrer = params[:feedback_url]
   end
 
   private

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -36,6 +36,10 @@
 
 
       <%= f.hidden_field :page_useful %>
+1      <%= hidden_field_tag :feedback_url, @feedback.referrer %>
+      <%= hidden_field_tag :feedback_query, @feedback.query %>
+      <%= hidden_field_tag :feedback_request_id, @feedback.request_id %>
+      <%= hidden_field_tag :feedback_date, @feedback.date %>
 
       <%= f.govuk_submit 'Submit feedback' %>
     <% end %>

--- a/spec/requests/feedback_controller_spec.rb
+++ b/spec/requests/feedback_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe FeedbackController, type: :request do
         get new_feedback_path, headers: { 'HTTP_REFERER' => 'http://test.host/404' }
         post feedbacks_path, params: {
           feedback: { message: },
+          feedback_url: 'http://test.host/404',
           authenticity_token: 'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw',
         }
         follow_redirect!
@@ -27,6 +28,48 @@ RSpec.describe FeedbackController, type: :request do
       it 'links Return to page at the referrer URL' do
         expect(response.body).to include('http://test.host/404')
       end
+    end
+  end
+
+  describe 'session cookie size' do
+    # The session cookie is a single browser-enforced 4096-byte budget shared by every
+    # feature that writes to `session` (duty calculator answers, myott preferences,
+    # meursing lookups, experiment opt-ins, and so on). This controller must never spend
+    # any of that budget itself, however much context a request carries, otherwise it can
+    # tip an already-long cookie (from any of those other sources) over the limit.
+    let(:large_context) { 'a' * 4500 }
+
+    let(:params_with_large_context) do
+      {
+        feedback: { message: },
+        feedback_url: large_context,
+        feedback_query: large_context,
+        feedback_request_id: large_context,
+        feedback_date: large_context,
+        authenticity_token: 'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw',
+      }
+    end
+
+    it 'does not raise CookieOverflow, regardless of how large the request context is' do
+      expect {
+        get new_feedback_path, params: params_with_large_context.except(:feedback, :authenticity_token)
+        post feedbacks_path, params: params_with_large_context
+      }.not_to raise_error
+    end
+
+    it 'never writes feedback context into the session' do
+      get new_feedback_path, params: params_with_large_context.except(:feedback, :authenticity_token)
+      post feedbacks_path, params: params_with_large_context
+
+      expect(session.to_hash.keys).not_to include('feedback_referrer', 'feedback_query', 'feedback_request_id', 'feedback_date')
+    end
+
+    it 'keeps the session cookie well under the browser 4096-byte limit' do
+      get new_feedback_path, params: params_with_large_context.except(:feedback, :authenticity_token)
+      post feedbacks_path, params: params_with_large_context
+
+      session_cookie = response.headers['Set-Cookie'].to_s.split("\n").find { |c| c.start_with?('_tradetarifffrontend_session=') }
+      expect(session_cookie.to_s.bytesize).to be < 4096
     end
   end
 
@@ -153,6 +196,10 @@ RSpec.describe FeedbackController, type: :request do
       get feedback_hrefs.first
       post feedbacks_path, params: {
         feedback: { message: },
+        feedback_url: 'http://www.example.com/search',
+        feedback_query: 'leather handbags',
+        feedback_request_id: 'search-request-123',
+        feedback_date: '2026-06-05',
         authenticity_token:,
       }
 


### PR DESCRIPTION
## What:
Stops the feedback flow (`/feedback`, e.g. `/xi/feedback`) from writing the referring  page URL, search query, request ID, and date of trade into the session cookie. These values now travel via hidden form fields from the feedback form to its submit action,  and via a redirect query param from submission to the thanks page, instead of via `session`.

Added regression coverage in `spec/requests/feedback_controller_spec.rb` proving the controller never writes to `session`, and that the response cookie stays under the 4096-byte limit even when the request carries an unusually large amount of context.


## Why:
`_tradetarifffrontend_session` uses Rails' `:cookie_store`, so the entire session is serialized into the cookie itself and shared across every feature that touches `session` (duty calculator answers, myott preferences, meursing lookups, experiment opt-ins, and more). `FeedbackController` was adding to that same shared 4096-byte budget on every visit to `/feedback`, and combined with whatever else a user's session already carried, this was overflowing the cookie (seen at 4120 bytes on `/xi/feedback`). Moving this data off the session removes the feedback flow's contribution to that overflow entirely, regardless of what else is in the cookie.


## Ticket:

https://transformuk.atlassian.net/browse/HMRC-2652

## Risk:

**Risk level:**🟠 
**Reason for rating:**

Changes how a live user journey (feedback) passes context between requests from session to hidden fields/redirect params, which  flags session handling as a higher-risk area. Behaviour is covered by updated and new request specs; no API.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────

- Copy or content changes to GOV.UK Frontend components (labels, hint text, page titles)
- Adding or updating GOV.UK Design System components with no behaviour change
- New tests or improved test coverage with no production code changes
- Dependency bumps with no API changes (minor/patch gems, npm packages)
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- Terraform formatting or variable renaming with no resource recreation
- Static asset changes (images, fonts, stylesheets) with no layout impact

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────

- Changes to page layout or navigation that affect all or many user journeys
- Modifications to how commodity data or tariff information is presented to traders
- New or modified API calls to the backend or admin services
- Adding or changing feature flags that affect live user journeys
- Changes to error pages, accessibility markup, or GOV.UK service header/footer
- Search UI changes (autocomplete behaviour, result rendering, filter logic)
- Significant Sass/CSS changes that could affect rendering across browsers or screen sizes
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- Removing or deprecating a route, controller action, or view partial still in use elsewhere

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────

- Changes to how legally significant content is surfaced (trade remedies, prohibitions, licensing, sanctions)
- Modifications to the declarable goods flow or any trader-facing regulatory journey
- Any change to how the service integrates with the identity/authentication layer
- Changes to production AWS infrastructure that cannot be easily rolled back
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Significant architectural shifts (e.g. new service boundaries, caching topology changes)
- Changes that affect GOV.UK service compliance, accessibility standards (WCAG 2.2 AA), or government design system conformance
