### PR TITLE
AI-1260: Introduce the revised find commodity page

### DIFF
--- a/app/assets/stylesheets/src/journeys/_interactive-search.scss
+++ b/app/assets/stylesheets/src/journeys/_interactive-search.scss
@@ -69,3 +69,26 @@
     padding: govuk.govuk-spacing(4) govuk.govuk-spacing(6);
   }
 }
+
+.app-find-commodity-service {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: govuk.govuk-spacing(3);
+
+  .switch-service-control {
+    top: 0;
+  }
+}
+
+@include govuk.govuk-media-query($from: tablet) {
+  .app-find-commodity-search-tabs .govuk-tabs__list-item {
+    box-sizing: border-box;
+    width: 50%;
+    margin-right: 0;
+
+    &:not(.govuk-tabs__list-item--selected) {
+      background-color: govuk.govuk-colour('blue', $variant: 'tint-95');
+    }
+  }
+}

--- a/app/controllers/concerns/find_commodity_page.rb
+++ b/app/controllers/concerns/find_commodity_page.rb
@@ -1,0 +1,21 @@
+module FindCommodityPage
+  extend ActiveSupport::Concern
+
+  private
+
+  def find_commodity_template
+    @ai_search_enabled = interactive_search_enabled_with_analytics?
+    @revised_find_commodity = TradeTariffFrontend.revised_find_commodity_enabled? && @ai_search_enabled && !TradeTariffFrontend::ServiceChooser.xi?
+
+    if @revised_find_commodity
+      disable_switch_service_banner
+      submitted_ai = @search.interactive_search || params[:interactive_search] == 'true'
+      @search_mode = @ai_search_enabled && submitted_ai && @search.errors.any? ? 'guided' : 'keyword'
+      'find_commodities/show_revised'
+    elsif @ai_search_enabled
+      'find_commodities/show_interactive'
+    else
+      'find_commodities/show'
+    end
+  end
+end

--- a/app/controllers/concerns/interactive_searchable.rb
+++ b/app/controllers/concerns/interactive_searchable.rb
@@ -226,7 +226,7 @@ module InteractiveSearchable
     @hero_story = nil
     @recent_stories = []
     record_guided_search_journey(outcome:)
-    render 'find_commodities/show_interactive'
+    render find_commodity_template
     clear_search_failure_suggestions
   end
 

--- a/app/controllers/find_commodities_controller.rb
+++ b/app/controllers/find_commodities_controller.rb
@@ -1,4 +1,6 @@
 class FindCommoditiesController < ApplicationController
+  include FindCommodityPage
+
   before_action :disable_switch_service_banner, only: [:show]
 
   def show
@@ -6,6 +8,6 @@ class FindCommoditiesController < ApplicationController
     @hero_story = News::Item.latest_for_home_page
     @recent_stories = News::Item.updates_page.slice(0, 3)
 
-    render :show_interactive if interactive_search_enabled_with_analytics?
+    render find_commodity_template
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,7 @@
 require 'addressable/uri'
 
 class SearchController < ApplicationController
+  include FindCommodityPage
   include GoodsNomenclatureHelper
   include ClassicSearchable
   include InteractiveSearchable
@@ -29,7 +30,12 @@ class SearchController < ApplicationController
       perform_classic_search
     end
   rescue Search::InvalidDate
-    redirect_to find_commodity_path(search_params.merge(invalid_date: true))
+    redirect_params = search_params.merge(invalid_date: true)
+    if TradeTariffFrontend.revised_find_commodity_enabled? && !TradeTariffFrontend::ServiceChooser.xi?
+      redirect_params[:interactive_search] = params[:interactive_search] == 'true'
+      redirect_params[:q] = params[:q] if params[:q].present?
+    end
+    redirect_to find_commodity_path(redirect_params)
   end
 
   def suggestions

--- a/app/helpers/search_analytics_helper.rb
+++ b/app/helpers/search_analytics_helper.rb
@@ -31,6 +31,7 @@ module SearchAnalyticsHelper
   private
 
   def search_analytics_mode(enabled)
+    return @search_mode if @revised_find_commodity
     return 'guided' if @guided_search_outcome.present?
     return 'guided' if enabled && controller_name == 'find_commodities' && cookies[:interactive_search] == 'true'
 

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -32,11 +32,11 @@ module ServiceHelper
     t("trade_tariff_heading.#{service_choice}")
   end
 
-  def switch_service_button
+  def switch_service_button(path: current_path)
     copy, link = if uk_service_choice?
-                   [t('service_banner.service_name.xi'), "/xi#{current_path}"]
+                   [t('service_banner.service_name.xi'), "/xi#{path}"]
                  else
