### PR TITLE
AI-1265: Show AI-assisted search issue banner

### DIFF
--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -97,9 +97,12 @@ module InteractiveSearchable
 
   def prepare_search_failure_suggestions
     suggestions = GuidedSearch::FailureSuggestions.new
-    retained = retained_search_failure_codes
+    retained = retained_search_failure_codes.filter_map { |request_id, retained_codes|
+      enabled_codes = suggestions.enabled_codes_for(retained_codes)
+      [request_id, enabled_codes] if enabled_codes.any?
+    }.to_h
     retained_codes = retained.fetch(@search.request_id, [])
-    codes = suggestions.known_codes(Array(retained_codes) + @results.search_failures)
+    codes = suggestions.enabled_codes_for(Array(retained_codes) + @results.search_failures)
 
     if codes.any?
       retained.delete(@search.request_id)
@@ -108,7 +111,7 @@ module InteractiveSearchable
     end
     store_search_failure_codes(retained)
 
-    @search_failure_suggestions = suggestions.enabled_codes_for(codes)
+    @search_failure_suggestions = codes
   end
 
   def redirectable_interactive_blocking?

--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -1,6 +1,8 @@
 module InteractiveSearchable
   extend ActiveSupport::Concern
 
+  FAILURE_SUGGESTIONS_SESSION_KEY = :guided_search_failure_codes
+
   private
 
   def perform_interactive_search
@@ -9,12 +11,16 @@ module InteractiveSearchable
       return
     end
 
-    return render_interactive_question if validate_interactive_answer == :invalid
+    if validate_interactive_answer == :invalid
+      prepare_search_failure_suggestions
+      return render_interactive_question
+    end
 
     merge_current_answer
 
     @results = @search.perform
     sync_interactive_request_id
+    prepare_search_failure_suggestions
 
     if @search.errors.any?
       render_interactive_search_page(outcome: 'backend_error')
@@ -23,7 +29,10 @@ module InteractiveSearchable
 
     respond_to do |format|
       format.html { route_interactive_results }
-      format.json { render json: SearchPresenter.new(@search, @results) }
+      format.json do
+        render json: SearchPresenter.new(@search, @results)
+        clear_search_failure_suggestions
+      end
       format.atom
     end
   end
@@ -83,6 +92,21 @@ module InteractiveSearchable
     return unless @results.respond_to?(:request_id) && @results.request_id.present?
 
     @search.request_id = @results.request_id
+  end
+
+  def prepare_search_failure_suggestions
+    suggestions = GuidedSearch::FailureSuggestions.new
+    retained = session[FAILURE_SUGGESTIONS_SESSION_KEY].to_h
+    retained_codes = retained['request_id'] == @search.request_id ? retained['codes'] : []
+    codes = suggestions.known_codes(Array(retained_codes) + @results.search_failures)
+
+    if codes.any?
+      session[FAILURE_SUGGESTIONS_SESSION_KEY] = { 'request_id' => @search.request_id, 'codes' => codes }
+    else
+      session.delete(FAILURE_SUGGESTIONS_SESSION_KEY)
+    end
+
+    @search_failure_suggestions = suggestions.messages_for(codes)
   end
 
   def redirectable_interactive_blocking?
@@ -162,6 +186,7 @@ module InteractiveSearchable
     mark_interactive_search_page
     record_guided_search_journey(outcome: 'no_results')
     render :interactive_no_results
+    clear_search_failure_suggestions
   end
 
   def render_interactive_unknown_results
@@ -170,6 +195,7 @@ module InteractiveSearchable
     mark_interactive_search_page
     record_guided_search_journey(outcome: 'unknown_results')
     render :interactive_unknown_results
+    clear_search_failure_suggestions
   end
 
   def render_interactive_blocking
@@ -178,6 +204,7 @@ module InteractiveSearchable
     mark_interactive_search_page
     record_guided_search_journey(outcome: 'blocking_guidance')
     render :interactive_blocking
+    clear_search_failure_suggestions
   end
 
   def render_interactive_results
@@ -186,6 +213,7 @@ module InteractiveSearchable
     mark_interactive_search_page
     record_guided_search_journey(outcome: 'results')
     render :interactive_results
+    clear_search_failure_suggestions
   end
 
   def render_interactive_search_page(outcome:)
@@ -194,6 +222,11 @@ module InteractiveSearchable
     @recent_stories = []
     record_guided_search_journey(outcome:)
     render 'find_commodities/show_interactive'
+    clear_search_failure_suggestions
+  end
+
+  def clear_search_failure_suggestions
+    session.delete(FAILURE_SUGGESTIONS_SESSION_KEY)
   end
 
   def mark_interactive_search_page

--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -34,10 +34,7 @@ module InteractiveSearchable
         render json: SearchPresenter.new(@search, @results)
         clear_search_failure_suggestions unless @results.has_pending_question?
       end
-      format.atom do
-        render
-        clear_search_failure_suggestions unless @results.has_pending_question?
-      end
+      format.atom
     end
   end
 

--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -2,6 +2,7 @@ module InteractiveSearchable
   extend ActiveSupport::Concern
 
   FAILURE_SUGGESTIONS_SESSION_KEY = :guided_search_failure_codes
+  MAX_RETAINED_FAILURE_JOURNEYS = 5
 
   private
 
@@ -31,9 +32,12 @@ module InteractiveSearchable
       format.html { route_interactive_results }
       format.json do
         render json: SearchPresenter.new(@search, @results)
-        clear_search_failure_suggestions
+        clear_search_failure_suggestions unless @results.has_pending_question?
       end
-      format.atom
+      format.atom do
+        render
+        clear_search_failure_suggestions unless @results.has_pending_question?
+      end
     end
   end
 
@@ -96,15 +100,16 @@ module InteractiveSearchable
 
   def prepare_search_failure_suggestions
     suggestions = GuidedSearch::FailureSuggestions.new
-    retained = session[FAILURE_SUGGESTIONS_SESSION_KEY].to_h
-    retained_codes = retained['request_id'] == @search.request_id ? retained['codes'] : []
+    retained = retained_search_failure_codes
+    retained_codes = retained.fetch(@search.request_id, [])
     codes = suggestions.known_codes(Array(retained_codes) + @results.search_failures)
 
     if codes.any?
