### PR TITLE
AI-1222: Direct classification support to the enquiry form

### DIFF
--- a/app/views/search/_interactive_error_sidebar.html.erb
+++ b/app/views/search/_interactive_error_sidebar.html.erb
@@ -9,11 +9,9 @@
           ['What is origin and why is it important for international trade?', '/howto/origin'],
         ],
       ) %>
-  <% if TradeTariffFrontend.webchat_enabled? %>
-    <%= govuk_section_break(size: 'm', visible: true) %>
+  <%= govuk_section_break(size: 'm', visible: true) %>
 
-    <%= govuk_details(summary_text: 'Get support') do %>
-      <%= render 'search/interactive_support_links' %>
-    <% end %>
+  <%= govuk_details(summary_text: 'Get support') do %>
+    <%= render 'search/interactive_support_links' %>
   <% end %>
 <% end %>

--- a/app/views/search/_interactive_results_sidebar.html.erb
+++ b/app/views/search/_interactive_results_sidebar.html.erb
@@ -9,11 +9,9 @@
           ['Ask for help on classifying your goods', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods'],
         ],
       ) %>
-  <% if TradeTariffFrontend.webchat_enabled? %>
-    <%= govuk_section_break(size: 'm', visible: true) %>
+  <%= govuk_section_break(size: 'm', visible: true) %>
 
-    <%= govuk_details(summary_text: 'Get support') do %>
-      <%= render 'search/interactive_support_links' %>
-    <% end %>
+  <%= govuk_details(summary_text: 'Get support') do %>
+    <%= render 'search/interactive_support_links' %>
   <% end %>
 <% end %>

--- a/app/views/search/_interactive_support_links.html.erb
+++ b/app/views/search/_interactive_support_links.html.erb
@@ -1,5 +1,11 @@
 <% if TradeTariffFrontend.webchat_enabled? %>
-  <%= tag.p(class: 'govuk-body govuk-!-margin-bottom-1') do %><%= tag.strong('Webchat:') %> <%= webchat_link 'Ask HMRC online' %><% end %>
+  <%= tag.h3('Webchat', class: 'govuk-heading-s govuk-!-margin-bottom-0') %>
+  <%= tag.p(class: 'govuk-body') do %>
+    <%= webchat_link 'Ask HMRC online' %>
+  <% end %>
 <% end %>
 
-<%= tag.p(class: 'govuk-body') do %><%= tag.strong('Email:') %> <%= govuk_mail_to 'classification.enquiries@hmrc.gov.uk' %><% end %>
+<%= tag.h3('Enquiry form', class: 'govuk-heading-s govuk-!-margin-bottom-0') %>
+<%= tag.p(class: 'govuk-body') do %>
+  <%= govuk_link_to 'Ask a classification question', product_experience_enquiry_form_path %>
+<% end %>

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -218,16 +218,20 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
       before { allow(TradeTariffFrontend).to receive(:webchat_enabled?).and_return(true) }
 
       it { is_expected.to have_css('.govuk-details__summary-text', text: 'Get support') }
-      it { is_expected.to have_css('p.govuk-body', text: 'Webchat: Ask HMRC online') }
-      it { is_expected.to have_css('p.govuk-body', text: 'Email: classification.enquiries@hmrc.gov.uk') }
-      it { is_expected.to have_link('Ask HMRC online') }
-      it { is_expected.to have_link('classification.enquiries@hmrc.gov.uk', href: 'mailto:classification.enquiries@hmrc.gov.uk') }
+      it { is_expected.to have_css('h3.govuk-heading-s', exact_text: 'Webchat') }
+      it { is_expected.to have_css('h3[class~="govuk-!-margin-bottom-0"] + p.govuk-body > a', text: 'Ask HMRC online') }
+      it { is_expected.to have_css('h3.govuk-heading-s', exact_text: 'Enquiry form') }
+      it { is_expected.to have_css('h3[class~="govuk-!-margin-bottom-0"] + p.govuk-body > a', text: 'Ask a classification question') }
+      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path) }
+      it { is_expected.not_to have_link('classification.enquiries@hmrc.gov.uk') }
     end
 
     context 'when webchat is disabled' do
       before { allow(TradeTariffFrontend).to receive(:webchat_enabled?).and_return(false) }
 
