### PR TITLE
AI-1260: Keep revised search validation in one error summary

### DIFF
--- a/app/javascript/controllers/guided_search_validation_controller.js
+++ b/app/javascript/controllers/guided_search_validation_controller.js
@@ -95,7 +95,10 @@ export default class extends Controller {
       this.formContentTarget.prepend(summary)
     }
 
-    if (revisedPage) summary.tabIndex = -1
+    if (revisedPage) {
+      summary.hidden = false
+      summary.tabIndex = -1
+    }
     const list = summary.querySelector('.govuk-error-summary__list')
     errors.forEach(message => {
       const item = document.createElement('li')

--- a/app/javascript/controllers/guided_search_validation_controller.js
+++ b/app/javascript/controllers/guided_search_validation_controller.js
@@ -49,8 +49,20 @@ export default class extends Controller {
   }
 
   #clearErrors() {
-    const summary = this.element.querySelector('.govuk-error-summary')
-    if (summary) summary.remove()
+    if (this.element.hasAttribute('data-search-mode-initial-mode-value')) {
+      this.element.querySelectorAll('.govuk-error-summary').forEach(summary => {
+        if (summary.dataset.searchModeError === 'guided') {
+          summary.remove()
+        } else {
+          summary.querySelectorAll('li').forEach(item => {
+            if (item.querySelector('a')?.getAttribute('href') === `#${this.textareaTarget.id}`) item.remove()
+          })
+          if (!summary.querySelector('li')) summary.remove()
+        }
+      })
+    } else {
+      this.element.querySelector('.govuk-error-summary')?.remove()
+    }
 
     const inlineError = this.formGroupTarget.querySelector('.govuk-error-message')
     if (inlineError) inlineError.remove()
@@ -64,21 +76,36 @@ export default class extends Controller {
   #showErrors(errors) {
     const textareaId = this.textareaTarget.id
 
-    const summary = document.createElement('div')
-    summary.className = 'govuk-error-summary'
-    summary.setAttribute('data-module', 'govuk-error-summary')
-    summary.innerHTML = `
-      <div role="alert">
-        <h2 class="govuk-error-summary__title">There is a problem</h2>
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            ${errors.map((msg) => `<li><a href="#${textareaId}">${msg}</a></li>`).join('')}
-          </ul>
-        </div>
-      </div>
-    `
+    const revisedPage = this.element.hasAttribute('data-search-mode-initial-mode-value')
+    let summary = revisedPage ? this.element.querySelector('.govuk-error-summary') : null
 
-    this.formContentTarget.prepend(summary)
+    if (!summary) {
+      summary = document.createElement('div')
+      summary.className = 'govuk-error-summary'
+      summary.setAttribute('data-module', 'govuk-error-summary')
+      if (revisedPage) summary.dataset.searchModeError = 'guided'
+      summary.innerHTML = `
+        <div role="alert">
+          <h2 class="govuk-error-summary__title">There is a problem</h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list"></ul>
+          </div>
+        </div>
+      `
+      this.formContentTarget.prepend(summary)
+    }
+
+    if (revisedPage) summary.tabIndex = -1
+    const list = summary.querySelector('.govuk-error-summary__list')
+    errors.forEach(message => {
+      const item = document.createElement('li')
+      if (revisedPage) item.dataset.searchModeError = 'guided'
+      const link = document.createElement('a')
+      link.href = `#${textareaId}`
+      link.textContent = message
+      item.append(link)
+      list.append(item)
+    })
 
     this.formGroupTarget.classList.add('govuk-form-group--error')
     this.textareaTarget.classList.add('govuk-textarea--error')

--- a/spec/javascript/controllers/guided_search_validation_controller_spec.js
+++ b/spec/javascript/controllers/guided_search_validation_controller_spec.js
@@ -118,6 +118,18 @@ describe('GuidedSearchValidationController', () => {
       expect(document.activeElement).toBe(summary);
     });
 
+    it('reveals a summary hidden after leaving keyword mode before focusing AI errors', async () => {
+      await setup({serverErrors: true});
+      document.querySelector('#new_search').dataset.searchModeInitialModeValue = 'guided';
+      const summary = document.querySelector('.govuk-error-summary');
+      summary.querySelector('li').dataset.searchModeError = 'keyword';
+      summary.querySelector('a').href = '#keyword-query';
+      summary.hidden = true;
+      submitForm();
+      expect(summary.hidden).toBe(false);
+      expect(document.activeElement).toBe(summary);
+    });
+
     it('keeps shared date errors when validating AI input', async () => {
       await setup({serverErrors: true});
       document.querySelector('#new_search').dataset.searchModeInitialModeValue = 'guided';

--- a/spec/javascript/controllers/guided_search_validation_controller_spec.js
+++ b/spec/javascript/controllers/guided_search_validation_controller_spec.js
@@ -108,6 +108,31 @@ describe('GuidedSearchValidationController', () => {
     delete global.fetch;
   });
 
+  describe('revised entry page', () => {
+    it('scopes and focuses AI query errors', async () => {
+      await setup();
+      document.querySelector('#new_search').dataset.searchModeInitialModeValue = 'keyword';
+      submitForm();
+      const summary = document.querySelector('.govuk-error-summary');
+      expect(summary.dataset.searchModeError).toBe('guided');
+      expect(document.activeElement).toBe(summary);
+    });
+
+    it('keeps shared date errors when validating AI input', async () => {
+      await setup({serverErrors: true});
+      document.querySelector('#new_search').dataset.searchModeInitialModeValue = 'guided';
+      document.querySelector('.govuk-error-summary ul').innerHTML = '<li><a href="#date-error">Enter a valid date</a></li>';
+      submitForm();
+      expect(document.querySelectorAll('.govuk-error-summary')).toHaveLength(1);
+      const summary = document.querySelector('.govuk-error-summary');
+      expect(summary.textContent).toContain('Enter a valid date');
+      expect(document.activeElement).toBe(summary);
+      expect(summary.querySelector('a[href="#search-q-field"]').closest('li').dataset.searchModeError).toBe('guided');
+      submitForm();
+      expect(summary.querySelectorAll('li')).toHaveLength(2);
+    });
+  });
+
   describe('keyword search', () => {
     it('bypasses validation entirely', async () => {
       await setup({hiddenFieldValue: 'false', textareaValue: ''});


### PR DESCRIPTION
## What:

- [x] Keep date and AI validation errors in one focused summary, showing the relevant errors when switching search modes.

Validation: all 183 JavaScript tests passed. Browser coverage is included in #3339.

## Why:

Prevent duplicate error summaries. This is a small prerequisite for the revised entry page.

## Ticket:

[AI-1260](https://transformuk.atlassian.net/browse/AI-1260)

## Risk:

**Risk level:** 🟢

**Reason for rating:** The new behaviour is limited to the revised form, which is introduced separately for development/staging.