-      session[FAILURE_SUGGESTIONS_SESSION_KEY] = { 'request_id' => @search.request_id, 'codes' => codes }
-    else
-      session.delete(FAILURE_SUGGESTIONS_SESSION_KEY)
+      retained.delete(@search.request_id)
+      retained[@search.request_id] = codes
+      retained = retained.to_a.last(MAX_RETAINED_FAILURE_JOURNEYS).to_h
     end
+    store_search_failure_codes(retained)
 
     @search_failure_suggestions = suggestions.enabled_codes_for(codes)
   end
@@ -226,7 +231,21 @@ module InteractiveSearchable
   end
 
   def clear_search_failure_suggestions
-    session.delete(FAILURE_SUGGESTIONS_SESSION_KEY)
+    retained = retained_search_failure_codes
+    retained.delete(@search.request_id)
+    store_search_failure_codes(retained)
+  end
+
+  def retained_search_failure_codes
+    session[FAILURE_SUGGESTIONS_SESSION_KEY].to_h
+  end
+
+  def store_search_failure_codes(retained)
+    if retained.any?
+      session[FAILURE_SUGGESTIONS_SESSION_KEY] = retained
+    else
+      session.delete(FAILURE_SUGGESTIONS_SESSION_KEY)
+    end
   end
 
   def mark_interactive_search_page

--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -106,7 +106,7 @@ module InteractiveSearchable
       session.delete(FAILURE_SUGGESTIONS_SESSION_KEY)
     end
 
-    @search_failure_suggestions = suggestions.messages_for(codes)
+    @search_failure_suggestions = suggestions.enabled_codes_for(codes)
   end
 
   def redirectable_interactive_blocking?

--- a/app/models/search/internal_search_result.rb
+++ b/app/models/search/internal_search_result.rb
@@ -58,6 +58,10 @@ class Search
       meta&.dig('interactive_search').present?
     end
 
+    def search_failures
+      Array(meta&.dig('search_failures'))
+    end
+
     def has_pending_question?
       return false unless interactive_search?
 

--- a/app/services/guided_search/failure_suggestions.rb
+++ b/app/services/guided_search/failure_suggestions.rb
@@ -1,0 +1,59 @@
+module GuidedSearch
+  class FailureSuggestions
+    CODE_PATTERN = /\A[a-z0-9_]{1,64}\z/
+    SUPPORTED_LEVELS = %w[warn].freeze
+    ConfigurationError = Class.new(StandardError)
+
+    def initialize(
+      config: Rails.application.config.search_failure_messages,
+      logger: Rails.logger
+    )
+      @config = config.to_h.deep_stringify_keys
+      @logger = logger
+      validate_configuration!
+    end
+
+    def messages_for(codes)
+      messages = known_codes(codes).filter_map do |code|
+        entry = @config[code]
+        I18n.t(entry.fetch('translation_key')) if entry&.fetch('enabled', false)
+      end
+      messages.uniq
+    end
+
+    def known_codes(codes)
+      known = Array(codes).filter_map do |code|
+        normalized_code = code if code.is_a?(String) && code.match?(CODE_PATTERN)
+        next normalized_code if @config.key?(normalized_code)
+
+        @logger.warn(
+          { event: 'guided_search.unknown_failure_code', failure_code: normalized_code || 'invalid' }.to_json,
+        )
+        nil
+      end
+      known.uniq
+    end
+
+    private
+
+    def validate_configuration!
+      @config.each do |code, entry|
+        unless code.match?(CODE_PATTERN)
+          raise ConfigurationError, "#{code} must be a valid failure code"
+        end
+
+        unless [true, false].include?(entry['enabled'])
+          raise ConfigurationError, "#{code} must define enabled as a boolean"
+        end
+
+        if entry['translation_key'].blank?
+          raise ConfigurationError, "#{code} must define translation_key"
+        end
+
+        next if SUPPORTED_LEVELS.include?(entry['level'])
+
+        raise ConfigurationError, "#{code} has an unsupported level"
+      end
+    end
+  end
+end

--- a/app/services/guided_search/failure_suggestions.rb
+++ b/app/services/guided_search/failure_suggestions.rb
@@ -13,12 +13,8 @@ module GuidedSearch
       validate_configuration!
     end
 
-    def messages_for(codes)
-      messages = known_codes(codes).filter_map do |code|
-        entry = @config[code]
-        I18n.t(entry.fetch('translation_key')) if entry&.fetch('enabled', false)
-      end
-      messages.uniq
+    def enabled_codes_for(codes)
+      known_codes(codes).select { |code| @config.dig(code, 'enabled') }
     end
 
     def known_codes(codes)
@@ -44,10 +40,6 @@ module GuidedSearch
 
         unless [true, false].include?(entry['enabled'])
           raise ConfigurationError, "#{code} must define enabled as a boolean"
-        end
-
-        if entry['translation_key'].blank?
-          raise ConfigurationError, "#{code} must define translation_key"
         end
 
         next if SUPPORTED_LEVELS.include?(entry['level'])

--- a/app/views/search/_failure_suggestions.html.erb
+++ b/app/views/search/_failure_suggestions.html.erb
@@ -1,0 +1,8 @@
+<% if suggestions.present? %>
+  <%= govuk_inset_text do %>
+    <p class="govuk-body"><strong><%= t('search.failure_suggestions.heading') %></strong></p>
+    <% suggestions.each do |suggestion| %>
+      <p class="govuk-body"><%= suggestion %></p>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/search/_failure_suggestions.html.erb
+++ b/app/views/search/_failure_suggestions.html.erb
@@ -1,8 +1,15 @@
 <% if suggestions.present? %>
-  <%= govuk_inset_text do %>
-    <p class="govuk-body"><strong><%= t('search.failure_suggestions.heading') %></strong></p>
-    <% suggestions.each do |suggestion| %>
-      <p class="govuk-body"><%= suggestion %></p>
-    <% end %>
-  <% end %>
+  <div class="govuk-notification-banner"
+       role="region"
+       aria-labelledby="search-failure-suggestions-title"
+       data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="search-failure-suggestions-title">
+        <%= t('search.failure_suggestions.heading') %>
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <p class="govuk-body"><%= t('search.failure_suggestions.body') %></p>
+    </div>
+  </div>
 <% end %>

--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -15,8 +15,6 @@
     <p class="govuk-body-l">We need to ask you some questions about the products.</p>
   </div>
 
