### PR TITLE
AI-1271: Expose server-resolved search analytics context

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -163,9 +163,17 @@ class ApplicationController < ActionController::Base
     @path_info = { search_suggestions_path: search_suggestions_path(format: :json),
                    faq_send_feedback_path: green_lanes_send_feedback_path }
 
-    if interactive_search_enabled?
+    if interactive_search_enabled_with_analytics?
       @path_info[:interactive_search_suggestions_path] = interactive_search_suggestions_path(format: :json)
     end
+  end
+
+  def interactive_search_enabled_with_analytics?
+    enabled = interactive_search_enabled?
+    @search_feature_evaluation = Current.flagsmith_evaluations.fetch(
+      'interactive_search', { enabled:, source: 'default', reason: 'missing_evaluation' }
+    ).dup
+    enabled
   end
 
   def country

--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -86,7 +86,7 @@ module InteractiveSearchable
   end
 
   def interactive_search?
-    @search.interactive_search && interactive_search_enabled?
+    @search.interactive_search && interactive_search_enabled_with_analytics?
   end
 
   def sync_interactive_request_id
@@ -255,15 +255,18 @@ module InteractiveSearchable
   def record_guided_search_journey(outcome:)
     @guided_search_outcome = outcome
     current_question = @results&.current_question
+    @guided_search_metrics = {
+      question_count: @results&.answered_questions&.size.to_i + (current_question.present? ? 1 : 0),
+      option_count: Array(current_question&.dig('options')).size,
+      result_count: @results&.size.to_i,
+      client_elapsed_ms: bounded_integer(params[:client_elapsed_ms], maximum: 86_400_000),
+    }
 
     GuidedSearch::JourneyInstrumentation.record(
       browser_session_id: guided_search_browser_session_id,
       request_id: @search.request_id,
       outcome:,
-      question_count: @results&.answered_questions&.size.to_i + (current_question.present? ? 1 : 0),
-      option_count: Array(current_question&.dig('options')).size,
-      result_count: @results&.size.to_i,
-      client_elapsed_ms: bounded_integer(params[:client_elapsed_ms], maximum: 86_400_000),
+      **@guided_search_metrics,
       experiment: @search.experiment,
     )
   end

--- a/app/controllers/find_commodities_controller.rb
+++ b/app/controllers/find_commodities_controller.rb
@@ -6,6 +6,6 @@ class FindCommoditiesController < ApplicationController
     @hero_story = News::Item.latest_for_home_page
     @recent_stories = News::Item.updates_page.slice(0, 3)
 
-    render :show_interactive if interactive_search_enabled?
+    render :show_interactive if interactive_search_enabled_with_analytics?
   end
 end

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -9,7 +9,7 @@ module AnalyticsHelper
     policy = JSON.parse(cookie)
     return false unless policy.is_a?(Hash)
 
-    !!policy.fetch('usage', false)
+    [true, 'true'].include?(policy['usage'])
   rescue JSON::ParserError
     false
   end

