### PR TITLE
AI-1266: Link the canonical search resilience contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This directory is the starting point for understanding the Trade Tariff Frontend
 - [Development and delivery](development-and-delivery.md) summarises local setup, checks, PR, and deployment conventions.
 - [Style guide](style-guide.md) covers Ruby/Rails, tests, GOV.UK Frontend components, and PR review expectations.
 - [Search analytics](search-analytics.md) defines the GTM event properties and Amplitude survey setup.
+- [AI-assisted search failure and fallback scenarios](https://github.com/trade-tariff/trade-tariff-backend/blob/main/docs/search-resilience.md) defines reduced guided-search outcomes, response failure codes and frontend warning policy. The backend repository owns this contract.
 - [Code Wiki guide](code-wiki.md) explains how to use generated repository documentation safely.
 - Existing domain notes: [Rules of Origin](../doc/rules_of_origin.md).
 


### PR DESCRIPTION
## What:

- [x] Link the frontend documentation index to the canonical backend search resilience contract.

Verification: independent review, git diff --check and applicable pre-commit hooks including Markdown lint passed. Published file content was read back and matched the verified local file. No runtime tests were needed for this documentation-only change.

The target is docs/search-resilience.md on backend main; merge this index link after that document lands. The backend repository owns the detailed matrix so the frontend does not maintain a competing copy.

## Why:

Frontend contributors need one reference for reduced guided-search outcomes, backend failure metadata and warning policy, including the accepted omission of a duplicate-validation banner.

## Ticket:

[AI-1266](https://transformuk.atlassian.net/browse/AI-1266)

## Risk:

**Risk level:** Green (low-risk)

**Reason for rating:** Documentation link only. No UI, accessibility, API, environment or deployment behaviour changes.