-  <%= render 'search/failure_suggestions', suggestions: @search_failure_suggestions %>
-
   <div data-interactive-question-target="form">
     <% question = @results.current_question %>
 

--- a/app/views/search/interactive_question.html.erb
+++ b/app/views/search/interactive_question.html.erb
@@ -15,6 +15,8 @@
     <p class="govuk-body-l">We need to ask you some questions about the products.</p>
   </div>
 
+  <%= render 'search/failure_suggestions', suggestions: @search_failure_suggestions %>
+
   <div data-interactive-question-target="form">
     <% question = @results.current_question %>
 

--- a/app/views/search/interactive_results.html.erb
+++ b/app/views/search/interactive_results.html.erb
@@ -4,4 +4,6 @@
 
 <%= page_header "Search results" %>
 
+<%= render 'search/failure_suggestions', suggestions: @search_failure_suggestions %>
+
 <%= render 'search/interactive_results_content' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -67,6 +67,7 @@ module TradeTariffFrontend
     config.x.http.retry_options = {}
 
     config.guide_links = config_for(:guide_links)
+    config.search_failure_messages = config_for(:search_failure_messages).freeze
     # Prevent invalid queries from causing an error, e.g., `/api/uk/search_references.json?query[letter]=%`
     config.middleware.use FilterBadUrlEncoding
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,11 +155,8 @@ en:
   search:
     label: "Search the %{service_name}"
     failure_suggestions:
-      heading: "About these results"
-      query_expansion_failed: "These results are based on the words you entered. Try searching again if they are not useful."
-      meaning_matching_failed: "These results use keyword matching. Try searching again if they are not useful."
-      interactive_search_failed: "These are the best available matches. Try searching again if you want to answer questions and refine the results."
-      opensearch_failed: "These results are based on the meaning of your description. Try searching again if they are not useful."
+      heading: "Issues with AI-assisted search"
+      body: "We are aware of some issues affecting AI-assisted search and are working to fix these as soon as possible."
 
   geographical_areas:
     descriptions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,12 @@ en:
       xi: "Northern Ireland Online Tariff"
   search:
     label: "Search the %{service_name}"
+    failure_suggestions:
+      heading: "About these results"
+      query_expansion_failed: "These results are based on the words you entered. Try searching again if they are not useful."
+      meaning_matching_failed: "These results use keyword matching. Try searching again if they are not useful."
+      interactive_search_failed: "These are the best available matches. Try searching again if you want to answer questions and refine the results."
+      opensearch_failed: "These results are based on the meaning of your description. Try searching again if they are not useful."
 
   geographical_areas:
     descriptions:

--- a/config/search_failure_messages.yml
+++ b/config/search_failure_messages.yml
@@ -1,0 +1,21 @@
+shared:
+  query_expansion_failed:
+    enabled: true
+    level: warn
+    translation_key: search.failure_suggestions.query_expansion_failed
+  embedding_generation_failed:
+    enabled: true
+    level: warn
+    translation_key: search.failure_suggestions.meaning_matching_failed
+  vector_retrieval_failed:
+    enabled: true
+    level: warn
+    translation_key: search.failure_suggestions.meaning_matching_failed
+  interactive_search_failed:
+    enabled: true
+    level: warn
+    translation_key: search.failure_suggestions.interactive_search_failed
+  opensearch_failed:
+    enabled: true
+    level: warn
+    translation_key: search.failure_suggestions.opensearch_failed

--- a/config/search_failure_messages.yml
+++ b/config/search_failure_messages.yml
@@ -2,20 +2,15 @@ shared:
   query_expansion_failed:
     enabled: true
     level: warn
-    translation_key: search.failure_suggestions.query_expansion_failed
   embedding_generation_failed:
     enabled: true
     level: warn
-    translation_key: search.failure_suggestions.meaning_matching_failed
   vector_retrieval_failed:
     enabled: true
     level: warn
-    translation_key: search.failure_suggestions.meaning_matching_failed
   interactive_search_failed:
     enabled: true
     level: warn
-    translation_key: search.failure_suggestions.interactive_search_failed
   opensearch_failed:
     enabled: true
     level: warn
-    translation_key: search.failure_suggestions.opensearch_failed

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -207,8 +207,8 @@ RSpec.describe 'Search', :js do
 
         expect(page).to have_css('h1', text: 'Search for a commodity')
         expect(page).to have_content('What type of fish?')
-        expect(page).to have_css('.govuk-inset-text', text: 'About these results')
-        expect(page).to have_content('These results are based on the words you entered.')
+        expect(page).to have_css('.govuk-notification-banner', text: 'Issues with AI-assisted search')
+        expect(page).to have_content('We are aware of some issues affecting AI-assisted search')
         expect(page).to have_css('[data-controller="interactive-question"][data-interactive-question-request-id-value="guided-request-123"]')
         expect(page).to have_css('[data-controller="guided-search-page"][data-guided-search-page-outcome-value="question"]')
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -207,8 +207,7 @@ RSpec.describe 'Search', :js do
 
         expect(page).to have_css('h1', text: 'Search for a commodity')
         expect(page).to have_content('What type of fish?')
