### PR TITLE
AI-1224: Add enquiry feature flag context

### DIFF
--- a/app/controllers/product_experience/enquiry_form_controller.rb
+++ b/app/controllers/product_experience/enquiry_form_controller.rb
@@ -92,7 +92,7 @@ module ProductExperience
 
     def enquiry_context
       {
-        'test_condition' => enabled_feature_flag_names.presence&.to_sentence || 'none',
+        'feature_flags' => enabled_feature_flag_names,
         'search_request_id' => params[:request_id].presence,
       }.compact
     end
@@ -206,7 +206,7 @@ module ProductExperience
         job_title: data['occupation'],
         email: data['email_address'],
         enquiry_category: submission_category(data),
-        test_condition: data.fetch('test_condition', 'none'),
+        feature_flags: data.fetch('feature_flags', []),
         search_request_id: data['search_request_id'],
       }
       common_attributes[:other_category] = data['other_category'] if data['category'] == 'other'

--- a/app/controllers/product_experience/enquiry_form_controller.rb
+++ b/app/controllers/product_experience/enquiry_form_controller.rb
@@ -93,8 +93,13 @@ module ProductExperience
     def enquiry_context
       {
         'feature_flags' => enabled_feature_flag_names,
-        'search_request_id' => params[:request_id].presence,
+        'search_request_id' => safe_search_request_id(params[:request_id]),
       }.compact
+    end
+
+    def safe_search_request_id(value)
+      request_id = value.to_s
+      request_id if request_id.match?(/\A[a-zA-Z0-9-]{1,64}\z/)
     end
 
     def enabled_feature_flag_names

--- a/app/controllers/product_experience/enquiry_form_controller.rb
+++ b/app/controllers/product_experience/enquiry_form_controller.rb
@@ -87,7 +87,18 @@ module ProductExperience
       clear_enquiry_data
       session[:enquiry_form_draft_id] = SecureRandom.uuid
       session[:submission_token] = SecureRandom.uuid
-      write_enquiry_data({})
+      write_enquiry_data(enquiry_context)
+    end
+
+    def enquiry_context
+      {
+        'test_condition' => enabled_feature_flag_names.presence&.to_sentence || 'none',
+        'search_request_id' => params[:request_id].presence,
+      }.compact
+    end
+
+    def enabled_feature_flag_names
+      TradeTariffFrontend.enabled_flagsmith_feature_names
     end
 
     def hide_feedback_useful_banner
@@ -195,6 +206,8 @@ module ProductExperience
         job_title: data['occupation'],
         email: data['email_address'],
         enquiry_category: submission_category(data),
+        test_condition: data.fetch('test_condition', 'none'),
+        search_request_id: data['search_request_id'],
       }
       common_attributes[:other_category] = data['other_category'] if data['category'] == 'other'
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,6 +81,12 @@ module ApplicationHelper
     feedback_path(feedback_context_params.merge(options))
   end
 
+  def enquiry_form_path_with_context
+    request_id = feedback_search_request_id || params[:feedback_request_id].presence
+
+    product_experience_enquiry_form_path(request_id:)
+  end
+
   def feedback_context_params
     return current_feedback_params if controller_path == 'feedback'
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -82,7 +82,7 @@ module ApplicationHelper
   end
 
   def enquiry_form_path_with_context
-    request_id = feedback_search_request_id || params[:feedback_request_id].presence
+    request_id = feedback_search_request_id || params[:feedback_request_id].presence || @feedback&.request_id.presence
 
     product_experience_enquiry_form_path(request_id:)
   end

--- a/app/models/enquiry_form.rb
+++ b/app/models/enquiry_form.rb
@@ -12,12 +12,6 @@ class EnquiryForm
       },
     }
 
-    super(
-      json_api_params,
-      {
-        'Authorization' => TradeTariffFrontend.green_lanes_api_token,
-        'Content-Type' => 'application/json',
-      },
-    )
+    super(json_api_params, { 'Content-Type' => 'application/json' })
   end
 end

--- a/app/models/enquiry_form.rb
+++ b/app/models/enquiry_form.rb
@@ -12,6 +12,12 @@ class EnquiryForm
       },
     }
 
