### PR TITLE
AI-1260: Use Flagsmith to control the revised find commodity page

### DIFF
--- a/app/controllers/ai_search_information_controller.rb
+++ b/app/controllers/ai_search_information_controller.rb
@@ -3,8 +3,6 @@ class AiSearchInformationController < ApplicationController
                 :disable_switch_service_banner
 
   def show
-    unless TradeTariffFrontend.revised_find_commodity_enabled? && interactive_search_enabled?
-      redirect_to find_commodity_path
-    end
+    redirect_to find_commodity_path unless interactive_search_enabled?
   end
 end

--- a/app/controllers/concerns/find_commodity_page.rb
+++ b/app/controllers/concerns/find_commodity_page.rb
@@ -5,7 +5,7 @@ module FindCommodityPage
 
   def find_commodity_template
     @ai_search_enabled = interactive_search_enabled_with_analytics?
-    @revised_find_commodity = TradeTariffFrontend.revised_find_commodity_enabled? && @ai_search_enabled && !TradeTariffFrontend::ServiceChooser.xi?
+    @revised_find_commodity = @ai_search_enabled && !TradeTariffFrontend::ServiceChooser.xi?
 
     if @revised_find_commodity
       disable_switch_service_banner

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -31,7 +31,7 @@ class SearchController < ApplicationController
     end
   rescue Search::InvalidDate
     redirect_params = search_params.merge(invalid_date: true)
-    if TradeTariffFrontend.revised_find_commodity_enabled? && !TradeTariffFrontend::ServiceChooser.xi?
+    if interactive_search_enabled? && !TradeTariffFrontend::ServiceChooser.xi?
       redirect_params[:interactive_search] = params[:interactive_search] == 'true'
       redirect_params[:q] = params[:q] if params[:q].present?
     end

--- a/lib/trade_tariff_frontend/config.rb
+++ b/lib/trade_tariff_frontend/config.rb
@@ -16,10 +16,6 @@ module TradeTariffFrontend
       environment == 'production'
     end
 
-    def revised_find_commodity_enabled?
-      %w[development staging].include?(environment)
-    end
-
     def waf_integration_enabled?
       waf_integration_url.present?
     end

--- a/spec/features/search_analytics_spec.rb
+++ b/spec/features/search_analytics_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Search analytics in the browser', :js, type: :feature do
     )
     accept_usage_cookies
 
-    choose 'Guided search'
+    find('#ai-search-tab').click
     fill_in 'Describe the products you are trading', with: 'horses'
     click_button 'Search for a commodity'
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe 'Search', :js do
       it 'submits the journey and renders final intercept links with new-tab attributes' do
         visit find_commodity_path
 
-        choose 'Guided search'
+        find('#ai-search-tab').click
         fill_in 'Describe the products you are trading', with: 'smoked haddock'
         click_button 'Search for a commodity'
 
@@ -228,7 +228,7 @@ RSpec.describe 'Search', :js do
       it 'only shows the unknown answer guidance after submitting the unknown option' do
         visit find_commodity_path
 
-        choose 'Guided search'
+        find('#ai-search-tab').click
         fill_in 'Describe the products you are trading', with: 'smoked haddock'
         click_button 'Search for a commodity'
 

--- a/spec/lib/trade_tariff_frontend_spec.rb
+++ b/spec/lib/trade_tariff_frontend_spec.rb
@@ -20,26 +20,6 @@ RSpec.describe TradeTariffFrontend do
     )
   end
 
-  describe '.revised_find_commodity_enabled?' do
-    subject(:enabled) { described_class.revised_find_commodity_enabled? }
-
-    %w[development staging production preview test].each do |deployment|
-      context "when deployed to #{deployment}" do
-        before { stub_const('ENV', ENV.to_hash.merge('ENVIRONMENT' => deployment)) }
-
-        it 'limits rollout to development and staging' do
-          expect(enabled).to eq(%w[development staging].include?(deployment))
-        end
-      end
-    end
-
-    context 'without a configured environment' do
-      before { stub_const('ENV', ENV.to_hash.except('ENVIRONMENT')) }
-
-      it { is_expected.to be false }
-    end
-  end
-
   describe '.enquiries_email' do
     it 'returns the default classification enquiries email' do
       expect(described_class.enquiries_email).to eq('classification.enquiries@hmrc.gov.uk')

--- a/spec/requests/ai_search_banner_spec.rb
+++ b/spec/requests/ai_search_banner_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe 'AI-assisted search banner', :aggregate_failures, type: :request do
   include_context 'with news updates stubbed'
 
-  let(:environment) { 'staging' }
+  let(:environment) { 'production' }
   let(:hero_story) { build(:news_item, title: 'Latest tariff update') }
 
   before do
@@ -35,17 +35,5 @@ RSpec.describe 'AI-assisted search banner', :aggregate_failures, type: :request 
     page = Capybara.string(response.body)
     expect(page).to have_css('h2', text: hero_story.title)
     expect(page).not_to have_link('AI-assisted search', href: ai_search_information_path)
