### PR TITLE
AI-1271: Publish browser search journey events for Amplitude

### DIFF
--- a/app/javascript/controllers/guided_search_page_controller.js
+++ b/app/javascript/controllers/guided_search_page_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
+import { trackSearchJourney } from 'search-analytics'
 
 export default class extends Controller {
   static values = {
@@ -9,7 +10,11 @@ export default class extends Controller {
 
   connect() {
     const submittedAt = Number(window.sessionStorage.getItem('guidedSearchSubmittedAt'))
-    if (!Number.isFinite(submittedAt) || submittedAt <= 0 || !this.hasEventUrlValue) return
+    const navigationMs = Number.isFinite(submittedAt) && submittedAt > 0
+      ? Math.max(0, Math.round(Date.now() - submittedAt)) : null
+
+    trackSearchJourney('page_visible', { client_navigation_ms: navigationMs })
+    if (navigationMs === null || !this.hasEventUrlValue) return
 
     window.sessionStorage.removeItem('guidedSearchSubmittedAt')
 
@@ -25,7 +30,7 @@ export default class extends Controller {
         event_type: 'page_visible',
         request_id: this.requestIdValue,
         destination: this.outcomeValue,
-        client_navigation_ms: Math.max(0, Math.round(Date.now() - submittedAt)),
+        client_navigation_ms: navigationMs,
       }),
     }).catch(() => {})
   }

