### PR TITLE
AI-1262: Add the AI beta banner and information page

### DIFF
--- a/app/assets/stylesheets/src/journeys/_interactive-search.scss
+++ b/app/assets/stylesheets/src/journeys/_interactive-search.scss
@@ -92,3 +92,8 @@
     }
   }
 }
+
+.app-ai-search-banner {
+  border-left-color: settings.$tariff-brand-colour;
+  background: govuk.govuk-colour('blue', $variant: 'tint-95');
+}

--- a/app/controllers/ai_search_information_controller.rb
+++ b/app/controllers/ai_search_information_controller.rb
@@ -1,0 +1,10 @@
+class AiSearchInformationController < ApplicationController
+  before_action :disable_search_form,
+                :disable_switch_service_banner
+
+  def show
+    unless TradeTariffFrontend.revised_find_commodity_enabled? && interactive_search_enabled?
+      redirect_to find_commodity_path
+    end
+  end
+end

--- a/app/controllers/find_commodities_controller.rb
+++ b/app/controllers/find_commodities_controller.rb
@@ -5,9 +5,10 @@ class FindCommoditiesController < ApplicationController
 
   def show
     @no_shared_search = true
-    @hero_story = News::Item.latest_for_home_page
+    template = find_commodity_template
+    @hero_story = News::Item.latest_for_home_page unless @revised_find_commodity
     @recent_stories = News::Item.updates_page.slice(0, 3)
 
-    render find_commodity_template
+    render template
   end
 end

--- a/app/views/ai_search_information/show.html.erb
+++ b/app/views/ai_search_information/show.html.erb
@@ -21,7 +21,7 @@
     <p class="govuk-body">Users should not enter personal, sensitive or confidential information - the AI tools are designed for general assistance only and are not designed to handle secure or case-specific data that may carry privacy or commercial risks.</p>
     <p class="govuk-body">For more information refer to <%= govuk_link_to 'the UK Online Trade Tariff Terms and Conditions', terms_path, new_tab: true %>.</p>
 
-    <h2 class="govuk-heading-m">Can I use AI-assisted search on other devices</h2>
+    <h2 class="govuk-heading-m">Can I use AI-assisted search on other devices?</h2>
     <p class="govuk-body">Access is being made available to a sample of visitors and participants who opt in. A cookie in your browser allows you to continue to use AI-assisted search in that browser.</p>
     <p class="govuk-body">Access does not automatically transfer to another browser or device. Another browser may be selected for the beta service, or a participant can opt in using that browser.</p>
     <p class="govuk-body">Sharing a search page link does not automatically give someone else access to AI-assisted search.</p>

--- a/app/views/ai_search_information/show.html.erb
+++ b/app/views/ai_search_information/show.html.erb
@@ -1,0 +1,36 @@
+<% content_for :title, 'AI-assisted search - Service updates' %>
+
+<% content_for :top_breadcrumbs do %>
+  <%= generate_breadcrumbs 'AI-assisted search',
+                           [[t('breadcrumb.home'), home_path],
+                            [t('breadcrumb.news'), news_items_path]] %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= page_header 'AI-assisted search', 'UK Integrated Online Tariff' %>
+
+    <p class="govuk-body-l">Assisted search is currently in beta phase. While we strive for accuracy, at this stage there might be some errors in the service.</p>
+    <p class="govuk-body">It remains the responsibility of the user to ensure accurate completion of declarations.</p>
+    <p class="govuk-body">If you find any problems, <%= govuk_link_to 'use feedback to report them', feedback_path %>.</p>
+
+    <h2 class="govuk-heading-m">How assisted search uses AI</h2>
+    <p class="govuk-body">Assisted search uses AI, including large language models, generative AI and other approved data sources.</p>
+    <p class="govuk-body">These tools are designed to support users by making commodity codes easier to find and do not replace or supersede official HMRC guidance or formal tariff decisions.</p>
+    <p class="govuk-body">Search queries and responses will only be recorded and analysed to help improve the service.</p>
+    <p class="govuk-body">Users should not enter personal, sensitive or confidential information - the AI tools are designed for general assistance only and are not designed to handle secure or case-specific data that may carry privacy or commercial risks.</p>
+    <p class="govuk-body">For more information refer to <%= govuk_link_to 'the UK Online Trade Tariff Terms and Conditions', terms_path, new_tab: true %>.</p>
+
+    <h2 class="govuk-heading-m">Can I use AI-assisted search on other devices</h2>
+    <p class="govuk-body">Access is being made available to a sample of visitors and participants who opt in. A cookie in your browser allows you to continue to use AI-assisted search in that browser.</p>
+    <p class="govuk-body">Access does not automatically transfer to another browser or device. Another browser may be selected for the beta service, or a participant can opt in using that browser.</p>
+    <p class="govuk-body">Sharing a search page link does not automatically give someone else access to AI-assisted search.</p>
+
+    <h2 class="govuk-heading-m">Service changes and availability</h2>
+    <p class="govuk-body">AI-assisted search might:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>be updated, changed, suspended or withdrawn at any time without notice</li>
+      <li>evolve as the service is improved.</li>
+    </ul>
+  </div>
+</div>