-      it { is_expected.not_to have_css('.govuk-details__summary-text', text: 'Get support') }
+      it { is_expected.to have_css('.govuk-details__summary-text', text: 'Get support') }
+      it { is_expected.not_to have_link('Ask HMRC online') }
+      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path) }
     end
   end
 end

--- a/spec/views/search/_interactive_unknown_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_unknown_results_content.html.erb_spec.rb
@@ -51,18 +51,19 @@ RSpec.describe 'search/_interactive_unknown_results_content', type: :view do
     context 'when webchat is enabled' do
       before { allow(TradeTariffFrontend).to receive(:webchat_enabled?).and_return(true) }
 
-      it { is_expected.to have_css('p.govuk-body', text: 'Webchat: Ask HMRC online') }
-      it { is_expected.to have_css('p.govuk-body', text: 'Email: classification.enquiries@hmrc.gov.uk') }
-      it { is_expected.to have_link('Ask HMRC online') }
-      it { is_expected.to have_link('classification.enquiries@hmrc.gov.uk', href: 'mailto:classification.enquiries@hmrc.gov.uk') }
+      it { is_expected.to have_css('h3.govuk-heading-s', exact_text: 'Webchat') }
+      it { is_expected.to have_css('h3[class~="govuk-!-margin-bottom-0"] + p.govuk-body > a', text: 'Ask HMRC online') }
+      it { is_expected.to have_css('h3.govuk-heading-s', exact_text: 'Enquiry form') }
+      it { is_expected.to have_css('h3[class~="govuk-!-margin-bottom-0"] + p.govuk-body > a', text: 'Ask a classification question') }
+      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path) }
+      it { is_expected.not_to have_link('classification.enquiries@hmrc.gov.uk') }
     end
 
     context 'when webchat is disabled' do
       before { allow(TradeTariffFrontend).to receive(:webchat_enabled?).and_return(false) }
 
       it { is_expected.not_to have_link('Ask HMRC online') }
-      it { is_expected.to have_css('p.govuk-body', text: 'Email: classification.enquiries@hmrc.gov.uk') }
-      it { is_expected.to have_link('classification.enquiries@hmrc.gov.uk', href: 'mailto:classification.enquiries@hmrc.gov.uk') }
+      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path) }
     end
   end
 
@@ -71,6 +72,13 @@ RSpec.describe 'search/_interactive_unknown_results_content', type: :view do
     it { is_expected.to have_link('Classifying your goods') }
     it { is_expected.to have_link('How to use quotas') }
     it { is_expected.to have_link('How to value your goods for import or export') }
+
+    context 'when webchat is disabled' do
+      before { allow(TradeTariffFrontend).to receive(:webchat_enabled?).and_return(false) }
+
+      it { is_expected.to have_css('.govuk-details', text: 'Ask a classification question') }
+      it { is_expected.not_to have_css('.govuk-details', text: 'Ask HMRC online') }
+    end
   end
 
   describe 'alternative search cards' do


### PR DESCRIPTION
## What:

- [x] Put each support link on a new line beneath its heading
- [x] Replace the classification email with an enquiry form link
- [x] Keep the support content consistent across AI search result states

<img width="460" height="360" alt="Get support component showing Webchat and Enquiry form links on separate lines beneath their headings" src="https://github.com/user-attachments/assets/35c6e699-4639-4117-abae-16dd5f494465" />

## Why:

Direct classification questions through the enquiry form so HMRC receives the information needed to respond, while retaining webchat as the other support option.

## Ticket:

[AI-1222](https://transformuk.atlassian.net/browse/AI-1222)

## Risk:

**Risk level:** 🟢

**Reason for rating:** This is a localised support copy and link change with view coverage. It does not change search behaviour, tariff data, backend APIs, routes, or deployment configuration.