-        expect(page).to have_css('.govuk-notification-banner', text: 'Issues with AI-assisted search')
-        expect(page).to have_content('We are aware of some issues affecting AI-assisted search')
+        expect(page).not_to have_css('.govuk-notification-banner')
         expect(page).to have_css('[data-controller="interactive-question"][data-interactive-question-request-id-value="guided-request-123"]')
         expect(page).to have_css('[data-controller="guided-search-page"][data-guided-search-page-outcome-value="question"]')
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe 'Search', :js do
             body: {
               'data' => [guided_search_result],
               'meta' => {
+                'search_failures' => %w[query_expansion_failed],
                 'interactive_search' => {
                   'query' => 'smoked haddock',
                   'request_id' => 'guided-request-123',
@@ -206,6 +207,8 @@ RSpec.describe 'Search', :js do
 
         expect(page).to have_css('h1', text: 'Search for a commodity')
         expect(page).to have_content('What type of fish?')
+        expect(page).to have_css('.govuk-inset-text', text: 'About these results')
+        expect(page).to have_content('These results are based on the words you entered.')
         expect(page).to have_css('[data-controller="interactive-question"][data-interactive-question-request-id-value="guided-request-123"]')
         expect(page).to have_css('[data-controller="guided-search-page"][data-guided-search-page-outcome-value="question"]')
 

--- a/spec/models/search/internal_search_result_spec.rb
+++ b/spec/models/search/internal_search_result_spec.rb
@@ -266,6 +266,23 @@ RSpec.describe Search::InternalSearchResult do
     end
   end
 
+  describe '#search_failures' do
+    it 'returns the failure codes from top-level response metadata' do
+      result = described_class.new(
+        [commodity_attrs],
+        'search_failures' => %w[query_expansion_failed opensearch_failed],
+      )
+
+      expect(result.search_failures).to eq(%w[query_expansion_failed opensearch_failed])
+    end
+
+    it 'returns an empty array when response metadata has no failure codes' do
+      result = described_class.new([commodity_attrs], nil)
+
+      expect(result.search_failures).to eq([])
+    end
+  end
+
   describe '#has_pending_question?' do
     context 'when last answer has nil answer' do
       subject { described_class.new([commodity_attrs], meta) }

--- a/spec/requests/guided_search_failure_suggestions_spec.rb
+++ b/spec/requests/guided_search_failure_suggestions_spec.rb
@@ -1,0 +1,167 @@
+require 'spec_helper'
+
+RSpec.describe 'Guided search failure suggestions', type: :request do
+  before { enable_feature(:interactive_search) }
+
+  let(:commodity_data) do
+    {
+      'id' => '0101210000',
+      'type' => 'commodity',
+      'attributes' => {
+        'goods_nomenclature_item_id' => '0101210000',
+        'producline_suffix' => GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX,
+        'goods_nomenclature_class' => 'Commodity',
+        'description' => 'Pure-bred breeding animals',
+        'formatted_description' => 'Pure-bred breeding animals',
+        'declarable' => true,
+        'score' => 12.5,
+        'confidence' => 'strong',
+      },
+    }
+  end
+
+  it 'shows a lightweight suggestion when a question response is degraded', :aggregate_failures do
+    stub_search_response(
+      failures: %w[query_expansion_failed],
+      answers: [pending_answer],
+    )
+
+    post perform_search_path, params: { q: 'horses', interactive_search: 'true' }
+
+    page = Capybara.string(response.body)
+    expect(page).to have_css('.govuk-inset-text', text: 'About these results')
+    expect(page).to have_text('These results are based on the words you entered.')
+    expect(page).not_to have_css('[role="alert"]', text: 'These results are based on the words you entered.')
+  end
+
+  it 'shows a lightweight suggestion when the final results response is degraded', :aggregate_failures do
+    stub_search_response(failures: %w[embedding_generation_failed], answers: [completed_answer])
+
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+    }
+
+    page = Capybara.string(response.body)
+    expect(page).to have_css('.govuk-inset-text', text: 'About these results')
+    expect(page).to have_text('These results use keyword matching.')
+  end
+
+  it 'retains a suggestion for the same request until the final results page', :aggregate_failures do
+    stub_api_request('search', :post, internal: true).to_return(
+      search_response(failures: %w[query_expansion_failed], answers: [pending_answer]),
+      search_response(failures: [], answers: [completed_answer]),
+    )
+
+    post perform_search_path, params: { q: 'horses', interactive_search: 'true' }
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+      current_question: 'What type of horse?',
+      current_options: %w[Racing Breeding].to_json,
+      interactive_search_form: { answer: '' },
+    }
+
+    expect(Capybara.string(response.body)).to have_text('These results are based on the words you entered.')
+
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+    }
+
+    expect(Capybara.string(response.body)).to have_text('These results are based on the words you entered.')
+
+    stub_search_response(failures: [], answers: [completed_answer])
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+    }
+
+    expect(Capybara.string(response.body)).not_to have_text('These results are based on the words you entered.')
+  end
+
+  it 'deduplicates shared copy and uses one inset for multiple suggestions', :aggregate_failures do
+    stub_search_response(
+      failures: %w[embedding_generation_failed vector_retrieval_failed opensearch_failed],
+      answers: [completed_answer],
+    )
+
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+    }
+
+    page = Capybara.string(response.body)
+    expect(page).to have_css('.govuk-inset-text', count: 1)
+    expect(page).to have_text('These results use keyword matching.', count: 1)
+    expect(page).to have_text('These results are based on the meaning of your description.', count: 1)
+  end
+
+  it 'ignores unknown codes and records a bounded warning', :aggregate_failures do
+    allow(Rails.logger).to receive(:warn)
+    stub_search_response(failures: %w[future_failure], answers: [completed_answer])
+
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+    }
+
+    expect(Capybara.string(response.body)).not_to have_css('.govuk-inset-text')
+    expect(Rails.logger).to have_received(:warn).with(
+      { event: 'guided_search.unknown_failure_code', failure_code: 'future_failure' }.to_json,
+    )
+  end
+
+  it 'does not show copy for a disabled failure' do
+    configured_messages = Rails.application.config.search_failure_messages.deep_dup
+    configured_messages['query_expansion_failed']['enabled'] = false
+    allow(Rails.application.config).to receive(:search_failure_messages).and_return(configured_messages)
+    stub_search_response(failures: %w[query_expansion_failed], answers: [completed_answer])
+
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+    }
+
+    expect(Capybara.string(response.body)).not_to have_css('.govuk-inset-text')
+  end
+
+  def pending_answer
+    { 'question' => 'What type of horse?', 'options' => %w[Racing Breeding], 'answer' => nil }
+  end
+
+  def completed_answer
+    pending_answer.merge('answer' => 'Breeding')
+  end
+
+  def stub_search_response(failures:, answers:, request_id: 'guided-request-123')
+    stub_api_request('search', :post, internal: true).to_return(
+      search_response(failures:, answers:, request_id:),
+    )
+  end
+
+  def search_response(failures:, answers:, request_id: 'guided-request-123')
+    {
+      status: 200,
+      body: {
+        'data' => [commodity_data],
+        'meta' => {
+          'search_failures' => failures,
+          'interactive_search' => {
+            'query' => 'horses',
+            'request_id' => request_id,
+            'answers' => answers,
+          },
+        },
+      }.to_json,
+      headers: { 'content-type' => 'application/json; charset=utf-8' },
+    }
+  end
+end

--- a/spec/requests/guided_search_failure_suggestions_spec.rb
+++ b/spec/requests/guided_search_failure_suggestions_spec.rb
@@ -106,32 +106,6 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
     expect(Capybara.string(response.body)).to have_text('Issues with AI-assisted search')
   end
 