-                   [t('service_banner.service_name.uk'), current_path]
+                   [t('service_banner.service_name.uk'), path]
                  end
 
     tag.span class: %w[switch-service-control govuk-!-display-none-print] do

--- a/app/javascript/controllers/search_mode_controller.js
+++ b/app/javascript/controllers/search_mode_controller.js
@@ -22,6 +22,7 @@ export default class extends Controller {
   }
 
   select(event) {
+    event.preventDefault()
     this.#setMode(event.currentTarget.dataset.mode)
   }
 
@@ -31,6 +32,7 @@ export default class extends Controller {
     const positions = {
       ArrowRight: (current + 1) % tabs.length,
       ArrowLeft: (current + tabs.length - 1) % tabs.length,
+      ' ': current,
       Home: 0,
       End: tabs.length - 1,
     }
@@ -48,6 +50,7 @@ export default class extends Controller {
     this.tabTargets.forEach(tab => {
       const selected = tab.dataset.mode === mode
       tab.setAttribute('aria-selected', selected.toString())
+      tab.closest('.govuk-tabs__list-item')?.classList.toggle('govuk-tabs__list-item--selected', selected)
       tab.tabIndex = selected ? 0 : -1
     })
     for (const name of ['keyword', 'guided']) {

--- a/app/javascript/src/search-autocomplete.js
+++ b/app/javascript/src/search-autocomplete.js
@@ -75,6 +75,7 @@ export function initializeSearchAutocomplete(autocompleteElement, dependencies) 
     id: inputId,
     name: `${inputId}-autocomplete`,
     required: 'true',
+    defaultValue: autocompleteElement.dataset.inputValue || '',
     className: 'govuk-input',
     placeholder: 'Enter the name of the goods or commodity code',
     confirmOnBlur: false,
@@ -111,6 +112,17 @@ export function initializeSearchAutocomplete(autocompleteElement, dependencies) 
   });
 
   autocompleteInput = document.getElementById(inputId);
+  const describedBy = autocompleteElement.dataset.describedBy;
+  if (describedBy) {
+    const associateHint = () => {
+      const ids = autocompleteInput.getAttribute('aria-describedby')?.split(/\s+/).filter(Boolean) || [];
+      if (!ids.includes(describedBy)) autocompleteInput.setAttribute('aria-describedby', [...ids, describedBy].join(' '));
+    };
+    associateHint();
+    // The autocomplete removes its own assistive hint after typing.
+    new MutationObserver(associateHint).observe(autocompleteInput, { attributes: true, attributeFilter: ['aria-describedby'] });
+  }
+  syncSubmittedQuery();
   autocompleteInput.addEventListener('input', () => {
     explicitSuggestionSelection = false;
     queryCapturedBeforeBlur = false;
@@ -163,6 +175,8 @@ function renderFallbackInput(autocompleteElement) {
   input.placeholder = 'Enter the name of the goods or commodity code';
   input.type = 'text';
   input.required = true;
+  input.value = autocompleteElement.dataset.inputValue || '';
+  if (autocompleteElement.dataset.describedBy) input.setAttribute('aria-describedby', autocompleteElement.dataset.describedBy);
   wrapper.appendChild(input);
   autocompleteElement.replaceChildren(wrapper);
 }

--- a/app/views/find_commodities/_guided_tips.html.erb
+++ b/app/views/find_commodities/_guided_tips.html.erb
@@ -1,0 +1,13 @@
+<p>To find a commodity code, you must specify what the item is. If the item is a gift, you must still specify the product.</p>
+<p>Expect technical language. Commodity code descriptions can be quite formal. For example, a laptop might be described as a “Portable automatic data-processing machines, weighing not more than 10 kg, consisting of at least a central processing unit, a keyboard and a display.”</p>
+<p>Use plain English and avoid using foreign words or special characters. The search is also unable to pick up on any spelling mistakes.</p>
+<p>Do not enter any personal or sensitive information in your search queries.</p>
+<p>Make sure you’re using the correct country’s classification. Commodity codes can vary between countries. Make sure you’re using the right code for the country you’re importing to or from.</p>
+<p>If you are struggling to understand the duty you may need to pay then this guidance may help you: <%= govuk_link_to "Tax and customs for goods sent from abroad: Tax and duty - GOV.UK", "https://www.gov.uk/goods-sent-from-abroad/tax-and-duty" %></p>
+
+<h3 class="govuk-heading-s">Steps for using guided search</h3>
+<ol class="special-numbered-list govuk-!-margin-bottom-0">
+  <li>Give as much detail as possible about the product you’re searching for. The more detail you give, the better the search results.</li>
+  <li>To improve the search results, you might be asked some questions about the product.</li>
+  <li>You will be shown the best matches for your product based on the information you’ve supplied.</li>
+</ol>

--- a/app/views/find_commodities/_keyword_tips.html.erb
+++ b/app/views/find_commodities/_keyword_tips.html.erb
@@ -1,0 +1,14 @@
+<p>To find a commodity code, you must specify what the item is. If the item is a gift, you must still specify the product.</p>
+<p>Do not use brand names. It is best to use general terms like trainers or sports footwear instead of 'Nike trainers'.</p>
+<p>Expect technical language. Commodity code descriptions can be quite formal. For example, a laptop might be described as a “Portable automatic data-processing machines, weighing not more than 10 kg, consisting of at least a central processing unit, a keyboard and a display.”</p>
+<p>Use plain English and avoid using foreign words or special characters. The search is also unable to pick up on any spelling mistakes.</p>
+<p>Make sure you're using the correct country's classification. Commodity codes can vary between countries. Make sure you're using the right code for the country you're importing to or from.</p>
+<p>If you are struggling to understand the duty you may need to pay then this guidance may help you: <%= govuk_link_to "Tax and customs for goods sent from abroad: Tax and duty - GOV.UK", "https://www.gov.uk/goods-sent-from-abroad/tax-and-duty" %></p>
+
+<h3 class="govuk-heading-s">Steps for searching the tariff</h3>
+<ol class="special-numbered-list govuk-!-margin-bottom-0">
+  <li>Be specific about the product you are looking for. It's often not enough to describe a product as 'clothing' or 'electronics'. You must specify what the product is, for example, 'cotton shirt', 'car tyres', or 'laptop'.</li>
+  <li>For raw materials and manufactured products, it can be useful to search for products by the material or what they are made from. For example, steel, wood, stone or glass.</li>
+  <li>The search tool will suggest a number of sections. Select the section which best describes the product you are importing or exporting.</li>
+  <li>You will be shown the relevant commodities based on your section. Choose the one which most closely matches your product.</li>
+</ol>

--- a/app/views/find_commodities/_revised_search_form.html.erb
+++ b/app/views/find_commodities/_revised_search_form.html.erb
@@ -1,0 +1,62 @@
+<% controllers = @ai_search_enabled ? 'search-mode guided-search-validation' : nil %>
+<%= form_with model: @search, url: perform_search_path(day: nil, month: nil, year: nil),
+              method: :post, scope: nil, local: true, id: 'new_search',
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+              data: { controller: controllers, search_mode_initial_mode_value: @search_mode,
+                      action: @ai_search_enabled ? 'submit->guided-search-validation#validateAndSubmit' : nil } do |f| %>
+  <div data-guided-search-validation-target="formContent" class="govuk-tabs govuk-!-margin-top-6 govuk-!-margin-bottom-8">
+    <%= f.govuk_error_summary %>
+    <%= hidden_field_tag :experiment, @search.experiment if @search.experiment.present? %>
+    <%= hidden_field_tag :interactive_search, 'false', data: { search_mode_target: 'hiddenField', guided_search_validation_target: 'hiddenField' } %>
+
+    <% if @ai_search_enabled %>
+      <ul class="govuk-tabs__list app-find-commodity-search-tabs govuk-!-margin-bottom-5" role="tablist" aria-label="Search method" data-search-mode-target="tabs" hidden>
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected" role="presentation">
+          <%= govuk_link_to 'Keyword search', '#keyword-search-panel', id: 'keyword-search-tab', class: 'govuk-tabs__tab',
+                role: 'tab', aria: { controls: 'keyword-search-panel', selected: true },
+                data: { mode: 'keyword', search_mode_target: 'tab', action: 'click->search-mode#select keydown->search-mode#navigate' } %>
+        </li>
+        <li class="govuk-tabs__list-item" role="presentation">
+          <%= govuk_link_to safe_join([govuk_tag(text: 'Beta', colour: 'magenta', classes: 'govuk-!-margin-right-1'), 'AI-assisted search'], ' '),
+                '#ai-search-panel', id: 'ai-search-tab', class: 'govuk-tabs__tab', role: 'tab', tabindex: -1,
+                aria: { controls: 'ai-search-panel', selected: false },
+                data: { mode: 'guided', search_mode_target: 'tab', action: 'click->search-mode#select keydown->search-mode#navigate' } %>
+        </li>
+      </ul>
+    <% end %>
+
+    <div id="keyword-search-panel" data-search-mode-target="keywordSection">
+      <h2 class="govuk-heading-m">Keyword search</h2>
+      <%= govuk_details(summary_text: 'Tips for using keyword or commodity code search') do %>
+        <%= render 'find_commodities/keyword_tips' %>
+      <% end %>
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="revised-keyword-query">Search the UK Integrated Online Tariff</label>
+        <div class="govuk-hint" id="revised-keyword-hint">For example, tomatoes or 1234 5678 90</div>
+        <%= render 'shared/search/autocomplete', input_id: 'revised-keyword-query', described_by: 'revised-keyword-hint',
+                   input_value: @search_mode == 'keyword' && @search.errors.any? ? @search.q : nil %>
+      </div>
+    </div>
+
+    <% if @ai_search_enabled %>
+      <div id="ai-search-panel" data-search-mode-target="guidedSection" hidden>
+        <h2 class="govuk-heading-m">AI-assisted search</h2>
+        <p>Enter as much information as possible, such as the type of product, what it is made of, its function and how it's presented or packaged.</p>
+        <%= govuk_details(summary_text: 'Tips for using AI-assisted search') do %>
+          <%= render 'find_commodities/guided_tips' %>
+        <% end %>
+        <%= f.govuk_text_area :q, label: { text: 'Describe the products you are trading' },
+              hint: { text: 'For example, 55" 4K Ultra HD OLED Smart TV' }, rows: 5,
+              placeholder: 'Enter a detailed description of the goods', disabled: true,
+              form_group: { data: { guided_search_validation_target: 'formGroup' } },
+              data: { guided_search_validation_target: 'textarea' } %>
+      </div>
+    <% end %>
+
+    <%= f.govuk_date_field :as_of,
+          legend: { text: 'When are you planning to trade the products?', size: 's', tag: nil },
+          hint: { text: safe_join(["You can enter the date your products will be traded. This is important, as commodities, duties and quotas change over time. If you don't enter a date, today's date is used.", tag.br, tag.br, 'For example 27 3 2021']) },
+          form_group: { class: 'govuk-!-margin-top-6' }, maxlength_enabled: true %>
+    <%= f.govuk_submit 'Search for a commodity' %>
+  </div>
+<% end %>

--- a/app/views/find_commodities/show_revised.html.erb
+++ b/app/views/find_commodities/show_revised.html.erb
@@ -1,0 +1,30 @@
+<div data-guided-search-validation-page-content>
+  <%= page_header 'Find commodity codes, import duties, taxes and controls' %>
+
+  <%= render 'news_items/hero_story', news_item: @hero_story if @hero_story %>
+
+  <p class="app-find-commodity-service govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+    <strong>Tariff for England, Scotland or Wales (GB)</strong>
+    <%= switch_service_button(path: find_commodity_path) %>
+  </p>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m">Search for a commodity</h2>
+      <p>Commodity codes are internationally recognised reference numbers. A commodity code describes a specific product when importing or exporting goods. You will use this code on any customs declarations.</p>
+      <p>These codes can be very specific, so you need to be very clear about what you're importing or exporting. This will help avoid any delays at customs.</p>
+
+      <%= render 'find_commodities/revised_search_form' %>
+      <%= govuk_section_break(size: 'l', visible: true, classes: 'app-section-break--thick') %>
+      <%= render 'search/other_ways_to_search', include_keyword: false %>
+    </div>
+
+    <div class="govuk-grid-column-one-third" id="recent-news">
+      <%= render '/pages/howto_sidebar_links' %>
+      <%= render 'news_items/recent_news', news_items: @recent_stories %>
+    </div>
+  </div>
+</div>
+<div data-guided-search-validation-loading-page class="govuk-!-display-none">
+  <%= render 'search/interactive_search_thinking' %>
+</div>

--- a/app/views/search/_other_ways_to_search.html.erb
+++ b/app/views/search/_other_ways_to_search.html.erb
@@ -7,7 +7,7 @@
           href: find_commodity_path,
           description: 'Search using keywords or use a known commodity code',
           heading_level: 3,
-        },
+        }.then { |card| card if local_assigns.fetch(:include_keyword, true) },
         {
           title: 'Goods classifications',
           href: browse_sections_path,
@@ -20,5 +20,5 @@
           description: 'Look for your product in the A-Z',
           heading_level: 3,
         },
-      ],
+      ].compact,
     ) %>