-    super(json_api_params, { 'Content-Type' => 'application/json' })
+    super(
+      json_api_params,
+      {
+        'Authorization' => TradeTariffFrontend.green_lanes_api_token,
+        'Content-Type' => 'application/json',
+      },
+    )
   end
 end

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -23,7 +23,7 @@
                             max_chars: 500 %>
 
         <p class="form-hint">
-          If you have any questions or need assistance, use our <%= govuk_link_to 'enquiry form', product_experience_enquiry_form_path %>.
+          If you have any questions or need assistance, use our <%= govuk_link_to 'enquiry form', enquiry_form_path_with_context %>.
         </p>
 
       <div hidden>

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -47,7 +47,7 @@
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods">Ask HMRC for advice on classifying your goods</a></li>
         <li class="govuk-footer__list-item"><a class="govuk-footer__link" target="_blank" href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries">Imports and exports: general enquiries</a></li>
         <li class="govuk-footer__list-item"><%= govuk_link_to 'Feedback', feedback_path_with_context, class: "govuk-footer__link" %></li>
-        <li class="govuk-footer__list-item"><%= govuk_link_to 'Enquiry Form', product_experience_enquiry_form_path, class: "govuk-footer__link" %></li>
+        <li class="govuk-footer__list-item"><%= govuk_link_to 'Enquiry Form', enquiry_form_path_with_context, class: "govuk-footer__link" %></li>
       </ul>
     </div>
 

--- a/app/views/search/_interactive_support_links.html.erb
+++ b/app/views/search/_interactive_support_links.html.erb
@@ -7,5 +7,5 @@
 
 <%= tag.h3('Enquiry form', class: 'govuk-heading-s govuk-!-margin-bottom-0') %>
 <%= tag.p(class: 'govuk-body') do %>
-  <%= govuk_link_to 'Ask a classification question', product_experience_enquiry_form_path %>
+  <%= govuk_link_to 'Ask a classification question', enquiry_form_path_with_context %>
 <% end %>

--- a/lib/trade_tariff_frontend/config.rb
+++ b/lib/trade_tariff_frontend/config.rb
@@ -68,6 +68,7 @@ module TradeTariffFrontend
     def enabled_flagsmith_feature_names
       Config.registered_flags.filter_map { |method_name, registration|
         next unless public_send(method_name)
+        next if Current.flagsmith_unavailable
 
         flag_name = registration.fetch(:name)
         flag = Current.flagsmith_flags&.get_flag(flag_name)

--- a/lib/trade_tariff_frontend/config.rb
+++ b/lib/trade_tariff_frontend/config.rb
@@ -72,7 +72,7 @@ module TradeTariffFrontend
         flag_name = registration.fetch(:name)
         flag = Current.flagsmith_flags&.get_flag(flag_name)
 
-        flag_name.humanize if flag && !flag.is_default
+        flag_name if flag && !flag.is_default
       }.sort
     end
 

--- a/lib/trade_tariff_frontend/config.rb
+++ b/lib/trade_tariff_frontend/config.rb
@@ -65,6 +65,17 @@ module TradeTariffFrontend
       ENV.fetch('DEVELOPER_PORTAL_URL') { "https://hub.#{base_domain}/" }
     end
 
+    def enabled_flagsmith_feature_names
+      Config.registered_flags.filter_map { |method_name, registration|
+        next unless public_send(method_name)
+
+        flag_name = registration.fetch(:name)
+        flag = Current.flagsmith_flags&.get_flag(flag_name)
+
+        flag_name.humanize if flag && !flag.is_default
+      }.sort
+    end
+
     def enquiries_email
       DEFAULT_ENQUIRIES_EMAIL
     end

--- a/spec/controllers/product_experience/enquiry_form_controller_spec.rb
+++ b/spec/controllers/product_experience/enquiry_form_controller_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe ProductExperience::EnquiryFormController, :aggregate_failures, ty
 
       expect(session[:product_experience_enquiry]).to be_nil
     end
+
+    it 'omits an invalid search request identifier from the enquiry draft' do
+      get :show, params: { request_id: { nested: 'value' } }
+
+      draft = ProductExperience::EnquiryFormDraftStore.read(session[:enquiry_form_draft_id])
+
+      expect(draft).not_to include('search_request_id')
+    end
   end
 
   describe 'POST #submit' do

