### PR TITLE
AI-1259: Expose request country

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,11 @@ RUN apk add --no-cache \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone && \
     rm -f /usr/local/lib/ruby/gems/*/specifications/default/json-*.gemspec && \
+    rm -f /usr/local/lib/ruby/gems/*/specifications/default/resolv-*.gemspec && \
     rm -rf /usr/local/lib/ruby/gems/*/gems/json-* && \
-    rm -rf /usr/local/lib/ruby/*/json.rb /usr/local/lib/ruby/*/json /usr/local/lib/ruby/*/*-linux-musl/json
+    rm -rf /usr/local/lib/ruby/gems/*/gems/resolv-[0-9]* && \
+    rm -rf /usr/local/lib/ruby/*/json.rb /usr/local/lib/ruby/*/json /usr/local/lib/ruby/*/*-linux-musl/json && \
+    rm -f /usr/local/lib/ruby/*/resolv.rb
 
 ENV RAILS_SERVE_STATIC_FILES=true \
     RAILS_ENV=production \

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'rails', '~> 8.1'
+gem 'resolv', '>= 0.7.2'
 
 gem 'faraday'
 gem 'faraday-http-cache'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -666,6 +666,7 @@ GEM
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
+    resolv (0.7.2)
     rexml (3.4.4)
     rinku (2.0.6)
     roo (3.0.0)
@@ -853,6 +854,7 @@ DEPENDENCIES
   rails (~> 8.1)
   rails-controller-testing!
   redis
+  resolv (>= 0.7.2)
   roo
   routing-filter!
   rspec-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,9 +51,10 @@ class ApplicationController < ActionController::Base
   end
 
   def set_current_request_country
-    country_code = request.headers['CloudFront-Viewer-Country'].to_s
-    country_code = '' unless country_code.match?(/\A[A-Z]{2}\z/)
-    Current.request_country = ActiveSupport::StringInquirer.new(country_code.downcase)
+    country_code = TradeTariffFrontend::RequestCountry.normalize(
+      request.headers[TradeTariffFrontend::RequestCountry::HEADER],
+    )
+    Current.request_country = ActiveSupport::StringInquirer.new(country_code)
   end
 
   def is_switch_service_banner_enabled?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -154,6 +154,7 @@ class ApplicationController < ActionController::Base
     payload[:search_request_id] = @search&.request_id
     payload[:user_agent] = request.env['HTTP_USER_AGENT']
     payload[:experiment_label] = Current.experiment if Current.experiment.present?
+    payload[:request_country] = Current.request_country.presence&.to_s || 'unknown'
     payload.merge!(@handled_exception_log_context) if defined?(@handled_exception_log_context) && @handled_exception_log_context.present?
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,9 +12,9 @@ class ApplicationController < ActionController::Base
   include BotProtection
   include ErrorHandling
 
+  prepend_before_action :set_current_request_country
   before_action :maintenance_mode_if_active
   before_action :set_cache
-  before_action :set_current_request_country
   before_action :set_current_flagsmith_identity
   before_action :set_path_info
   before_action :set_search

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ class ApplicationController < ActionController::Base
 
   before_action :maintenance_mode_if_active
   before_action :set_cache
+  before_action :set_current_request_country
   before_action :set_current_flagsmith_identity
   before_action :set_path_info
   before_action :set_search
@@ -47,6 +48,12 @@ class ApplicationController < ActionController::Base
 
   def disable_switch_service_banner
     @disable_switch_service_banner = true
+  end
+
+  def set_current_request_country
+    country_code = request.headers['CloudFront-Viewer-Country'].to_s
+    country_code = '' unless country_code.match?(/\A[A-Z]{2}\z/)
+    Current.request_country = ActiveSupport::StringInquirer.new(country_code.downcase)
   end
 
   def is_switch_service_banner_enabled?

--- a/app/controllers/concerns/flagsmith_setup.rb
+++ b/app/controllers/concerns/flagsmith_setup.rb
@@ -9,6 +9,9 @@ module FlagsmithSetup
 
     traits = session[:flagsmith_optin_traits]
     Current.flagsmith_optin_traits = traits.is_a?(Hash) ? traits.to_h.transform_keys(&:to_s) : {}
+    if Current.request_country.present?
+      Current.flagsmith_optin_traits['request_country'] = { value: Current.request_country.to_s, transient: true }
+    end
 
     resolve_experiment_url_optins
   end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,8 @@
 class Current < ActiveSupport::CurrentAttributes
+  # The CloudFront-derived country for the current request.
+  # Normalised for StringInquirer predicates such as Current.request_country.gb?.
+  attribute :request_country, default: -> { ActiveSupport::StringInquirer.new('') }
+
   # The resolved Flagsmith identity for the current request.
   # Set by ApplicationController#set_current_flagsmith_identity.
   attribute :flagsmith_identity

--- a/app/services/client_builder.rb
+++ b/app/services/client_builder.rb
@@ -40,6 +40,7 @@ class ClientBuilder
         conn.options.timeout = 10
         conn.ssl.verify = false
         conn.ssl.ca_file = cert_path
+        conn.use TradeTariffFrontend::RequestCountryMiddleware
         conn.adapter :net_http_persistent
         conn.response :json, content_type: /\bjson$/
         conn.headers['User-Agent'] = user_agent

--- a/app/services/duty_calculator/client_builder.rb
+++ b/app/services/duty_calculator/client_builder.rb
@@ -45,6 +45,7 @@ module DutyCalculator
         faraday.options.timeout = 10
         faraday.ssl.verify = false
         faraday.ssl.ca_file = cert_path
+        faraday.use TradeTariffFrontend::RequestCountryMiddleware
         faraday.adapter :net_http_persistent
 
         faraday.headers['User-Agent'] = user_agent

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,8 +62,15 @@ Rails.application.configure do
   # information to avoid inadvertent exposure of personally identifiable information (PII).
   config.log_level = ENV.fetch('RAILS_LOG_LEVEL', :info)
 
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
+  # Prepend all request log lines with the following tags.
+  config.log_tags = [
+    :request_id,
+    lambda do |request|
+      country_code = request.headers['CloudFront-Viewer-Country'].to_s
+      country_code = 'unknown' unless country_code.match?(/\A[A-Z]{2}\z/)
+      "request_country=#{country_code.downcase}"
+    end,
+  ]
 
   # Use a different cache store in production.
   config.cache_store = :redis_cache_store,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,7 +105,6 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  config.logger = ActiveSupport::Logger.new($stdout)
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Logstash.new
   config.lograge.custom_options = lambda do |event|

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,6 +106,7 @@ Rails.application.configure do
       search_request_id: event.payload[:search_request_id],
       user_agent: event.payload[:user_agent],
       experiment_label: event.payload[:experiment_label],
+      request_country: event.payload[:request_country],
       params: event.payload[:params].except('controller', 'action', 'format', 'utf8', 'experiment'),
       exception_class: event.payload[:exception_class],
       exception_message: event.payload[:exception_message],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,9 +66,10 @@ Rails.application.configure do
   config.log_tags = [
     :request_id,
     lambda do |request|
-      country_code = request.headers['CloudFront-Viewer-Country'].to_s
-      country_code = 'unknown' unless country_code.match?(/\A[A-Z]{2}\z/)
-      "request_country=#{country_code.downcase}"
+      country_code = TradeTariffFrontend::RequestCountry.normalize(
+        request.headers[TradeTariffFrontend::RequestCountry::HEADER],
+      )
+      "request_country=#{country_code.presence || 'unknown'}"
     end,
   ]
 

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -10,6 +10,7 @@ module TradeTariffFrontend
 
   autoload :Presenter,      'trade_tariff_frontend/presenter'
   autoload :ExperimentUrls, 'trade_tariff_frontend/experiment_urls'
+  autoload :RequestCountryMiddleware, 'trade_tariff_frontend/request_country_middleware'
   autoload :ServiceChooser, 'trade_tariff_frontend/service_chooser'
   autoload :ViewContext,    'trade_tariff_frontend/view_context'
 

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -10,6 +10,7 @@ module TradeTariffFrontend
 
   autoload :Presenter,      'trade_tariff_frontend/presenter'
   autoload :ExperimentUrls, 'trade_tariff_frontend/experiment_urls'
+  autoload :RequestCountry, 'trade_tariff_frontend/request_country'
   autoload :RequestCountryMiddleware, 'trade_tariff_frontend/request_country_middleware'
   autoload :ServiceChooser, 'trade_tariff_frontend/service_chooser'
   autoload :ViewContext,    'trade_tariff_frontend/view_context'

--- a/lib/trade_tariff_frontend/request_country.rb
+++ b/lib/trade_tariff_frontend/request_country.rb
@@ -7,6 +7,8 @@ module TradeTariffFrontend
 
     def normalize(value)
       country_code = value.to_s
+      return '' if country_code == 'XX'
+
       country_code.match?(COUNTRY_CODE_PATTERN) ? country_code.downcase : ''
     end
   end

--- a/lib/trade_tariff_frontend/request_country.rb
+++ b/lib/trade_tariff_frontend/request_country.rb
@@ -1,0 +1,13 @@
+module TradeTariffFrontend
+  module RequestCountry
+    HEADER = 'CloudFront-Viewer-Country'.freeze
+    COUNTRY_CODE_PATTERN = /\A[A-Z]{2}\z/
+
+    module_function
+
+    def normalize(value)
+      country_code = value.to_s
+      country_code.match?(COUNTRY_CODE_PATTERN) ? country_code.downcase : ''
+    end
+  end
+end

--- a/lib/trade_tariff_frontend/request_country_middleware.rb
+++ b/lib/trade_tariff_frontend/request_country_middleware.rb
@@ -1,0 +1,9 @@
+module TradeTariffFrontend
+  class RequestCountryMiddleware < Faraday::Middleware
+    HEADER = 'X-Request-Country'.freeze
+
+    def on_request(env)
+      env.request_headers[HEADER] = Current.request_country.presence&.to_s || 'unknown'
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -73,6 +73,66 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
+  describe 'request country resolution' do
+    controller do
+      def index
+        render json: {
+          request_country: Current.request_country,
+          request_country_class: Current.request_country.class.name,
+          gb: Current.request_country.gb?,
+          traits: Current.flagsmith_optin_traits,
+        }
+      end
+    end
+
+    it 'exposes GB as a transient trait', :aggregate_failures do
+      request.headers['CloudFront-Viewer-Country'] = 'GB'
+
+      get :index
+
+      expect(response.parsed_body).to eq(
+        'request_country' => 'gb',
+        'request_country_class' => 'ActiveSupport::StringInquirer',
+        'gb' => true,
+        'traits' => { 'request_country' => { 'value' => 'gb', 'transient' => true } },
+      )
+    end
+
+    it 'exposes another country without matching GB' do
+      request.headers['CloudFront-Viewer-Country'] = 'FR'
+
+      get :index
+
+      expect(response.parsed_body).to include(
+        'request_country' => 'fr',
+        'gb' => false,
+        'traits' => { 'request_country' => { 'value' => 'fr', 'transient' => true } },
+      )
+    end
+
+    it 'uses an empty inquiry when the header is missing' do
+      get :index
+
+      expect(response.parsed_body).to include(
+        'request_country' => '',
+        'gb' => false,
+        'traits' => {},
+      )
+    end
+
+    it 'rejects an invalid country value' do
+      request.headers['CloudFront-Viewer-Country'] = 'not-a-country'
+
+      get :index
+
+      expect(response.parsed_body).to include(
+        'request_country' => '',
+        'gb' => false,
+        'traits' => {},
+      )
+    end
+  end
+
   describe '#interactive_search_enabled?' do
     controller do
       def index

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -215,6 +215,7 @@ RSpec.describe ApplicationController, type: :controller do
     it 'adds frontend and search request ids to the logging payload' do
       request.request_id = 'frontend-request-id'
       Current.experiment = 'trstd-trdr'
+      Current.request_country = ActiveSupport::StringInquirer.new('gb')
       controller.instance_variable_set(:@search, Search.new(q: '94036099', request_id: 'search-request-id'))
 
       payload = {}
@@ -224,7 +225,16 @@ RSpec.describe ApplicationController, type: :controller do
         request_id: 'frontend-request-id',
         search_request_id: 'search-request-id',
         experiment_label: 'trstd-trdr',
+        request_country: 'gb',
       )
+    end
+
+    it 'logs an unknown request country when unavailable' do
+      payload = {}
+
+      controller.send(:append_info_to_payload, payload)
+
+      expect(payload[:request_country]).to eq('unknown')
     end
 
     it 'adds structured details for handled Faraday errors' do

--- a/spec/lib/trade_tariff_frontend/request_country_middleware_spec.rb
+++ b/spec/lib/trade_tariff_frontend/request_country_middleware_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe TradeTariffFrontend::RequestCountryMiddleware do
+  subject(:request_headers) do
+    headers = nil
+    connection = Faraday.new do |faraday|
+      faraday.use described_class
+      faraday.adapter :test do |stub|
+        stub.get('/') do |env|
+          headers = env.request_headers
+          [200, {}, '']
+        end
+      end
+    end
+    connection.get('/')
+    headers
+  end
+
+  it 'forwards the current request country' do
+    Current.request_country = ActiveSupport::StringInquirer.new('gb')
+
+    expect(request_headers['X-Request-Country']).to eq('gb')
+  end
+
+  it 'forwards unknown when unavailable' do
+    expect(request_headers['X-Request-Country']).to eq('unknown')
+  end
+end

--- a/spec/lib/trade_tariff_frontend/request_country_spec.rb
+++ b/spec/lib/trade_tariff_frontend/request_country_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.describe TradeTariffFrontend::RequestCountry do
   describe '.normalize' do
     it { expect(described_class.normalize('GB')).to eq('gb') }
+    it { expect(described_class.normalize('XX')).to eq('') }
     it { expect(described_class.normalize(nil)).to eq('') }
     it { expect(described_class.normalize('not-a-country')).to eq('') }
   end

--- a/spec/lib/trade_tariff_frontend/request_country_spec.rb
+++ b/spec/lib/trade_tariff_frontend/request_country_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe TradeTariffFrontend::RequestCountry do
+  describe '.normalize' do
+    it { expect(described_class.normalize('GB')).to eq('gb') }
+    it { expect(described_class.normalize(nil)).to eq('') }
+    it { expect(described_class.normalize('not-a-country')).to eq('') }
+  end
+end

--- a/spec/models/current_spec.rb
+++ b/spec/models/current_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Current do
     expect(described_class.flagsmith_unavailable).to be true
   end
 
+  it 'defaults request_country to an empty inquiry' do
+    expect(described_class.request_country).to be_a(ActiveSupport::StringInquirer).and be_empty
+  end
+
   it 'resets flagsmith_identity between examples' do
     expect(described_class.flagsmith_identity).to be_nil
   end

--- a/spec/rails/application/configuration_production_spec.rb
+++ b/spec/rails/application/configuration_production_spec.rb
@@ -1,17 +1,35 @@
 require 'spec_helper'
 
 RSpec.describe Rails::Application::Configuration do
-  it 'logs the trusted experiment label rather than request parameters' do
-    production_config = described_class.new(Rails.root)
+  let(:production_config) { described_class.new(Rails.root) }
+
+  before do
     production_config.lograge = ActiveSupport::OrderedOptions.new
     allow(Rails.application).to receive(:config).and_return(production_config)
     allow(Rails.application).to receive(:configure) { |&block| Rails.application.instance_eval(&block) }
     load Rails.root.join('config/environments/production.rb')
+  end
 
+  it 'logs the trusted experiment label rather than request parameters' do
     event = instance_double(ActiveSupport::Notifications::Event,
                             payload: { experiment_label: 'trstd-trdr', params: { 'experiment' => 'spoofed' } })
 
     expect(production_config.lograge.custom_options.call(event))
       .to include(experiment_label: 'trstd-trdr', params: {})
+  end
+
+  it 'tags request logs with the normalised request country' do
+    country_tag = production_config.log_tags.second
+
+    expect(country_tag.call(instance_double(ActionDispatch::Request,
+                                            headers: { 'CloudFront-Viewer-Country' => 'GB' })))
+      .to eq('request_country=gb')
+  end
+
+  it 'tags request logs with an unknown country when unavailable' do
+    country_tag = production_config.log_tags.second
+
+    expect(country_tag.call(instance_double(ActionDispatch::Request, headers: {})))
+      .to eq('request_country=unknown')
   end
 end

--- a/spec/rails/application/configuration_production_spec.rb
+++ b/spec/rails/application/configuration_production_spec.rb
@@ -32,4 +32,8 @@ RSpec.describe Rails::Application::Configuration do
     expect(country_tag.call(instance_double(ActionDispatch::Request, headers: {})))
       .to eq('request_country=unknown')
   end
+
+  it 'keeps the final production logger tagged' do
+    expect(production_config.logger).to respond_to(:tagged)
+  end
 end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,4 +1,21 @@
 RSpec.describe ApplicationController, type: :request do
+  it 'captures the request country before an earlier callback halts the request' do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('MAINTENANCE').and_return('true')
+    events = []
+
+    ActiveSupport::Notifications.subscribed(
+      ->(*args) { events << ActiveSupport::Notifications::Event.new(*args) },
+      'process_action.action_controller',
+    ) do
+      get '/news', headers: { 'CloudFront-Viewer-Country' => 'GB' }
+    end
+
+    event = events.find { |candidate| candidate.payload[:controller] == 'NewsItemsController' }
+
+    expect(event.payload[:request_country]).to eq('gb')
+  end
+
   describe 'GET #index' do
     subject(:do_response) { get('/healthcheck') && response }
 

--- a/spec/services/client_builder_spec.rb
+++ b/spec/services/client_builder_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe ClientBuilder do
       end
     end
 
+    context 'when sending a backend request' do
+      before do
+        allow(Faraday).to receive(:new).and_call_original
+      end
+
+      it 'adds the request country middleware' do
+        expect(builder.call.builder.handlers).to include(TradeTariffFrontend::RequestCountryMiddleware)
+      end
+    end
+
     context 'when the services are not configured' do
       before do
         allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choices).and_return(nil)

--- a/spec/services/duty_calculator/client_builder_spec.rb
+++ b/spec/services/duty_calculator/client_builder_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe DutyCalculator::ClientBuilder do
+  subject(:build_client) { described_class.new(:uk).call }
+
+  let(:connection) { Faraday::Connection.new }
+
+  before do
+    allow(Faraday).to receive(:new).and_yield(connection).and_return(connection)
+    allow(Uktt::Http).to receive(:new)
+  end
+
+  it 'adds the request country middleware' do
+    build_client
+
+    expect(connection.builder.handlers).to include(TradeTariffFrontend::RequestCountryMiddleware)
+  end
+end


### PR DESCRIPTION
## What:

- [x] Expose the CloudFront country as `Current.request_country`, supporting predicates such as `.gb?`
- [x] Pass valid countries to Flagsmith as a transient `request_country` trait
- [x] Add `request_country` to structured controller logs
- [x] Tag every request-scoped frontend log line with `request_country`
- [x] Send `X-Request-Country` with every backend HTTP request
- [x] Use `unknown` when the country is unavailable
- [x] Bump `resolv` to 0.7.2 and remove the vulnerable 0.7.0 default copy from the production image

## Why:

Give the frontend, Flagsmith and backend one request-scoped country signal without persisting raw IP addresses or confusing it with tariff journey countries.

The `resolv` bump unblocks container publishing after CVE-2026-80212 caused the Ruby 4.0.6 base image to fail the vulnerability scan.

## Ticket:

[AI-1259](https://transformuk.atlassian.net/browse/AI-1259)

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Additive request context and read-only observability. The `resolv` patch replaces the vulnerable default gem with 0.7.2; the rebuilt image passed the HIGH/CRITICAL Trivy scan and full test suite. No user-facing journey, cache, raw IP, session or persistent identity behaviour changes.