### PR TITLE
AI-1251: Replace classification email support links

### DIFF
--- a/app/helpers/intercept_guidance_helper.rb
+++ b/app/helpers/intercept_guidance_helper.rb
@@ -41,6 +41,7 @@ private
       fragment.css(selector).each { |node| append_classes(node, classes) }
     end
     fragment.css('a').each { |node| apply_new_tab_standard(node) }
+    replace_classification_support_link(fragment)
 
     fragment.to_html.html_safe
   end
@@ -52,5 +53,35 @@ private
   def apply_new_tab_standard(node)
     node['target'] = '_blank'
     node['rel'] = (node['rel'].to_s.split + %w[noopener noreferrer]).uniq.join(' ')
+  end
+
+  def replace_classification_support_link(fragment)
+    email_link = fragment.css('a[href]').find do |link|
+      link['href'].casecmp?("mailto:#{TradeTariffFrontend.enquiries_email}")
+    end
+    return if email_link.blank?
+
+    promote_support_label(email_link.ancestors('p').first, from: 'Email:', to: 'Enquiry form')
+
+    webchat_paragraph = fragment.css('p').find do |paragraph|
+      paragraph.at_css('strong')&.text&.strip == 'Webchat:'
+    end
+    promote_support_label(webchat_paragraph, from: 'Webchat:', to: 'Webchat')
+
+    email_link.content = 'Ask a classification question'
+    email_link['href'] = product_experience_enquiry_form_path
+    email_link.remove_attribute('target')
+    email_link.remove_attribute('rel')
+  end
+
+  def promote_support_label(paragraph, from:, to:)
+    label = paragraph&.at_css('strong')
+    return unless label&.text&.strip == from
+
+    heading = Nokogiri::XML::Node.new('h3', paragraph.document)
+    heading.content = to
+    heading['class'] = GOVUK_MARKDOWN_CLASSES.fetch('h3').join(' ')
+    paragraph.add_previous_sibling(heading)
+    label.remove
   end
 end

--- a/spec/helpers/intercept_guidance_helper_spec.rb
+++ b/spec/helpers/intercept_guidance_helper_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe InterceptGuidanceHelper do
       expect(html).not_to have_css('a .govuk-visually-hidden', text: '(opens in new tab)')
     end
 
+    it 'replaces classification email support with the enquiry form', :aggregate_failures do
+      message = <<~MARKDOWN
+        **Webchat:** [Ask HMRC online]({{webchat_url}})
+
+        **Email:** [{{enquiries_email}}](mailto:{{enquiries_email}})
+      MARKDOWN
+      allow(TradeTariffFrontend).to receive_messages(
+        enquiries_email: 'classification.enquiries@hmrc.gov.uk',
+        webchat_url: 'https://example.com/webchat',
+      )
+
+      html = render_intercept_message(message, search:)
+
+      expect(html).to have_css('h3.govuk-heading-s + p.govuk-body > a', text: 'Ask HMRC online')
+      expect(html).to have_css('h3.govuk-heading-s', exact_text: 'Webchat')
+      expect(html).to have_css('h3.govuk-heading-s + p.govuk-body > a[href="/enquiry_form"]', text: 'Ask a classification question')
+      expect(html).to have_css('h3.govuk-heading-s', exact_text: 'Enquiry form')
+      expect(html).not_to have_link('classification.enquiries@hmrc.gov.uk')
+    end
+
     it 'does not linkify goods nomenclature code references', :aggregate_failures do
       msg = 'Review Chapter 71, headings 3207 to 3210, subheading 8703.10 and commodity 0101210000.'
       html = render_intercept_message(msg, search:)


### PR DESCRIPTION
## What:

- [x] Replace the remaining beta-search classification email link with the enquiry form
- [x] Present Webchat and Enquiry form links beneath semantic headings
- [x] Keep the internal enquiry link in the current browser tab

## Why:

Users should follow one consistent support pattern across every beta-search outcome and provide classification questions through the enquiry form.

## Ticket:

[AI-1251](https://transformuk.atlassian.net/browse/AI-1251)

## Risk:

**Risk level:** 🟢

**Reason for rating:**
This is a localised support copy, markup, and link-target change. It does not change search behaviour, tariff data, backend APIs, routes, or deployment configuration.