-  end
-
-  context 'when deployed to production' do
-    let(:environment) { 'production' }
-
-    it 'retains the existing banner selection' do
-      get find_commodity_path
-
-      page = Capybara.string(response.body)
-      expect(page).to have_css('h2', text: hero_story.title)
-      expect(page).not_to have_text('Introducing AI-assisted search')
-    end
   end
 end

--- a/spec/requests/ai_search_information_controller_spec.rb
+++ b/spec/requests/ai_search_information_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe 'AI-assisted search information', type: :request do
   subject(:page) { Capybara.string(response.body) }
 
-  let(:environment) { 'development' }
+  let(:environment) { 'production' }
   let(:path) { '/news/service-updates/ai-assisted-search' }
 
   before do
@@ -12,7 +12,7 @@ RSpec.describe 'AI-assisted search information', type: :request do
   end
 
   describe 'GET /news/service-updates/ai-assisted-search' do
-    %w[development staging].each do |deployed_environment|
+    %w[development staging production].each do |deployed_environment|
       context "when eligible in #{deployed_environment}" do
         let(:environment) { deployed_environment }
 
@@ -36,16 +36,6 @@ RSpec.describe 'AI-assisted search information', type: :request do
         disable_feature(:interactive_search)
         get path
       end
-
-      it 'returns to find commodity' do
-        expect(response).to redirect_to(find_commodity_path)
-      end
-    end
-
-    context 'when deployed to production' do
-      let(:environment) { 'production' }
-
-      before { get path }
 
       it 'returns to find commodity' do
         expect(response).to redirect_to(find_commodity_path)

--- a/spec/requests/find_commodities_controller_spec.rb
+++ b/spec/requests/find_commodities_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe FindCommoditiesController, type: :request do
 
     it { is_expected.to have_http_status :ok }
     it { is_expected.to have_attributes content_type: %r{text/html} }
-    it { expect(response.body).not_to include('search_type_guided') }
+    it { expect(Capybara.string(response.body)).not_to have_link('AI-assisted search') }
 
     context 'when interactive search is enabled' do
       before do
@@ -23,7 +23,7 @@ RSpec.describe FindCommoditiesController, type: :request do
         get find_commodity_path
       end
 
-      it { expect(response.body).to include('search_type_guided') }
+      it { expect(Capybara.string(response.body)).to have_link('AI-assisted search') }
     end
 
     context 'when interactive search is enabled on the XI service' do
@@ -32,7 +32,7 @@ RSpec.describe FindCommoditiesController, type: :request do
         get '/xi/find_commodity'
       end
 
-      it { expect(response.body).not_to include('search_type_guided') }
+      it { expect(Capybara.string(response.body)).not_to have_link('AI-assisted search') }
     end
 
     context 'with a malformed search param' do

--- a/spec/requests/revised_find_commodities_spec.rb
+++ b/spec/requests/revised_find_commodities_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Revised find commodity page', :aggregate_failures, type: :reques
     guided ? enable_feature(:interactive_search) : disable_feature(:interactive_search)
   end
 
-  let(:environment) { 'staging' }
+  let(:environment) { 'production' }
   let(:guided) { false }
 
   def entry_page(params = {})
@@ -18,7 +18,7 @@ RSpec.describe 'Revised find commodity page', :aggregate_failures, type: :reques
     Capybara.string(response.body)
   end
 
-  %w[development staging].each do |deployment|
+  %w[development staging production].each do |deployment|
     context "when deployed to #{deployment}" do
       let(:environment) { deployment }
 
@@ -98,22 +98,6 @@ RSpec.describe 'Revised find commodity page', :aggregate_failures, type: :reques
 
       analytics = JSON.parse(Nokogiri::HTML(response.body).at_css('#search-analytics-context').text)
       expect(analytics).to include('search_mode' => 'keyword', 'search_experience' => 'guided_beta')
-    end
-  end
-
-  context 'when deployed to production' do
-    let(:environment) { 'production' }
-
-    it 'keeps the existing classic page' do
-      expect(entry_page).to have_css('h1', text: 'Look up commodity codes, import duties, taxes and controls')
-    end
-
-    context 'with AI search enabled' do
-      let(:guided) { true }
-
-      it 'keeps the existing radio page' do
-        expect(entry_page).to have_field('Guided search', type: 'radio')
-      end
     end
   end
 

--- a/spec/requests/search_analytics_spec.rb
+++ b/spec/requests/search_analytics_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Search analytics', :aggregate_failures, type: :request do
 
     get find_commodity_path
 
-    expect(response.body).to include('search_type_guided')
+    expect(Capybara.string(response.body)).to have_link('AI-assisted search')
     expect(analytics_context).to include(
       'search_experience' => 'guided_beta',
       'feature_flag_source' => 'flagsmith',


### PR DESCRIPTION
## What:

- [x] Remove the development/staging restriction from the revised find commodity page, AI information page and validation redirects.
- [x] Cover production behaviour with `interactive_search` enabled and disabled.

## Why:

Flagsmith should control rollout in every environment, including production. Existing service and visitor eligibility still apply; this PR does not change flag values.

## Ticket:

[AI-1260](https://transformuk.atlassian.net/browse/AI-1260)

## Risk:

**Risk level:** 🟢

**Reason for rating:** Removes a redundant environment restriction while retaining the existing feature flag as the rollout control.