--- a/app/javascript/controllers/guided_search_result_controller.js
+++ b/app/javascript/controllers/guided_search_result_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
+import { trackSearchJourney } from 'search-analytics'
 
 export default class extends Controller {
   static values = {
@@ -12,6 +13,12 @@ export default class extends Controller {
   select() {
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
     const confidence = this.hasConfidenceValue ? this.confidenceValue.toLowerCase() : 'unknown'
+
+    trackSearchJourney('result_selected', {
+      goods_nomenclature_item_id: this.goodsNomenclatureItemIdValue,
+      result_rank: this.rankValue,
+      confidence,
+    })
 
     window.fetch(this.eventUrlValue, {
       method: 'POST',

--- a/app/javascript/controllers/interactive_question_controller.js
+++ b/app/javascript/controllers/interactive_question_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
+import { trackSearchJourney } from 'search-analytics'
 
 export default class extends Controller {
   static targets = ['pageHeader', 'header', 'form', 'dontKnow', 'thinking']
@@ -85,6 +86,13 @@ export default class extends Controller {
   }
 
   #recordDontKnow() {
+    const elapsedMs = this.#clientElapsedMs()
+    trackSearchJourney('dont_know', {
+      used_dont_know: true,
+      question_count: this.questionNumberValue,
+      client_elapsed_ms: elapsedMs,
+    })
+
     if (!this.hasEventUrlValue) return
 
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
@@ -99,7 +107,7 @@ export default class extends Controller {
         event_type: 'dont_know',
         request_id: this.requestIdValue,
         question_number: this.questionNumberValue,
-        client_elapsed_ms: this.#clientElapsedMs(),
+        client_elapsed_ms: elapsedMs,
       }),
     }).catch(() => {})
   }

--- a/app/javascript/controllers/search_analytics_controller.js
+++ b/app/javascript/controllers/search_analytics_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from '@hotwired/stimulus'
+import { publishSearchContext, searchAnalyticsContext, trackSearchJourney } from 'search-analytics'
+
+export default class extends Controller {
+  connect() {
+    const context = searchAnalyticsContext()
+    if (!context?.search_state) return
+    // Guided pages publish with their existing submit-to-visible timing.
+    if (context.search_mode === 'guided' && context.search_state !== 'entry') return
+
+    trackSearchJourney('page_visible')
+  }
+
+  submit(event) {
+    publishSearchContext(event.target)
+  }
+}

--- a/app/javascript/src/search-analytics.js
+++ b/app/javascript/src/search-analytics.js
@@ -1,0 +1,60 @@
+import CookieManager from 'cookie-manager'
+
+const METRICS = [
+  'question_count', 'option_count', 'result_count', 'used_dont_know',
+  'client_elapsed_ms', 'client_navigation_ms', 'result_rank', 'confidence',
+  'goods_nomenclature_item_id',
+]
+
+export function searchAnalyticsContext() {
+  try {
+    if (new CookieManager().usage() !== true) return null
+    const element = document.getElementById('search-analytics-context')
+    return element ? JSON.parse(element.textContent) : null
+  } catch (_) {
+    return null
+  }
+}
+
+function push(properties) {
+  try {
+    window.dataLayer?.push(properties)
+  } catch (_) {
+    // Analytics must never interrupt search or the server-side journey events.
+  }
+}
+
+export function publishSearchContext(form) {
+  const context = searchAnalyticsContext()
+  if (!context || form.id !== 'new_search') return
+
+  const guided = context.search_experience === 'guided_beta' &&
+    form.querySelector('[name="interactive_search"]')?.value === 'true'
+
+  // Update GTM's variables before its existing search-submitted trigger runs.
+  // Clear the previous results so a refinement cannot look survey-eligible.
+  push({
+    ...context,
+    ...Object.fromEntries(METRICS.map(key => [key, null])),
+    event: 'ott_search_context',
+    search_mode: guided ? 'guided' : 'keyword',
+    search_state: 'submitted',
+    request_id: null,
+    used_dont_know: false,
+    outcome: null,
+    destination: null,
+  })
+}
+
+export function trackSearchJourney(outcome, metrics = {}) {
+  const context = searchAnalyticsContext()
+  if (!context) return
+
+  push({
+    ...context,
+    ...Object.fromEntries(Object.entries(metrics).filter(([key]) => METRICS.includes(key))),
+    event: 'ott_search_journey',
+    outcome,
+    destination: context.search_state,
+  })
+}

--- a/app/javascript/src/search-analytics.js
+++ b/app/javascript/src/search-analytics.js
@@ -26,7 +26,7 @@ function push(properties) {
 
 export function publishSearchContext(form) {
   const context = searchAnalyticsContext()
-  if (!context || form.id !== 'new_search') return
+  if (!context || form.id !== 'new_search' || !form.querySelector('[name="q"]')) return
 
   const guided = context.search_experience === 'guided_beta' &&
     form.querySelector('[name="interactive_search"]')?.value === 'true'

--- a/app/javascript/src/search-autocomplete.js
+++ b/app/javascript/src/search-autocomplete.js
@@ -1,3 +1,5 @@
+import { publishSearchContext } from 'search-analytics';
+
 export function initializeSearchAutocomplete(autocompleteElement, dependencies) {
   const {
     accessibleAutocomplete,
@@ -102,6 +104,7 @@ export function initializeSearchAutocomplete(autocompleteElement, dependencies) 
 
         explicitSuggestionSelection = false;
         submittedQueryInput.value = latestTypedQuery;
+        publishSearchContext(form);
         form.submit();
       }
     },

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,9 @@
   <% end %>
 </head>
 
-<body class="govuk-template__body <%= service_choice || service_default %>-service">
+<body class="govuk-template__body <%= service_choice || service_default %>-service"
+      data-controller="search-analytics"
+      data-action="submit@window->search-analytics#submit:capture">
   <%= render 'shared/gtm', part: 'body' if analytics_allowed? %>
   <%= content_tag :div, class: 'path_info', data: @path_info do %>
   <% end %>

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory is the starting point for understanding the Trade Tariff Frontend
 - [Duty calculator architecture](architecture/duty-calculator.md) maps the import duty calculation journey, option construction, and high-risk decision points.
 - [Development and delivery](development-and-delivery.md) summarises local setup, checks, PR, and deployment conventions.
 - [Style guide](style-guide.md) covers Ruby/Rails, tests, GOV.UK Frontend components, and PR review expectations.
+- [Search analytics](search-analytics.md) defines the GTM event properties and Amplitude survey setup.
 - [Code Wiki guide](code-wiki.md) explains how to use generated repository documentation safely.
 - Existing domain notes: [Rules of Origin](../doc/rules_of_origin.md).
 

--- a/docs/search-analytics.md
+++ b/docs/search-analytics.md
@@ -20,7 +20,7 @@ Each event carries the complete context, so GTM can read its properties together
 
 | `outcome` | When it fires |
 | --- | --- |
-| `page_visible` | Entry, question, results, no results, unknown results, blocking guidance or handled guided input/backend error connects in the browser |
+| `page_visible` | A search page becomes visible in the browser: entry, question, results, no results, unknown results, blocking guidance, or a handled guided input/backend error |
 | `dont_know` | The trader submits the unknown-answer choice |
 | `result_selected` | The trader selects a Guided Search commodity result |
 

--- a/docs/search-analytics.md
+++ b/docs/search-analytics.md
@@ -6,9 +6,11 @@ the GTM mappings and survey trigger below must also be configured and checked.
 
 ## Events
 
-`ott_search_context` supplies the current context before GTM loads. It also
-updates the chosen mode when the initial search form submits, including an
-autocomplete submission. This is an enrichment signal, not a search count.
+`ott_search_context` supplies the current context before GTM loads on search
+pages only. Consented JSON metadata remains available on other pages for the
+shared search box, but those page loads do not publish search events. Submitting
+a commodity search from any page publishes the chosen mode and context,
+including an autocomplete submission. This is an enrichment signal, not a search count.
 An attempted submission can fail validation. Keep the existing
 `ott_search_submitted` trigger and attach the context properties to its tag.
 The frontend does not emit another copy of that existing event.
@@ -128,6 +130,9 @@ In GTM Preview, check beta guided, beta keyword and classic sessions. Confirm
 the existing submitted event sees the correct experience/mode, including
 autocomplete, and that `ott_search_journey` fires once per rendered page.
 Check the question, results, no-results and guidance states separately.
+On a non-search page, confirm neither search event fires on load, then submit
+the shared commodity search and check its context is published before the
+existing submitted event. Quota and chemical searches must not publish it.
 
 In Amplitude, inspect the received event properties and verify a test survey
 appears only on the intended results state. Check a default/unavailable flag

--- a/docs/search-analytics.md
+++ b/docs/search-analytics.md
@@ -1,0 +1,135 @@
+# Search analytics for Amplitude
+
+The frontend publishes search context to `window.dataLayer`. GTM owns delivery
+to GA and Amplitude. Deploying the frontend makes the properties available;
+the GTM mappings and survey trigger below must also be configured and checked.
+
+## Events
+
+`ott_search_context` supplies the current context before GTM loads. It also
+updates the chosen mode when the initial search form submits, including an
+autocomplete submission. This is an enrichment signal, not a search count.
+An attempted submission can fail validation. Keep the existing
+`ott_search_submitted` trigger and attach the context properties to its tag.
+The frontend does not emit another copy of that existing event.
+
+`ott_search_journey` reports the rendered state and Guided Search interactions.
+Each event carries the complete context, so GTM can read its properties together.
+
+| `outcome` | When it fires |
+| --- | --- |
+| `page_visible` | Entry, question, results, no results, unknown results, blocking guidance or handled guided input/backend error connects in the browser |
+| `dont_know` | The trader submits the unknown-answer choice |
+| `result_selected` | The trader selects a Guided Search commodity result |
+
+Questions and results share `/search`. Use `search_state`, not the URL, to
+distinguish them. `destination` repeats that state on journey events.
+
+## Properties
+
+| Property | Meaning |
+| --- | --- |
+| `search_experience` | `guided_beta` or `classic`, from the application's resolved flag decision |
+| `search_mode` | `guided` or `keyword`, from the actual journey or initial form choice |
+| `search_state` | `entry`, `submitted`, `question`, `results`, `no_results`, `unknown_results`, `blocking_guidance`, `input_error`, `backend_error`; null outside search |
+| `feature_flag_name` | `interactive_search` |
+| `feature_flag_enabled` | Boolean effective decision, including service restrictions and defaults |
+| `feature_flag_source` | `flagsmith` or `default` |
+| `feature_flag_fallback_reason` | Null after successful evaluation; otherwise `missing_flag`, `unavailable`, `not_configured`, `missing_identity`, `unsupported_service` or `missing_evaluation` |
+| `request_id` | Existing search request ID, including the backend-returned Guided Search ID; null before a request has been assigned |
+| `experiment` | Existing server-resolved experiment label, or null |
+| `question_count` | Answered questions plus the current pending question |
+| `option_count` | Options on the current pending question, excluding the UI's extra unknown-answer choice |
+| `result_count` | Results returned for the current search |
+| `used_dont_know` | True on the unknown-answer event; false on other events |
+| `client_elapsed_ms` | Time spent on the question before submitting, or before choosing the unknown answer |
+| `client_navigation_ms` | Guided submit-to-visible duration when a submission timestamp is available; otherwise null |
+| `result_rank` | One-based rank of the selected Guided Search result |
+| `confidence` | Confidence of the selected result, such as `strong`, `good` or `unknown` |
+| `goods_nomenclature_item_id` | Selected commodity code |
+
+Unused fields are explicitly null to clear previous values in GTM. A new
+search submission clears previous result counts, rank, confidence and request
+ID. A numeric keyword query still has `search_mode = keyword`; there is no
+commodity-code search mode. A beta trader choosing keyword search remains
+`search_experience = guided_beta`.
+
+An unavailable flag evaluation must not be counted as an intentional control
+assignment. For beta/control analysis, filter to `feature_flag_source = flagsmith`
+before comparing the experience values. The effective experience is still
+reported for default decisions because it describes what the trader received.
+
+## GTM and Amplitude setup
+
+1. Create Data Layer Variables for the properties above using the exact keys.
+2. Add `search_experience`, `search_mode`, the four `feature_flag_*` properties
+   and `experiment` to the existing `ott_search_submitted` tag. Keep its current
+   Search Term, Search Type, Search Origin, Journey and Unique Search ID mapping.
+   Add `request_id` where available on destination events for correlation.
+3. Create a Custom Event trigger for `ott_search_journey`. Send that event and
+   its non-null properties through the existing Amplitude browser tag. If GA
+   is also required, map the same properties to its event tag.
+4. Ensure Guides & Surveys receives the browser event. With the Amplitude GTM
+   template, enable Guides & Surveys in the SDK setup. With standalone
+   engagement initialization, configure event forwarding after it boots:
+
+   ```javascript
+   window.engagement.forwardEvent({
+     event_type: 'ott_search_journey',
+     event_properties: propertiesFromThisDataLayerEvent,
+   });
+   ```
+
+   Use the configured SDK integration or standalone forwarding once. Avoid
+   forwarding a second copy when the Amplitude integration already does it.
+   A GA export or server ingestion alone does not provide this browser trigger.
+5. Configure the survey's event trigger with:
+
+   ```text
+   event = ott_search_journey
+   outcome = page_visible
+   search_state = results
+   search_experience = guided_beta
+   feature_flag_source = flagsmith
+   feature_flag_enabled = true
+   ```
+
+   Add `search_mode = guided` only if the survey should exclude beta traders
+   who chose keyword search. Include `no_results` or `unknown_results` only
+   if those states are explicitly in the survey audience.
+
+Keep these properties on events. A persistent user property could retain an
+old beta assignment after the flag or service changes.
+
+References: [Google's data layer contract](https://developers.google.com/tag-platform/tag-manager/datalayer),
+[Amplitude GTM template](https://amplitude.com/docs/data/source-catalog/google-tag-manager),
+[Guides & Surveys event forwarding](https://www.amplitude.com/docs/sdks/guides-and-surveys/sdk).
+
+## Consent and scope
+
+The context is rendered only with usage-cookie consent. Browser events also
+check current consent, so revoking it stops new events on an already loaded
+page. Analytics receives no raw questions, options, answers or expanded search
+text, no Flagsmith identity or traits, and no new trader identifier. The new
+payload does not copy the search term; its existing GTM mapping is unchanged.
+No analytics properties are added to URLs, links or form parameters.
+
+Existing server-side `guided_search.journey` monitoring is independent of GTM
+and analytics consent. The new event does not replace those server requests.
+Exact classic matches that redirect to a commodity page are not a rendered
+search-results state and do not trigger the results survey.
+
+## Verification before closing AI-1271
+
+Repository request and browser tests verify the emitted payload and consent.
+They do not verify a remote GTM container or Amplitude project configuration.
+
+In GTM Preview, check beta guided, beta keyword and classic sessions. Confirm
+the existing submitted event sees the correct experience/mode, including
+autocomplete, and that `ott_search_journey` fires once per rendered page.
+Check the question, results, no-results and guidance states separately.
+
+In Amplitude, inspect the received event properties and verify a test survey
+appears only on the intended results state. Check a default/unavailable flag
+and rejected usage cookies are excluded. Keep AI-1271 open until this live
+check and the Guides & Surveys forwarding check have passed.

--- a/spec/features/search_analytics_spec.rb
+++ b/spec/features/search_analytics_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+RSpec.describe 'Search analytics in the browser', :js, type: :feature do
+  include_context 'with latest news stubbed'
+  include_context 'with news updates stubbed'
+
+  def journey_event(outcome)
+    page.evaluate_async_script(<<~JS, outcome)
+      const outcome = arguments[0];
+      const done = arguments[1];
+      const deadline = Date.now() + 4000;
+      function check() {
+        const event = window.dataLayer?.find(item => item.event === 'ott_search_journey' && item.outcome === outcome);
+        if (event || Date.now() >= deadline) done(event || null);
+        else setTimeout(check, 20);
+      }
+      check();
+    JS
+  end
+
+  def accept_usage_cookies
+    visit find_commodity_path
+    click_button 'Accept additional cookies', visible: true
+    visit find_commodity_path
+  end
+
+  let(:commodity) do
+    {
+      id: '123',
+      type: 'commodity',
+      attributes: {
+        goods_nomenclature_item_id: '0101210000',
+        goods_nomenclature_class: 'Commodity',
+        description: 'Horses',
+        classification_description: 'Horses',
+        self_text: 'Horses',
+        declarable: true,
+        confidence: 'strong',
+        score: 12.5,
+      },
+    }
+  end
+
+  it 'tracks guided questions and rendered results' do
+    enable_feature(:interactive_search)
+    question = { question: 'What type of horse?', options: %w[Racing Breeding], answer: nil }
+    stub_api_request('search', :post, internal: true).to_return(
+      {
+        body: { data: [commodity], meta: { interactive_search: { request_id: 'browser-request', answers: [question] } } }.to_json,
+        headers: { 'content-type' => 'application/json' },
+      },
+      {
+        body: { data: [commodity], meta: { interactive_search: { request_id: 'browser-request', answers: [question.merge(answer: 'Racing')] } } }.to_json,
+        headers: { 'content-type' => 'application/json' },
+      },
+    )
+    accept_usage_cookies
+
+    choose 'Guided search'
+    fill_in 'Describe the products you are trading', with: 'horses'
+    click_button 'Search for a commodity'
+
+    expect(page).to have_content('What type of horse?')
+    expect(journey_event('page_visible')).to include(
+      'search_experience' => 'guided_beta', 'search_mode' => 'guided',
+      'destination' => 'question', 'question_count' => 1, 'option_count' => 2
+    )
+
+    choose 'Racing'
+    click_button 'Submit'
+
+    expect(page).to have_link('View this commodity code', count: 1)
+    event = journey_event('page_visible')
+    expect(event).to include(
+      'search_state' => 'results', 'destination' => 'results', 'result_count' => 1,
+      'request_id' => 'browser-request', 'feature_flag_source' => 'flagsmith'
+    )
+    expect(event['client_navigation_ms']).to be_a(Numeric)
+    expect(event.to_json).not_to match(/horses|Racing|Breeding|What type/)
+    expect(page).to have_current_path('/search', ignore_query: true)
+    expect(Rack::Utils.parse_query(URI.parse(page.current_url).query).keys).to match_array(%w[day month year])
+  end
+
+  it 'tracks classic results without adding URL parameters' do
+    disable_feature(:interactive_search)
+    stub_api_request('search', :post).to_return(jsonapi_response(:search, attributes_for(:search_outcome, :fuzzy_match)))
+    accept_usage_cookies
+
+    fill_in 'search-q-field', with: 'toothbrush'
+    click_button 'Search for a commodity'
+
+    expect(page).to have_css('h1', text: 'Search results')
+    expect(journey_event('page_visible')).to include(
+      'search_experience' => 'classic', 'search_mode' => 'keyword', 'destination' => 'results',
+    )
+    expect(page).to have_current_path('/search')
+  end
+end

--- a/spec/javascript/controllers/search_analytics_controller_spec.js
+++ b/spec/javascript/controllers/search_analytics_controller_spec.js
@@ -91,12 +91,36 @@ describe('search journey analytics integration', () => {
     // GTM may register a document capture listener before Stimulus starts.
     document.addEventListener('submit', observeSubmission, true)
     await start({ ...guidedContext, search_state: 'entry' },
-      '<form id="new_search"><input name="interactive_search" value="false"></form>')
+      '<form id="new_search"><input name="q"><input name="interactive_search" value="false"></form>')
     window.dataLayer.length = 0
     document.querySelector('form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
     document.removeEventListener('submit', observeSubmission, true)
 
     expect(submittedContext).toMatchObject({ search_mode: 'keyword', search_experience: 'guided_beta' })
+  })
+
+  it.each(['order_number', 'cas'])('ignores the unrelated search form containing %s', async field => {
+    await start({ ...guidedContext, search_state: null },
+      `<form id="new_search"><input name="${field}"></form>`)
+
+    document.querySelector('form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+
+    expect(window.dataLayer).toEqual([])
+  })
+
+  it('waits for a commodity search on a non-search page', async () => {
+    await start({ ...guidedContext, search_state: null, search_mode: 'keyword', request_id: null, result_count: null },
+      '<form id="new_search"><input name="q" value="coffee"></form>')
+
+    expect(window.dataLayer).toEqual([])
+
+    document.querySelector('form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+
+    expect(window.dataLayer).toEqual([expect.objectContaining({
+      event: 'ott_search_context', search_state: 'submitted', search_mode: 'keyword',
+      search_experience: 'guided_beta', feature_flag_source: 'flagsmith',
+    })])
+    expect(JSON.stringify(window.dataLayer)).not.toContain('coffee')
   })
 
   it('reports selected rank and confidence while retaining the server event', async () => {

--- a/spec/javascript/controllers/search_analytics_controller_spec.js
+++ b/spec/javascript/controllers/search_analytics_controller_spec.js
@@ -1,0 +1,136 @@
+import { Application } from '@hotwired/stimulus'
+import Cookies from 'js-cookie'
+import SearchAnalyticsController from '../../../app/javascript/controllers/search_analytics_controller'
+import GuidedSearchPageController from '../../../app/javascript/controllers/guided_search_page_controller'
+import GuidedSearchResultController from '../../../app/javascript/controllers/guided_search_result_controller'
+import InteractiveQuestionController from '../../../app/javascript/controllers/interactive_question_controller'
+
+describe('search journey analytics integration', () => {
+  let application
+
+  async function start(context, content = '') {
+    document.head.innerHTML = `<meta name="csrf-token" content="csrf-token-123">
+      <script type="application/json" id="search-analytics-context">${JSON.stringify(context)}</script>`
+    document.body.innerHTML = `<div data-controller="search-analytics"
+      data-action="submit@window->search-analytics#submit:capture">${content}</div>`
+    application = Application.start()
+    application.register('search-analytics', SearchAnalyticsController)
+    application.register('guided-search-page', GuidedSearchPageController)
+    application.register('guided-search-result', GuidedSearchResultController)
+    application.register('interactive-question', InteractiveQuestionController)
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+
+  const guidedContext = {
+    search_experience: 'guided_beta', search_mode: 'guided',
+    search_state: 'results', request_id: 'request-123',
+    feature_flag_name: 'interactive_search', feature_flag_enabled: true,
+    feature_flag_source: 'flagsmith', result_count: 3,
+  }
+
+  const guidedPage = `<div data-controller="guided-search-page"
+    data-guided-search-page-event-url-value="/search/guided-search-event"
+    data-guided-search-page-request-id-value="request-123"
+    data-guided-search-page-outcome-value="results"></div>`
+
+  beforeEach(() => {
+    Cookies.set('cookies_policy', JSON.stringify({ usage: true }))
+    window.dataLayer = []
+    window.fetch = jest.fn().mockResolvedValue({ ok: true })
+  })
+
+  afterEach(() => {
+    application?.stop()
+    Cookies.remove('cookies_policy')
+    window.sessionStorage.clear()
+    delete window.dataLayer
+    delete window.fetch
+    jest.restoreAllMocks()
+  })
+
+  it('emits one guided results event even without navigation timing', async () => {
+    await start(guidedContext, guidedPage)
+
+    expect(window.dataLayer).toEqual([expect.objectContaining({
+      ...guidedContext, event: 'ott_search_journey', outcome: 'page_visible', destination: 'results',
+    })])
+  })
+
+  it('reports timing to both analytics and existing server monitoring', async () => {
+    window.sessionStorage.setItem('guidedSearchSubmittedAt', '1000')
+    jest.spyOn(Date, 'now').mockReturnValue(2234)
+
+    await start(guidedContext, guidedPage)
+
+    expect(window.dataLayer).toEqual([expect.objectContaining({ client_navigation_ms: 1234 })])
+    expect(JSON.parse(window.fetch.mock.calls[0][1].body)).toMatchObject({
+      event_type: 'page_visible', request_id: 'request-123', client_navigation_ms: 1234,
+    })
+  })
+
+  it('preserves server monitoring when consent is absent', async () => {
+    Cookies.remove('cookies_policy')
+    window.sessionStorage.setItem('guidedSearchSubmittedAt', '1000')
+    await start(guidedContext, guidedPage)
+
+    expect(window.fetch).toHaveBeenCalled()
+    expect(window.dataLayer).toEqual([])
+  })
+
+  it('exposes classic results at the same shared URL', async () => {
+    await start({ ...guidedContext, search_experience: 'classic', search_mode: 'keyword' })
+
+    expect(window.dataLayer).toEqual([expect.objectContaining({
+      event: 'ott_search_journey', search_experience: 'classic', destination: 'results',
+    })])
+  })
+
+  it('updates mode before GTM observes a submission', async () => {
+    let submittedContext
+    const observeSubmission = () => { submittedContext = window.dataLayer.at(-1) }
+    // GTM may register a document capture listener before Stimulus starts.
+    document.addEventListener('submit', observeSubmission, true)
+    await start({ ...guidedContext, search_state: 'entry' },
+      '<form id="new_search"><input name="interactive_search" value="false"></form>')
+    window.dataLayer.length = 0
+    document.querySelector('form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    document.removeEventListener('submit', observeSubmission, true)
+
+    expect(submittedContext).toMatchObject({ search_mode: 'keyword', search_experience: 'guided_beta' })
+  })
+
+  it('reports selected rank and confidence while retaining the server event', async () => {
+    await start(guidedContext, `<a href="#" data-controller="guided-search-result"
+      data-action="click->guided-search-result#select"
+      data-guided-search-result-event-url-value="/search/guided-search-event"
+      data-guided-search-result-request-id-value="request-123"
+      data-guided-search-result-goods-nomenclature-item-id-value="0101210000"
+      data-guided-search-result-rank-value="2"
+      data-guided-search-result-confidence-value="Good">View code</a>`)
+    document.querySelector('a').click()
+
+    expect(window.dataLayer).toEqual([expect.objectContaining({
+      outcome: 'result_selected', result_rank: 2, confidence: 'good',
+      goods_nomenclature_item_id: '0101210000', request_id: 'request-123',
+    })])
+    expect(window.fetch).toHaveBeenCalled()
+  })
+
+  it('reports I do not know without sending the answer text', async () => {
+    await start({ ...guidedContext, search_state: 'question' }, `<div data-controller="interactive-question"
+      data-interactive-question-event-url-value="/search/guided-search-event"
+      data-interactive-question-request-id-value="request-123"
+      data-interactive-question-question-number-value="2">
+      <form data-action="submit->interactive-question#submitWithThinking">
+        <input type="radio" name="interactive_search_form[answer]" value="I don't know" checked>
+      </form></div>`)
+    document.querySelector('form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+
+    expect(window.dataLayer).toEqual([expect.objectContaining({
+      outcome: 'dont_know', used_dont_know: true, question_count: 2,
+      client_elapsed_ms: expect.any(Number),
+    })])
+    expect(JSON.stringify(window.dataLayer)).not.toContain("I don't know")
+    expect(window.fetch).toHaveBeenCalled()
+  })
+})

--- a/spec/javascript/search-analytics.spec.js
+++ b/spec/javascript/search-analytics.spec.js
@@ -1,0 +1,113 @@
+import Cookies from 'js-cookie'
+import { publishSearchContext, trackSearchJourney } from '../../app/javascript/src/search-analytics'
+
+describe('search analytics', () => {
+  const context = {
+    event: 'ott_search_context',
+    search_experience: 'guided_beta',
+    search_mode: 'guided',
+    search_state: 'results',
+    feature_flag_name: 'interactive_search',
+    feature_flag_enabled: true,
+    feature_flag_source: 'flagsmith',
+    feature_flag_fallback_reason: null,
+    request_id: 'request-123',
+    experiment: 'trstd-trdr',
+    question_count: 2,
+    option_count: 0,
+    result_count: 3,
+    client_elapsed_ms: 500,
+    client_navigation_ms: null,
+    used_dont_know: false,
+    result_rank: null,
+    confidence: null,
+    goods_nomenclature_item_id: null,
+    outcome: null,
+    destination: null,
+  }
+
+  beforeEach(() => {
+    document.head.innerHTML = `<script type="application/json" id="search-analytics-context">${JSON.stringify(context)}</script>`
+    document.body.innerHTML = ''
+    Cookies.set('cookies_policy', JSON.stringify({ usage: true }))
+    window.dataLayer = []
+  })
+
+  afterEach(() => {
+    Cookies.remove('cookies_policy')
+    delete window.dataLayer
+  })
+
+  it('publishes a self-contained results event', () => {
+    trackSearchJourney('page_visible', { client_navigation_ms: 1234 })
+
+    expect(window.dataLayer).toEqual([{
+      ...context,
+      event: 'ott_search_journey',
+      outcome: 'page_visible',
+      destination: 'results',
+      client_navigation_ms: 1234,
+    }])
+  })
+
+  it.each([false, 'false', null, 1, {}, []])('respects rejected or invalid consent: %j', usage => {
+    Cookies.set('cookies_policy', JSON.stringify({ usage }))
+
+    trackSearchJourney('page_visible')
+    publishSearchContext(document.createElement('form'))
+
+    expect(window.dataLayer).toEqual([])
+  })
+
+  it('does nothing without server consent context', () => {
+    document.head.innerHTML = ''
+    trackSearchJourney('page_visible')
+    expect(window.dataLayer).toEqual([])
+  })
+
+  it('does not break a journey when analytics is blocked', () => {
+    window.dataLayer.push = () => { throw new Error('blocked') }
+    expect(() => trackSearchJourney('page_visible')).not.toThrow()
+  })
+
+  it('does not send arbitrary interaction properties', () => {
+    trackSearchJourney('dont_know', {
+      used_dont_know: true,
+      client_elapsed_ms: 123,
+      question: 'private question',
+      answer: 'private answer',
+      expanded_query: 'private expanded query',
+    })
+
+    expect(window.dataLayer[0]).toMatchObject({ outcome: 'dont_know', used_dont_know: true, client_elapsed_ms: 123 })
+    expect(JSON.stringify(window.dataLayer)).not.toContain('private')
+  })
+
+  it('enriches keyword submission within beta and clears prior result context', () => {
+    document.body.innerHTML = '<form id="new_search"><input name="q" value="0101210000"><input name="interactive_search" value="false"></form>'
+
+    publishSearchContext(document.querySelector('form'))
+
+    expect(window.dataLayer).toEqual([expect.objectContaining({
+      event: 'ott_search_context',
+      search_experience: 'guided_beta',
+      search_mode: 'keyword',
+      request_id: null,
+      search_state: 'submitted',
+      question_count: null,
+      result_count: null,
+      client_elapsed_ms: null,
+    })])
+    expect(JSON.stringify(window.dataLayer)).not.toContain('0101210000')
+    expect(window.dataLayer.some(event => event.event === 'ott_search_submitted')).toBe(false)
+  })
+
+  it('does not infer beta membership from a submitted field', () => {
+    document.getElementById('search-analytics-context').textContent = JSON.stringify({ ...context, search_experience: 'classic' })
+    document.body.innerHTML = '<form id="new_search"><input name="interactive_search" value="true"></form>'
+
+    publishSearchContext(document.querySelector('form'))
+
+    expect(window.dataLayer[0]).toMatchObject({ search_experience: 'classic', search_mode: 'keyword' })
+  })
+})

--- a/spec/javascript/search-analytics.spec.js
+++ b/spec/javascript/search-analytics.spec.js
@@ -104,7 +104,7 @@ describe('search analytics', () => {
 
   it('does not infer beta membership from a submitted field', () => {
     document.getElementById('search-analytics-context').textContent = JSON.stringify({ ...context, search_experience: 'classic' })
-    document.body.innerHTML = '<form id="new_search"><input name="interactive_search" value="true"></form>'
+    document.body.innerHTML = '<form id="new_search"><input name="q"><input name="interactive_search" value="true"></form>'
 
     publishSearchContext(document.querySelector('form'))
 

--- a/spec/javascript/search-autocomplete.spec.js
+++ b/spec/javascript/search-autocomplete.spec.js
@@ -1,5 +1,7 @@
 /* eslint-env node, jest */
 
+import Cookies from 'js-cookie';
+
 import {
   initializeSearchAutocomplete,
   initializeSearchAutocompletes,
@@ -81,6 +83,25 @@ describe('initializeSearchAutocomplete', () => {
     autocompleteConfig.onConfirm('tahini paste');
 
     expect(new FormData(form).get('q')).toBe('tahini paste');
+  });
+
+  it('publishes keyword context before programmatic submission', () => {
+    Cookies.set('cookies_policy', JSON.stringify({ usage: true }));
+    document.head.innerHTML = `<script type="application/json" id="search-analytics-context">${JSON.stringify({
+      search_experience: 'guided_beta', search_mode: 'guided', search_state: 'results',
+    })}</script>`;
+    window.dataLayer = [];
+    let submittedContext;
+    form.submit.mockImplementation(() => { submittedContext = window.dataLayer.at(-1); });
+
+    autocompleteConfig.onConfirm('tahini');
+
+    expect(submittedContext).toMatchObject({
+      search_experience: 'guided_beta', search_mode: 'keyword', search_state: 'submitted',
+    });
+    Cookies.remove('cookies_policy');
+    delete window.dataLayer;
+    document.head.innerHTML = '';
   });
 
   it('submits an explicitly clicked suggestion from an older result set', () => {


### PR DESCRIPTION
## What:

- [x] Publish `ott_search_journey` for rendered search states, unknown answers and result selection.
- [x] Attach search experience, guided/keyword mode, flag metadata, counts, timings and existing correlation IDs.
- [x] Update context before normal and autocomplete commodity search submissions from any page, without duplicating `ott_search_submitted`.
- [x] Keep unrelated page loads and quota/chemical searches out of these search events.
- [x] Recheck usage-cookie consent in the browser.
- [x] Document [GTM mappings and survey targeting](https://github.com/trade-tariff/trade-tariff-frontend/blob/AI-1271-search-analytics/docs/search-analytics.md).

## Why:

Questions and results share `/search`. Amplitude needs an explicit rendered-results event to target surveys using the actual beta/control decision.

Each event carries its complete context. A new submission clears old result metrics so a refinement cannot inherit survey eligibility. No raw search text, Q&amp;A, new URL parameters or new trader identifier are added.

GA and Amplitude are already connected. This supplies additional search properties to that existing integration.

## Ticket:

[AI-1271](https://transformuk.atlassian.net/browse/AI-1271)

## Risk:

**Risk level:** 🟢 low-risk

**Reason for rating:** Low-risk confirmed by Will. Guided Search is not live; this adds search properties to the existing analytics setup without changing search results, navigation or consent choices.