--- a/app/views/shared/search/_autocomplete.html.erb
+++ b/app/views/shared/search/_autocomplete.html.erb
@@ -1,16 +1,20 @@
 <% input_id = local_assigns.fetch(:input_id, 'q') %>
 <% input_name = local_assigns.fetch(:input_name, 'q') %>
+<% described_by = local_assigns[:described_by] %>
+<% input_value = local_assigns[:input_value] %>
 <div
   class="govuk-fieldset"
   id="autocomplete"
   data-module="search-autocomplete"
   data-input-id="<%= input_id %>"
   data-input-name="<%= input_name %>"
+  data-described-by="<%= described_by %>"
+  data-input-value="<%= input_value %>"
 >
 
   <noscript>
     <div class="autocomplete__wrapper">
-      <input autocomplete="off" class="autocomplete__input autocomplete__input--default" id="<%= input_id %>" name="<%= input_name %>" placeholder="Enter the name of the goods or commodity code" type="text" required="">
+      <input autocomplete="off" class="autocomplete__input autocomplete__input--default" id="<%= input_id %>" name="<%= input_name %>" placeholder="Enter the name of the goods or commodity code" type="text" required="" value="<%= input_value %>" aria-describedby="<%= described_by %>">
     </div>
   </noscript>
 </div>

