### PR TITLE
Stop the feedback footer/banner link from nesting itself into feedback_url

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -82,11 +82,22 @@ module ApplicationHelper
   end
 
   def feedback_context_params
+    return current_feedback_params if controller_path == 'feedback'
+
     {
       feedback_url: request.original_url,
       feedback_query: feedback_search_query,
       feedback_request_id: feedback_search_request_id,
       feedback_date: feedback_search_date,
+    }.compact
+  end
+
+  def current_feedback_params
+    {
+      feedback_url: params[:feedback_url],
+      feedback_query: params[:feedback_query],
+      feedback_request_id: params[:feedback_request_id],
+      feedback_date: params[:feedback_date],
     }.compact
   end
 

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -36,7 +36,7 @@
 
 
       <%= f.hidden_field :page_useful %>
-1      <%= hidden_field_tag :feedback_url, @feedback.referrer %>
+      <%= hidden_field_tag :feedback_url, @feedback.referrer %>
       <%= hidden_field_tag :feedback_query, @feedback.query %>
       <%= hidden_field_tag :feedback_request_id, @feedback.request_id %>
       <%= hidden_field_tag :feedback_date, @feedback.date %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -334,6 +334,63 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#feedback_context_params' do
+    context 'when not on the feedback controller' do
+      before do
+        allow(helper.request).to receive(:original_url).and_return('http://test.host/commodities/1234567890')
+        controller.params[:q] = 'leather handbags'
+      end
+
+      it 'derives feedback_url from the current page URL' do
+        expect(helper.feedback_context_params).to include(feedback_url: 'http://test.host/commodities/1234567890')
+      end
+    end
+
+    context 'when already on the feedback controller' do
+      before do
+        allow(helper.controller).to receive(:controller_path).and_return('feedback')
+        controller.params[:feedback_url] = 'http://test.host/commodities/1234567890'
+        controller.params[:feedback_query] = 'leather handbags'
+      end
+
+      it 'passes through the existing feedback_url instead of the current (feedback) page URL' do
+        expect(helper.feedback_context_params).to eq(
+          feedback_url: 'http://test.host/commodities/1234567890',
+          feedback_query: 'leather handbags',
+        )
+      end
+
+      it 'ignores request.original_url so the feedback page cannot nest itself into feedback_url' do
+        allow(helper.request).to receive(:original_url)
+          .and_return('http://test.host/feedback?feedback_url=http://test.host/commodities/1234567890')
+
+        expect(helper.feedback_context_params[:feedback_url]).not_to include('/feedback?feedback_url=')
+      end
+    end
+  end
+
+  describe '#current_feedback_params' do
+    it 'passes through the feedback params already on the request' do
+      controller.params[:feedback_url] = 'http://test.host/commodities/1234567890'
+      controller.params[:feedback_query] = 'leather handbags'
+      controller.params[:feedback_request_id] = 'abc-123'
+      controller.params[:feedback_date] = '2026-01-01'
+
+      expect(helper.current_feedback_params).to eq(
+        feedback_url: 'http://test.host/commodities/1234567890',
+        feedback_query: 'leather handbags',
+        feedback_request_id: 'abc-123',
+        feedback_date: '2026-01-01',
+      )
+    end
+
+    it 'omits params that are not present' do
+      controller.params[:feedback_url] = 'http://test.host/commodities/1234567890'
+
+      expect(helper.current_feedback_params).to eq(feedback_url: 'http://test.host/commodities/1234567890')
+    end
+  end
+
   describe '#duty_calculator_link' do
     subject(:link) { helper.duty_calculator_link(declarable_code) }
 

--- a/spec/requests/feedback_controller_spec.rb
+++ b/spec/requests/feedback_controller_spec.rb
@@ -73,6 +73,32 @@ RSpec.describe FeedbackController, type: :request do
     end
   end
 
+  describe 'self-referential feedback_url' do
+    # The layout footer renders a "Feedback" link (via ApplicationHelper#feedback_context_params)
+    # on every page, including the feedback page itself. If that helper always derived
+    # feedback_url from the current page's own URL, visiting /feedback (which already carries
+    # ?feedback_url=...) and following its own footer link would wrap the URL in another layer
+    # of ?feedback_url=..., compounding indefinitely on repeated visits.
+    let(:original_page) { 'http://test.host/404' }
+
+    def footer_feedback_href
+      response.body[/<a[^>]+href="([^"]+)"[^>]*>Feedback<\/a>/, 1]
+    end
+
+    before { get new_feedback_path, params: { feedback_url: original_page } }
+
+    it 'points the footer feedback link at the original page' do
+      expect(Rack::Utils.parse_query(URI.parse(footer_feedback_href).query)).to eq('feedback_url' => original_page)
+    end
+
+    it 'does not grow the link when following it from the feedback page itself' do
+      first_href = footer_feedback_href
+      get first_href
+
+      expect(footer_feedback_href).to eq(first_href)
+    end
+  end
+
   describe 'POST #create' do
     before { post feedbacks_path, params: }
 


### PR DESCRIPTION
## What:
`ApplicationHelper#feedback_context_params` now passes through the existing  `feedback_url`/`feedback_query` /`feedback_request_id`/`feedback_date` params when already on the feedback page, instead of always rebuilding `feedback_url` from `request.original_url`. Also fixes a stray leading `1`  in `feedback/new.html.erb` that would have  rendered as visible text above the feedback form
## Why:
The layout renders a "Feedback" link on every page (including the feedback page itself) via `feedback_context_params`, which always derived `feedback_url` from the current page's own URL. On the feedback page, that URL already carries `?feedback_url=...`, so each visit to that link wrapped it in another layer of `?feedback_url=...`, compounding indefinitely on repeated visits (e.g. `/feedback?feedback_url=/feedback?feedback_url=/feedback?feedback_url=...`).

## Ticket:
N/A

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
Small, additive guard clause in a shared helper plus a markup typo fix; behaviour change is scoped to how a footer/banner link is generated and is covered by new unit and request specs. No API, data, or auth changes.