### PR TITLE
AI-1252: Add feature flags to feedback emails

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -9,6 +9,7 @@ class FeedbackController < ApplicationController
     @feedback.query = feedback_query
     @feedback.request_id = feedback_request_id
     @feedback.date = feedback_date
+    @feedback.feature_flags = feedback_feature_flags
   end
 
   def create
@@ -18,6 +19,7 @@ class FeedbackController < ApplicationController
     @feedback.query = params[:feedback_query]
     @feedback.request_id = params[:feedback_request_id]
     @feedback.date = params[:feedback_date]
+    @feedback.feature_flags = feedback_feature_flags
 
     return redirect_to(find_commodity_path) unless @feedback.valid_page_useful_options?
 
@@ -69,6 +71,13 @@ class FeedbackController < ApplicationController
 
   def feedback_date
     params[:feedback_date].presence || referrer_date_param
+  end
+
+  def feedback_feature_flags
+    return TradeTariffFrontend.enabled_flagsmith_feature_names unless params.key?(:feedback_feature_flags)
+
+    registered_names = TradeTariffFrontend::Config.registered_flags.values.pluck(:name)
+    params[:feedback_feature_flags].to_s.split(',') & registered_names
   end
 
   def referrer_date_param

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,6 +95,7 @@ module ApplicationHelper
       feedback_query: feedback_search_query,
       feedback_request_id: feedback_search_request_id,
       feedback_date: feedback_search_date,
+      feedback_feature_flags: TradeTariffFrontend.enabled_flagsmith_feature_names.join(','),
     }.compact
   end
 
@@ -104,6 +105,7 @@ module ApplicationHelper
       feedback_query: params[:feedback_query],
       feedback_request_id: params[:feedback_request_id],
       feedback_date: params[:feedback_date],
+      feedback_feature_flags: params[:feedback_feature_flags],
     }.compact
   end
 

--- a/app/mailers/frontend_mailer.rb
+++ b/app/mailers/frontend_mailer.rb
@@ -12,6 +12,7 @@ class FrontendMailer < ActionMailer::Base
     @request_id = feedback.request_id
     @date = feedback.date
     @page_useful = feedback.page_useful
+    @feature_flags = feedback.feature_flags
 
     mail subject: 'Trade Tariff Feedback'
   end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -5,7 +5,7 @@ class Feedback
 
   include ActiveModel::Model
 
-  attr_accessor :message, :telephone, :authenticity_token, :referrer, :page_useful, :query, :request_id, :date
+  attr_accessor :message, :telephone, :authenticity_token, :referrer, :page_useful, :query, :request_id, :date, :feature_flags
 
   validates :message, presence: true,
                       length: { minimum: 10, maximum: 500 }

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -40,6 +40,7 @@
       <%= hidden_field_tag :feedback_query, @feedback.query %>
       <%= hidden_field_tag :feedback_request_id, @feedback.request_id %>
       <%= hidden_field_tag :feedback_date, @feedback.date %>
+      <%= hidden_field_tag :feedback_feature_flags, Array(@feedback.feature_flags).join(',') %>
 
       <%= f.govuk_submit 'Submit feedback' %>
     <% end %>

--- a/app/views/frontend_mailer/new_feedback.html.erb
+++ b/app/views/frontend_mailer/new_feedback.html.erb
@@ -11,11 +11,13 @@
 <% end %>
 
 <% if @request_id %>
-  <p>Request ID: <%= @request_id %></p>
+  <p>Search request ID: <%= @request_id %></p>
 <% end %>
 
 <% if @date %>
   <p>Date of trade: <%= @date %></p>
 <% end %>
+
+<p>Feature flags: <%= Array(@feature_flags).presence&.join(', ') || 'None' %></p>
 
 <p>Found this page useful: <%= @page_useful if @page_useful %></p>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -344,6 +344,21 @@ RSpec.describe ApplicationHelper, type: :helper do
       it 'derives feedback_url from the current page URL' do
         expect(helper.feedback_context_params).to include(feedback_url: 'http://test.host/commodities/1234567890')
       end
