### PR TITLE
Fix worktree hook bootstrap

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -377,7 +377,6 @@
                 run_setup_step "Installing JS dependencies" yarn install --frozen-lockfile || fail_worktree_setup
                 run_setup_step "Building CSS assets" yarn build:css || fail_worktree_setup
                 run_setup_step "Precompiling assets" bundle exec bin/rails assets:precompile || fail_worktree_setup
-                run_setup_step "Installing pre-commit hooks" pre-commit install || fail_worktree_setup
 
                 touch "$MARKER"
                 echo ""


### PR DESCRIPTION
## What:

- [x] Remove the redundant pre-commit installer from first-time worktree setup
- [x] Keep the Nix git-hooks shell hook as the authoritative hook installer
- [x] Verify fresh setup, repeat entry, shared hook configuration, and hook execution

## Why:

The Nix shell hook installs the generated hooks and configures `core.hooksPath` before the first-time worktree bootstrap runs. The bootstrap then calls `pre-commit install` again, which refuses to run when `core.hooksPath` is already configured. Removing the duplicate installer allows setup to complete and write its initialization marker.

Verified with a fresh worktree, a repeat direnv entry, `nix flake check --no-build`, both generated Git hooks, and the pre-commit checks for `flake.nix`.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Low-risk local development tooling change. It removes one redundant command and does not affect application, deployment, or production behaviour.
