### PR TITLE
Spike AI-1146: connect frontend demo to composed VAT answer paths

### DIFF
--- a/app/controllers/duty_calculator/steps/vat_controller.rb
+++ b/app/controllers/duty_calculator/steps/vat_controller.rb
@@ -2,7 +2,10 @@ module DutyCalculator
   module Steps
     class VatController < BaseController
       def show
-        @step = Steps::Vat.new
+        @vat_guidance_journeys = vat_guidance_journeys
+        @vat_guidance_available = @vat_guidance_journeys.any?
+        @vat_guidance_candidate = guided_vat_candidate
+        @step = Steps::Vat.new(vat: @vat_guidance_candidate)
       end
 
       def create
@@ -12,6 +15,25 @@ module DutyCalculator
       end
 
       private
+
+      def vat_guidance_journeys
+        return [] unless Rails.env.development? || Rails.env.test? || ENV['VAT_GUIDANCE_DEMO_ENABLED'] == 'true'
+
+        @vat_guidance_journeys ||= VatGuidancePrototype::ComposedJourneyRepository.new.for_commodity(user_session.commodity_code)
+      rescue VatGuidancePrototype::ComposedJourneyRepository::InvalidArtifact,
+             VatGuidancePrototype::ComposedJourneyRepository::JourneyNotFound,
+             Faraday::Error,
+             SystemCallError
+        []
+      end
+
+      def guided_vat_candidate
+        guidance_session = session[VatGuidanceController::SESSION_KEY]
+        return unless guidance_session&.fetch('journey_id', nil) == user_session.commodity_code
+
+        candidate = guidance_session['candidate_vat']
+        candidate if vat_guidance_journeys.any? && applicable_vat_options.key?(candidate)
+      end
 
       def permitted_params
         params.require(:duty_calculator_steps_vat).permit(

--- a/app/controllers/duty_calculator/steps/vat_guidance_controller.rb
+++ b/app/controllers/duty_calculator/steps/vat_guidance_controller.rb
@@ -1,0 +1,99 @@
+module DutyCalculator
+  module Steps
+    class VatGuidanceController < BaseController
+      SESSION_KEY = 'duty_calculator_vat_guidance'.freeze
+      TREATMENT_TO_VAT = {
+        'standard' => 'VAT',
+        'reduced' => 'VATR',
+        'zero' => 'VATZ',
+      }.freeze
+
+      before_action :load_journey, only: %i[question answer result]
+
+      rescue_from VatGuidancePrototype::ComposedJourneyRepository::JourneyNotFound, with: :return_to_vat
+      rescue_from VatGuidancePrototype::ComposedJourneyRepository::InvalidArtifact,
+                  Faraday::Error,
+                  SystemCallError,
+                  with: :return_to_vat
+
+      def start
+        journey_id = params[:journey_id].presence || user_session.commodity_code
+        journey = repository.for_commodity(user_session.commodity_code).find { |candidate| candidate.id == journey_id }
+        raise VatGuidancePrototype::ComposedJourneyRepository::JourneyNotFound, journey_id unless journey
+
+        session[SESSION_KEY] = { 'journey_id' => journey.id, 'answers' => [] }
+
+        redirect_to vat_guidance_question_path
+      end
+
+      def question
+        @state = engine.evaluate(session_data['answers'])
+        return redirect_to vat_guidance_result_path unless @state.question?
+
+        @question = @state.question
+        @answer_form = VatGuidancePrototype::AnswerForm.new(question: @question)
+      end
+
+      def answer
+        @state = engine.evaluate(session_data['answers'])
+        return redirect_to vat_guidance_result_path unless @state.question?
+
+        @question = @state.question
+        @answer_form = VatGuidancePrototype::AnswerForm.new(question: @question, answer: answer_params[:answer])
+
+        if @answer_form.valid?
+          session_data['answers'] << { 'question_id' => @question.id, 'answer_id' => @answer_form.answer }
+          session[SESSION_KEY] = session_data
+
+          destination = engine.evaluate(session_data['answers']).question? ? vat_guidance_question_path : vat_guidance_result_path
+          redirect_to destination
+        else
+          render :question, status: :unprocessable_content
+        end
+      end
+
+      def result
+        @state = engine.evaluate(session_data['answers'])
+        return redirect_to vat_guidance_question_path if @state.question?
+
+        if @journey.evidence_only
+          session_data.delete('candidate_vat')
+        else
+          session_data['candidate_vat'] = TREATMENT_TO_VAT.fetch(@state.route.fetch('treatment'))
+        end
+        session[SESSION_KEY] = session_data
+      end
+
+    private
+
+      def repository
+        @repository ||= VatGuidancePrototype::ComposedJourneyRepository.new
+      end
+
+      def load_journey
+        return return_to_vat if session_data['journey_id'].blank?
+
+        @journey = repository.for_commodity(user_session.commodity_code).find do |candidate|
+          candidate.id == session_data['journey_id']
+        end
+        raise VatGuidancePrototype::ComposedJourneyRepository::JourneyNotFound, session_data['journey_id'] unless @journey
+      end
+
+      def engine
+        @engine ||= VatGuidancePrototype::ComposedRouteEngine.new(journey: @journey)
+      end
+
+      def session_data
+        @session_data ||= session[SESSION_KEY] || { 'answers' => [] }
+      end
+
+      def answer_params
+        params.fetch(:vat_guidance_prototype_answer_form, {}).permit(:answer)
+      end
+
+      def return_to_vat(_error = nil)
+        redirect_to vat_path, alert: 'Guided VAT questions are not available for this commodity.'
+      end
+    end
+  end
+end

--- a/app/models/vat_guidance_prototype/answer_form.rb
+++ b/app/models/vat_guidance_prototype/answer_form.rb
@@ -1,0 +1,30 @@
+module VatGuidancePrototype
+  class AnswerForm
+    include ActiveModel::Model
+
+    attr_accessor :answer
+    attr_reader :question
+
+    validates :answer, presence: true
+    validate :answer_is_supported
+
+    def initialize(question:, answer: nil)
+      @question = question
+      super(answer:)
+    end
+
+    def options
+      question.answers.map { |candidate| Option.new(id: candidate.id, name: candidate.label) }
+    end
+
+  private
+
+    Option = Data.define(:id, :name)
+
+    def answer_is_supported
+      return if answer.blank? || question.answers.any? { |candidate| candidate.id == answer }
+
+      errors.add(:answer, 'Select one of the available answers')
+    end
+  end
+end

--- a/app/services/vat_guidance_prototype/composed_journey_repository.rb
+++ b/app/services/vat_guidance_prototype/composed_journey_repository.rb
@@ -1,0 +1,160 @@
+module VatGuidancePrototype
+  class ComposedJourneyRepository
+    InvalidArtifact = Class.new(StandardError)
+    JourneyNotFound = Class.new(StandardError)
+
+    Journey = Data.define(
+      :id,
+      :kind,
+      :commodity_code,
+      :applicable_commodity_codes,
+      :title,
+      :description,
+      :status,
+      :review_mode,
+      :production_eligible,
+      :evidence_only,
+      :rule_order,
+      :connection_ids,
+      :exhaustion_note,
+      :routes,
+    )
+
+    def initialize(client: Rails.application.config.http_client_uk)
+      @client = client
+    end
+
+    def all
+      @all ||= commodity_journeys + notice_journeys
+    end
+
+    def find(journey_id)
+      all.find { |journey| journey.id == journey_id.to_s } || raise(JourneyNotFound, journey_id)
+    end
+
+    def for_commodity(commodity_code)
+      all.select { |journey| journey.applicable_commodity_codes.include?(commodity_code.to_s) }
+    end
+
+    def service_position
+      artifact.fetch('service_position')
+    end
+
+    def spike_status
+      artifact.fetch('spike_status')
+    end
+
+    def summary
+      artifact.fetch('summary')
+    end
+
+  private
+
+    attr_reader :client
+
+    def artifact
+      @artifact ||= begin
+        response = client.get('vat_guidance_demo')
+        attributes = response.body.dig('data', 'attributes')
+        validate!(attributes)
+        attributes
+      end
+    rescue Faraday::Error, NoMethodError, KeyError => e
+      raise InvalidArtifact, "VAT guidance demo is unavailable: #{e.message}"
+    end
+
+    def validate!(attributes)
+      unless attributes.is_a?(Hash) && attributes['ticket'] == 'AI-1146'
+        raise InvalidArtifact, 'VAT guidance demo returned the wrong artifact'
+      end
+
+      status = attributes.fetch('spike_status')
+      unless status['end_to_end_simulation_ready'] == true &&
+          status['runtime_approved'] == false &&
+          status['production_ready'] == false
+        raise InvalidArtifact, 'VAT guidance demo safety status is invalid'
+      end
+
+      journeys = attributes.fetch('composed_commodity_journeys')
+      unless journeys.is_a?(Array) && journeys.any? && journeys.all? { |journey| journey['production_eligible'] == false }
+        raise InvalidArtifact, 'VAT guidance demo journeys are not safe for simulation'
+      end
+
+      notices = attributes.fetch('notice_journeys')
+      unless notices.is_a?(Array) && notices.any? && notices.all? { |journey| safe_notice_journey?(journey) }
+        raise InvalidArtifact, 'VAT guidance demo notice journeys are not safe for simulation'
+      end
+    end
+
+    def safe_notice_journey?(journey)
+      routes = journey['resolved_answer_paths']
+      commodity_codes = journey['applicable_commodity_codes']
+      journey['kind'] == 'notice' && journey['evidence_only'] == true &&
+        journey['review_mode'] == 'pending_domain_review' && journey['production_eligible'] == false &&
+        commodity_codes.is_a?(Array) && commodity_codes.any? && commodity_codes.all? { |code| code.match?(/\A\d{10}\z/) } &&
+        routes.is_a?(Array) && routes.any? && routes.all? { |route| disconnected_notice_route?(route) }
+    end
+
+    def disconnected_notice_route?(route)
+      route['additional_code'].nil? && route['measure_ids'] == [] && route['connection_ids'] == []
+    end
+
+    def commodity_journeys
+      artifact.fetch('composed_commodity_journeys').map { |journey| build_commodity_journey(journey) }
+    end
+
+    def notice_journeys
+      artifact.fetch('notice_journeys').map { |journey| build_notice_journey(journey) }
+    end
+
+    def build_commodity_journey(attributes)
+      commodity_code = attributes.fetch('commodity_code')
+      rules = attributes.fetch('rule_order')
+      routes = attributes.fetch('resolved_answer_paths')
+      raise InvalidArtifact, "Commodity #{commodity_code} has no composed routes" unless routes.is_a?(Array) && routes.any?
+
+      Journey.new(
+        id: commodity_code,
+        kind: 'commodity',
+        commodity_code:,
+        applicable_commodity_codes: [commodity_code],
+        title: "Commodity #{commodity_code.scan(/../).join(' ')}",
+        description: "Exercises #{rules.map { |rule| rule.delete_prefix('rule-family:').humanize }.to_sentence}.",
+        status: attributes.fetch('status'),
+        review_mode: attributes.fetch('review_mode'),
+        production_eligible: attributes.fetch('production_eligible'),
+        evidence_only: false,
+        rule_order: rules,
+        connection_ids: attributes.fetch('connection_ids'),
+        exhaustion_note: attributes.fetch('exhaustion_note'),
+        routes:,
+      )
+    rescue KeyError => e
+      raise InvalidArtifact, "Invalid commodity journey: #{e.message}"
+    end
+
+    def build_notice_journey(attributes)
+      routes = attributes.fetch('resolved_answer_paths')
+      raise InvalidArtifact, "Notice journey #{attributes['id']} has no answer paths" unless routes.is_a?(Array) && routes.any?
+
+      Journey.new(
+        id: attributes.fetch('id'),
+        kind: attributes.fetch('kind'),
+        commodity_code: nil,
+        applicable_commodity_codes: attributes.fetch('applicable_commodity_codes'),
+        title: attributes.fetch('title'),
+        description: attributes.fetch('description'),
+        status: attributes.fetch('status'),
+        review_mode: attributes.fetch('review_mode'),
+        production_eligible: attributes.fetch('production_eligible'),
+        evidence_only: attributes.fetch('evidence_only'),
+        rule_order: [],
+        connection_ids: [],
+        exhaustion_note: nil,
+        routes:,
+      )
+    rescue KeyError => e
+      raise InvalidArtifact, "Invalid notice journey: #{e.message}"
+    end
+  end
+end

--- a/app/services/vat_guidance_prototype/composed_route_engine.rb
+++ b/app/services/vat_guidance_prototype/composed_route_engine.rb
@@ -1,0 +1,101 @@
+module VatGuidancePrototype
+  class ComposedRouteEngine
+    InvalidAnswer = Class.new(StandardError)
+    InvalidRoutes = Class.new(StandardError)
+
+    Answer = Data.define(:id, :label)
+    Question = Data.define(:id, :text, :answers)
+    TrailItem = Data.define(:question, :answer, :evidence)
+
+    State = Data.define(:status, :question, :route, :reason, :trail) do
+      def question?
+        status == :question
+      end
+
+      def determined?
+        status == :determined
+      end
+    end
+
+    def initialize(journey:)
+      @journey = journey
+    end
+
+    def evaluate(raw_answers = [])
+      answers = normalize_answers(raw_answers)
+      candidates = matching_routes(answers)
+      raise InvalidAnswer, 'The answers do not match a composed route' if candidates.empty?
+
+      completed = candidates.select { |route| route.fetch('steps').length == answers.length }
+      if completed.any?
+        raise InvalidRoutes, 'A completed route overlaps an unfinished route' unless completed.length == candidates.length
+        raise InvalidRoutes, 'The answers resolve to more than one route' unless completed.one?
+
+        route = completed.sole
+        return State.new(status: :determined, question: nil, route:, reason: nil, trail: build_trail(route, answers))
+      end
+
+      State.new(
+        status: :question,
+        question: build_question(candidates, answers.length),
+        route: nil,
+        reason: nil,
+        trail: build_trail(candidates.first, answers),
+      )
+    end
+
+  private
+
+    attr_reader :journey
+
+    def normalize_answers(raw_answers)
+      Array(raw_answers).map do |answer|
+        answer = answer.stringify_keys
+        answer.slice('question_id', 'answer_id').tap do |normalized|
+          unless normalized.values.all?(&:present?)
+            raise InvalidAnswer, 'Each answer must identify a question and answer'
+          end
+        end
+      end
+    end
+
+    def matching_routes(answers)
+      journey.routes.select do |route|
+        steps = route.fetch('steps')
+        next false if steps.length < answers.length
+
+        answers.each_with_index.all? do |answer, index|
+          step = steps.fetch(index)
+          step['question_id'] == answer['question_id'] && step['answer_id'] == answer['answer_id']
+        end
+      end
+    end
+
+    def build_question(routes, index)
+      steps = routes.map { |route| route.fetch('steps').fetch(index) }
+      question_ids = steps.pluck('question_id').uniq
+      question_texts = steps.pluck('question').uniq
+      unless question_ids.one? && question_texts.one?
+        raise InvalidRoutes, 'Composed routes disagree on the next question'
+      end
+
+      answers = steps.group_by { |step| step.fetch('answer_id') }.map do |id, answer_steps|
+        labels = answer_steps.pluck('answer').uniq
+        raise InvalidRoutes, "Composed routes disagree on answer #{id}" unless labels.one?
+
+        Answer.new(id:, label: labels.sole)
+      end
+
+      Question.new(id: question_ids.sole, text: question_texts.sole, answers: answers.sort_by(&:id))
+    end
+
+    def build_trail(route, answers)
+      answers.each_with_index.map do |answer, index|
+        step = route.fetch('steps').fetch(index)
+        question = Question.new(id: step.fetch('question_id'), text: step.fetch('question'), answers: [])
+        selected_answer = Answer.new(id: answer.fetch('answer_id'), label: step.fetch('answer'))
+        TrailItem.new(question:, answer: selected_answer, evidence: step['evidence'])
+      end
+    end
+  end
+end

--- a/app/views/duty_calculator/steps/vat/show.html.erb
+++ b/app/views/duty_calculator/steps/vat/show.html.erb
@@ -3,8 +3,28 @@
 <%= form_for @step, url: vat_path do |f| %>
   <%= f.govuk_error_summary %>
   <span class="govuk-caption-xl"><%= t('duty_calculator.shared.caption') %></span>
+  <h1 class="govuk-heading-xl">Which VAT rate is applicable to your trade?</h1>
 
-  <%= f.govuk_collection_radio_buttons :vat, @step.vat_options, :id, :name, legend: { text: 'Which VAT rate is applicable to your trade?', size: 'xl', tag: 'h1' }, hint: { text: "There are #{applicable_vat_options.keys.count} VAT rates applicable to the trade in this commodity code. Select which rate applies to your trade. For guidance on applicable VAT rates, please see the document <a href='https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services' target='_blank' class='govuk-link'>VAT rates on different goods and services (opens in new browser window)</a>.".html_safe }, include_hidden: true %>
+  <% if @vat_guidance_available %>
+    <%= govuk_inset_text do %>
+      <% if @vat_guidance_candidate.present? %>
+        <p class="govuk-body"><strong>Guided VAT result: <%= applicable_vat_options.fetch(@vat_guidance_candidate) %></strong></p>
+        <p class="govuk-body">Review the suggested rate and confirm your selection below. The guided result is not an HMRC determination.</p>
+        <% selected_journey_id = session.dig(DutyCalculator::Steps::VatGuidanceController::SESSION_KEY, 'journey_id') %>
+        <%= button_tag 'Review the guided VAT questions', formaction: vat_guidance_start_path, name: 'journey_id', value: selected_journey_id, class: 'govuk-button govuk-button--secondary' %>
+      <% else %>
+        <p class="govuk-body"><strong>Not sure which VAT rate applies?</strong></p>
+        <p class="govuk-body">Choose guidance for this commodity before selecting a VAT rate.</p>
+        <% @vat_guidance_journeys.each do |journey| %>
+          <h2 class="govuk-heading-s"><%= journey.title %></h2>
+          <p class="govuk-body"><%= journey.description %></p>
+          <%= button_tag 'Start this guidance', formaction: vat_guidance_start_path, name: 'journey_id', value: journey.id, class: 'govuk-button govuk-button--secondary' %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_collection_radio_buttons :vat, @step.vat_options, :id, :name, legend: { text: 'VAT rates', hidden: true }, hint: { text: "There are #{applicable_vat_options.keys.count} VAT rates applicable to the trade in this commodity code. Select which rate applies to your trade. For guidance on applicable VAT rates, please see the document <a href='https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services' target='_blank' class='govuk-link'>VAT rates on different goods and services (opens in new browser window)</a>.".html_safe }, include_hidden: true %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/duty_calculator/steps/vat_guidance/question.html.erb
+++ b/app/views/duty_calculator/steps/vat_guidance/question.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, @question.text %>
+<% content_for :back_link do %>
+  <%= back_link vat_path %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @journey.title %> — calculate import duties</span>
+
+    <%= govuk_warning_text(text: 'This guided result uses synthetic review decisions and is not an HMRC determination.') %>
+
+    <%= form_for @answer_form,
+                 url: vat_guidance_answer_path,
+                 builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+      <%= form.govuk_error_summary %>
+      <%= form.govuk_collection_radio_buttons :answer,
+                                               @answer_form.options,
+                                               :id,
+                                               :name,
+                                               legend: { text: @question.text, size: 'xl', tag: 'h1' },
+                                               include_hidden: true %>
+      <%= form.govuk_submit 'Continue' %>
+    <% end %>
+
+    <p class="govuk-body-s">Guidance for commodity <%= user_session.commodity_code.scan(/../).join(' ') %>.</p>
+  </div>
+</div>

--- a/app/views/duty_calculator/steps/vat_guidance/result.html.erb
+++ b/app/views/duty_calculator/steps/vat_guidance/result.html.erb
@@ -1,0 +1,39 @@
+<% content_for :title, 'Guided VAT result' %>
+<% content_for :back_link do %>
+  <%= back_link vat_path %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @journey.title %> — calculate import duties</span>
+    <h1 class="govuk-heading-xl">Guided VAT result</h1>
+
+    <%= govuk_warning_text(text: 'This result uses synthetic review decisions. It is not an HMRC determination. Review and confirm the VAT rate before continuing.') %>
+
+    <%= govuk_inset_text do %>
+      <p class="govuk-heading-l govuk-!-margin-bottom-1"><%= @state.route.fetch('treatment').humanize %></p>
+      <% if @journey.evidence_only %>
+        <p class="govuk-body govuk-!-margin-bottom-0">Evidence-only outcome — no VAT option has been selected.</p>
+      <% else %>
+        <p class="govuk-body govuk-!-margin-bottom-0">Suggested VAT option: <strong><%= DutyCalculator::Steps::VatGuidanceController::TREATMENT_TO_VAT.fetch(@state.route.fetch('treatment')) %></strong></p>
+      <% end %>
+    <% end %>
+
+    <h2 class="govuk-heading-l">Answers used</h2>
+    <%= govuk_summary_list(actions: false, rows: @state.trail.map { |item|
+      { key: { text: item.question.text }, value: { text: item.answer.label } }
+    }) %>
+
+    <h2 class="govuk-heading-l">Evidence used</h2>
+    <% evidence_items = @state.trail.filter_map(&:evidence) + [@state.route['terminal_evidence']].compact %>
+    <% evidence_items.uniq.each do |evidence| %>
+      <blockquote class="govuk-inset-text">
+        <p class="govuk-body"><%= evidence.fetch('quote') %></p>
+        <% source_path = evidence.fetch('node_id').delete_prefix('document:') %>
+        <p class="govuk-body-s"><%= link_to 'Read the source guidance', "https://www.gov.uk#{source_path}", class: 'govuk-link' %></p>
+      </blockquote>
+    <% end %>
+
+    <%= link_to 'Return to VAT rate selection', vat_path, class: 'govuk-button' %>
+  </div>
+</div>

--- a/config/routes/duty_calculator.rb
+++ b/config/routes/duty_calculator.rb
@@ -34,6 +34,13 @@ scope path: '/duty-calculator/' do
   get 'vat', to: 'duty_calculator/steps/vat#show'
   post 'vat', to: 'duty_calculator/steps/vat#create'
 
+  if Rails.env.development? || Rails.env.test? || ENV['VAT_GUIDANCE_DEMO_ENABLED'] == 'true'
+    post 'vat-guidance/start', to: 'duty_calculator/steps/vat_guidance#start', as: :vat_guidance_start
+    get 'vat-guidance/question', to: 'duty_calculator/steps/vat_guidance#question', as: :vat_guidance_question
+    post 'vat-guidance/answer', to: 'duty_calculator/steps/vat_guidance#answer', as: :vat_guidance_answer
+    get 'vat-guidance/result', to: 'duty_calculator/steps/vat_guidance#result', as: :vat_guidance_result
+  end
+
   get 'confirm', to: 'duty_calculator/steps/confirmation#show'
 
   get 'interstitial', to: 'duty_calculator/steps/interstitial#show'

--- a/docs/spikes/guided-vat-prototype.md
+++ b/docs/spikes/guided-vat-prototype.md
@@ -1,0 +1,67 @@
+# AI-1146 guided VAT duty-calculator integration
+
+The duty calculator's existing VAT step demonstrates the AI-1146 backend artifact end to end. For a supported commodity, it loads the hash-validated, precomposed commodity route from `GET /uk/api/v2/vat_guidance_demo` and offers guided VAT questions alongside the existing VAT-rate choices.
+
+The demo uses synthetic review decisions. It is not an HMRC determination, is not approved for runtime or production use, and must not be used to make a VAT declaration.
+
+## Run locally
+
+Start Trade Tariff Backend on port 3000:
+
+```sh
+cd ../trade-tariff-backend
+RAILS_ENV=development bundle exec rails server -p 3000
+```
+
+Start Trade Tariff Frontend on port 3001:
+
+```sh
+cd ../trade-tariff-frontend
+RAILS_ENV=development asdf exec bundle exec rails server -p 3001
+```
+
+Open a supported commodity's duty calculation and continue to its VAT step, for example:
+
+```text
+http://localhost:3001/duty-calculator/2005202000/import-date
+```
+
+The frontend development configuration points its UK API client at `http://localhost:3000/uk/api`. If the validation login is enabled, use the locally configured `BASIC_PASSWORD`.
+
+The endpoint and nested duty-calculator routes are enabled automatically in development and test. For a deployed demo, set `VAT_GUIDANCE_DEMO_ENABLED=true` on both applications and configure the frontend UK API host to the corresponding backend deployment.
+
+## Demo flow
+
+1. The frontend requests the AI-1146 projection from Trade Tariff Backend.
+2. The backend verifies the committed artifact hash and rejects any artifact that is runtime-approved, production-ready, not simulation-ready or contains a production-eligible journey.
+3. The frontend independently validates the safety flags and looks up the current duty-calculator commodity among the 11 composed commodity journeys.
+4. When guidance exists, the VAT step offers the commodity-composed journey and any backend-associated notice journeys. The user chooses the relevant guidance and answers GOV.UK radio-button questions without leaving the duty calculation.
+5. `ComposedRouteEngine` filters the 72 backend-generated routes by the answer prefix and requires one unambiguous next question or terminal route.
+6. The result displays the candidate treatment, answer trail and source evidence, then returns to the VAT step with the matching VAT option selected for explicit confirmation.
+
+The frontend does not maintain or infer a second VAT ruleset. It cannot select an answer, question or result absent from the backend artifact.
+
+The standalone `/vat-guidance-prototype` chooser is not routed. For the curated Chapter 20 commodities, the VAT step offers both the commodity-composed route and the associated evidence-only VAT Notice 701/14 and 709/1 journeys. Protective-equipment and Chapter 84 commodities receive their own composed journey only.
+
+## Safety boundary
+
+- `end_to_end_simulation_ready` must be `true`.
+- `runtime_approved` and `production_ready` must remain `false`.
+- Every composed journey must remain `production_eligible: false`.
+- Missing, malformed, unsupported or unsafe backend responses leave the existing VAT-rate form usable without guided controls.
+- Results are labelled as candidates produced with synthetic review decisions.
+- The guidance result does not bypass the existing VAT form: the user returns to the VAT step and explicitly submits the selected option before it affects the calculation.
+
+## Verification
+
+Run the frontend contract and browser-journey specs:
+
+```sh
+asdf exec bundle exec rspec \
+  spec/services/vat_guidance_prototype/composed_journey_repository_spec.rb \
+  spec/services/vat_guidance_prototype/composed_route_engine_spec.rb \
+  spec/requests/duty_calculator/steps/vat_guidance_controller_spec.rb \
+  spec/features/vat_guidance_demo_spec.rb
+```
+
+The backend request and artifact specs live in the AI-1146 backend branch. For a manual demonstration, begin a duty calculation for a supported commodity, exercise at least one standard route and one VATZ or VATR route, return to the VAT step, and confirm that the suggested option is selected but is not saved until the user submits the VAT form.

--- a/spec/features/vat_guidance_demo_spec.rb
+++ b/spec/features/vat_guidance_demo_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe 'Guided VAT within the duty calculator', :user_session, type: :feature do
+  let(:user_session) do
+    build(
+      :duty_calculator_user_session,
+      :with_commodity_information,
+      :with_import_date,
+      :with_import_destination,
+      :with_country_of_origin,
+      :with_customs_value,
+      commodity_code: '2005202000',
+    )
+  end
+  let(:commodity) { build(:duty_calculator_commodity, goods_nomenclature_item_id: '2005202000') }
+  let(:commodity_context_service) { instance_double(DutyCalculator::CommodityContextService, call: commodity) }
+
+  before do
+    stub_vat_guidance_demo
+    allow(DutyCalculator::CommodityContextService).to receive(:new).and_return(commodity_context_service)
+  end
+
+  it 'returns a commodity-specific result to the VAT step for explicit confirmation', :aggregate_failures do
+    visit vat_path
+
+    expect(page).to have_css('h1', text: 'Which VAT rate is applicable to your trade?')
+    expect(page).to have_text('VAT Notice 709/1 — catering and food exceptions')
+    first(:button, 'Start this guidance').click
+
+    expect(page).to have_css('h1', text: 'Is the product supplied in the course of catering?')
+    choose 'No'
+    click_button 'Continue'
+
+    expect(page).to have_css('h1', text: 'Is the product packaged and ready to eat?')
+    choose 'Yes'
+    click_button 'Continue'
+
+    expect(page).to have_css('h1', text: 'Guided VAT result')
+    expect(page).to have_text('Zero')
+    expect(page).to have_text('VATZ')
+    expect(page).to have_text('not an HMRC determination')
+    expect(page).to have_link('Read the source guidance', href: %r{gov\.uk/guidance/food-products})
+
+    click_link 'Return to VAT rate selection'
+
+    expect(page).to have_text('Guided VAT result: VAT zero rate (0.0)')
+    expect(page).to have_checked_field('VAT zero rate (0.0)')
+    click_button 'Continue'
+
+    expect(page).to have_current_path(confirm_path)
+    expect(user_session.vat).to eq('VATZ')
+  end
+
+  it 'does not expose the removed standalone prototype URL' do
+    visit '/vat-guidance-prototype'
+
+    expect(page.status_code).to eq(404)
+  end
+end

--- a/spec/requests/duty_calculator/steps/vat_guidance_controller_spec.rb
+++ b/spec/requests/duty_calculator/steps/vat_guidance_controller_spec.rb
@@ -1,0 +1,88 @@
+RSpec.describe DutyCalculator::Steps::VatGuidanceController, :user_session, type: :request do
+  let(:user_session) { build(:duty_calculator_user_session, :with_commodity_information, commodity_code:) }
+  let(:commodity_code) { '2005202000' }
+
+  before { stub_vat_guidance_demo }
+
+  it 'starts from the duty-calculator commodity and completes its composed route', :aggregate_failures do
+    post vat_guidance_start_path
+    expect(response).to redirect_to(vat_guidance_question_path)
+
+    get vat_guidance_question_path
+    expect(response.body).to include('Is the product supplied in the course of catering?')
+
+    post vat_guidance_answer_path, params: {
+      vat_guidance_prototype_answer_form: { answer: 'no' },
+    }
+    follow_redirect!
+    expect(response.body).to include('Is the product packaged and ready to eat?')
+
+    post vat_guidance_answer_path, params: {
+      vat_guidance_prototype_answer_form: { answer: 'yes' },
+    }
+    follow_redirect!
+
+    expect(response.body).to include('Guided VAT result')
+    expect(response.body).to include('VATZ')
+    expect(response.body).to include('Return to VAT rate selection')
+    expect(response.body).to include('not an HMRC determination')
+  end
+
+  it 'renders an accessible validation error for an unanswered question', :aggregate_failures do
+    post vat_guidance_start_path
+    post vat_guidance_answer_path, params: {
+      vat_guidance_prototype_answer_form: { answer: '' },
+    }
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.body).to include('Error:')
+    expect(response.body).to include('can&#39;t be blank')
+  end
+
+  it 'keeps the 701/14 food-exception journey inside the VAT step and evidence-only', :aggregate_failures do
+    post vat_guidance_start_path, params: { journey_id: 'notice-701-14-food-exceptions' }
+    follow_redirect!
+    expect(response.body).to include('standard-rated food exception identified by VAT Notice 701/14')
+
+    post vat_guidance_answer_path, params: {
+      vat_guidance_prototype_answer_form: { answer: 'no' },
+    }
+    follow_redirect!
+
+    expect(response.body).to include('Guided VAT result')
+    expect(response.body).to include('Evidence-only outcome — no VAT option has been selected.')
+    expect(session.dig(described_class::SESSION_KEY, 'candidate_vat')).to be_nil
+  end
+
+  it 'keeps the 709/1 catering journey and its 701/14 follow-up inside the VAT step', :aggregate_failures do
+    post vat_guidance_start_path, params: { journey_id: 'notice-709-1-catering-reference-expanded' }
+    follow_redirect!
+    expect(response.body).to include('Is the supply made in the course of catering?')
+
+    post vat_guidance_answer_path, params: {
+      vat_guidance_prototype_answer_form: { answer: 'no' },
+    }
+    follow_redirect!
+    expect(response.body).to include('Does the item fall within a standard-rated food exception identified by VAT Notice 701/14?')
+
+    post vat_guidance_answer_path, params: {
+      vat_guidance_prototype_answer_form: { answer: 'no' },
+    }
+    follow_redirect!
+
+    expect(response.body).to include('Guided VAT result')
+    expect(response.body).to include('Evidence-only outcome — no VAT option has been selected.')
+    expect(session.dig(described_class::SESSION_KEY, 'candidate_vat')).to be_nil
+  end
+
+  context 'when the commodity has no composed guidance journey' do
+    let(:commodity_code) { '9999999999' }
+
+    it 'returns to the VAT step without starting an unrelated journey', :aggregate_failures do
+      post vat_guidance_start_path
+
+      expect(response).to redirect_to(vat_path)
+      expect(flash[:alert]).to eq('Guided VAT questions are not available for this commodity.')
+    end
+  end
+end

