### PR TITLE
HMRC-2677: enable read-only root filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,10 @@ ENV RAILS_SERVE_STATIC_FILES=true \
     SSL_PORT=8443 \
     TZ=Europe/London
 
-RUN addgroup -S tariff && \
-    adduser -S tariff -G tariff
+# Pin uid/gid so the ecs-service module's writable-volume permissions init container
+# can chown the read-only-root-filesystem mounts to a known id (container_user).
+RUN addgroup -S -g 1000 tariff && \
+    adduser -S -u 1000 -G tariff tariff
 
 WORKDIR /home/tariff
 
@@ -68,11 +70,6 @@ USER tariff
 
 COPY --chown=tariff:tariff --from=builder /build .
 COPY --chown=tariff:tariff --from=builder /usr/local/bundle/ /usr/local/bundle/
-
-# The builder stage deletes tmp/log (see above), so recreate them here, owned by
-# tariff, ready for the read-only-root-filesystem writable-volume mounts at
-# /home/tariff/tmp and /home/tariff/log. bootsnap writes to tmp/cache on boot.
-RUN mkdir -p tmp log
 
 HEALTHCHECK CMD nc -z 0.0.0.0 $SSL_PORT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,11 @@ USER tariff
 COPY --chown=tariff:tariff --from=builder /build .
 COPY --chown=tariff:tariff --from=builder /usr/local/bundle/ /usr/local/bundle/
 
+# The builder stage deletes tmp/log (see above), so recreate them here, owned by
+# tariff, ready for the read-only-root-filesystem writable-volume mounts at
+# /home/tariff/tmp and /home/tariff/log. bootsnap writes to tmp/cache on boot.
+RUN mkdir -p tmp log
+
 HEALTHCHECK CMD nc -z 0.0.0.0 $SSL_PORT
 
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,7 +20,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
 
 ## Resources
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,7 +20,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.3.0 |
 
 ## Resources
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
 
   region = var.region
 
@@ -24,6 +24,10 @@ module "service" {
 
   task_role_policy_arns = [aws_iam_policy.task.arn]
   enable_ecs_exec       = true
+
+  # frontend's WORKDIR (and therefore Rails.root) is /home/tariff, not /app like the
+  # other services this module backs — bootsnap writes to tmp/cache on boot.
+  writable_paths = ["/tmp", "/home/tariff/tmp", "/home/tariff/log"]
 
   service_environment_config = local.frontend_service_env_vars
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.3.0"
 
   region = var.region
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,7 +27,10 @@ module "service" {
 
   # frontend's WORKDIR (and therefore Rails.root) is /home/tariff, not /app like the
   # other services this module backs — bootsnap writes to tmp/cache on boot.
+  # container_user matches the pinned uid/gid in the image; the module's init container
+  # chowns the writable mounts to it so the non-root process can write to them.
   writable_paths = ["/tmp", "/home/tariff/tmp", "/home/tariff/log"]
+  container_user = "1000:1000"
 
   service_environment_config = local.frontend_service_env_vars
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,8 +29,9 @@ module "service" {
   # other services this module backs — bootsnap writes to tmp/cache on boot.
   # container_user matches the pinned uid/gid in the image; the module's init container
   # chowns the writable mounts to it so the non-root process can write to them.
-  writable_paths = ["/tmp", "/home/tariff/tmp", "/home/tariff/log"]
-  container_user = "1000:1000"
+  readonly_root_filesystem = true
+  writable_paths           = ["/tmp", "/home/tariff/tmp", "/home/tariff/log"]
+  container_user           = "1000:1000"
 
   service_environment_config = local.frontend_service_env_vars
 


### PR DESCRIPTION
## What:

Enables `readonly_root_filesystem` for the frontend service and pins the container uid/gid to `1000` in the Dockerfile. `writable_paths = ["/tmp", "/home/tariff/tmp", "/home/tariff/log"]` - `WORKDIR` is `/home/tariff`, not `/app`.


## Why:

Security Hub control ECS.5. bootsnap writes to `/home/tariff/tmp` at boot (fails to start without it), the New Relic agent writes to `/home/tariff/log`, and `ClientBuilder` writes the backend TLS cert to `/tmp`. `container_user` matches the pinned uid so the module's init container can `chown` the mounts.

## Ticket:

HMRC-2677 — module PR: trade-tariff/trade-tariff-platform-terraform-modules#107

## Risk:

**Risk level:** 🟠

**Reason for rating:**
Infrastructure change altering the container filesystem - new task definition revision with an init container (deploy-order dependency). Tested in development: task boots, all writes confirmed (`/tmp/backend.crt`, bootsnap cache, New Relic log), and `aws ecs execute-command` works.