-  it 'clears a failure after a terminal Atom response' do
-    stub_api_request('search', :post, internal: true).to_return(
-      search_response(failures: %w[query_expansion_failed], answers: [pending_answer]),
-      search_response(failures: [], answers: [completed_answer]),
-      search_response(failures: [], answers: [completed_answer]),
-    )
-
-    post perform_search_path, params: {
-      q: 'horses',
-      interactive_search: 'true',
-      request_id: 'guided-request-123',
-    }
-    post perform_search_path(format: :atom), params: {
-      q: 'horses',
-      interactive_search: 'true',
-      request_id: 'guided-request-123',
-    }
-    post perform_search_path, params: {
-      q: 'horses',
-      interactive_search: 'true',
-      request_id: 'guided-request-123',
-    }
-
-    expect(Capybara.string(response.body)).not_to have_text('Issues with AI-assisted search')
-  end
-
   it 'retains failures independently for concurrent journeys' do
     stub_api_request('search', :post, internal: true).to_return(
       search_response(failures: %w[query_expansion_failed], answers: [pending_answer], request_id: 'journey-a'),

--- a/spec/requests/guided_search_failure_suggestions_spec.rb
+++ b/spec/requests/guided_search_failure_suggestions_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
     }
   end
 
-  it 'shows the issue banner when a question response is degraded', :aggregate_failures do
+  it 'does not show the issue banner while asking questions', :aggregate_failures do
     stub_search_response(
       failures: %w[query_expansion_failed],
       answers: [pending_answer],
@@ -29,8 +29,8 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
     post perform_search_path, params: { q: 'horses', interactive_search: 'true' }
 
     page = Capybara.string(response.body)
-    expect(page).to have_css('.govuk-notification-banner', text: 'Issues with AI-assisted search')
-    expect(page).to have_text('We are aware of some issues affecting AI-assisted search')
+    expect(page).not_to have_css('.govuk-notification-banner')
+    expect(page).not_to have_text('Issues with AI-assisted search')
     expect(page).not_to have_text('These results are based on the words you entered.')
     expect(page).not_to have_css('[role="alert"]')
   end
@@ -66,7 +66,7 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
       interactive_search_form: { answer: '' },
     }
 
-    expect(Capybara.string(response.body)).to have_text('Issues with AI-assisted search')
+    expect(Capybara.string(response.body)).not_to have_text('Issues with AI-assisted search')
 
     post perform_search_path, params: {
       q: 'horses',
@@ -140,7 +140,7 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
       )
     end
     responses += (1..6).map do |number|
-      search_response(failures: [], answers: [pending_answer], request_id: "journey-#{number}")
+      search_response(failures: [], answers: [completed_answer], request_id: "journey-#{number}")
     end
     stub_api_request('search', :post, internal: true).to_return(*responses)
 
@@ -221,7 +221,7 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
           request_id: "disabled-journey-#{number}",
         )
       end,
-      search_response(failures: [], answers: [pending_answer], request_id: 'enabled-journey'),
+      search_response(failures: [], answers: [completed_answer], request_id: 'enabled-journey'),
     ]
     stub_api_request('search', :post, internal: true).to_return(*responses)
 

--- a/spec/requests/guided_search_failure_suggestions_spec.rb
+++ b/spec/requests/guided_search_failure_suggestions_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
     }
   end
 
-  it 'shows a lightweight suggestion when a question response is degraded', :aggregate_failures do
+  it 'shows the issue banner when a question response is degraded', :aggregate_failures do
     stub_search_response(
       failures: %w[query_expansion_failed],
       answers: [pending_answer],
@@ -29,12 +29,13 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
     post perform_search_path, params: { q: 'horses', interactive_search: 'true' }
 
     page = Capybara.string(response.body)
-    expect(page).to have_css('.govuk-inset-text', text: 'About these results')
-    expect(page).to have_text('These results are based on the words you entered.')
-    expect(page).not_to have_css('[role="alert"]', text: 'These results are based on the words you entered.')
+    expect(page).to have_css('.govuk-notification-banner', text: 'Issues with AI-assisted search')
+    expect(page).to have_text('We are aware of some issues affecting AI-assisted search')
+    expect(page).not_to have_text('These results are based on the words you entered.')
+    expect(page).not_to have_css('[role="alert"]')
   end
 
-  it 'shows a lightweight suggestion when the final results response is degraded', :aggregate_failures do
+  it 'shows the issue banner when the final results response is degraded', :aggregate_failures do
     stub_search_response(failures: %w[embedding_generation_failed], answers: [completed_answer])
 
     post perform_search_path, params: {
@@ -44,8 +45,9 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
     }
 
     page = Capybara.string(response.body)
-    expect(page).to have_css('.govuk-inset-text', text: 'About these results')
-    expect(page).to have_text('These results use keyword matching.')
+    expect(page).to have_css('.govuk-notification-banner', text: 'Issues with AI-assisted search')
+    expect(page).to have_text('We are aware of some issues affecting AI-assisted search')
+    expect(page).not_to have_text('These results use keyword matching.')
   end
 
   it 'retains a suggestion for the same request until the final results page', :aggregate_failures do
@@ -64,7 +66,7 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
       interactive_search_form: { answer: '' },
     }
 
-    expect(Capybara.string(response.body)).to have_text('These results are based on the words you entered.')
+    expect(Capybara.string(response.body)).to have_text('Issues with AI-assisted search')
 
     post perform_search_path, params: {
       q: 'horses',
@@ -72,7 +74,7 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
       request_id: 'guided-request-123',
     }
 
-    expect(Capybara.string(response.body)).to have_text('These results are based on the words you entered.')
+    expect(Capybara.string(response.body)).to have_text('Issues with AI-assisted search')
 
     stub_search_response(failures: [], answers: [completed_answer])
     post perform_search_path, params: {
@@ -81,10 +83,10 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
       request_id: 'guided-request-123',
     }
 
-    expect(Capybara.string(response.body)).not_to have_text('These results are based on the words you entered.')
+    expect(Capybara.string(response.body)).not_to have_text('Issues with AI-assisted search')
   end
 
-  it 'deduplicates shared copy and uses one inset for multiple suggestions', :aggregate_failures do
+  it 'uses one issue banner for multiple failures', :aggregate_failures do
     stub_search_response(
       failures: %w[embedding_generation_failed vector_retrieval_failed opensearch_failed],
       answers: [completed_answer],
@@ -97,9 +99,11 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
     }
 
     page = Capybara.string(response.body)