--- a/spec/services/vat_guidance_prototype/composed_journey_repository_spec.rb
+++ b/spec/services/vat_guidance_prototype/composed_journey_repository_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe VatGuidancePrototype::ComposedJourneyRepository do
+  subject(:repository) { described_class.new }
+
+  before { stub_vat_guidance_demo }
+
+  describe '#for_commodity' do
+    it 'returns the composed and associated notice journeys for a prepared-food commodity' do
+      expect(repository.for_commodity('2005202000').map(&:id)).to contain_exactly(
+        '2005202000',
+        'notice-701-14-food-exceptions',
+        'notice-709-1-catering-reference-expanded',
+      )
+    end
+
+    it 'does not return food notice guidance for an unrelated commodity' do
+      expect(repository.for_commodity('8407100010')).to be_empty
+    end
+  end
+
+  it 'loads non-production composed journeys from the backend artifact', :aggregate_failures do
+    journey = repository.find('2005202000')
+
+    expect(repository.spike_status).to include('runtime_approved' => false, 'production_ready' => false)
+    expect(journey.commodity_code).to eq('2005202000')
+    expect(journey.title).to eq('Commodity 20 05 20 20 00')
+    expect(journey.production_eligible).to be(false)
+    expect(journey.routes.size).to eq(2)
+  end
+
+  it 'loads the evidence-only 709/1 notice comparison without a commodity or measure connection', :aggregate_failures do
+    journey = repository.find('notice-709-1-catering-reference-expanded')
+
+    expect(journey.kind).to eq('notice')
+    expect(journey.commodity_code).to be_nil
+    expect(journey.evidence_only).to be(true)
+    expect(journey.review_mode).to eq('pending_domain_review')
+    expect(journey.production_eligible).to be(false)
+    expect(journey.routes).to contain_exactly(
+      include('treatment' => 'standard', 'additional_code' => nil, 'measure_ids' => []),
+      include('treatment' => 'standard', 'additional_code' => nil, 'measure_ids' => []),
+      include('treatment' => 'zero', 'additional_code' => nil, 'measure_ids' => []),
+    )
+  end
+
+  it 'rejects an artifact that claims runtime approval' do
+    response = vat_guidance_demo_response
+    response.dig('data', 'attributes', 'spike_status')['runtime_approved'] = true
+    stub_vat_guidance_demo(response)
+
+    expect { repository.all }.to raise_error(described_class::InvalidArtifact, /safety status is invalid/)
+  end
+
+  it 'rejects an evidence-only notice journey containing a measure connection' do
+    response = vat_guidance_demo_response
+    route = response.dig('data', 'attributes', 'notice_journeys', 0, 'resolved_answer_paths', 0)
+    route['additional_code'] = 'VATZ'
+    route['measure_ids'] = ['-1']
+    route['connection_ids'] = ['connection-proposal:unsafe']
+    stub_vat_guidance_demo(response)
+
+    expect { repository.all }.to raise_error(described_class::InvalidArtifact, /notice journeys are not safe/)
+  end
+end