+
+      it 'includes enabled feature flags' do
+        allow(TradeTariffFrontend).to receive(:enabled_flagsmith_feature_names)
+          .and_return(%w[interactive_search webchat])
+
+        expect(helper.feedback_context_params).to include(
+          feedback_feature_flags: 'interactive_search,webchat',
+        )
+      end
+
+      it 'includes an explicit empty feature flag context' do
+        allow(TradeTariffFrontend).to receive(:enabled_flagsmith_feature_names).and_return([])
+
+        expect(helper.feedback_context_params).to include(feedback_feature_flags: '')
+      end
     end
 
     context 'when already on the feedback controller' do
@@ -401,12 +416,14 @@ RSpec.describe ApplicationHelper, type: :helper do
       controller.params[:feedback_query] = 'leather handbags'
       controller.params[:feedback_request_id] = 'abc-123'
       controller.params[:feedback_date] = '2026-01-01'
+      controller.params[:feedback_feature_flags] = 'interactive_search,webchat'
 
       expect(helper.current_feedback_params).to eq(
         feedback_url: 'http://test.host/commodities/1234567890',
         feedback_query: 'leather handbags',
         feedback_request_id: 'abc-123',
         feedback_date: '2026-01-01',
+        feedback_feature_flags: 'interactive_search,webchat',
       )
     end
 

--- a/spec/mailers/frontend_mailer_spec.rb
+++ b/spec/mailers/frontend_mailer_spec.rb
@@ -9,5 +9,19 @@ RSpec.describe FrontendMailer, type: :mailer do
     it { expect(mail.subject).to eq('Trade Tariff Feedback') }
     it { expect(mail.from).to eq(['no-reply@example.com']) }
     it { expect(mail.to).to eq(['support@example.com']) }
+
+    context 'with enabled feature flags' do
+      let(:feedback) { build(:feedback, feature_flags: %w[interactive_search webchat]) }
+
+      it 'includes their names' do
+        expect(mail.body).to include('Feature flags: interactive_search, webchat')
+      end
+    end
+
+    context 'without enabled feature flags' do
+      it 'reports none' do
+        expect(mail.body).to include('Feature flags: None')
+      end
+    end
   end
 end

--- a/spec/requests/feedback_controller_spec.rb
+++ b/spec/requests/feedback_controller_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe FeedbackController, type: :request do
 
     it { is_expected.to have_http_status :success }
 
+    it 'captures enabled feature flags' do
+      enable_feature(:webchat)
+
+      get new_feedback_path
+
+      feedback_form = Nokogiri::HTML(response.body)
+      expect(feedback_form.at_css('input[name="feedback_feature_flags"]')['value']).to eq('webchat')
+    end
+
     it 'preserves the search request identifier in the enquiry link' do
       get new_feedback_path(feedback_request_id: 'search-request-123')
 
@@ -67,6 +76,7 @@ RSpec.describe FeedbackController, type: :request do
         feedback_query: large_context,
         feedback_request_id: large_context,
         feedback_date: large_context,
+        feedback_feature_flags: large_context,
         authenticity_token: 'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw',
       }
     end
@@ -82,7 +92,13 @@ RSpec.describe FeedbackController, type: :request do
       get new_feedback_path, params: params_with_large_context.except(:feedback, :authenticity_token)
       post feedbacks_path, params: params_with_large_context
 
-      expect(session.to_hash.keys).not_to include('feedback_referrer', 'feedback_query', 'feedback_request_id', 'feedback_date')
+      expect(session.to_hash.keys).not_to include(
+        'feedback_referrer',
+        'feedback_query',
+        'feedback_request_id',
+        'feedback_date',
+        'feedback_feature_flags',
+      )
     end
 
     it 'keeps the session cookie well under the browser 4096-byte limit' do
@@ -136,6 +152,10 @@ RSpec.describe FeedbackController, type: :request do
       expect(ActionMailer::Base.deliveries.count).to eq(1)
     end
 