--- a/app/views/find_commodities/_ai_search_banner.html.erb
+++ b/app/views/find_commodities/_ai_search_banner.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_inset_text(classes: 'app-ai-search-banner') do %>
+  <%= govuk_tag(text: 'Beta', colour: 'magenta') %>
+  <h2 class="govuk-heading-m govuk-!-margin-top-2 govuk-!-margin-bottom-2">Introducing AI-assisted search</h2>
+  <p>By entering a description of the goods and answering a few clarifying questions, AI-assisted search will help you find the correct commodity code. Find out more about <%= govuk_link_to 'AI-assisted search', ai_search_information_path, new_tab: true %>.</p>
+<% end %>

--- a/app/views/find_commodities/show_revised.html.erb
+++ b/app/views/find_commodities/show_revised.html.erb
@@ -1,7 +1,11 @@
 <div data-guided-search-validation-page-content>
   <%= page_header 'Find commodity codes, import duties, taxes and controls' %>
 
-  <%= render 'news_items/hero_story', news_item: @hero_story if @hero_story %>
+  <% if @ai_search_enabled %>
+    <%= render 'find_commodities/ai_search_banner' %>
+  <% elsif @hero_story %>
+    <%= render 'news_items/hero_story', news_item: @hero_story %>
+  <% end %>
 
   <p class="app-find-commodity-service govuk-!-margin-top-6 govuk-!-margin-bottom-6">
     <strong>Tariff for England, Scotland or Wales (GB)</strong>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
   end
   get 'cookies', to: redirect(path: '/cookies/policy')
 
+  get '/news/service-updates/ai-assisted-search', to: 'ai_search_information#show', as: :ai_search_information
   get '/news/collections/:collection_id(/:story_year)', to: 'news_items#index', as: :news_collection
   get '/news/years/:story_year', to: 'news_items#index', as: :news_year
   get '/news/stories/:id', to: 'news_items#show', as: :news_item

--- a/spec/requests/ai_search_banner_spec.rb
+++ b/spec/requests/ai_search_banner_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'AI-assisted search banner', :aggregate_failures, type: :request 
     expect(page).to have_css('h2', text: 'Introducing AI-assisted search')
     expect(page).to have_css('a[href="/news/service-updates/ai-assisted-search"][target="_blank"]', text: 'AI-assisted search')
     expect(page).not_to have_text(hero_story.title)
+    expect(News::Item).not_to have_received(:latest_for_home_page)
   end
 
   it 'shows the introduction on an AI validation response' do