--- a/spec/features/enquiry_form_revised_flow_spec.rb
+++ b/spec/features/enquiry_form_revised_flow_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Revised enquiry form flow', :aggregate_failures, type: :feature 
         email: 'trader@example.com',
         enquiry_category: 'valuation',
         enquiry_description: include('I need help understanding tariff quota duties'),
-        test_condition: 'none',
+        feature_flags: [],
       ),
     )
   end
@@ -158,7 +158,7 @@ RSpec.describe 'Revised enquiry form flow', :aggregate_failures, type: :feature 
 
     expect(EnquiryForm).to have_received(:create!).with(
       hash_including(
-        test_condition: 'Interactive search',
+        feature_flags: %w[interactive_search],
         search_request_id: 'search-request-123',
       ),
     )
@@ -182,7 +182,7 @@ RSpec.describe 'Revised enquiry form flow', :aggregate_failures, type: :feature 
     end
 
     expect(EnquiryForm).to have_received(:create!).with(
-      hash_including(test_condition: 'Webchat'),
+      hash_including(feature_flags: %w[webchat]),
     )
   end
 

--- a/spec/features/enquiry_form_revised_flow_spec.rb
+++ b/spec/features/enquiry_form_revised_flow_spec.rb
@@ -138,7 +138,51 @@ RSpec.describe 'Revised enquiry form flow', :aggregate_failures, type: :feature 
         email: 'trader@example.com',
         enquiry_category: 'valuation',
         enquiry_description: include('I need help understanding tariff quota duties'),
+        test_condition: 'none',
       ),
+    )
+  end
+
+  it 'submits feature flag and search context' do
+    enable_feature(:interactive_search)
+    visit product_experience_enquiry_form_path(request_id: 'search-request-123')
+    disable_feature(:interactive_search)
+
+    choose 'Valuation'
+    click_button 'Continue'
+    fill_in 'How can we help you?', with: 'The search results did not answer my question.'
+    click_button 'Continue'
+    fill_in 'Email address', with: 'trader@example.com'
+    click_button 'Continue'
+    click_button 'Submit'
+
+    expect(EnquiryForm).to have_received(:create!).with(
+      hash_including(
+        test_condition: 'Interactive search',
+        search_request_id: 'search-request-123',
+      ),
+    )
+  end
+
+  it 'submits globally enabled feature flags from the XI service' do
+    TradeTariffFrontend::ServiceChooser.with_source(:xi) do
+      enable_feature(:webchat)
+      enable_feature(:interactive_search)
+      visit product_experience_enquiry_form_path
+      disable_feature(:webchat)
+      disable_feature(:interactive_search)
+
+      choose 'Valuation'
+      click_button 'Continue'
+      fill_in 'How can we help you?', with: 'The service did not answer my question.'
+      click_button 'Continue'
+      fill_in 'Email address', with: 'trader@example.com'
+      click_button 'Continue'
+      click_button 'Submit'
+    end
+
+    expect(EnquiryForm).to have_received(:create!).with(
+      hash_including(test_condition: 'Webchat'),
     )
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -369,6 +369,32 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#enquiry_form_path_with_context' do
+    subject(:path) { helper.enquiry_form_path_with_context }
+
+    it 'includes the current search request id' do
+      assign(:search, build(:search, request_id: 'search-request-123'))
+
+      expect(path).to eq('/enquiry_form?request_id=search-request-123')
+    end
+
+    it 'falls back to the request params' do
+      controller.params[:request_id] = 'search-request-456'
+
+      expect(path).to eq('/enquiry_form?request_id=search-request-456')
+    end
+
+    it 'preserves context from the feedback page' do
+      controller.params[:feedback_request_id] = 'search-request-789'
+
+      expect(path).to eq('/enquiry_form?request_id=search-request-789')
+    end
+
+    it 'omits a missing request id' do
+      expect(path).to eq('/enquiry_form')
+    end
+  end
+
   describe '#current_feedback_params' do
     it 'passes through the feedback params already on the request' do
       controller.params[:feedback_url] = 'http://test.host/commodities/1234567890'