--- a/app/helpers/search_analytics_helper.rb
+++ b/app/helpers/search_analytics_helper.rb
@@ -1,0 +1,56 @@
+module SearchAnalyticsHelper
+  def search_analytics_context
+    evaluation = @search_feature_evaluation || { enabled: false, source: 'default', reason: 'missing_evaluation' }
+    enabled = evaluation[:enabled]
+
+    {
+      event: 'ott_search_context',
+      search_experience: enabled ? 'guided_beta' : 'classic',
+      search_mode: search_analytics_mode(enabled),
+      search_state: search_analytics_state,
+      feature_flag_name: 'interactive_search',
+      feature_flag_enabled: enabled,
+      feature_flag_source: evaluation[:source],
+      feature_flag_fallback_reason: evaluation[:reason],
+      request_id: search_analytics_request_id,
+      experiment: Current.experiment,
+      question_count: nil,
+      option_count: nil,
+      result_count: search_analytics_results? ? @results&.size : nil,
+      client_elapsed_ms: nil,
+      client_navigation_ms: nil,
+      used_dont_know: false,
+      result_rank: nil,
+      confidence: nil,
+      goods_nomenclature_item_id: nil,
+      outcome: nil,
+      destination: nil,
+    }.merge(@guided_search_metrics || {})
+  end
+
+  private
+
+  def search_analytics_mode(enabled)
+    return 'guided' if @guided_search_outcome.present?
+    return 'guided' if enabled && controller_name == 'find_commodities' && cookies[:interactive_search] == 'true'
+
+    'keyword'
+  end
+
+  def search_analytics_state
+    return @guided_search_outcome if @guided_search_outcome.present?
+    return 'entry' if controller_name == 'find_commodities'
+    return unless search_analytics_results?
+
+    @results&.any? ? 'results' : 'no_results'
+  end
+
+  def search_analytics_results?
+    controller_name == 'search' && action_name == 'search'
+  end
+
+  def search_analytics_request_id
+    identifier = @search&.request_id.to_s
+    identifier if identifier.match?(/\A[a-zA-Z0-9-]{1,64}\z/)
+  end
+end