--- a/spec/requests/ai_search_banner_spec.rb
+++ b/spec/requests/ai_search_banner_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe 'AI-assisted search banner', :aggregate_failures, type: :request do
+  include_context 'with news updates stubbed'
+
+  let(:environment) { 'staging' }
+  let(:hero_story) { build(:news_item, title: 'Latest tariff update') }
+
+  before do
+    allow(TradeTariffFrontend).to receive(:environment).and_return(environment)
+    allow(News::Item).to receive(:latest_for_home_page).and_return(hero_story)
+    enable_feature(:interactive_search)
+  end
+
+  it 'replaces hero news with the beta introduction and a new-tab information link' do
+    get find_commodity_path
+
+    page = Capybara.string(response.body)
+    expect(page).to have_css('h2', text: 'Introducing AI-assisted search')
+    expect(page).to have_css('a[href="/news/service-updates/ai-assisted-search"][target="_blank"]', text: 'AI-assisted search')
+    expect(page).not_to have_text(hero_story.title)
+  end
+
+  it 'shows the introduction on an AI validation response' do
+    post perform_search_path, params: { interactive_search: 'true', q: 'a' }
+
+    expect(Capybara.string(response.body)).to have_css('h2', text: 'Introducing AI-assisted search')
+  end
+
+  it 'retains hero news when AI is disabled' do
+    disable_feature(:interactive_search)
+    get find_commodity_path
+
+    page = Capybara.string(response.body)
+    expect(page).to have_css('h2', text: hero_story.title)
+    expect(page).not_to have_link('AI-assisted search', href: ai_search_information_path)
+  end
+
+  context 'when deployed to production' do
+    let(:environment) { 'production' }
+
+    it 'retains the existing banner selection' do
+      get find_commodity_path
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css('h2', text: hero_story.title)
+      expect(page).not_to have_text('Introducing AI-assisted search')
+    end
+  end
+end

--- a/spec/requests/ai_search_information_controller_spec.rb
+++ b/spec/requests/ai_search_information_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe 'AI-assisted search information', type: :request do
+  subject(:page) { Capybara.string(response.body) }
+
+  let(:environment) { 'development' }
+  let(:path) { '/news/service-updates/ai-assisted-search' }
+
+  before do
+    allow(TradeTariffFrontend).to receive(:environment).and_return(environment)
+    enable_feature(:interactive_search)
+  end
+
+  describe 'GET /news/service-updates/ai-assisted-search' do
+    %w[development staging].each do |deployed_environment|
+      context "when eligible in #{deployed_environment}" do
+        let(:environment) { deployed_environment }
+
+        before { get path }
+
+        it 'shows the beta information', :aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(page).to have_css('h1', text: 'AI-assisted search')
+          expect(page).to have_link('the UK Online Trade Tariff Terms and Conditions', href: terms_path, target: '_blank')
+          expect(page).to have_link('use feedback to report them', href: feedback_path)
+          expect(page).to have_css('h2', text: 'How assisted search uses AI')
+          expect(page).to have_css('h2', text: 'Can I use AI-assisted search on other devices')
+          expect(page).to have_css('h2', text: 'Service changes and availability')
+          expect(page).to have_content('Access does not automatically transfer to another browser or device.')
+        end
+      end
+    end
+
+    context 'when AI search is disabled' do
+      before do
+        disable_feature(:interactive_search)
+        get path
+      end
+
+      it 'returns to find commodity' do
+        expect(response).to redirect_to(find_commodity_path)
+      end
+    end
+
+    context 'when deployed to production' do
+      let(:environment) { 'production' }
+
+      before { get path }
+
+      it 'returns to find commodity' do
+        expect(response).to redirect_to(find_commodity_path)
+      end
+    end
+
+    context 'when using the XI service' do
+      before { get "/xi#{path}" }
+
+      it 'returns to the XI find commodity page' do
+        expect(response).to redirect_to('/xi/find_commodity')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What:

- [x] Add the AI beta introduction and an information page explaining the service.
- [x] Replace hero news for eligible visitors and avoid fetching the unused story.

## Why:

Explain AI-assisted search and its limitations before users start. Follows #3339.

## Ticket:

[AI-1262](https://transformuk.atlassian.net/browse/AI-1262)

## Risk:

**Risk level:** 🟢

**Reason for rating:** Stakeholder-approved development/staging rollout for eligible beta users. Production enablement remains separate.