--- a/spec/lib/trade_tariff_frontend_spec.rb
+++ b/spec/lib/trade_tariff_frontend_spec.rb
@@ -121,6 +121,21 @@ RSpec.describe TradeTariffFrontend do
     end
   end
 
+  describe '.enabled_flagsmith_feature_names' do
+    it 'does not inspect flags again after the SDK becomes unavailable', :aggregate_failures do
+      Current.flagsmith_identity = Flagsmith::AnonymousIdentity.new('anon-123')
+      allow(described_class::ServiceChooser).to receive_messages(service_name: 'uk', xi?: false)
+      stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => 'development'))
+
+      flags = instance_double(TestFlagsmithClient::TestFlags)
+      allow(flags).to receive(:get_flag).and_raise(Faraday::ConnectionFailed.new('timeout'))
+      allow(FlagsmithClient.instance).to receive(:get_flags_for).and_return(flags)
+
+      expect(described_class.enabled_flagsmith_feature_names).to be_empty
+      expect(flags).to have_received(:get_flag).once
+    end
+  end
+
   describe '.developer_portal_url' do
     around do |example|
       described_class.instance_variable_set(:@base_domain, nil)

--- a/spec/models/enquiry_form_spec.rb
+++ b/spec/models/enquiry_form_spec.rb
@@ -14,9 +14,13 @@ RSpec.describe EnquiryForm do
                 attributes: attributes,
               },
             ),
-            headers: { 'Content-Type' => 'application/json' },
+            headers: {
+              'Authorization' => 'Bearer frontend-token',
+              'Content-Type' => 'application/json',
+            },
           )
           .and_return(jsonapi_response(:enquiry_form_submission, { resource_id: resource_id }))
+        allow(TradeTariffFrontend).to receive(:green_lanes_api_token).and_return('Bearer frontend-token')
       end
 
       it { is_expected.to be_a described_class }

--- a/spec/models/enquiry_form_spec.rb
+++ b/spec/models/enquiry_form_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe EnquiryForm do
 
     context 'when the request is successful' do
       before do
+        allow(TradeTariffFrontend).to receive(:green_lanes_api_token)
+
         stub_api_request('enquiry_form/submissions', :post)
           .with(
             body: hash_including(
@@ -14,16 +16,18 @@ RSpec.describe EnquiryForm do
                 attributes: attributes,
               },
             ),
-            headers: {
-              'Authorization' => 'Bearer frontend-token',
-              'Content-Type' => 'application/json',
-            },
+            headers: { 'Content-Type' => 'application/json' },
           )
           .and_return(jsonapi_response(:enquiry_form_submission, { resource_id: resource_id }))
-        allow(TradeTariffFrontend).to receive(:green_lanes_api_token).and_return('Bearer frontend-token')
       end
 
       it { is_expected.to be_a described_class }
+
+      it 'does not add the Green Lanes authentication token' do
+        response
+
+        expect(TradeTariffFrontend).not_to have_received(:green_lanes_api_token)
+      end
 
       it 'returns the resource id' do
         expect(response['resource_id']).to eq(resource_id)

--- a/spec/requests/feedback_controller_spec.rb
+++ b/spec/requests/feedback_controller_spec.rb
@@ -20,6 +20,17 @@ RSpec.describe FeedbackController, type: :request do
       )
     end
 
+    it 'preserves a search request identifier recovered from the referrer' do
+      get new_feedback_path,
+          headers: { 'HTTP_REFERER' => 'http://test.host/search?request_id=search-request-456' }
+
+      enquiry_link = Nokogiri::HTML(response.body).css('a').find { |link| link.text.strip == 'enquiry form' }
+
+      expect(enquiry_link['href']).to eq(
+        product_experience_enquiry_form_path(request_id: 'search-request-456'),
+      )
+    end
+
     context 'with HTTP_REFERER set' do
       before do
         get new_feedback_path, headers: { 'HTTP_REFERER' => 'http://test.host/404' }

--- a/spec/requests/feedback_controller_spec.rb
+++ b/spec/requests/feedback_controller_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe FeedbackController, type: :request do
 
     it { is_expected.to have_http_status :success }
 
