### PR TITLE
AI-1187: Stop linking guided search result descriptions

### DIFF
--- a/app/models/goods_nomenclature/description_formatter.rb
+++ b/app/models/goods_nomenclature/description_formatter.rb
@@ -1,42 +1,19 @@
 class GoodsNomenclature
   class DescriptionFormatter
     include ActionView::Helpers::SanitizeHelper
-    include CommoditiesHelper
 
     ALLOWED_SOURCE_TAGS = %w[br sub sup].freeze
-    ALLOWED_RESULT_TAGS = %w[a br sub sup].freeze
-    ALLOWED_RESULT_ATTRIBUTES = %w[href rel target].freeze
 
     def initialize(text)
       @text = text.to_s
     end
 
     def to_html
-      fragment = Nokogiri::HTML::DocumentFragment.parse(linkified_text)
-      add_link_attributes(fragment)
-
       sanitize(
-        fragment.to_html,
-        tags: ALLOWED_RESULT_TAGS,
-        attributes: ALLOWED_RESULT_ATTRIBUTES,
+        @text,
+        tags: ALLOWED_SOURCE_TAGS,
+        attributes: [],
       ).html_safe
     end
-
-    private
-
-    def linkified_text
-      convert_text_to_links(
-        sanitize(@text, tags: ALLOWED_SOURCE_TAGS, attributes: []),
-      )
-    end
-
-    def add_link_attributes(fragment)
-      fragment.css('a').each do |link|
-        link['target'] = '_blank'
-        link['rel'] = 'noopener noreferrer'
-      end
-    end
-
-    def url_options = {}
   end
 end

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -216,28 +216,12 @@ RSpec.describe GoodsNomenclature do
         expect(formatted_self_text).not_to include('<script>')
       end
 
-      it 'linkifies dotted goods codes to a new tab search link' do
-        expect(formatted_self_text).to include('href="/search?q=870310"')
-      end
-
-      it 'opens linkified goods codes in a new tab' do
-        expect(formatted_self_text).to include('target="_blank"')
-      end
-
-      it 'adds a safe rel attribute to generated goods code links' do
-        expect(formatted_self_text).to include('rel="noopener noreferrer"')
+      it 'does not link dotted goods codes' do
+        expect(formatted_self_text).not_to include('<a')
       end
 
       it 'preserves the displayed dotted goods code text' do
-        expect(formatted_self_text).to include('>8703.10</a>')
-      end
-
-      it 'does not link unrelated numeric values' do
-        expect(formatted_self_text).not_to include('href="/search?q=1000"')
-      end
-
-      it 'keeps dotted goods codes linked to the full code' do
-        expect(formatted_self_text).not_to include('href="/search?q=8703"')
+        expect(formatted_self_text).to include('subheading 8703.10')
       end
     end
   end
@@ -257,12 +241,12 @@ RSpec.describe GoodsNomenclature do
       expect(formatted_classification_description).to include('cm<sub>3</sub><br>')
     end
 
-    it 'linkifies recognised code references' do
-      expect(formatted_classification_description).to include('href="/search?q=87"')
+    it 'does not link recognised code references' do
+      expect(formatted_classification_description).not_to include('<a')
     end
 
     it 'preserves the displayed chapter reference text' do
-      expect(formatted_classification_description).to include('>chapter 87</a>')
+      expect(formatted_classification_description).to include('chapter 87')
     end
   end
 end

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -123,21 +123,21 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
       expect(rendered).not_to include('&lt;sub&gt;')
     end
 
-    it 'linkifies recognised goods codes in self text' do
+    it 'does not link goods code references in result descriptions' do
       render partial: 'search/interactive_results_content'
 
-      expect(rendered).to have_link('8703.10', href: '/search?q=870310')
-    end
-
-    it 'opens linkified goods code references in a new tab' do
-      render partial: 'search/interactive_results_content'
-
-      expect(rendered).to have_css('p.govuk-body-s a[target="_blank"][rel="noopener noreferrer"]', text: '8703.10')
+      expect(rendered).not_to have_css('.interactive-result h3 a, .interactive-result p.govuk-body-s a')
     end
   end
 
   describe 'commodity links' do
     it { is_expected.to have_link('View this commodity code (opens in new tab)', href: /2007919930/) }
+
+    it 'is the only link on the result card' do
+      render partial: 'search/interactive_results_content'
+
+      expect(rendered).to have_css('.interactive-result a', count: 1)
+    end
 
     it 'opens commodity links in a new tab' do
       render partial: 'search/interactive_results_content'

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
       'description' => 'Containing less than 70% by weight of sugar',
       'formatted_description' => 'Containing less than 70% by weight of sugar',
       'self_text' => 'Citrus marmalade and jam products with 8703.10 and 1000 cm<sup>3</sup>',
-      'classification_description' => 'Citrus fruit jam<br>with less than 70% sugar and 5 cm<sub>3</sub>',
+      'classification_description' => 'Citrus fruit jam<br>with less than 70% sugar and 5 cm<sub>3</sub><br>Other<br>Other, excluding preparations of heading 9406',
       'full_description' => 'Citrus fruit jam with less than 70% sugar',
       'heading_description' => 'Jams and marmalades',
       'declarable' => true,


### PR DESCRIPTION
## What:

- [x] Stop commodity code references in guided search result descriptions and self text becoming links
- [x] Preserve line breaks, subscripts, superscripts, and the existing commodity CTA behaviour

## Why:

Description links can point traders towards excluded classifications and compete with the result card's intended action.

## Ticket:

https://transformuk.atlassian.net/browse/AI-1187

## Risk:

**Risk level:** 🟢 Green

**Reason for rating:**

This is an isolated presentation change to the guided search result formatter with focused regression coverage. It does not change classification wording, the commodity CTA, backend APIs, or linkification elsewhere in the service.