--- a/spec/features/revised_find_commodities_spec.rb
+++ b/spec/features/revised_find_commodities_spec.rb
@@ -1,0 +1,167 @@
+require 'spec_helper'
+
+RSpec.describe 'Revised find commodity' do
+  include_context 'with latest news stubbed'
+  include_context 'with news updates stubbed'
+
+  before do
+    allow(TradeTariffFrontend).to receive(:environment).and_return('staging')
+    enable_feature(:interactive_search)
+    stub_api_request('search_suggestions').with(query: hash_including('q')).to_return(jsonapi_response(:search_suggestion, []))
+  end
+
+  context 'with JavaScript', :js do
+    before { visit find_commodity_path }
+
+    it 'has one primary heading in either mode', :aggregate_failures do
+      expect(page).to have_css('h1', count: 1, visible: :visible)
+      find('#ai-search-tab').click
+      expect(page).to have_css('h1', count: 1, visible: :visible)
+      expect(page).to have_css('legend', text: 'When are you planning to trade the products?')
+    end
+
+    it 'starts on keyword despite a saved mode', :aggregate_failures do
+      page.execute_script("document.cookie = 'interactive_search=true; path=/'")
+      visit find_commodity_path
+
+      expect(page).to have_css('#keyword-search-tab[aria-selected="true"]')
+      expect(page).to have_field('revised-keyword-query', visible: :visible)
+      expect(page).not_to have_field('Describe the products you are trading', visible: :visible)
+    end
+
+    it 'restores a rejected keyword query and associates its hint', :aggregate_failures do
+      fill_in 'revised-keyword-query', with: 'coffee beans'
+      fill_in 'Month', with: '0'
+      click_button 'Search for a commodity'
+
+      expect(page).to have_content('You must enter a valid date')
+      expect(page).to have_field('revised-keyword-query', with: 'coffee beans')
+      find_field('revised-keyword-query').send_keys(' roasted')
+      expect(page).to have_css('#revised-keyword-query[aria-describedby~="revised-keyword-hint"]')
+    end
+
+    it 'combines date and AI errors in one summary across mode switches', :aggregate_failures do
+      find('#ai-search-tab').click
+      fill_in 'Describe the products you are trading', with: 'fresh tomatoes'
+      fill_in 'Month', with: '0'
+      click_button 'Search for a commodity'
+      expect(page).to have_content('You must enter a valid date')
+
+      fill_in 'Describe the products you are trading', with: ''
+      click_button 'Search for a commodity'
+      expect(page).to have_css('.govuk-error-summary', count: 1)
+      expect(page).to have_css('.govuk-error-summary:focus', text: 'Enter a search term')
+      within '.govuk-error-summary' do
+        expect(page).to have_content('You must enter a valid date')
+      end
+
+      find('#keyword-search-tab').click
+      within '.govuk-error-summary' do
+        expect(page).to have_content('You must enter a valid date')
+        expect(page).not_to have_css('li', text: 'Enter a search term', visible: :visible)
+      end
+      find('#ai-search-tab').click
+      expect(page).to have_css('.govuk-error-summary', count: 1, text: 'Enter a search term')
+    end
+
+    it 'keeps drafts and the shared date', :aggregate_failures do
+      fill_in 'revised-keyword-query', with: 'tomatoes'
+      fill_in 'Day', with: '12'
+      fill_in 'Month', with: '10'
+      fill_in 'Year', with: '2026'
+      find('#ai-search-tab').click
+      fill_in 'Describe the products you are trading', with: 'fresh tomatoes'
+      find('#keyword-search-tab').click
+
+      expect(page).to have_field('revised-keyword-query', with: 'tomatoes')
+      find('#ai-search-tab').click
+      expect(page).to have_field('Describe the products you are trading', with: 'fresh tomatoes')
+      expect(page).to have_field('Day', with: '12')
+      expect(page).to have_field('Month', with: '10')
+      expect(page).to have_field('Year', with: '2026')
+      submitted_queries = page.evaluate_script(<<~JS)
+        Array.from(new FormData(document.querySelector('#new_search')))
+          .filter(([name]) => name === 'q' || name === 'search[q]')
+          .map(([, value]) => value)
+      JS
+      expect(submitted_queries).to eq(['fresh tomatoes'])
+    end
+
+    it 'supports keyboard tabs and newlines', :aggregate_failures do
+      find('#keyword-search-tab').send_keys(:right)
+      expect(page).to have_css('#ai-search-tab[aria-selected="true"]:focus')
+      description = find_field('Describe the products you are trading')
+      description.send_keys('fresh', :enter, 'tomatoes')
+
+      expect(description.value).to eq("fresh\ntomatoes")
+      expect(page).to have_current_path(find_commodity_path)
+      find('#ai-search-tab').send_keys(:left)
+      expect(page).to have_css('#keyword-search-tab[aria-selected="true"]:focus')
+    end
+
+    it 'submits AI text into the journey' do
+      stub_api_request('search', :post, internal: true)
+        .with { |request| JSON.parse(request.body)['q'] == 'fresh tomatoes' }
+        .to_return(
+          body: {
+            data: [],
+            meta: {
+              interactive_search: {
+                query: 'fresh tomatoes',
+                request_id: 'revised-journey',
+                answers: [{ question: 'How are the tomatoes prepared?', options: %w[Fresh Dried], answer: nil }],
+              },
+            },
+          }.to_json,
+          headers: { 'content-type' => 'application/json' },
+        )
+      fill_in 'revised-keyword-query', with: 'unused keyword'
+      find('#ai-search-tab').click
+      fill_in 'Describe the products you are trading', with: 'fresh tomatoes'
+      click_button 'Search for a commodity'
+
+      expect(page).to have_content('How are the tomatoes prepared?')
+    end
+
+    it 'hides AI errors in keyword mode', :aggregate_failures do
+      find('#ai-search-tab').click
+      click_button 'Search for a commodity'
+      expect(page).to have_css('.govuk-error-summary', text: 'Enter a search term')
+
+      find('#keyword-search-tab').click
+      expect(page).not_to have_css('.govuk-error-summary', visible: :visible)
+      expect(page).to have_field('revised-keyword-query', visible: :visible)
+    end
+
+    context 'with a mobile viewport' do
+      before { page.current_window.resize_to(375, 812) }
+
+      after { page.current_window.resize_to(1200, 800) }
+
+      it 'keeps one usable search panel', :aggregate_failures do
+        expect(page).to have_field('revised-keyword-query', visible: :visible)
+        expect(page).not_to have_field('Describe the products you are trading', visible: :visible)
+        find('#ai-search-tab').click
+        expect(page).to have_field('Describe the products you are trading', visible: :visible)
+        expect(page).not_to have_field('revised-keyword-query', visible: :visible)
+        expect(page.evaluate_script('document.documentElement.scrollWidth <= window.innerWidth')).to be(true)
+      end
+    end
+  end
+
+  context 'without JavaScript' do
+    before do
+      stub_api_request('search', :post).to_return(jsonapi_response(:search, attributes_for(:search_outcome, :fuzzy_match)))
+      visit find_commodity_path
+    end
+
+    it 'submits a usable keyword search', :aggregate_failures do
+      expect(find_field('revised-keyword-query')['aria-describedby']).to eq('revised-keyword-hint')
+      fill_in 'revised-keyword-query', with: 'toothbrush'
+      click_button 'Search for a commodity'
+
+      expect(page).to have_css('h1', text: 'Search results')
+      expect(page).to have_current_path('/search')
+    end
+  end
+end