+    it 'preserves the search request identifier in the enquiry link' do
+      get new_feedback_path(feedback_request_id: 'search-request-123')
+
+      enquiry_link = Nokogiri::HTML(response.body).css('a').find { |link| link.text.strip == 'enquiry form' }
+
+      expect(enquiry_link['href']).to eq(
+        product_experience_enquiry_form_path(request_id: 'search-request-123'),
+      )
+    end
+
     context 'with HTTP_REFERER set' do
       before do
         get new_feedback_path, headers: { 'HTTP_REFERER' => 'http://test.host/404' }

--- a/spec/views/layout/application.html.erb_spec.rb
+++ b/spec/views/layout/application.html.erb_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe 'layouts/application', type: :view do
     expect(rendered).not_to have_css('.app-feedback-useful-banner')
   end
 
+  it 'preserves search context in the enquiry link' do
+    assign :search, Search.new(request_id: 'search-request-123')
+
+    render
+
+    expect(rendered).to have_link('Enquiry Form', href: '/enquiry_form?request_id=search-request-123')
+  end
+
   context 'when rendering an interactive search page' do
     before { assign(:interactive_search_page, true) }
 

--- a/spec/views/search/_interactive_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_results_content.html.erb_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
       it { is_expected.to have_css('h3[class~="govuk-!-margin-bottom-0"] + p.govuk-body > a', text: 'Ask HMRC online') }
       it { is_expected.to have_css('h3.govuk-heading-s', exact_text: 'Enquiry form') }
       it { is_expected.to have_css('h3[class~="govuk-!-margin-bottom-0"] + p.govuk-body > a', text: 'Ask a classification question') }
-      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path) }
+      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path(request_id: 'test-uuid-123')) }
       it { is_expected.not_to have_link('classification.enquiries@hmrc.gov.uk') }
     end
 
@@ -231,7 +231,7 @@ RSpec.describe 'search/_interactive_results_content', type: :view do
 
       it { is_expected.to have_css('.govuk-details__summary-text', text: 'Get support') }
       it { is_expected.not_to have_link('Ask HMRC online') }
-      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path) }
+      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path(request_id: 'test-uuid-123')) }
     end
   end
 end

--- a/spec/views/search/_interactive_unknown_results_content.html.erb_spec.rb
+++ b/spec/views/search/_interactive_unknown_results_content.html.erb_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'search/_interactive_unknown_results_content', type: :view do
       it { is_expected.to have_css('h3[class~="govuk-!-margin-bottom-0"] + p.govuk-body > a', text: 'Ask HMRC online') }
       it { is_expected.to have_css('h3.govuk-heading-s', exact_text: 'Enquiry form') }
       it { is_expected.to have_css('h3[class~="govuk-!-margin-bottom-0"] + p.govuk-body > a', text: 'Ask a classification question') }
-      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path) }
+      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path(request_id: 'test-uuid-123')) }
       it { is_expected.not_to have_link('classification.enquiries@hmrc.gov.uk') }
     end
 
@@ -63,7 +63,7 @@ RSpec.describe 'search/_interactive_unknown_results_content', type: :view do
       before { allow(TradeTariffFrontend).to receive(:webchat_enabled?).and_return(false) }
 
       it { is_expected.not_to have_link('Ask HMRC online') }
-      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path) }
+      it { is_expected.to have_link('Ask a classification question', href: product_experience_enquiry_form_path(request_id: 'test-uuid-123')) }
     end
   end
 


### PR DESCRIPTION
## What:

- [x] Capture enabled feature flags when an enquiry starts
- [x] Preserve search request IDs through enquiry links and the server-side draft
- [x] Submit the captured context with the existing enquiry payload

## Why:

Enquiries need the feature-flag and search context that applied when the user started the journey so support teams can understand and investigate the experience behind each question.

## Ticket:

[AI-1224](https://transformuk.atlassian.net/browse/AI-1224)

## Risk:

**Risk level:** 🟢

**Reason for rating:**
The change adds optional context fields with safe defaults to the existing enquiry flow. Existing unflagged enquiries continue to use the same journey and payload behavior.