### PR TITLE
AI-1188: Hide confidence components

### DIFF
--- a/app/views/search/_interactive_result.html.erb
+++ b/app/views/search/_interactive_result.html.erb
@@ -19,7 +19,4 @@
         },
         new_tab: true %>
   </div>
-  <div class="interactive-result__confidence">
-    <%= render_confidence_meter(result.try(:confidence)) %>
-  </div>
 </div>

--- a/app/views/search/_interactive_results_content.html.erb
+++ b/app/views/search/_interactive_results_content.html.erb
@@ -55,15 +55,6 @@
       <%= govuk_button_link_to 'Start search again', find_commodity_path, secondary: true %>
       <%= govuk_link_to 'Cancel', find_commodity_path %>
     </div>
-
-    <%= govuk_details(summary_text: 'How we calculate confidence', classes: 'govuk-!-margin-top-6') do %>
-      <p>Our system analyses your search term and answers to find the most relevant commodity codes.</p>
-      <%= govuk_list [
-        safe_join([tag.strong('Strong result'), ' - High confidence this is the correct classification']),
-        safe_join([tag.strong('Good result'), ' - Likely correct but you may want to verify']),
-        safe_join([tag.strong('Possible result'), ' - Worth considering but less certain'])
-      ], type: :bullet %>
-    <% end %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -147,7 +147,8 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
   end
 
   describe 'confidence meter' do
-    it { is_expected.to have_css('.confidence-indicator') }
+    it { is_expected.not_to have_css('.interactive-result__confidence') }
+    it { is_expected.not_to have_css('.confidence-indicator') }
   end
 
   describe 'other results divider' do
@@ -186,20 +187,17 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
   end
 
   describe 'confidence explainer' do
-    it { is_expected.to have_text('Strong result') }
-    it { is_expected.to have_text('Good result') }
-    it { is_expected.to have_text('Possible result') }
-    it { is_expected.not_to have_text('Low confidence, included for completeness') }
+    it { is_expected.not_to have_css('.govuk-details__summary-text', text: 'How we calculate confidence') }
   end
 
   describe 'actions' do
     it { is_expected.to have_link('Start search again', href: find_commodity_path) }
     it { is_expected.to have_link('Cancel', href: find_commodity_path) }
 
-    it 'renders the actions before the confidence explainer' do
+    it 'renders the actions before other search options' do
       render partial: 'search/interactive_results_content'
 
-      expect(rendered.index('Start search again')).to be < rendered.index('How we calculate confidence')
+      expect(rendered.index('Start search again')).to be < rendered.index('Other ways to search for a commodity')
     end
   end
 
@@ -208,12 +206,6 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
     it { is_expected.to have_link('Keyword or commodity code', href: find_commodity_path) }
     it { is_expected.to have_link('Goods classifications', href: browse_sections_path) }
     it { is_expected.to have_link('A-Z product index', href: a_z_index_path(letter: 'a')) }
-
-    it 'renders after the confidence explainer' do
-      render partial: 'search/interactive_results_content'
-
-      expect(rendered.index('How we calculate confidence')).to be < rendered.index('Other ways to search for a commodity')
-    end
   end
 
   describe 'sidebar' do


### PR DESCRIPTION
## What:

- [x] Hide confidence meters from guided-search results
- [x] Hide the confidence calculation details and explanatory content
- [x] Let result descriptions fill the space previously used by the meter
- [x] Update view coverage for the hidden components

**Before - confidence meters and calculation details visible**

<img width="963" height="1277" alt="Guided search results before the change, showing confidence meters and confidence calculation details" src="https://github.com/user-attachments/assets/4b6b18c4-509e-44e6-8e9f-f514ae1e927f" />

**After - confidence meters and calculation details hidden**

<img width="1167" height="1365" alt="Guided search results after the change, with confidence meters and confidence calculation details hidden" src="https://github.com/user-attachments/assets/9f9cd5bf-caee-429a-a04b-412b5a3d0f54" />

The after state demonstrates both acceptance criteria: the confidence meters and confidence-calculation details are absent, and the result descriptions use the released width.

## Why:

Confidence indicators could suggest that strong results are definitively correct before their accuracy has been reviewed with HMRC. This temporarily hides the presentation while retaining the underlying implementation for future review.

## Ticket:

[AI-1188](https://transformuk.atlassian.net/browse/AI-1188)

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Small, reversible view-only change with focused coverage. It does not change search requests, ranking, result data, analytics, APIs or JavaScript behaviour.