--- a/spec/services/vat_guidance_prototype/composed_route_engine_spec.rb
+++ b/spec/services/vat_guidance_prototype/composed_route_engine_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe VatGuidancePrototype::ComposedRouteEngine do
+  subject(:engine) { described_class.new(journey:) }
+
+  let(:journey) do
+    stub_vat_guidance_demo
+    VatGuidancePrototype::ComposedJourneyRepository.new.find('2005202000')
+  end
+
+  it 'walks a composed route from its answer prefix to the exact candidate treatment', :aggregate_failures do
+    first = engine.evaluate
+    second = engine.evaluate([{ question_id: 'catering', answer_id: 'no' }])
+    result = engine.evaluate([
+      { question_id: 'catering', answer_id: 'no' },
+      { question_id: 'packaged-ready', answer_id: 'yes' },
+    ])
+
+    expect(first.question.text).to eq('Is the product supplied in the course of catering?')
+    expect(first.question.answers.map(&:id)).to contain_exactly('yes', 'no')
+    expect(second.question.text).to eq('Is the product packaged and ready to eat?')
+    expect(result).to be_determined
+    expect(result.route).to include('treatment' => 'zero', 'additional_code' => 'VATZ')
+    expect(result.trail.size).to eq(2)
+  end
+
+  it 'rejects an answer that is absent from every composed route' do
+    expect {
+      engine.evaluate([{ question_id: 'catering', answer_id: 'sometimes' }])
+    }.to raise_error(described_class::InvalidAnswer, /do not match/)
+  end
+end