+    it 'reports when no feature flags were enabled' do
+      expect(ActionMailer::Base.deliveries.last.body).to include('Feature flags: None')
+    end
+
     context 'when honeypot (telephone field) captcha data included' do
       let(:params) do
         {
@@ -169,6 +189,23 @@ RSpec.describe FeedbackController, type: :request do
 
       it 'includes users selected choice in the email' do
         expect(ActionMailer::Base.deliveries.last.body).to include('Found this page useful: yes')
+      end
+    end
+
+    context 'with unknown feature flags' do
+      let(:params) do
+        {
+          feedback: { message: },
+          feedback_feature_flags: 'interactive_search,unknown_feature',
+          authenticity_token: 'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw',
+        }
+      end
+
+      it 'omits unregistered names' do
+        email = Nokogiri::HTML(ActionMailer::Base.deliveries.last.body.to_s)
+        feature_flags = email.css('p').find { |paragraph| paragraph.text.start_with?('Feature flags:') }
+
+        expect(feature_flags.text).to eq('Feature flags: interactive_search')
       end
     end
 
@@ -218,7 +255,9 @@ RSpec.describe FeedbackController, type: :request do
       )
     end
 
-    it 'sends the search URL, query, request id and date of trade to support when the URL has no query param', :aggregate_failures do
+    it 'sends the search and feature flag context to support when the URL has no query param', :aggregate_failures do
+      enable_feature(:interactive_search)
+      enable_feature(:webchat)
       post perform_search_path, params: { q: 'leather handbags', request_id: 'search-request-123', day: '5', month: '6', year: '2026' }
 
       expect(response).to have_http_status(:ok)
@@ -237,16 +276,22 @@ RSpec.describe FeedbackController, type: :request do
           'feedback_query' => 'leather handbags',
           'feedback_request_id' => 'search-request-123',
           'feedback_date' => '2026-06-05',
+          'feedback_feature_flags' => 'interactive_search,webchat',
         )
       end
 
       get feedback_hrefs.first
+
+      feedback_form = Nokogiri::HTML(response.body)
+      expect(feedback_form.at_css('input[name="feedback_feature_flags"]')['value']).to eq('interactive_search,webchat')
+
       post feedbacks_path, params: {
         feedback: { message: },
         feedback_url: 'http://www.example.com/search',
         feedback_query: 'leather handbags',
         feedback_request_id: 'search-request-123',
         feedback_date: '2026-06-05',
+        feedback_feature_flags: 'interactive_search,webchat',
         authenticity_token:,
       }
 
@@ -254,8 +299,9 @@ RSpec.describe FeedbackController, type: :request do
 
       expect(email_body).to include('URL: http://www.example.com/search')
       expect(email_body).to include('Query: leather handbags')
-      expect(email_body).to include('Request ID: search-request-123')
+      expect(email_body).to include('Search request ID: search-request-123')
       expect(email_body).to include('Date of trade: 2026-06-05')
+      expect(email_body).to include('Feature flags: interactive_search, webchat')
     end
   end
 end


### PR DESCRIPTION
## What:

- [x] Capture enabled registered feature flags when the originating page renders a feedback link
- [x] Preserve the flag context through feedback submission without using the session
- [x] Include multiple enabled flag names, or an explicit `None`, in support emails
- [x] Rename the email label from `Request ID` to `Search request ID`
- [x] Filter unregistered feature flag names before email delivery
- [x] Cover the feedback context, form, and email flow with request, helper, mailer, model, feature, and view specs

## Why:

Feedback needs to identify the page state a user experienced so support can attribute comments to the correct feature flag configuration. Capturing the registered names alongside the existing search context preserves that state across the feedback form, including cases where no flags were enabled or several flags affected the same page.

Verified with 141 relevant RSpec examples and the changed-file pre-commit hooks. There are no backend API, environment, deployment, accessibility, or visible journey changes.

## Ticket:

[AI-1252](https://transformuk.atlassian.net/browse/AI-1252)

## Risk:

**Risk level:** 🟢

**Reason for rating:**

This adds diagnostic metadata to internal feedback emails using the existing covered feedback context path. It does not change tariff data, backend calls, public form controls, accessibility markup, or deployment configuration.