### PR TITLE
Fix preview app HTTP bind lost by HTTPS-only hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ USER tariff
 COPY --chown=tariff:tariff --from=builder /build .
 COPY --chown=tariff:tariff --from=builder /usr/local/bundle/ /usr/local/bundle/
 
-HEALTHCHECK CMD nc -z 0.0.0.0 $SSL_PORT
+HEALTHCHECK CMD sh -c 'if [ -n "$SSL_CERT_PEM" ]; then nc -z 0.0.0.0 "${SSL_PORT:-8443}"; else nc -z 0.0.0.0 "${PORT:-3000}"; fi'
 
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -31,14 +31,7 @@ threads threads_count, threads_count
 
 environment ENV['RACK_ENV'] || 'development'
 
-rails_env = ENV.fetch('RAILS_ENV', 'development')
-
-# Explicit HTTP bind,  default is 3000.
-if rails_env == 'development'
-  bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 3000)}"
-end
-
-# Explicit HTTPS bind
+# Explicit HTTPS bind when TLS material is supplied (ECS services behind the ALB).
 cert = ENV['SSL_CERT_PEM']&.gsub('\\n', "\n")
 key  = ENV['SSL_KEY_PEM']&.gsub('\\n', "\n")
 
@@ -46,6 +39,9 @@ if cert.to_s != '' && key.to_s != ''
   ssl_bind '0.0.0.0', ENV.fetch('SSL_PORT', 8443),
            cert_pem: cert,
            key_pem: key
+else
+  # No TLS material configured (local dev, tests, Preevy preview apps): bind plain HTTP.
+  bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 3000)}"
 end
 
 # Allow puma to be restarted by `bin/rails restart` command.


### PR DESCRIPTION
## What:
Fixes the Preview App: Puma was silently binding to no port at all inside preview containers, so `preview-up.yml`'s health check always failed. `config/puma.rb` now falls back to a plain-HTTP bind whenever no TLS certificate is configured (any `RAILS_ENV`), instead of only doing so when `RAILS_ENV=='development'`. The `Dockerfile` `HEALTHCHECK` now checks whichever port that actually is (`SSL_PORT` when a cert is present, `PORT` otherwise), instead of always checking `SSL_PORT`.

## Why:
`HMRC-1963`/`HMRC-1965` made Puma HTTPS-only and removed the HTTP fallback for ECS, which is correct there since ECS task secrets always include `SSL_CERT_PEM`/`SSL_KEY_PEM`. But the Dockerfile always sets `RAILS_ENV=production`, and the Preevy preview app's `frontend-configuration` secret sets `PORT=8080` with no TLS material (confirmed against a real preview `.env`). So in preview containers neither the HTTP bind (`RAILS_ENV != 'development'`) nor the HTTPS bind (`no cert`) ever ran — Puma bound to nothing, `compose.yml`'s `8080:8080` mapping pointed at an empty socket, and the health check retried and failed every time.

## Ticket:
N/A

## Risk:

**Risk level:** 🟠

**Reason for rating:**
Changes the server bind logic used by every environment (dev, preview, and ECS), so it touches networking behaviour directly. For any environment that already supplies `SSL_CERT_PEM`/`SSL_KEY_PEM` (real ECS prod/staging), the change is a no-op — it only changes behaviour where no cert is configured, which today has no working listener at all. Socialising per the repo's risk guidance for networking-adjacent changes.

---

**Manual evidence:**
- Read the leftover Preevy preview `.env` in this checkout to confirm the preview secret sets `PORT=8080` with no `SSL_CERT_PEM`/`SSL_KEY_PEM`.
- Traced `git log` on `Dockerfile`/`config/puma.rb` to confirm `HMRC-1963`/`HMRC-1965` introduced the HTTPS-only, dev-only-HTTP bind logic.
- `bundle exec rubocop config/puma.rb` — no offenses.
- Could not build/run the container locally to verify end-to-end (local Docker/Alpine CDN TLS trust issue on this machine, unrelated to the repo) — requesting the `needs-preview` label on this PR to verify against the real `Preview App Up` workflow.

**Test commands:**
```
bundle exec rubocop config/puma.rb
```