--- a/spec/javascript/controllers/search_mode_controller_spec.js
+++ b/spec/javascript/controllers/search_mode_controller_spec.js
@@ -12,10 +12,10 @@ describe('SearchModeController', () => {
   async function setup(initialMode = 'keyword') {
     document.body.innerHTML = `
       <form data-controller="search-mode" data-search-mode-initial-mode-value="${initialMode}">
-        <div hidden data-search-mode-target="tabs" role="tablist">
-          <button type="button" id="keyword-tab" role="tab" aria-controls="keyword" data-search-mode-target="tab" data-mode="keyword" data-action="click->search-mode#select keydown->search-mode#navigate">Keyword</button>
-          <button type="button" id="guided-tab" role="tab" aria-controls="guided" data-search-mode-target="tab" data-mode="guided" data-action="click->search-mode#select keydown->search-mode#navigate">AI-assisted</button>
-        </div>
+        <ul hidden data-search-mode-target="tabs" role="tablist">
+          <li class="govuk-tabs__list-item"><a href="#keyword" id="keyword-tab" role="tab" aria-controls="keyword" data-search-mode-target="tab" data-mode="keyword" data-action="click->search-mode#select keydown->search-mode#navigate">Keyword</a></li>
+          <li class="govuk-tabs__list-item"><a href="#guided" id="guided-tab" role="tab" aria-controls="guided" data-search-mode-target="tab" data-mode="guided" data-action="click->search-mode#select keydown->search-mode#navigate">AI-assisted</a></li>
+        </ul>
         <div id="keyword" data-search-mode-target="keywordSection"><input name="q" value="bicycle"></div>
         <div id="guided" hidden data-search-mode-target="guidedSection"><textarea name="q" disabled>cotton shirt</textarea></div>
         <input name="interactive_search" value="false" data-search-mode-target="hiddenField">
@@ -46,7 +46,11 @@ describe('SearchModeController', () => {
   })
   it('preserves each query and shared date while submitting only the active query', async () => {
     await setup()
-    tab('guided').click()
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true })
+    tab('guided').dispatchEvent(click)
+    expect(click.defaultPrevented).toBe(true)
+    expect(tab('guided').parentElement.classList.contains('govuk-tabs__list-item--selected')).toBe(true)
+    expect(tab('keyword').parentElement.classList.contains('govuk-tabs__list-item--selected')).toBe(false)
     expect(panel('guided').hidden).toBe(false)
     expect(new FormData(form()).getAll('q')).toEqual(['cotton shirt'])
     expect(new FormData(form()).get('interactive_search')).toBe('true')
@@ -59,7 +63,7 @@ describe('SearchModeController', () => {
   it.each([
     ['ArrowRight', 'keyword', 'guided'], ['ArrowLeft', 'keyword', 'guided'],
     ['ArrowRight', 'guided', 'keyword'], ['Home', 'guided', 'keyword'],
-    ['End', 'keyword', 'guided']
+    ['End', 'keyword', 'guided'], [' ', 'keyword', 'keyword']
   ])('moves focus and selection with %s from %s', async (key, start, expected) => {
     await setup()
     tab(start).click()

--- a/spec/javascript/search-autocomplete.spec.js
+++ b/spec/javascript/search-autocomplete.spec.js
@@ -200,6 +200,8 @@ describe('initializeSearchAutocompletes', () => {
     document.body.innerHTML = `
       <form>
         <div
+          data-described-by="query-hint"
+          data-input-value="coffee beans"
           data-module="search-autocomplete"
           data-input-id="search-q-field"
           data-input-name="q"
@@ -216,6 +218,8 @@ describe('initializeSearchAutocompletes', () => {
     const fallback = document.querySelector('#search-q-field');
     expect(fallback.name).toBe('q');
     expect(fallback.required).toBe(true);
+    expect(fallback.value).toBe('coffee beans');
+    expect(fallback.getAttribute('aria-describedby')).toBe('query-hint');
     expect(fallback.getAttribute('role')).toBeNull();
   });
 });

--- a/spec/requests/revised_find_commodities_spec.rb
+++ b/spec/requests/revised_find_commodities_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper'
+
+RSpec.describe 'Revised find commodity page', :aggregate_failures, type: :request do
+  include_context 'with latest news stubbed'
+  include_context 'with news updates stubbed'
+
+  before do
+    allow(TradeTariffFrontend).to receive(:environment).and_return(environment)
+    guided ? enable_feature(:interactive_search) : disable_feature(:interactive_search)
+  end
+
+  let(:environment) { 'staging' }
+  let(:guided) { false }
+
+  def entry_page(params = {})
+    get find_commodity_path, params: params
+    expect(response).to have_http_status(:ok)
+    Capybara.string(response.body)
+  end
+
+  %w[development staging].each do |deployment|
+    context "when deployed to #{deployment}" do
+      let(:environment) { deployment }
+
+      it 'keeps the existing page outside the AI cohort' do
+        page = entry_page
+        expect(page).to have_css('h1', text: 'Look up commodity codes, import duties, taxes and controls')
+        expect(page).not_to have_link('AI-assisted search')
+      end
+
+      context 'with AI search enabled' do
+        let(:guided) { true }
+
+        it 'offers the two search modes' do
+          page = entry_page
+          expect(page).to have_link('Switch to the Northern Ireland Online Tariff')
+          expect(page).to have_link('Keyword search')
+          expect(page).to have_link('AI-assisted search')
+          expect(page).not_to have_text('What type of search are you doing?')
+          expect(page).not_to have_text('Importing goods into Northern Ireland?')
+        end
+
+        it 'ignores a remembered AI preference' do
+          cookies[:interactive_search] = 'true'
+          page = entry_page
+          expect(page).to have_css('[data-search-mode-initial-mode-value="keyword"]')
+        end
+
+        it 'retains AI mode for invalid dates' do
+          page = entry_page(interactive_search: 'true', q: 'coffee', invalid_date: true, day: '22', month: '0', year: '2026')
+          expect(page).to have_css('[data-search-mode-initial-mode-value="guided"]')
+          expect(page).to have_text('You must enter a valid date')
+          expect(page).to have_field('Describe the products you are trading', with: 'coffee', disabled: true)
+        end
+      end
+    end
+  end
+
+  context 'with AI validation errors' do
+    let(:guided) { true }
+
+    it 'retains AI mode and description after an invalid-date submission' do
+      post perform_search_path, params: { interactive_search: 'true', search: { q: 'coffee beans', 'as_of(3i)' => '22', 'as_of(2i)' => '0', 'as_of(1i)' => '2026' } }
+      follow_redirect!
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('data-search-mode-initial-mode-value="guided"')
+      expect(Capybara.string(response.body)).to have_field('Describe the products you are trading', with: 'coffee beans', disabled: true)
+      expect(response.body).to include('You must enter a valid date')
+    end
+
+    it 'retains keyword text after an invalid-date submission' do
+      post perform_search_path, params: { interactive_search: 'false', q: 'coffee beans', search: { 'as_of(3i)' => '22', 'as_of(2i)' => '0', 'as_of(1i)' => '2026' } }
+      follow_redirect!
+
+      expect(Capybara.string(response.body)).to have_field('revised-keyword-query', with: 'coffee beans')
+      expect(response.body).to include('You must enter a valid date')
+    end
+
+    it 'returns to the revised AI panel' do
+      post perform_search_path, params: { interactive_search: 'true', q: 'a' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('data-search-mode-initial-mode-value="guided"')
+      expect(response.body).to include('Search term must be at least 2 characters')
+      expect(Capybara.string(response.body)).to have_css('.switch-service-control', count: 1)
+      expect(Capybara.string(response.body)).to have_link('Switch to the Northern Ireland Online Tariff', href: '/xi/find_commodity')
+    end
+  end
+
+  context 'with analytics consent' do
+    let(:guided) { true }
+
+    it 'reports the actual initial mode' do
+      cookies[:cookies_policy] = { usage: true }.to_json
+      cookies[:interactive_search] = 'true'
+      entry_page
+
+      analytics = JSON.parse(Nokogiri::HTML(response.body).at_css('#search-analytics-context').text)
+      expect(analytics).to include('search_mode' => 'keyword', 'search_experience' => 'guided_beta')
+    end
+  end
+
+  context 'when deployed to production' do
+    let(:environment) { 'production' }
+
+    it 'keeps the existing classic page' do
+      expect(entry_page).to have_css('h1', text: 'Look up commodity codes, import duties, taxes and controls')
+    end
+
+    context 'with AI search enabled' do
+      let(:guided) { true }
+
+      it 'keeps the existing radio page' do
+        expect(entry_page).to have_field('Guided search', type: 'radio')
+      end
+    end
+  end
+
+  context 'when on the XI service' do
+    let(:guided) { true }
+
+    it 'keeps the existing page' do
+      get '/xi/find_commodity'
+      expect(response.body).not_to include('data-controller="search-mode')
+      expect(response.body).to include('Look up commodity codes, import duties, taxes and controls')
+    end
+  end
+end


### PR DESCRIPTION
## What:

- [x] Add the approved find commodity layout with keyword/AI search, updated tips and navigation.
- [x] Preserve queries and dates, with accessible validation and keyboard, mobile and no-JavaScript support.

Validation: 253 Ruby tests, 184 JavaScript tests and asset compilation passed. The development UI was reviewed with stakeholders against Figma; error-path fixes have regression coverage.

## Why:

Deliver the revised entry experience for eligible AI beta users. Depends on #3342.

## Ticket:

[AI-1260](https://transformuk.atlassian.net/browse/AI-1260)

## Risk:

**Risk level:** 🟢

**Reason for rating:** Stakeholder-approved, gated to development/staging and AI eligibility. Production and XI retain their existing pages.