### PR TITLE
Rename feedback search request ID parameter

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -7,7 +7,7 @@ class FeedbackController < ApplicationController
     @feedback.page_useful = params[:page_useful]
     @feedback.referrer = feedback_url
     @feedback.query = feedback_query
-    @feedback.request_id = feedback_request_id
+    @feedback.request_id = search_request_id
     @feedback.date = feedback_date
     @feedback.feature_flags = feedback_feature_flags
   end
@@ -17,7 +17,7 @@ class FeedbackController < ApplicationController
     @feedback.authenticity_token = params[:authenticity_token]
     @feedback.referrer = params[:feedback_url]
     @feedback.query = params[:feedback_query]
-    @feedback.request_id = params[:feedback_request_id]
+    @feedback.request_id = params[:search_request_id]
     @feedback.date = params[:feedback_date]
     @feedback.feature_flags = feedback_feature_flags
 
@@ -52,8 +52,8 @@ class FeedbackController < ApplicationController
     params[:feedback_query].presence || referrer_query_param('q')
   end
 
-  def feedback_request_id
-    params[:feedback_request_id].presence || referrer_query_param('request_id')
+  def search_request_id
+    params[:search_request_id].presence || referrer_query_param('request_id')
   end
 
   def referrer_query_param(key)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -82,7 +82,7 @@ module ApplicationHelper
   end
 
   def enquiry_form_path_with_context
-    request_id = feedback_search_request_id || params[:feedback_request_id].presence || @feedback&.request_id.presence
+    request_id = feedback_search_request_id || params[:search_request_id].presence || @feedback&.request_id.presence
 
     product_experience_enquiry_form_path(request_id:)
   end
@@ -93,7 +93,7 @@ module ApplicationHelper
     {
       feedback_url: request.original_url,
       feedback_query: feedback_search_query,
-      feedback_request_id: feedback_search_request_id,
+      search_request_id: feedback_search_request_id,
       feedback_date: feedback_search_date,
       feedback_feature_flags: TradeTariffFrontend.enabled_flagsmith_feature_names.join(','),
     }.compact
@@ -103,7 +103,7 @@ module ApplicationHelper
     {
       feedback_url: params[:feedback_url],
       feedback_query: params[:feedback_query],
-      feedback_request_id: params[:feedback_request_id],
+      search_request_id: params[:search_request_id],
       feedback_date: params[:feedback_date],
       feedback_feature_flags: params[:feedback_feature_flags],
     }.compact

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -38,7 +38,7 @@
       <%= f.hidden_field :page_useful %>
       <%= hidden_field_tag :feedback_url, @feedback.referrer %>
       <%= hidden_field_tag :feedback_query, @feedback.query %>
-      <%= hidden_field_tag :feedback_request_id, @feedback.request_id %>
+      <%= hidden_field_tag :search_request_id, @feedback.request_id %>
       <%= hidden_field_tag :feedback_date, @feedback.date %>
       <%= hidden_field_tag :feedback_feature_flags, Array(@feedback.feature_flags).join(',') %>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -400,7 +400,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it 'preserves context from the feedback page' do
-      controller.params[:feedback_request_id] = 'search-request-789'
+      controller.params[:search_request_id] = 'search-request-789'
 
       expect(path).to eq('/enquiry_form?request_id=search-request-789')
     end
@@ -414,14 +414,14 @@ RSpec.describe ApplicationHelper, type: :helper do
     it 'passes through the feedback params already on the request' do
       controller.params[:feedback_url] = 'http://test.host/commodities/1234567890'
       controller.params[:feedback_query] = 'leather handbags'
-      controller.params[:feedback_request_id] = 'abc-123'
+      controller.params[:search_request_id] = 'abc-123'
       controller.params[:feedback_date] = '2026-01-01'
       controller.params[:feedback_feature_flags] = 'interactive_search,webchat'
 
       expect(helper.current_feedback_params).to eq(
         feedback_url: 'http://test.host/commodities/1234567890',
         feedback_query: 'leather handbags',
-        feedback_request_id: 'abc-123',
+        search_request_id: 'abc-123',
         feedback_date: '2026-01-01',
         feedback_feature_flags: 'interactive_search,webchat',
       )

--- a/spec/requests/feedback_controller_spec.rb
+++ b/spec/requests/feedback_controller_spec.rb
@@ -283,6 +283,7 @@ RSpec.describe FeedbackController, type: :request do
       get feedback_hrefs.first
 
       feedback_form = Nokogiri::HTML(response.body)
+      expect(feedback_form.at_css('input[name="search_request_id"]')['value']).to eq('search-request-123')
       expect(feedback_form.at_css('input[name="feedback_feature_flags"]')['value']).to eq('interactive_search,webchat')
 
       post feedbacks_path, params: {

--- a/spec/requests/feedback_controller_spec.rb
+++ b/spec/requests/feedback_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe FeedbackController, type: :request do
     end
 
     it 'preserves the search request identifier in the enquiry link' do
-      get new_feedback_path(feedback_request_id: 'search-request-123')
+      get new_feedback_path(search_request_id: 'search-request-123')
 
       enquiry_link = Nokogiri::HTML(response.body).css('a').find { |link| link.text.strip == 'enquiry form' }
 
@@ -74,7 +74,7 @@ RSpec.describe FeedbackController, type: :request do
         feedback: { message: },
         feedback_url: large_context,
         feedback_query: large_context,
-        feedback_request_id: large_context,
+        search_request_id: large_context,
         feedback_date: large_context,
         feedback_feature_flags: large_context,
         authenticity_token: 'YZDyyHGMqRyXH1ALc0-helPFpCAcUgdyGlErrPgbtvwYxK4ftq6t2xNcfgoknWADYZY9zxncvyiZhvFPTS-irw',
@@ -95,7 +95,7 @@ RSpec.describe FeedbackController, type: :request do
       expect(session.to_hash.keys).not_to include(
         'feedback_referrer',
         'feedback_query',
-        'feedback_request_id',
+        'search_request_id',
         'feedback_date',
         'feedback_feature_flags',
       )
@@ -274,7 +274,7 @@ RSpec.describe FeedbackController, type: :request do
         expect(feedback_params).to include(
           'feedback_url' => 'http://www.example.com/search',
           'feedback_query' => 'leather handbags',
-          'feedback_request_id' => 'search-request-123',
+          'search_request_id' => 'search-request-123',
           'feedback_date' => '2026-06-05',
           'feedback_feature_flags' => 'interactive_search,webchat',
         )
@@ -289,7 +289,7 @@ RSpec.describe FeedbackController, type: :request do
         feedback: { message: },
         feedback_url: 'http://www.example.com/search',
         feedback_query: 'leather handbags',
-        feedback_request_id: 'search-request-123',
+        search_request_id: 'search-request-123',
         feedback_date: '2026-06-05',
         feedback_feature_flags: 'interactive_search,webchat',
         authenticity_token:,


### PR DESCRIPTION
## What:

- [x] Rename the feedback context parameter from `feedback_request_id` to `search_request_id`
- [x] Preserve the search request ID through feedback links, form submission and enquiry links
- [x] Update request and helper coverage for the renamed parameter
- [x] Verify 111 relevant RSpec examples and RuboCop checks

## Why:

The identifier belongs to the search journey and is passed to the search endpoints as `request_id`. Calling the feedback transport parameter `feedback_request_id` incorrectly suggests that feedback creates or owns a separate request identifier. The new name matches the existing `search_request_id` terminology used in application logging and clearly distinguishes it from the frontend HTTP request ID.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

This is a small internal parameter rename with focused request and helper coverage. It does not change search behaviour, feedback content or external service calls.
