### PR TITLE
BAU: Fix rubyzip path traversal vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -743,7 +743,7 @@ GEM
     ruby-lsp-rspec (0.1.29)
       ruby-lsp (~> 0.26.0)
     ruby-progressbar (1.13.0)
-    rubyzip (3.2.2)
+    rubyzip (3.4.1)
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)


### PR DESCRIPTION
## What:

- [x] Update rubyzip from `3.2.2` to `3.4.1`.

## Why:

The existing rubyzip version is flagged by the deployment image scan for CVE-2026-85396. Crafted archive entries can escape the intended extraction directory.

This updates Roo's archive dependency to a release containing the [upstream path traversal fix](https://github.com/rubyzip/rubyzip/commit/17edfbf4423b83211b075acc23a7d8640da63449). No application code or other dependencies change.

## Ticket:

BAU

## Risk:

**Risk level:** 🟢 low-risk

**Reason for rating:** A targeted dependency update within the existing 3.x series. Spreadsheet imports continue to use the existing Roo integration; there are no UI, API or configuration changes.
