### PR TITLE
AI-1182: Reset answers between guided search questions

### DIFF
--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -32,6 +32,7 @@ module InteractiveSearchable
     if @results.exact_match?
       render_interactive_results
     elsif @results.has_pending_question?
+      @form = InteractiveSearchForm.new
       render_interactive_question
     elsif @results.blocking_guidance?
       return redirect_to_interactive_blocking if redirectable_interactive_blocking?

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe SearchController, type: :request do
+  describe 'POST /search' do
+    context 'when guided search advances to a new question' do
+      before do
+        enable_feature(:interactive_search)
+        stub_api_request('search', :post, internal: true).to_return(
+          status: 200,
+          body: {
+            data: [],
+            meta: {
+              interactive_search: {
+                query: 'horse',
+                request_id: 'guided-request-123',
+                answers: [
+                  { question: 'What is the horse used for?', options: %w[Sport Other], answer: 'Other' },
+                  { question: 'What is it made from?', options: %w[Wood Other], answer: nil },
+                ],
+              },
+            },
+          }.to_json,
+          headers: { 'content-type' => 'application/json; charset=utf-8' },
+        )
+      end
+
+      it 'does not select the previous answer' do
+        post perform_search_path,
+             params: {
+               q: 'horse',
+               interactive_search: 'true',
+               request_id: 'guided-request-123',
+               current_question: 'What is the horse used for?',
+               current_options: %w[Sport Other].to_json,
+               interactive_search_form: { answer: 'Other' },
+             }
+
+        expect(Capybara.string(response.body)).to have_unchecked_field('Other')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What:

- [x] Reset the guided-search answer form when advancing to a new question
- [x] Add request coverage for consecutive questions that both contain an "Other" option

## Why:

Rails reused the form object bound to the previous answer when it rendered the next question. If both questions contained the same option, that value was carried forward and rendered as selected. A fresh form is now bound when the journey advances, so each new question starts without a selected answer.

## Ticket:

[AI-1182](https://transformuk.atlassian.net/browse/AI-1182)

## Risk:

**Risk level:** 🟢

**Reason for rating:** This is a narrow, reversible form-state correction with request coverage. It does not change the guided-search API, question options, markup, accessibility behaviour, or result rendering.