-    expect(page).to have_css('.govuk-inset-text', count: 1)
-    expect(page).to have_text('These results use keyword matching.', count: 1)
-    expect(page).to have_text('These results are based on the meaning of your description.', count: 1)
+    expect(page).to have_css('.govuk-notification-banner', count: 1)
+    expect(page).to have_text('Issues with AI-assisted search', count: 1)
+    expect(page).to have_text('We are aware of some issues affecting AI-assisted search', count: 1)
+    expect(page).not_to have_text('These results use keyword matching.')
+    expect(page).not_to have_text('These results are based on the meaning of your description.')
   end
 
   it 'ignores unknown codes and records a bounded warning', :aggregate_failures do
@@ -112,7 +116,7 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
       request_id: 'guided-request-123',
     }
 
-    expect(Capybara.string(response.body)).not_to have_css('.govuk-inset-text')
+    expect(Capybara.string(response.body)).not_to have_css('.govuk-notification-banner')
     expect(Rails.logger).to have_received(:warn).with(
       { event: 'guided_search.unknown_failure_code', failure_code: 'future_failure' }.to_json,
     )
@@ -130,7 +134,7 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
       request_id: 'guided-request-123',
     }
 
-    expect(Capybara.string(response.body)).not_to have_css('.govuk-inset-text')
+    expect(Capybara.string(response.body)).not_to have_css('.govuk-notification-banner')
   end
 
   def pending_answer

--- a/spec/requests/guided_search_failure_suggestions_spec.rb
+++ b/spec/requests/guided_search_failure_suggestions_spec.rb
@@ -182,6 +182,33 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
     expect(Capybara.string(response.body)).not_to have_css('.govuk-notification-banner')
   end
 
+  it 'does not let disabled-only journeys evict an enabled failure' do
+    configured_messages = Rails.application.config.search_failure_messages.deep_dup
+    configured_messages['query_expansion_failed']['enabled'] = false
+    allow(Rails.application.config).to receive(:search_failure_messages).and_return(configured_messages)
+    responses = [
+      search_response(failures: %w[opensearch_failed], answers: [pending_answer], request_id: 'enabled-journey'),
+      *(1..5).map do |number|
+        search_response(
+          failures: %w[query_expansion_failed],
+          answers: [pending_answer],
+          request_id: "disabled-journey-#{number}",
+        )
+      end,
+      search_response(failures: [], answers: [pending_answer], request_id: 'enabled-journey'),
+    ]
+    stub_api_request('search', :post, internal: true).to_return(*responses)
+
+    post perform_search_path, params: { q: 'horses', interactive_search: 'true', request_id: 'enabled-journey' }
+    (1..5).each do |number|
+      post perform_search_path,
+           params: { q: 'horses', interactive_search: 'true', request_id: "disabled-journey-#{number}" }
+    end
+    post perform_search_path, params: { q: 'horses', interactive_search: 'true', request_id: 'enabled-journey' }
+
+    expect(Capybara.string(response.body)).to have_text('Issues with AI-assisted search')
+  end
+
   def pending_answer
     { 'question' => 'What type of horse?', 'options' => %w[Racing Breeding], 'answer' => nil }
   end

--- a/spec/requests/guided_search_failure_suggestions_spec.rb
+++ b/spec/requests/guided_search_failure_suggestions_spec.rb
@@ -86,6 +86,77 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
     expect(Capybara.string(response.body)).not_to have_text('Issues with AI-assisted search')
   end
 