--- a/spec/support/vat_guidance_demo_helper.rb
+++ b/spec/support/vat_guidance_demo_helper.rb
@@ -1,0 +1,213 @@
+module VatGuidanceDemoHelper
+  def vat_guidance_demo_response
+    {
+      data: {
+        id: 'ai-1146',
+        type: 'vat_guidance_demo',
+        attributes: {
+          schema_version: 1,
+          ticket: 'AI-1146',
+          source_artifact_sha256: 'a' * 64,
+          service_position: "The service guides using the trader's own answers and presents candidate VAT treatments for review.",
+          spike_status: {
+            end_to_end_simulation_ready: true,
+            hmrc_demo_ready: false,
+            production_ready: false,
+            runtime_approved: false,
+          },
+          summary: {
+            answer_paths: 53,
+            pinned_measure_proposals: 12,
+            composed_spike_commodities: 11,
+          },
+          composed_commodity_journeys: [{
+            commodity_code: '2005202000',
+            status: 'spike_simulation_complete',
+            review_mode: 'synthetic_spike_fixture',
+            production_eligible: false,
+            rule_order: ['rule-family:potato-crisps-exception'],
+            connection_ids: ['connection-proposal:test'],
+            exhaustion_note: {
+              standard_by_default_permitted_after_all_rules_decline: true,
+            },
+            resolved_answer_paths: [
+              {
+                id: 'composed-route:standard',
+                steps: [vat_guidance_demo_step('yes', 'Yes')],
+                resolution: 'explicit_guidance',
+                treatment: 'standard',
+                additional_code: nil,
+                measure_ids: [],
+                connection_ids: [],
+              },
+              {
+                id: 'composed-route:zero',
+                steps: [
+                  vat_guidance_demo_step('no', 'No'),
+                  {
+                    question_id: 'packaged-ready',
+                    question: 'Is the product packaged and ready to eat?',
+                    answer_id: 'yes',
+                    answer: 'Yes',
+                    evidence: vat_guidance_demo_evidence,
+                  },
+                ],
+                resolution: 'synthetic_spike_rule_connections',
+                treatment: 'zero',
+                additional_code: 'VATZ',
+                measure_ids: ['-1012550499'],
+                connection_ids: ['connection-proposal:test'],
+              },
+            ],
+          }],
+          notice_journeys: [{
+            id: 'notice-701-14-food-exceptions',
+            kind: 'notice',
+            applicable_commodity_codes: %w[2005202000 2008939120 2008979890],
+            title: 'VAT Notice 701/14 — food exceptions',
+            description: 'Exercises the standalone food-exception path from VAT Notice 701/14.',
+            status: 'spike_evidence_only',
+            review_mode: 'pending_domain_review',
+            production_eligible: false,
+            evidence_only: true,
+            resolved_answer_paths: [
+              {
+                id: 'answer-path:70114-zero-food',
+                steps: [vat_guidance_food_exception_step('no', 'No')],
+                resolution: 'evidence_only_notice_comparison',
+                treatment: 'zero',
+                additional_code: nil,
+                measure_ids: [],
+                connection_ids: [],
+                terminal_evidence: vat_guidance_food_evidence,
+              },
+              {
+                id: 'answer-path:70114-standard-food',
+                steps: [vat_guidance_food_exception_step('yes', 'Yes')],
+                resolution: 'evidence_only_notice_comparison',
+                treatment: 'standard',
+                additional_code: nil,
+                measure_ids: [],
+                connection_ids: [],
+                terminal_evidence: vat_guidance_food_evidence,
+              },
+            ],
+          }, {
+            id: 'notice-709-1-catering-reference-expanded',
+            kind: 'notice',
+            applicable_commodity_codes: %w[2005202000 2008939120 2008979890],
+            title: 'VAT Notice 709/1 — catering and food exceptions',
+            description: 'Exercises the reference-expanded catering path and its VAT Notice 701/14 food-exception follow-up.',
+            status: 'spike_evidence_only',
+            review_mode: 'pending_domain_review',
+            production_eligible: false,
+            evidence_only: true,
+            resolved_answer_paths: [
+              {
+                id: 'answer-path:7091-standard-catering',
+                steps: [vat_guidance_notice_step('yes', 'Yes')],
+                resolution: 'evidence_only_notice_comparison',
+                treatment: 'standard',
+                additional_code: nil,
+                measure_ids: [],
+                connection_ids: [],
+                terminal_evidence: vat_guidance_notice_evidence,
+              },
+              {
+                id: 'answer-path:7091-zero-food',
+                steps: [
+                  vat_guidance_notice_step('no', 'No'),
+                  vat_guidance_food_exception_step('no', 'No'),
+                ],
+                resolution: 'evidence_only_notice_comparison',
+                treatment: 'zero',
+                additional_code: nil,
+                measure_ids: [],
+                connection_ids: [],
+                terminal_evidence: vat_guidance_food_evidence,
+              },
+              {
+                id: 'answer-path:7091-standard-food-exception',
+                steps: [
+                  vat_guidance_notice_step('no', 'No'),
+                  vat_guidance_food_exception_step('yes', 'Yes'),
+                ],
+                resolution: 'evidence_only_notice_comparison',
+                treatment: 'standard',
+                additional_code: nil,
+                measure_ids: [],
+                connection_ids: [],
+                terminal_evidence: vat_guidance_food_evidence,
+              },
+            ],
+          }],
+        },
+      },
+    }.deep_stringify_keys
+  end
+
+  def stub_vat_guidance_demo(response = vat_guidance_demo_response)
+    stub_api_request('vat_guidance_demo', backend: 'uk').to_return(
+      status: 200,
+      headers: { 'content-type' => 'application/json' },
+      body: JSON.generate(response),
+    )
+  end
+
+private
+
+  def vat_guidance_demo_step(answer_id, answer)
+    {
+      question_id: 'catering',
+      question: 'Is the product supplied in the course of catering?',
+      answer_id:,
+      answer:,
+      evidence: vat_guidance_demo_evidence,
+    }
+  end
+
+  def vat_guidance_demo_evidence
+    {
+      quote: 'You must always standard rate food supplied in the course of catering.',
+      node_id: 'document:/guidance/food-products-and-vat-notice-70114#food-supplied-in-the-course-of-catering',
+    }
+  end
+
+  def vat_guidance_notice_step(answer_id, answer)
+    {
+      question_id: 'course-of-catering-expanded',
+      question: 'Is the supply made in the course of catering?',
+      answer_id:,
+      answer:,
+      evidence: vat_guidance_notice_evidence,
+    }
+  end
+
+  def vat_guidance_food_exception_step(answer_id, answer)
+    {
+      question_id: 'food-standard-exception',
+      question: 'Does the item fall within a standard-rated food exception identified by VAT Notice 701/14?',
+      answer_id:,
+      answer:,
+      evidence: vat_guidance_food_evidence,
+    }
+  end
+
+  def vat_guidance_notice_evidence
+    {
+      quote: 'Other supplies are standard-rated because they’re made in the course of catering.',
+      node_id: 'document:/guidance/catering-takeaway-food-and-vat-notice-7091#information-in-this-notice',
+    }
+  end
+
+  def vat_guidance_food_evidence
+    {
+      quote: 'Most food of a kind used for human consumption is zero-rated. There are, however, some exceptions.',
+      node_id: 'document:/guidance/food-products-and-vat-notice-70114#food-not-supplied-in-the-course-of-catering',
+    }
+  end
+end
+
+RSpec.configure do |config|
+  config.include VatGuidanceDemoHelper
+end


