### PR TITLE
fix: fully remove default json gem from production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,9 @@ RUN apk add --no-cache \
     apk upgrade --no-cache libcrypto3 libssl3 && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone && \
-    rm -f /usr/local/lib/ruby/gems/*/specifications/default/json-*.gemspec
+    rm -f /usr/local/lib/ruby/gems/*/specifications/default/json-*.gemspec && \
+    rm -rf /usr/local/lib/ruby/gems/*/gems/json-* && \
+    rm -rf /usr/local/lib/ruby/*/json.rb /usr/local/lib/ruby/*/json /usr/local/lib/ruby/*/*-linux-musl/json
 
 ENV RAILS_SERVE_STATIC_FILES=true \
     RAILS_ENV=production \


### PR DESCRIPTION
## What:
Extends the Dockerfile's json cleanup (from #3300) to delete the actual default `json` gem directory and its stdlib-loadable copy, not just the gemspec.

## Why:
Security Hub flagged CVE-2026-33210 on a deploy built today, even though #3300 (merged 2026-08-26, removing the default `json` gemspec) was already in that build. The base image `ruby:4.0.6-alpine` bundles a vulnerable default `json 2.18.0` at `/usr/local/lib/ruby/gems/4.0.0/gems/json-2.18.0/` plus a stdlib copy at `/usr/local/lib/ruby/4.0.0/json.rb`/`json/`. Deleting only the gemspec (the previous fix) left these files on disk with the vulnerable version still identifiable, which is what scanners were fingerprinting.

The app itself was never at risk either way: Bundler resolves `json 2.21.2` from a separate `GEM_HOME` (`/usr/local/bundle`), completely independent of the base image's default gem paths.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Deletes unused default-gem files from the production image only; no application code path touches these files (confirmed Bundler resolves its own separate gem path). No behaviour change. Note: this sandbox's network couldn't reach Alpine's package CDN to run a full `docker build`, so this should get a normal CI build check before merge.