+  it 'retains a failure when a JSON response has a pending question' do
+    stub_api_request('search', :post, internal: true).to_return(
+      search_response(failures: %w[query_expansion_failed], answers: [pending_answer]),
+      search_response(failures: [], answers: [completed_answer]),
+    )
+
+    post perform_search_path(format: :json), params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+    }
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+    }
+
+    expect(Capybara.string(response.body)).to have_text('Issues with AI-assisted search')
+  end
+
+  it 'clears a failure after a terminal Atom response' do
+    stub_api_request('search', :post, internal: true).to_return(
+      search_response(failures: %w[query_expansion_failed], answers: [pending_answer]),
+      search_response(failures: [], answers: [completed_answer]),
+      search_response(failures: [], answers: [completed_answer]),
+    )
+
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+    }
+    post perform_search_path(format: :atom), params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+    }
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'guided-request-123',
+    }
+
+    expect(Capybara.string(response.body)).not_to have_text('Issues with AI-assisted search')
+  end
+
+  it 'retains failures independently for concurrent journeys' do
+    stub_api_request('search', :post, internal: true).to_return(
+      search_response(failures: %w[query_expansion_failed], answers: [pending_answer], request_id: 'journey-a'),
+      search_response(failures: %w[opensearch_failed], answers: [pending_answer], request_id: 'journey-b'),
+      search_response(failures: [], answers: [completed_answer], request_id: 'journey-b'),
+      search_response(failures: [], answers: [completed_answer], request_id: 'journey-a'),
+    )
+
+    %w[journey-a journey-b].each do |request_id|
+      post perform_search_path, params: { q: 'horses', interactive_search: 'true', request_id: }
+    end
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'journey-b',
+    }
+    post perform_search_path, params: {
+      q: 'horses',
+      interactive_search: 'true',
+      request_id: 'journey-a',
+    }
+
+    expect(Capybara.string(response.body)).to have_text('Issues with AI-assisted search')
+  end
+
   it 'uses one issue banner for multiple failures', :aggregate_failures do
     stub_search_response(
       failures: %w[embedding_generation_failed vector_retrieval_failed opensearch_failed],

--- a/spec/requests/guided_search_failure_suggestions_spec.rb
+++ b/spec/requests/guided_search_failure_suggestions_spec.rb
@@ -131,6 +131,32 @@ RSpec.describe 'Guided search failure suggestions', type: :request do
     expect(Capybara.string(response.body)).to have_text('Issues with AI-assisted search')
   end
 
+  it 'retains only the five most recent enabled failure journeys', :aggregate_failures do
+    responses = (1..6).map do |number|
+      search_response(
+        failures: %w[opensearch_failed],
+        answers: [pending_answer],
+        request_id: "journey-#{number}",
+      )
+    end
+    responses += (1..6).map do |number|
+      search_response(failures: [], answers: [pending_answer], request_id: "journey-#{number}")
+    end
+    stub_api_request('search', :post, internal: true).to_return(*responses)
+
+    (1..6).each do |number|
+      post perform_search_path, params: { q: 'horses', interactive_search: 'true', request_id: "journey-#{number}" }
+    end
+
+    post perform_search_path, params: { q: 'horses', interactive_search: 'true', request_id: 'journey-1' }
+    expect(Capybara.string(response.body)).not_to have_text('Issues with AI-assisted search')
+
+    (2..6).each do |number|
+      post perform_search_path, params: { q: 'horses', interactive_search: 'true', request_id: "journey-#{number}" }
+      expect(Capybara.string(response.body)).to have_text('Issues with AI-assisted search')
+    end
+  end
+
   it 'uses one issue banner for multiple failures', :aggregate_failures do
     stub_search_response(
       failures: %w[embedding_generation_failed vector_retrieval_failed opensearch_failed],

--- a/spec/services/guided_search/failure_suggestions_spec.rb
+++ b/spec/services/guided_search/failure_suggestions_spec.rb
@@ -1,0 +1,118 @@
+RSpec.describe GuidedSearch::FailureSuggestions do
+  subject(:suggestions) { described_class.new(config:, logger:) }
+
+  let(:logger) { instance_double(ActiveSupport::Logger, warn: nil) }
+  let(:config) do
+    {
+      'query_expansion_failed' => {
+        'enabled' => true,
+        'level' => 'warn',
+        'translation_key' => 'search.failure_suggestions.query_expansion_failed',
+      },
+    }
+  end
+
+  describe '#initialize' do
+    it 'rejects an invalid failure code' do
+      config['Not a valid code'] = config.delete('query_expansion_failed')
+
+      expect { suggestions }.to raise_error(
+        GuidedSearch::FailureSuggestions::ConfigurationError,
+        /Not a valid code.*code/,
+      )
+    end
+
+    it 'rejects an unsupported display level' do
+      config['query_expansion_failed']['level'] = 'error'
+
+      expect { suggestions }.to raise_error(
+        GuidedSearch::FailureSuggestions::ConfigurationError,
+        /query_expansion_failed.*level/,
+      )
+    end
+
+    it 'rejects an entry without a translation key' do
+      config['query_expansion_failed'].delete('translation_key')
+
+      expect { suggestions }.to raise_error(
+        GuidedSearch::FailureSuggestions::ConfigurationError,
+        /query_expansion_failed.*translation_key/,
+      )
+    end
+
+    it 'rejects an entry without a boolean enabled value' do
+      config['query_expansion_failed']['enabled'] = 'yes'
+
+      expect { suggestions }.to raise_error(
+        GuidedSearch::FailureSuggestions::ConfigurationError,
+        /query_expansion_failed.*enabled/,
+      )
+    end
+  end
+
+  describe '#messages_for' do
+    it 'returns the translated suggestion for an enabled failure' do
+      allow(I18n).to receive(:t)
+        .with('search.failure_suggestions.query_expansion_failed')
+        .and_return('These results are based on the words you entered.')
+
+      expect(suggestions.messages_for(%w[query_expansion_failed]))
+        .to eq(['These results are based on the words you entered.'])
+    end
+
+    it 'does not return a suggestion when the failure is disabled' do
+      config['query_expansion_failed']['enabled'] = false
+
+      expect(suggestions.messages_for(%w[query_expansion_failed])).to eq([])
+    end
+
+    it 'returns shared translated copy only once' do
+      config['embedding_generation_failed'] = {
+        'enabled' => true,
+        'level' => 'warn',
+        'translation_key' => 'search.failure_suggestions.meaning_matching_failed',
+      }
+      config['vector_retrieval_failed'] = config['embedding_generation_failed'].dup
+      allow(I18n).to receive(:t)
+        .with('search.failure_suggestions.meaning_matching_failed')
+        .and_return('These results use keyword matching.')
+
+      expect(suggestions.messages_for(%w[embedding_generation_failed vector_retrieval_failed]))
+        .to eq(['These results use keyword matching.'])
+    end
+  end
+
+  describe '#known_codes' do
+    it 'ignores and logs an unknown failure code', :aggregate_failures do
+      expect(suggestions.known_codes(%w[query_expansion_failed future_failure]))
+        .to eq(%w[query_expansion_failed])
+      expect(logger).to have_received(:warn).with(
+        { event: 'guided_search.unknown_failure_code', failure_code: 'future_failure' }.to_json,
+      )
+    end
+  end
+
+  context 'with the application configuration' do
+    subject(:suggestions) { described_class.new }
+
+    let(:all_codes) do
+      %w[
+        query_expansion_failed
+        embedding_generation_failed
+        vector_retrieval_failed
+        interactive_search_failed
+        opensearch_failed
+      ]
+    end
+
+    it 'enables all five codes and returns four unique translated suggestions', :aggregate_failures do
+      expect(suggestions.known_codes(all_codes)).to eq(all_codes)
+      expect(suggestions.messages_for(all_codes)).to eq([
+        'These results are based on the words you entered. Try searching again if they are not useful.',
+        'These results use keyword matching. Try searching again if they are not useful.',
+        'These are the best available matches. Try searching again if you want to answer questions and refine the results.',
+        'These results are based on the meaning of your description. Try searching again if they are not useful.',
+      ])
+    end
+  end
+end

--- a/spec/services/guided_search/failure_suggestions_spec.rb
+++ b/spec/services/guided_search/failure_suggestions_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe GuidedSearch::FailureSuggestions do
       'query_expansion_failed' => {
         'enabled' => true,
         'level' => 'warn',
-        'translation_key' => 'search.failure_suggestions.query_expansion_failed',
       },
     }
   end
@@ -31,15 +30,6 @@ RSpec.describe GuidedSearch::FailureSuggestions do
       )
     end
 
-    it 'rejects an entry without a translation key' do
-      config['query_expansion_failed'].delete('translation_key')
-
-      expect { suggestions }.to raise_error(
-        GuidedSearch::FailureSuggestions::ConfigurationError,
-        /query_expansion_failed.*translation_key/,
-      )
-    end
-
     it 'rejects an entry without a boolean enabled value' do
       config['query_expansion_failed']['enabled'] = 'yes'
 