### PR DESCRIPTION
## What:
  Integrates the AI-1146 guided VAT proof of concept into the existing duty-calculator VAT step.

  For supported commodities, users can:

  - Select a commodity or notice-based guidance journey.
  - Answer GOV.UK-style questions sourced from the backend artifact.
  - Review the candidate VAT treatment, answer trail and supporting evidence.
  - Return to the existing VAT form and explicitly confirm the VAT rate.
  
The implementation validates the backend safety flags, fails closed on invalid or unavailable data, and is disabled outside development/test unless VAT_GUIDANCE_DEMO_ENABLED=true. Tests and local demonstration guidance are included.

## Why:
  To demonstrate the AI-1146 answer paths end to end within the real duty-calculator journey and assess whether structured guidance can help users understand the available VAT treatments.

  The frontend does not create a separate VAT ruleset or automatically persist a decision. The backend remains the source of truth, evidence-only journeys cannot select a rate, and the user must confirm any candidate treatment through the existing VAT form.

## Ticket:
[AI-1146](https://transformuk.atlassian.net/browse/AI-1146)

## Risk:

**Risk level:** 🔴 

**Reason for rating:**
  This changes a trader-facing regulatory journey and can influence VAT-rate selection, which is legally significant. Although the feature is gated, uses synthetic non-production-approved data, validates the backend contract and requires explicit user confirmation, it must not be enabled in production without authorised tax-content approval and explicit approval from Thor or Neil.