--- a/app/javascript/src/cookie-manager.js
+++ b/app/javascript/src/cookie-manager.js
@@ -26,19 +26,8 @@ export default class CookieManager {
   }
 
   usage() {
-    if (this.getCookiesPolicy()) {
-      const usage = this.getCookiesPolicy().usage;
-
-      if (usage === 'true') {
-        return true;
-      } else if (usage === 'false') {
-        return false;
-      } else {
-        return usage;
-      }
-    } else {
-      return false;
-    }
+    const usage = this.getCookiesPolicy()?.usage;
+    return usage === true || usage === 'true';
   }
 
   shouldOpenTree() {

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -11,6 +11,9 @@ class Current < ActiveSupport::CurrentAttributes
   # Reused for the request lifetime once feature flags have been fetched.
   attribute :flagsmith_flags
 
+  # Actual decisions and their sources, without identity or trait values.
+  attribute :flagsmith_evaluations, default: -> { {} }
+
   # Set when Flagsmith cannot be reached/configured during the current request.
   attribute :flagsmith_unavailable
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
 <%= render partial: 'layouts/base' %>
 
 <head>
+  <%= render 'shared/search_analytics' if analytics_allowed? %>
   <%= render 'shared/gtm', part: 'head' if analytics_allowed? %>
   <meta charset="utf-8">
   <title>

--- a/app/views/shared/_search_analytics.html.erb
+++ b/app/views/shared/_search_analytics.html.erb
@@ -1,5 +1,8 @@
-<script id="search-analytics-context" type="application/json" nonce="<%= content_security_policy_nonce %>"><%= raw json_escape(search_analytics_context.to_json) %></script>
+<% context = search_analytics_context %>
+<script id="search-analytics-context" type="application/json" nonce="<%= content_security_policy_nonce %>"><%= raw json_escape(context.to_json) %></script>
 <%= javascript_tag nonce: true do %>
   window.dataLayer = window.dataLayer || [];
-  window.dataLayer.push(JSON.parse(document.getElementById('search-analytics-context').textContent));
+  <% if context[:search_state].present? %>
+    window.dataLayer.push(JSON.parse(document.getElementById('search-analytics-context').textContent));
+  <% end %>
 <% end %>

--- a/app/views/shared/_search_analytics.html.erb
+++ b/app/views/shared/_search_analytics.html.erb
@@ -1,0 +1,5 @@
+<script id="search-analytics-context" type="application/json" nonce="<%= content_security_policy_nonce %>"><%= raw json_escape(search_analytics_context.to_json) %></script>
+<%= javascript_tag nonce: true do %>
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(JSON.parse(document.getElementById('search-analytics-context').textContent));
+<% end %>

--- a/lib/trade_tariff_frontend/flagsmith_backed_config.rb
+++ b/lib/trade_tariff_frontend/flagsmith_backed_config.rb
@@ -37,7 +37,9 @@ module TradeTariffFrontend
 
         TradeTariffFrontend::FlagsmithBackedConfig.define_method(method_name) do
           default = super()
-          next default unless service_names.empty? || service_names.include?(TradeTariffFrontend::ServiceChooser.service_name)
+          unless service_names.empty? || service_names.include?(TradeTariffFrontend::ServiceChooser.service_name)
+            next record_flagsmith_evaluation(flag_name, enabled: default, source: 'default', reason: 'unsupported_service')
+          end
 
           flagsmith_config_flag(flag_name, method_name:, default:)
         end
@@ -80,7 +82,7 @@ module TradeTariffFrontend
         instrument_flagsmith_config_fallback(flag_name:, method_name:, default:, reason: :missing_flag)
         default
       else
-        flag.enabled?
+        record_flagsmith_evaluation(flag_name, enabled: flag.enabled?, source: 'flagsmith')
       end
     rescue StandardError => e
       Current.flagsmith_unavailable = true
@@ -90,6 +92,9 @@ module TradeTariffFrontend
     end
 
     def instrument_flagsmith_config_fallback(flag_name:, method_name:, default:, reason:, error: nil)
+      evaluation_reason = reason == :previously_unavailable ? 'unavailable' : reason.to_s
+      record_flagsmith_evaluation(flag_name, enabled: default, source: 'default', reason: evaluation_reason)
+
       payload = {
         flag_name:,
         method_name:,
@@ -101,6 +106,11 @@ module TradeTariffFrontend
       payload[:error_class] = error.class.name if error
 
       ActiveSupport::Notifications.instrument(FALLBACK_EVENT, payload)
+    end
+
+    def record_flagsmith_evaluation(flag_name, enabled:, source:, reason: nil)
+      Current.flagsmith_evaluations[flag_name] = { enabled:, source:, reason: }
+      enabled
     end
   end
 end

--- a/spec/javascript/controllers/site_preferences_controller_spec.js
+++ b/spec/javascript/controllers/site_preferences_controller_spec.js
@@ -71,6 +71,14 @@ describe('SitePreferencesController', () => {
   });
 
   describe('connect', () => {
+    it('shows rejected consent for a malformed truthy usage value', () => {
+      cookieManager.setCookiesPolicy({usage: 1});
+      controllerInstance = application.getControllerForElementAndIdentifier(element, 'site-preferences');
+      controllerInstance.connect();
+
+      expect(controllerInstance.bannerTarget.innerHTML).toContain('Hide cookies banner rejected');
+    });
+
     it('should set the banner html to the accept reject target html by default', () => {
       cookieManager.setCookiesPolicy();
       application.start();

--- a/spec/javascript/cookie_manager_spec.js
+++ b/spec/javascript/cookie_manager_spec.js
@@ -63,6 +63,16 @@ describe('CookieManager', () => {
       cookieManager.setCookiesPolicy({usage: 'false', remember_settings: true});
       expect(cookieManager.usage()).toBe(false);
     });
+
+    it('accepts the legacy string true value', () => {
+      cookieManager.setCookiesPolicy({usage: 'true'});
+      expect(cookieManager.usage()).toBe(true);
+    });
+
+    it.each([1, {}, [], null, undefined, 'yes'])('rejects malformed usage value %p', usage => {
+      cookieManager.setCookiesPolicy({usage});
+      expect(cookieManager.usage()).toBe(false);
+    });
   });
 
   describe('shouldOpenTree', () => {

--- a/spec/requests/search_analytics_spec.rb
+++ b/spec/requests/search_analytics_spec.rb
@@ -27,6 +27,22 @@ RSpec.describe 'Search analytics', :aggregate_failures, type: :request do
       'search_state' => 'entry',
     )
     expect(response.body.index('search-analytics-context')).to be < response.body.index('gtm.start')
+    expect(response.body).to include('window.dataLayer.push(')
+  end
+
+  it 'keeps non-search page context unpublished' do
+    enable_feature(:interactive_search)
+
+    get privacy_path
+
+    expect(response).to have_http_status(:ok)
+    expect(analytics_context).to include(
+      'search_experience' => 'guided_beta',
+      'feature_flag_source' => 'flagsmith',
+      'search_state' => nil,
+    )
+    expect(response.body).to include('window.dataLayer = window.dataLayer || [];')
+    expect(response.body).not_to include('window.dataLayer.push(')
   end
 
   it 'identifies deliberately classic search' do

--- a/spec/requests/search_analytics_spec.rb
+++ b/spec/requests/search_analytics_spec.rb
@@ -1,0 +1,260 @@
+require 'spec_helper'
+
+RSpec.describe 'Search analytics', :aggregate_failures, type: :request do
+  include_context 'with latest news stubbed'
+  include_context 'with news updates stubbed'
+
+  def analytics_context
+    node = Nokogiri::HTML(response.body).at_css('#search-analytics-context')
+    JSON.parse(node.text) if node
+  end
+
+  before do
+    cookies['cookies_policy'] = { usage: true }.to_json
+  end
+
+  it 'exposes the resolved beta decision' do
+    enable_feature(:interactive_search)
+
+    get find_commodity_path
+
+    expect(analytics_context).to include(
+      'search_experience' => 'guided_beta',
+      'feature_flag_name' => 'interactive_search',
+      'feature_flag_enabled' => true,
+      'feature_flag_source' => 'flagsmith',
+      'feature_flag_fallback_reason' => nil,
+      'search_state' => 'entry',
+    )
+    expect(response.body.index('search-analytics-context')).to be < response.body.index('gtm.start')
+  end
+
+  it 'identifies deliberately classic search' do
+    disable_feature(:interactive_search)
+
+    get find_commodity_path
+
+    expect(analytics_context).to include(
+      'search_experience' => 'classic',
+      'search_mode' => 'keyword',
+      'feature_flag_enabled' => false,
+      'feature_flag_source' => 'flagsmith',
+    )
+  end
+
+  it 'distinguishes a default from control' do
+    get find_commodity_path
+
+    expect(analytics_context).to include(
+      'search_experience' => 'classic',
+      'feature_flag_enabled' => false,
+      'feature_flag_source' => 'default',
+      'feature_flag_fallback_reason' => 'missing_flag',
+    )
+  end
+
+  it 'identifies unavailable evaluation' do
+    allow(FlagsmithClient.instance).to receive(:get_flags_for).and_raise(Faraday::ConnectionFailed, 'offline')
+
+    get find_commodity_path
+
+    expect(analytics_context).to include(
+      'feature_flag_source' => 'default',
+      'feature_flag_fallback_reason' => 'unavailable',
+    )
+  end
+
+  it 'keeps the decision that rendered the page' do
+    enable_feature(:interactive_search)
+    flags = TEST_FLAGSMITH_CLIENT.get_flags_for(nil)
+    allow(flags).to receive(:get_flag).and_call_original
+    allow(flags).to receive(:get_flag).with('webchat').and_raise(StandardError, 'unrelated flag failure')
+    allow(FlagsmithClient.instance).to receive(:get_flags_for).and_return(flags)
+
+    get find_commodity_path
+
+    expect(response.body).to include('search_type_guided')
+    expect(analytics_context).to include(
+      'search_experience' => 'guided_beta',
+      'feature_flag_source' => 'flagsmith',
+      'feature_flag_fallback_reason' => nil,
+    )
+  end
+
+  it 'identifies the XI service restriction' do
+    enable_feature(:interactive_search)
+
+    get '/xi/find_commodity'
+
+    expect(analytics_context).to include(
+      'search_experience' => 'classic',
+      'feature_flag_enabled' => false,
+      'feature_flag_source' => 'default',
+      'feature_flag_fallback_reason' => 'unsupported_service',
+    )
+  end
+
+  it 'does not render analytics without consent' do
+    cookies.delete('cookies_policy')
+
+    get find_commodity_path
+
+    expect(analytics_context).to be_nil
+    expect(response.body).not_to include('gtm.start')
+  end
+
+  [false, 'false', 1, {}, []].each do |usage|
+    it "rejects non-consent usage value #{usage.inspect}" do
+      cookies['cookies_policy'] = { usage: }.to_json
+
+      get find_commodity_path
+
+      expect(analytics_context).to be_nil
+      expect(response.body).not_to include('gtm.start')
+    end
+  end
+
+  context 'with guided search' do
+    let(:results) { [] }
+    let(:intercept) { nil }
+    let(:answers) do
+      [
+        { question: 'Private question', options: ['Private option'], answer: 'Private answer' },
+        { question: 'Next private question', options: %w[One Two], answer: nil },
+      ]
+    end
+
+    before do
+      enable_feature(:interactive_search)
+      stub_api_request('search', :post, internal: true).to_return(
+        body: {
+          data: results,
+          meta: {
+            description_intercept: intercept,
+            interactive_search: {
+              query: 'horse',
+              request_id: 'backend-request-123',
+              expanded_query: 'Private expanded text',
+              answers:,
+            },
+          },
+        }.to_json,
+        headers: { 'content-type' => 'application/json' },
+      )
+    end
+
+    it 'exposes question metrics without text' do
+      post perform_search_path, params: { q: 'horse', interactive_search: 'true', client_elapsed_ms: '1234' }
+
+      expect(analytics_context).to include(
+        'search_mode' => 'guided', 'search_state' => 'question',
+        'request_id' => 'backend-request-123', 'question_count' => 2,
+        'option_count' => 2, 'result_count' => 0, 'client_elapsed_ms' => 1234
+      )
+      expect(analytics_context.to_json).not_to match(/Private|private|horse/)
+    end
+
+    it 'labels invalid input explicitly' do
+      post perform_search_path, params: { q: '', interactive_search: 'true' }
+
+      expect(analytics_context).to include('search_mode' => 'guided', 'search_state' => 'input_error')
+    end
+
+    context 'without results or more questions' do
+      let(:answers) { [] }
+
+      it 'exposes an explicit no-results state' do
+        post perform_search_path, params: { q: 'horse', interactive_search: 'true' }
+
+        expect(analytics_context).to include('search_state' => 'no_results', 'result_count' => 0)
+      end
+    end
+
+    context 'with final matches' do
+      let(:answers) { [] }
+      let(:confidence) { 'strong' }
+      let(:score) { 12.5 }
+      let(:results) do
+        [{
+          id: '123',
+          type: 'commodity',
+          attributes: {
+            goods_nomenclature_item_id: '0101210000',
+            goods_nomenclature_class: 'Commodity',
+            description: 'Horses',
+            declarable: true,
+            confidence:,
+            score:,
+          },
+        }]
+      end
+
+      it 'identifies results independently of URL' do
+        post perform_search_path, params: { q: 'horse', interactive_search: 'true' }
+
+        expect(response).to have_http_status(:ok)
+        expect(analytics_context).to include('search_state' => 'results', 'result_count' => 1)
+        expect(request.original_url).to eq('http://www.example.com/search')
+      end
+
+      context 'with unknown confidence' do
+        let(:confidence) { 'unknown' }
+
+        it 'distinguishes the unknown-results state' do
+          post perform_search_path, params: { q: 'horse', interactive_search: 'true' }
+
+          expect(analytics_context).to include('search_state' => 'unknown_results')
+        end
+      end
+
+      context 'with an exact code match' do
+        let(:score) { nil }
+
+        it 'retains the chosen guided mode' do
+          post perform_search_path, params: { q: '0101210000', interactive_search: 'true' }
+
+          expect(analytics_context).to include('search_state' => 'results', 'search_mode' => 'guided')
+        end
+      end
+    end
+
+    context 'with blocking guidance' do
+      let(:answers) { [] }
+      let(:intercept) { { excluded: true, message_header: 'Guidance', message: 'Guidance text' } }
+
+      it 'distinguishes guidance from results' do
+        post perform_search_path, params: { q: 'horse', interactive_search: 'true', request_id: 'existing-request' }
+
+        expect(analytics_context).to include('search_state' => 'blocking_guidance')
+      end
+    end
+  end
+
+  it 'reuses the trusted experiment label' do
+    experiment = Rails.application.config.experiment_urls.fetch(:trusted_trader_guided_search)
+
+    travel_to(Time.utc(2026, 7, 27, 12)) do
+      get experiment.path
+      get find_commodity_path, params: { experiment: 'spoofed' }
+    end
+
+    expect(analytics_context).to include('experiment' => 'trstd-trdr')
+  end
+
+  it 'keeps beta experience for keyword results' do
+    enable_feature(:interactive_search)
+    stub_api_request('search', :post).to_return(jsonapi_response(:search, {
+      type: 'fuzzy_match',
+      goods_nomenclature_match: { chapters: [], headings: [], commodities: [], sections: [] },
+      reference_match: { chapters: [], headings: [], commodities: [], sections: [] },
+    }))
+
+    post perform_search_path, params: { q: 'horse', request_id: 'keyword-request' }
+
+    expect(response).to have_http_status(:ok)
+    expect(analytics_context).to include(
+      'search_experience' => 'guided_beta', 'search_mode' => 'keyword',
+      'search_state' => 'no_results', 'request_id' => 'keyword-request'
+    )
+  end
+end

--- a/spec/requests/search_analytics_spec.rb
+++ b/spec/requests/search_analytics_spec.rb
@@ -110,6 +110,15 @@ RSpec.describe 'Search analytics', :aggregate_failures, type: :request do
     )
   end
 
+  it 'accepts legacy string consent' do
+    cookies['cookies_policy'] = { usage: 'true' }.to_json
+
+    get find_commodity_path
+
+    expect(analytics_context).to include('event' => 'ott_search_context', 'search_state' => 'entry')
+    expect(response.body).to include('gtm.start')
+  end
+
   it 'does not render analytics without consent' do
     cookies.delete('cookies_policy')
 


### PR DESCRIPTION
## What:

- [x] Publish server-resolved search context before GTM loads on search pages only.
- [x] Keep metadata available for the shared search box without publishing search events on unrelated page loads.
- [x] Separate the offered experience (`guided_beta` or `classic`) from the journey mode (`guided` or `keyword`).
- [x] Include the actual flag decision, source, fallback reason, rendered state, counts and existing request/experiment IDs.
- [x] Preserve the decision used to render the page if an unrelated flag later fails.
- [x] Require usage-cookie consent.

## Why:

Amplitude needs the actual beta/control decision. A flag default must not be mistaken for deliberate control, and the shared `/search` URL cannot distinguish questions from results.

`ott_search_context` supplies the rendered state without adding URL parameters, raw search text or a new trader identifier. Existing server journey monitoring remains independent of analytics consent.

GA and Amplitude are already connected. This supplies additional search properties to that existing integration.

## Ticket:

[AI-1271](https://transformuk.atlassian.net/browse/AI-1271)

## Risk:

**Risk level:** 🟢 low-risk

**Reason for rating:** Low-risk confirmed by Will. Guided Search is not live; this adds search metadata to the existing analytics setup without changing search results, navigation or consent choices. Consent parsing consistently rejects malformed values while preserving valid accept/reject behaviour.