@@ -50,35 +40,16 @@ RSpec.describe GuidedSearch::FailureSuggestions do
     end
   end
 
-  describe '#messages_for' do
-    it 'returns the translated suggestion for an enabled failure' do
-      allow(I18n).to receive(:t)
-        .with('search.failure_suggestions.query_expansion_failed')
-        .and_return('These results are based on the words you entered.')
-
-      expect(suggestions.messages_for(%w[query_expansion_failed]))
-        .to eq(['These results are based on the words you entered.'])
+  describe '#enabled_codes_for' do
+    it 'returns an enabled failure code' do
+      expect(suggestions.enabled_codes_for(%w[query_expansion_failed]))
+        .to eq(%w[query_expansion_failed])
     end
 
     it 'does not return a suggestion when the failure is disabled' do
       config['query_expansion_failed']['enabled'] = false
 
-      expect(suggestions.messages_for(%w[query_expansion_failed])).to eq([])
-    end
-
-    it 'returns shared translated copy only once' do
-      config['embedding_generation_failed'] = {
-        'enabled' => true,
-        'level' => 'warn',
-        'translation_key' => 'search.failure_suggestions.meaning_matching_failed',
-      }
-      config['vector_retrieval_failed'] = config['embedding_generation_failed'].dup
-      allow(I18n).to receive(:t)
-        .with('search.failure_suggestions.meaning_matching_failed')
-        .and_return('These results use keyword matching.')
-
-      expect(suggestions.messages_for(%w[embedding_generation_failed vector_retrieval_failed]))
-        .to eq(['These results use keyword matching.'])
+      expect(suggestions.enabled_codes_for(%w[query_expansion_failed])).to eq([])
     end
   end
 
@@ -105,14 +76,9 @@ RSpec.describe GuidedSearch::FailureSuggestions do
       ]
     end
 
-    it 'enables all five codes and returns four unique translated suggestions', :aggregate_failures do
+    it 'enables all five codes', :aggregate_failures do
       expect(suggestions.known_codes(all_codes)).to eq(all_codes)
-      expect(suggestions.messages_for(all_codes)).to eq([
-        'These results are based on the words you entered. Try searching again if they are not useful.',
-        'These results use keyword matching. Try searching again if they are not useful.',
-        'These are the best available matches. Try searching again if you want to answer questions and refine the results.',
-        'These results are based on the meaning of your description. Try searching again if they are not useful.',
-      ])
+      expect(suggestions.enabled_codes_for(all_codes)).to eq(all_codes)
     end
   end
 end

--- a/spec/views/search/_failure_suggestions.html.erb_spec.rb
+++ b/spec/views/search/_failure_suggestions.html.erb_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe 'search/_failure_suggestions', type: :view do
+  it 'renders nothing without suggestions' do
+    render partial: 'search/failure_suggestions', locals: { suggestions: [] }
+
+    expect(rendered).to be_blank
+  end
+
+  it 'renders all suggestions in one non-alert inset', :aggregate_failures do
+    render partial: 'search/failure_suggestions', locals: {
+      suggestions: ['First suggestion', 'Second suggestion'],
+    }
+
+    page = Capybara.string(rendered)
+    expect(page).to have_css('.govuk-inset-text', count: 1)
+    expect(page).to have_css('strong', text: 'About these results')
+    expect(page).to have_text('First suggestion').and have_text('Second suggestion')
+    expect(page).not_to have_css('[role="alert"]')
+  end
+end

--- a/spec/views/search/_failure_suggestions.html.erb_spec.rb
+++ b/spec/views/search/_failure_suggestions.html.erb_spec.rb
@@ -5,15 +5,20 @@ RSpec.describe 'search/_failure_suggestions', type: :view do
     expect(rendered).to be_blank
   end
 
-  it 'renders all suggestions in one non-alert inset', :aggregate_failures do
+  it 'renders one neutral notification banner', :aggregate_failures do
     render partial: 'search/failure_suggestions', locals: {
       suggestions: ['First suggestion', 'Second suggestion'],
     }
 
     page = Capybara.string(rendered)
-    expect(page).to have_css('.govuk-inset-text', count: 1)
-    expect(page).to have_css('strong', text: 'About these results')
-    expect(page).to have_text('First suggestion').and have_text('Second suggestion')
+    expect(page).to have_css('.govuk-notification-banner[role="region"]', count: 1)
+    expect(page).to have_css('.govuk-notification-banner__title', text: 'Issues with AI-assisted search')
+    expect(page).to have_css(
+      '.govuk-notification-banner__content .govuk-body',
+      text: 'We are aware of some issues affecting AI-assisted search and are working to fix these as soon as possible.',
+    )
+    expect(page).not_to have_text('First suggestion')
+    expect(page).not_to have_text('Second suggestion')
     expect(page).not_to have_css('[role="alert"]')
   end
 end


### PR DESCRIPTION
## What:

- [x] Read stable guided-search failure codes from backend response metadata.
- [x] Retain enabled failure codes independently for up to five concurrent request journeys and clear them at terminal outcomes.
- [x] Show one neutral GOV.UK notification banner on final guided-search results pages.
- [x] Use one generic heading and message for every enabled failure mode.
- [x] Keep all five failure modes independently configurable without failure-specific locale copy.
- [x] Ignore unknown codes safely and record a bounded structured warning.
- [x] Verify the change with 5,972 RSpec examples, 0 failures and 4 pre-existing pending examples.
- [x] Pass all configured pre-commit hooks, including RuboCop, YAML validation and secret scanning.

<img width="960" alt="AI-assisted search issue banner on the search results page" src="https://github.com/user-attachments/assets/2d8d541a-9cde-4453-8457-7e5f862183e6"/>

## Why:

When AI-assisted search is degraded, traders should see a calm service-status message on the final results page without technical details or different advice for each internal failure mode. The neutral banner uses region semantics, does not move focus, has no alert behaviour and introduces no JavaScript.

The guided-search journey is not live yet. The banner remains behind its existing feature flag, and each failure mode can be disabled independently through additive configuration. Backend responses must expose stable codes in `meta.search_failures`; no environment variables or deployment ordering changes are required.

Keep this PR in draft until the presentation has been socialised.

## Ticket:

[AI-1265](https://transformuk.atlassian.net/browse/AI-1265)

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Low risk because the guided-search journey is not live, the change is isolated behind its existing feature flag and the banner uses a standard GOV.UK component.
