### PR TITLE
AI-1260: Gate the revised find commodity page by deployment environment

### DIFF
--- a/lib/trade_tariff_frontend/config.rb
+++ b/lib/trade_tariff_frontend/config.rb
@@ -16,6 +16,10 @@ module TradeTariffFrontend
       environment == 'production'
     end
 
+    def revised_find_commodity_enabled?
+      %w[development staging].include?(environment)
+    end
+
     def waf_integration_enabled?
       waf_integration_url.present?
     end

--- a/spec/lib/trade_tariff_frontend_spec.rb
+++ b/spec/lib/trade_tariff_frontend_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe TradeTariffFrontend do
     )
   end
 
+  describe '.revised_find_commodity_enabled?' do
+    subject(:enabled) { described_class.revised_find_commodity_enabled? }
+
+    %w[development staging production preview test].each do |deployment|
+      context "when deployed to #{deployment}" do
+        before { stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => deployment)) }
+
+        it 'limits rollout to development and staging' do
+          expect(enabled).to eq(%w[development staging].include?(deployment))
+        end
+      end
+    end
+
+    context 'without a configured environment' do
+      before { stub_const('ENV', ENV.to_hash.except('ENVIRONMENT')) }
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe '.enquiries_email' do
     it 'returns the default classification enquiries email' do
       expect(described_class.enquiries_email).to eq('classification.enquiries@hmrc.gov.uk')


### PR DESCRIPTION
## What:

- [x] Add an environment gate for the revised find commodity page, enabled only in development and staging.

Validation: 64 configuration and request tests passed. No visible UI change.

## Why:

Allow the new page to be tested before a separate production release.

## Ticket:

[AI-1260](https://transformuk.atlassian.net/browse/AI-1260)

## Risk:

**Risk level:** 🟢

**Reason for rating:** Additive configuration, disabled in production.