### PR TITLE
feat(deploy): allow deploying a specific SHA via workflow_dispatch

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -2,6 +2,11 @@ name: Deploy to development
 
 on:
   workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Git SHA or ref to deploy (defaults to current HEAD)'
+        type: string
+        required: false
   pull_request:
     types:
       - opened
@@ -28,6 +33,7 @@ jobs:
       app-name: tariff-frontend
       environment: development
       test-flavour: none
+      checkout-ref: ${{ inputs.sha }}
     secrets:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -2,6 +2,11 @@ name: Deploy to production
 
 on:
   workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Git SHA or ref to deploy (defaults to current HEAD)'
+        type: string
+        required: false
   workflow_run:
     workflows:
       - 'Deploy to staging'
@@ -25,6 +30,7 @@ jobs:
     with:
       app-name: tariff-frontend
       environment: production
+      checkout-ref: ${{ inputs.sha }}
     secrets:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -2,6 +2,11 @@ name: Deploy to staging
 
 on:
   workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Git SHA or ref to deploy (defaults to current HEAD)'
+        type: string
+        required: false
   push:
     branches:
       - main
@@ -20,6 +25,7 @@ jobs:
     with:
       app-name: tariff-frontend
       environment: staging
+      checkout-ref: ${{ inputs.sha }}
     secrets:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## What:
Adds an optional `sha` input to the manual `workflow_dispatch` trigger on `deploy-to-development.yml`, `deploy-to-staging.yml` and `deploy-to-production.yml`, passed through as `checkout-ref` to the shared `deploy-ecs.yml` reusable workflow. Leaving it blank preserves current behaviour (deploys current HEAD/branch).

## Why:
There was no way to manually deploy an arbitrary commit to an environment, or manually roll production back to a specific SHA. The shared `deploy-ecs.yml` workflow already supported checking out and building an arbitrary ref — this just exposes that at the `workflow_dispatch` level, since GitHub Actions requires dispatch inputs to be declared on the calling workflow rather than the reusable one.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-474

## Risk:

**Risk level:** 🟠

**Reason for rating:** This changes a CI/CD deploy workflow (including production), which the risk guide flags as Amber regardless of how small the change is. The change is additive only — an unset `sha` input behaves identically to today, and no existing trigger paths (PR, push, workflow_run) are affected.